### PR TITLE
The client should always handle message ending '00 00'

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredInputStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredInputStream.java
@@ -23,9 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.spi.Logger;
-import org.neo4j.driver.internal.spi.Logging;
 import org.neo4j.driver.internal.util.BytePrinter;
 
 public class MonitoredInputStream extends InputStream
@@ -33,17 +31,10 @@ public class MonitoredInputStream extends InputStream
     private final InputStream realInput;
     private final Logger logger;
 
-    public MonitoredInputStream( InputStream inputStream, Logging logging )
+    public MonitoredInputStream( InputStream inputStream, Logger logger )
     {
         this.realInput = inputStream;
-        if ( logging != null )
-        {
-            this.logger = logging.getLogging( getClass().getName() );
-        }
-        else
-        {
-            this.logger = new DevNullLogger();
-        }
+        this.logger = logger;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredOutputStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/MonitoredOutputStream.java
@@ -23,27 +23,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
-import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.spi.Logger;
-import org.neo4j.driver.internal.spi.Logging;
 import org.neo4j.driver.internal.util.BytePrinter;
 
 public class MonitoredOutputStream extends OutputStream
 {
-    OutputStream realOut;
-    Logger logger;
+    private final OutputStream realOut;
+    private final Logger logger;
 
-    public MonitoredOutputStream( OutputStream outputStream, Logging logging )
+    public MonitoredOutputStream( OutputStream outputStream, Logger logger )
     {
         this.realOut = outputStream;
-        if( logging != null )
-        {
-            this.logger = logging.getLogging( getClass().getName() );
-        }
-        else
-        {
-            this.logger = new DevNullLogger();
-        }
+        this.logger = logger;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketProtocolV1.java
@@ -24,7 +24,7 @@ public class SocketProtocolV1 implements SocketProtocol
         this.input = new ChunkedInput();
 
         this.writer = new PackStreamMessageFormatV1.Writer( output, output.messageBoundaryHook() );
-        this.reader = new PackStreamMessageFormatV1.Reader( input );
+        this.reader = new PackStreamMessageFormatV1.Reader( input, input.messageBoundaryHook() );
     }
 
     @Override


### PR DESCRIPTION
When reading messages (ignoreMessage, failureMessage, etc.) from server, on message complete, we should always expect `00 00` as the mark of ending. This PR makes sure `00 00` message is always handled before next client-server conversation starts.