### PR TITLE
Added logging on input & output streams for network debugging

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredInputStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredInputStream.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.spi.Logger;
+import org.neo4j.driver.internal.spi.Logging;
+import org.neo4j.driver.internal.util.BytePrinter;
+
+public class MonitoredInputStream extends InputStream
+{
+    private final InputStream realInput;
+    private final Logger logger;
+
+    public MonitoredInputStream( InputStream inputStream, Logging logging )
+    {
+        this.realInput = inputStream;
+        if ( logging != null )
+        {
+            this.logger = logging.getLogging( getClass().getName() );
+        }
+        else
+        {
+            this.logger = new DevNullLogger();
+        }
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        int read = realInput.read();
+        logger.debug( "Input:\n" + BytePrinter.hex( (byte) read ) );
+        return read;
+    }
+
+    @Override
+    public int read( byte b[] ) throws IOException
+    {
+        int read = realInput.read( b );
+        logger.debug( "Input:\n" + BytePrinter.hex( b ) );
+        return read;
+    }
+
+    @Override
+    public int read( byte b[], int off, int len ) throws IOException
+    {
+        int read = realInput.read( b, off, len );
+        logger.debug( "Input:\n" + BytePrinter.hex( ByteBuffer.wrap( b ), off, len ) );
+        return read;
+    }
+
+    @Override
+    public long skip( long n ) throws IOException
+    {
+        return realInput.skip( n );
+    }
+
+    @Override
+    public int available() throws IOException
+    {
+        return realInput.available();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        realInput.close();
+    }
+
+    @Override
+    public synchronized void mark( int readlimit )
+    {
+        realInput.mark( readlimit );
+    }
+
+    @Override
+    public synchronized void reset() throws IOException
+    {
+        realInput.reset();
+    }
+
+    @Override
+    public boolean markSupported()
+    {
+        return realInput.markSupported();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredOutputStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredOutputStream.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.spi.Logger;
+import org.neo4j.driver.internal.spi.Logging;
+import org.neo4j.driver.internal.util.BytePrinter;
+
+public class MonitoredOutputStream extends OutputStream
+{
+    OutputStream realOut;
+    Logger logger;
+
+    public MonitoredOutputStream( OutputStream outputStream, Logging logging )
+    {
+        this.realOut = outputStream;
+        if( logging != null )
+        {
+            this.logger = logging.getLogging( getClass().getName() );
+        }
+        else
+        {
+            this.logger = new DevNullLogger();
+        }
+    }
+
+    @Override
+    public void write( int b ) throws IOException
+    {
+        realOut.write( b );
+        logger.debug( "Output:\n" + BytePrinter.hex( (byte) b ) );
+    }
+
+    @Override
+    public void write( byte b[], int off, int len ) throws IOException
+    {
+        realOut.write( b, off, len );
+        logger.debug( "Output:\n" + BytePrinter.hex( ByteBuffer.wrap( b ), off, len ) );
+    }
+
+    @Override
+    public void write( byte b[] ) throws IOException
+    {
+        realOut.write( b );
+        logger.debug( "Output:\n" + BytePrinter.hex( b ) );
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        realOut.flush();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        realOut.close();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.internal.messaging.AckFailureMessage;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.RunMessage;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.Logging;
 import org.neo4j.driver.internal.spi.StreamCollector;
 
 import static org.neo4j.driver.internal.messaging.DiscardAllMessage.DISCARD_ALL;
@@ -43,9 +44,12 @@ public class SocketConnection implements Connection
     private final SocketResponseHandler responseHandler = new SocketResponseHandler();
     private int requestCounter = 0;
 
-    public SocketConnection( String host, int port )
+    private Logging logging;
+
+    public SocketConnection( String host, int port, Logging logging )
     {
-        this.socket = new SocketClient( host, port );
+        this.logging = logging;
+        this.socket = new SocketClient( host, port, logging );
         socket.start();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnector.java
@@ -47,8 +47,8 @@ public class SocketConnector implements Connector
     public Connection connect( URI sessionURI ) throws ClientException
     {
         int port = sessionURI.getPort();
-        return new SocketConnection( sessionURI.getHost(), port == -1 ? DEFAULT_PORT : port
-        );
+        return new SocketConnection( sessionURI.getHost(), port == -1 ? DEFAULT_PORT : port,
+                logging /*The logging could be null if {@code setLogging} has never been invoked */ );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
@@ -26,18 +26,16 @@ import org.neo4j.driver.internal.spi.Logger;
 public class JULogger implements Logger
 {
     private final java.util.logging.Logger delegate;
-    private final boolean debugEnabled;
 
     public JULogger( String name )
     {
         delegate = java.util.logging.Logger.getLogger( name );
-        debugEnabled = delegate.isLoggable( Level.FINE );
     }
 
     @Override
     public void debug( String message )
     {
-        if ( debugEnabled )
+        if ( delegate.isLoggable( Level.FINE ) )
         {
             delegate.log( Level.FINE, message );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/BytePrinter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/BytePrinter.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.driver.util;
+package org.neo4j.driver.internal.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.driver.util.BytePrinter;
+import org.neo4j.driver.internal.util.BytePrinter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -21,10 +21,7 @@ package org.neo4j.driver.internal.messaging;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
@@ -41,8 +38,7 @@ import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.SimpleNode;
 import org.neo4j.driver.internal.SimplePath;
 import org.neo4j.driver.internal.SimpleRelationship;
-import org.neo4j.driver.internal.connector.socket.ChunkedInput;
-import org.neo4j.driver.util.BytePrinter;
+import org.neo4j.driver.internal.util.BytePrinter;
 import org.neo4j.driver.internal.packstream.BufferedChannelOutput;
 import org.neo4j.driver.internal.packstream.PackStream;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
@@ -31,7 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.driver.util.BytePrinter;
+import org.neo4j.driver.internal.util.BytePrinter;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;

--- a/driver/src/test/java/org/neo4j/driver/util/BytePrinterTest.java
+++ b/driver/src/test/java/org/neo4j/driver/util/BytePrinterTest.java
@@ -26,6 +26,8 @@ import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
+import org.neo4j.driver.internal.util.BytePrinter;
+
 import static org.junit.Assert.assertEquals;
 
 public class BytePrinterTest


### PR DESCRIPTION
When running tests, we could choose to enable network traffic logging by setting logging level to FINE and providing proper logging handler to MonitoredInputStream & MonitoredOutputStream.