### PR TITLE
One buffer in ChunkedInput&Output

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/BufferedChannelOutput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/BufferedChannelOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2015 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
@@ -41,7 +41,7 @@ public class BufferedChannelOutput implements PackOutput
 
     public BufferedChannelOutput( WritableByteChannel channel, int bufferSize )
     {
-        this(bufferSize);
+        this( bufferSize );
         reset( channel );
     }
 
@@ -51,75 +51,78 @@ public class BufferedChannelOutput implements PackOutput
     }
 
     @Override
-    public BufferedChannelOutput ensure( int size ) throws IOException
-    {
-        if ( buffer.remaining() < size )
-        {
-            flush();
-        }
-        return this;
-    }
-
-    @Override
     public BufferedChannelOutput flush() throws IOException
     {
         buffer.flip();
-        do { channel.write( buffer ); } while( buffer.remaining() > 0 );
+        do { channel.write( buffer ); } while ( buffer.remaining() > 0 );
         buffer.clear();
         return this;
     }
 
     @Override
-    public PackOutput put( byte value )
-    {
-        buffer.put( value );
-        return this;
-    }
-
-    @Override
-    public PackOutput put( byte[] data, int offset, int length ) throws IOException
+    public PackOutput writeBytes( byte[] data, int offset, int length ) throws IOException
     {
         int index = 0;
-        while(index < length)
+        while ( index < length )
         {
-            int amountToWrite = Math.min( buffer.remaining(), length - index );
-
-            buffer.put( data, offset, amountToWrite );
-            index += amountToWrite;
-
-            if( buffer.remaining() == 0)
+            if ( buffer.remaining() == 0 )
             {
                 flush();
             }
+
+            int amountToWrite = Math.min( buffer.remaining(), length - index );
+
+            buffer.put( data, offset + index, amountToWrite );
+            index += amountToWrite;
         }
         return this;
     }
 
     @Override
-    public PackOutput putShort( short value )
+    public PackOutput writeByte( byte value ) throws IOException
     {
+        ensure( 1 );
+        buffer.put( value );
+        return this;
+    }
+
+    @Override
+    public PackOutput writeShort( short value ) throws IOException
+    {
+        ensure( 2 );
         buffer.putShort( value );
         return this;
     }
 
     @Override
-    public PackOutput putInt( int value )
+    public PackOutput writeInt( int value ) throws IOException
     {
+        ensure( 4 );
         buffer.putInt( value );
         return this;
     }
 
     @Override
-    public PackOutput putLong( long value )
+    public PackOutput writeLong( long value ) throws IOException
     {
+        ensure( 8 );
         buffer.putLong( value );
         return this;
     }
 
     @Override
-    public PackOutput putDouble( double value )
+    public PackOutput writeDouble( double value ) throws IOException
     {
+        ensure( 8 );
         buffer.putDouble( value );
         return this;
+    }
+
+    private void ensure( int size ) throws IOException
+    {
+        if ( buffer.remaining() < size )
+        {
+            flush();
+        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackInput.java
@@ -21,38 +21,33 @@ package org.neo4j.driver.internal.packstream;
 
 import java.io.IOException;
 
+/**
+ * This is what {@link PackStream} uses to ingest data, implement this on top of any data source of your choice to
+ * deserialize the stream with {@link PackStream}.
+ */
 public interface PackInput
 {
-    /**
-     * Ensure the specified number of bytes are available for reading
-     * @throws PackStream.EndOfStream if there are not enough bytes available
-     */
-    PackInput ensure( int numBytes ) throws IOException;
+    /** True if there is at least one more consumable byte */
+    boolean hasMoreData() throws IOException;
 
-    /** Attempt to make up to the specified bytes available for reading */
-    PackInput attemptUpTo( int numBytes ) throws IOException;
+    /** Consume one byte */
+    byte readByte() throws IOException;
 
-    /** Attempt to make the specified number of bytes available for reading. */
-    boolean attempt( int numBytes ) throws IOException;
+    /** Consume a 2-byte signed integer */
+    short readShort() throws IOException;
 
-    byte get();
+    /** Consume a 4-byte signed integer */
+    int readInt() throws IOException;
 
-    /**
-     * Number of bytes immediately readable. This differs from {@link #ensure(int)} and {@link #attempt(int)} in that
-     * this does not load more bytes from any underlying source.
-     */
-    int remaining();
+    /** Consume an 8-byte signed integer */
+    long readLong() throws IOException;
 
-    short getShort();
+    /** Consume an 8-byte IEEE 754 "double format" floating-point number */
+    double readDouble() throws IOException;
 
-    int getInt();
-
-    long getLong();
-
-    double getDouble();
-
-    PackInput get( byte[] into, int offset, int toRead );
+    /** Consume a specified number of bytes */
+    PackInput readBytes( byte[] into, int offset, int toRead ) throws IOException;
 
     /** Get the next byte without forwarding the internal pointer */
-    byte peek();
+    byte peekByte() throws IOException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackOutput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackOutput.java
@@ -22,25 +22,28 @@ package org.neo4j.driver.internal.packstream;
 import java.io.IOException;
 
 /**
- * Client is responsible for calling {@link #ensure(int)} before any calls to 'put' operations,
- * other than to {@link #put(byte[], int, int)}.
+ * This is where {@link PackStream} writes its output to.
  */
 public interface PackOutput
 {
-    /** Ensure at least the given set of bytes can be written. Size will never exceed 16 */
-    PackOutput ensure( int size ) throws IOException;
-
+    /** If implementation has been buffering data, it should flush those buffers now. */
     PackOutput flush() throws IOException;
 
-    PackOutput put( byte value );
+    /** Produce a single byte */
+    PackOutput writeByte( byte value ) throws IOException;
 
-    PackOutput put( byte[] data, int offset, int amountToWrite ) throws IOException;
+    /** Produce binary data */
+    PackOutput writeBytes( byte[] data, int offset, int amountToWrite ) throws IOException;
 
-    PackOutput putShort( short value );
+    /** Produce a 4-byte signed integer */
+    PackOutput writeShort( short value ) throws IOException;
 
-    PackOutput putInt( int value );
+    /** Produce a 4-byte signed integer */
+    PackOutput writeInt( int value ) throws IOException;
 
-    PackOutput putLong( long value );
+    /** Produce an 8-byte signed integer */
+    PackOutput writeLong( long value ) throws IOException;
 
-    PackOutput putDouble( double value );
+    /** Produce an 8-byte IEEE 754 "double format" floating-point number */
+    PackOutput writeDouble( double value ) throws IOException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
@@ -179,59 +179,51 @@ public class PackStream
 
         public void packRaw( byte[] data ) throws IOException
         {
-            out.put( data, 0, data.length );
+            out.writeBytes( data, 0, data.length );
         }
 
         public void packNull() throws IOException
         {
-            out.ensure( 1 )
-               .put( NULL );
+            out.writeByte( NULL );
         }
 
         public void pack( boolean value ) throws IOException
         {
-            out.ensure( 1 )
-               .put( value ? TRUE : FALSE );
+            out.writeByte( value ? TRUE : FALSE );
         }
 
         public void pack( long value ) throws IOException
         {
             if ( value >= MINUS_2_TO_THE_4 && value < PLUS_2_TO_THE_7)
             {
-                out.ensure( 1 )
-                   .put( (byte) value );
+                out.writeByte( (byte) value );
             }
             else if ( value >= MINUS_2_TO_THE_7 && value < MINUS_2_TO_THE_4 )
             {
-                out.ensure( 2 )
-                   .put( INT_8 )
-                   .put( (byte) value );
+                out.writeByte( INT_8 )
+                   .writeByte( (byte) value );
             }
             else if ( value >= MINUS_2_TO_THE_15 && value < PLUS_2_TO_THE_15 )
             {
-                out.ensure( 3 )
-                   .put( INT_16 )
-                   .putShort( (short) value );
+                out.writeByte( INT_16 )
+                   .writeShort( (short) value );
             }
             else if ( value >= MINUS_2_TO_THE_31 && value < PLUS_2_TO_THE_31 )
             {
-                out.ensure( 5 )
-                   .put( INT_32 )
-                   .putInt( (int) value );
+                out.writeByte( INT_32 )
+                   .writeInt( (int) value );
             }
             else
             {
-                out.ensure( 9 )
-                   .put( INT_64 )
-                   .putLong( value );
+                out.writeByte( INT_64 )
+                   .writeLong( value );
             }
         }
 
         public void pack( double value ) throws IOException
         {
-            out.ensure( 9 )
-               .put( FLOAT_64 )
-               .putDouble( value );
+            out.writeByte( FLOAT_64 )
+               .writeDouble( value );
         }
 
         public void pack( byte[] values ) throws IOException
@@ -322,21 +314,18 @@ public class PackStream
         {
             if ( size <= Byte.MAX_VALUE )
             {
-                out.ensure( 2 )
-                   .put( BYTES_8 )
-                   .put( (byte) size );
+                out.writeByte( BYTES_8 )
+                   .writeByte( (byte) size );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.ensure( 3 )
-                   .put( BYTES_16 )
-                   .putShort( (short) size );
+                out.writeByte( BYTES_16 )
+                   .writeShort( (short) size );
             }
             else
             {
-                out.ensure( 5 )
-                   .put( BYTES_32 )
-                   .putInt( size );
+                out.writeByte( BYTES_32 )
+                   .writeInt( size );
             }
         }
 
@@ -344,26 +333,22 @@ public class PackStream
         {
             if ( size < 0x10 )
             {
-                out.ensure( 1 )
-                   .put( (byte) (TINY_TEXT | size) );
+                out.writeByte( (byte) (TINY_TEXT | size) );
             }
             else if ( size <= Byte.MAX_VALUE )
             {
-                out.ensure( 2 )
-                   .put( TEXT_8 )
-                   .put( (byte) size );
+                out.writeByte( TEXT_8 )
+                   .writeByte( (byte) size );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.ensure( 3 )
-                   .put( TEXT_16 )
-                   .putShort( (short) size );
+                out.writeByte( TEXT_16 )
+                   .writeShort( (short) size );
             }
             else
             {
-                out.ensure( 5 )
-                   .put( TEXT_32 )
-                   .putInt( size );
+                out.writeByte( TEXT_32 )
+                   .writeInt( size );
             }
         }
 
@@ -371,26 +356,22 @@ public class PackStream
         {
             if ( size < 0x10 )
             {
-                out.ensure( 1 )
-                   .put( (byte) (TINY_LIST | size) );
+                   out.writeByte( (byte) (TINY_LIST | size) );
             }
             else if ( size <= Byte.MAX_VALUE )
             {
-                out.ensure( 2 )
-                   .put( LIST_8 )
-                   .put( (byte) size );
+                out.writeByte( LIST_8 )
+                   .writeByte( (byte) size );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.ensure( 3 )
-                   .put( LIST_16 )
-                   .putShort( (short) size );
+                out.writeByte( LIST_16 )
+                   .writeShort( (short) size );
             }
             else
             {
-                out.ensure( 5 )
-                   .put( LIST_32 )
-                   .putInt( size );
+                out.writeByte( LIST_32 )
+                   .writeInt( size );
             }
         }
 
@@ -398,26 +379,22 @@ public class PackStream
         {
             if ( size < 0x10 )
             {
-                out.ensure( 1 )
-                   .put( (byte) (TINY_MAP | size) );
+                out.writeByte( (byte) (TINY_MAP | size) );
             }
             else if ( size <= Byte.MAX_VALUE )
             {
-                out.ensure( 2 )
-                   .put( MAP_8 )
-                   .put( (byte) size );
+                out.writeByte( MAP_8 )
+                   .writeByte( (byte) size );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.ensure( 3 )
-                   .put( MAP_16 )
-                   .putShort( (short) size );
+                out.writeByte( MAP_16 )
+                   .writeShort( (short) size );
             }
             else
             {
-                out.ensure( 5 )
-                   .put( MAP_32 )
-                   .putInt( size );
+                out.writeByte( MAP_32 )
+                   .writeInt( size );
             }
         }
 
@@ -425,23 +402,20 @@ public class PackStream
         {
             if ( size < 0x10 )
             {
-                out.ensure( 2 )
-                   .put( (byte) (TINY_STRUCT | size) )
-                   .put( (byte) signature );
+                out.writeByte( (byte) (TINY_STRUCT | size) )
+                   .writeByte( (byte) signature );
             }
             else if ( size <= Byte.MAX_VALUE )
             {
-                out.ensure( 3 )
-                   .put( STRUCT_8 )
-                   .put( (byte) size )
-                   .put( (byte) signature );
+                out.writeByte( STRUCT_8 )
+                   .writeByte( (byte) size )
+                   .writeByte( (byte) signature );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.ensure( 4 )
-                   .put( STRUCT_16 )
-                   .putShort( (short) size )
-                   .put( (byte) signature );
+                out.writeByte( STRUCT_16 )
+                   .writeShort( (short) size )
+                   .writeByte( (byte) signature );
             }
             else
             {
@@ -481,12 +455,12 @@ public class PackStream
 
         public boolean hasNext() throws IOException
         {
-            return in.remaining() > 0 || in.attempt( 1 );
+            return in.hasMoreData();
         }
 
         public long unpackStructHeader() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             final byte markerHighNibble = (byte) (markerByte & 0xF0);
             final byte markerLowNibble = (byte) (markerByte & 0x0F);
 
@@ -501,12 +475,12 @@ public class PackStream
 
         public char unpackStructSignature() throws IOException
         {
-            return (char) in.ensure( 1 ).get();
+            return (char) in.readByte();
         }
 
         public long unpackListHeader() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             final byte markerHighNibble = (byte) (markerByte & 0xF0);
             final byte markerLowNibble  = (byte) (markerByte & 0x0F);
 
@@ -522,7 +496,7 @@ public class PackStream
 
         public long unpackMapHeader() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             final byte markerHighNibble = (byte) (markerByte & 0xF0);
             final byte markerLowNibble = (byte) (markerByte & 0x0F);
 
@@ -538,31 +512,31 @@ public class PackStream
 
         public long unpackLong() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             if ( markerByte >= MINUS_2_TO_THE_4) { return markerByte; }
             switch(markerByte)
             {
-            case INT_8:   return in.ensure( 1 ).get();
-            case INT_16:  return in.ensure( 2 ).getShort();
-            case INT_32:  return in.ensure( 4 ).getInt();
-            case INT_64:  return in.ensure( 8 ).getLong();
+            case INT_8:   return in.readByte();
+            case INT_16:  return in.readShort();
+            case INT_32:  return in.readInt();
+            case INT_64:  return in.readLong();
             default: throw new Unexpected( "Expected an integer, but got: " + toHexString( markerByte ));
             }
         }
 
         public double unpackDouble() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             if(markerByte == FLOAT_64)
             {
-                return in.ensure( 8 ).getDouble();
+                return in.readDouble();
             }
             throw new Unexpected( "Expected a double, but got: " + toHexString( markerByte ));
         }
 
         public String unpackString() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             if( markerByte == TINY_TEXT ) // Note no mask, so we compare to 0x80.
             {
                 return PackValue.EMPTY_STRING;
@@ -599,7 +573,7 @@ public class PackStream
 
         public boolean unpackBoolean() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             switch(markerByte)
             {
             case TRUE: return true;
@@ -610,7 +584,7 @@ public class PackStream
 
         public PackValue unpack() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).get();
+            final byte markerByte = in.readByte();
             final byte markerHighNibble = (byte) (markerByte & 0xF0);
             final byte markerLowNibble = (byte) (markerByte & 0x0F);
 
@@ -628,23 +602,23 @@ public class PackStream
             }
             else if ( markerByte == FLOAT_64 )
             {
-                return new PackValue.FloatValue( in.ensure( 8 ).getDouble() );
+                return new PackValue.FloatValue( in.readDouble() );
             }
             else if ( markerByte == INT_8 )
             {
-                return PackValue.IntegerValue.getInstance( in.ensure( 1 ).get() );
+                return PackValue.IntegerValue.getInstance( in.readByte() );
             }
             else if ( markerByte == INT_16 )
             {
-                return PackValue.IntegerValue.getInstance( in.ensure( 2 ).getShort() );
+                return PackValue.IntegerValue.getInstance( in.readShort() );
             }
             else if ( markerByte == INT_32 )
             {
-                return PackValue.IntegerValue.getInstance( in.ensure( 4 ).getInt() );
+                return PackValue.IntegerValue.getInstance( in.readInt() );
             }
             else if ( markerByte == INT_64 )
             {
-                return PackValue.IntegerValue.getInstance( in.ensure( 8 ).getLong() );
+                return PackValue.IntegerValue.getInstance( in.readLong() );
             }
             else if ( markerByte == BYTES_8 )
             {
@@ -760,40 +734,23 @@ public class PackStream
 
         private int unpackUINT8() throws IOException
         {
-            return in.ensure( 1 ).get() & 0xFF;
+            return in.readByte() & 0xFF;
         }
 
         private int unpackUINT16() throws IOException
         {
-            return in.ensure( 2 ).getShort() & 0xFFFF;
+            return in.readShort() & 0xFFFF;
         }
 
         private long unpackUINT32() throws IOException
         {
-            return in.ensure( 4 ).getInt() & 0xFFFFFFFFL;
+            return in.readInt() & 0xFFFFFFFFL;
         }
 
         private byte[] unpackBytes( int size ) throws IOException
         {
-            if ( size == 0 ) return PackValue.EMPTY_BYTE_ARRAY;
             byte[] heapBuffer = new byte[size];
-            int index = 0;
-            while(index < size)
-            {
-                int toRead = Math.min( in.remaining(), size - index );
-                in.get( heapBuffer, index, toRead );
-                index += toRead;
-
-                if(in.remaining() == 0 && index < size)
-                {
-                    in.attemptUpTo( size - index );
-                    if(in.remaining() == 0)
-                    {
-                        throw new EndOfStream( "Expected " + (size - index) + " bytes available, " +
-                                                "but no more bytes accessible from underlying stream." );
-                    }
-                }
-            }
+            in.readBytes( heapBuffer, 0, heapBuffer.length );
             return heapBuffer;
         }
 
@@ -826,7 +783,7 @@ public class PackStream
 
         public PackType peekNextType() throws IOException
         {
-            final byte markerByte = in.ensure( 1 ).peek();
+            final byte markerByte = in.peekByte();
             final byte markerHighNibble = (byte) (markerByte & 0xF0);
 
             switch(markerHighNibble)

--- a/driver/src/main/java/org/neo4j/driver/internal/util/InputStreams.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/InputStreams.java
@@ -20,33 +20,30 @@
 package org.neo4j.driver.internal.util;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 
 import org.neo4j.driver.exceptions.ClientException;
 
 public class InputStreams
 {
     /**
-     * Reads from the input stream until the 'into' array is filled, or throws an exception.
+     * Reads from the input channel until the 'into' buffer is filled, or throws an exception.
      *
-     * @param in
+     * @param channel
      * @param into
      */
-    public static void readAll( InputStream in, byte[] into ) throws IOException
+    public static void readAll( ReadableByteChannel channel, ByteBuffer into ) throws IOException
     {
-        for ( int idx = 0, read; idx < into.length; )
+        while( into.remaining() > 0 )
         {
-            read = in.read( into, idx, into.length - idx );
+            int read = channel.read( into );
             if ( read == -1 )
             {
                 throw new ClientException(
                         "Connection terminated while receiving data. This can happen due to network " +
-                        "instabilities, or due to restarts of the database. Expected " + into.length + "bytes, " +
-                        "recieved " + idx + "." );
-            }
-            else
-            {
-                idx += read;
+                        "instabilities, or due to restarts of the database. Expected " + into.limit() + "bytes, " +
+                        "recieved " + BytePrinter.hex( into ) + "." );
             }
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
@@ -277,33 +277,23 @@ public class ParametersIT
     @Test
     public void shouldBeAbleToSetAndReturnSpecialStringArrayProperty()
     {
-        // Setting up
-        enableNetworkTrafficlogging( true );
-
         // When
         String[] arrayValue = new String[]{"Mjölnir", "Mjölnir", "Mjölnir"};
 
-        try
-        {
-            Result result = session.run(
-                    "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
+        Result result = session.run(
+                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
 
-            // Then
-            for ( Record record : result.retain() )
-            {
-                Value value = record.get( "a.value" );
-                assertThat( value.isList(), equalTo( true ) );
-                assertThat( value.size(), equalTo( 3L ) );
-                for ( Value item : value )
-                {
-                    assertThat( item.isText(), equalTo( true ) );
-                    assertThat( item.javaString(), equalTo( "Mjölnir" ) );
-                }
-            }
-        }
-        finally
+        // Then
+        for ( Record record : result.retain() )
         {
-            enableNetworkTrafficlogging( false );
+            Value value = record.get( "a.value" );
+            assertThat( value.isList(), equalTo( true ) );
+            assertThat( value.size(), equalTo( 3L ) );
+            for ( Value item : value )
+            {
+                assertThat( item.isText(), equalTo( true ) );
+                assertThat( item.javaString(), equalTo( "Mjölnir" ) );
+            }
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedInputTest.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.driver.internal.connector.socket;
 
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
 
-import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -34,15 +36,13 @@ public class ChunkedInputTest
     public void shouldExposeMultipleChunksAsCohesiveStream() throws Throwable
     {
         // Given
-        ChunkedInput ch = new ChunkedInput();
-
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 1, 2 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 3 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 4, 5 } ) );
+        ReadableByteChannel channel = Channels.newChannel(
+                new ByteArrayInputStream( new byte[]{ 0, 5, 1, 2, 3, 4, 5} ) );
+        ChunkedInput ch = new ChunkedInput( 2, channel );
 
         // When
         byte[] bytes = new byte[5];
-        ch.get( bytes, 0, 5 );
+        ch.readBytes( bytes, 0, 5 );
 
         // Then
         assertThat( bytes, equalTo( new byte[]{1, 2, 3, 4, 5} ) );
@@ -52,24 +52,20 @@ public class ChunkedInputTest
     public void shouldReadIntoMisalignedDestinationBuffer() throws Throwable
     {
         // Given
+        ReadableByteChannel channel = Channels.newChannel(
+                new ByteArrayInputStream( new byte[]{0, 7, 1, 2, 3, 4, 5, 6, 7} ) );
+        ChunkedInput ch = new ChunkedInput( 2, channel );
         byte[] bytes = new byte[3];
-        ChunkedInput ch = new ChunkedInput();
-
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 1, 2 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 3 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 4 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 5 } ) );
-        ch.addChunk( ByteBuffer.wrap( new byte[] { 6, 7 } ) );
 
         // When I read {1,2,3}
-        ch.get( bytes, 0, 3 );
+        ch.readBytes( bytes, 0, 3 );
 
         // Then
         assertThat( bytes, equalTo( new byte[]{1, 2, 3} ) );
 
 
         // When I read {4,5,6}
-        ch.get( bytes, 0, 3 );
+        ch.readBytes( bytes, 0, 3 );
 
         // Then
         assertThat( bytes, equalTo( new byte[]{4, 5, 6} ) );
@@ -77,19 +73,19 @@ public class ChunkedInputTest
 
         // When I read {7}
         Arrays.fill( bytes, (byte) 0 );
-        ch.get( bytes, 0, 1 );
+        ch.readBytes( bytes, 0, 1 );
 
         // Then
         assertThat( bytes, equalTo( new byte[]{7, 0, 0} ) );
     }
 
     @Test
-    public void shouldAddReceivedChunksIntoList() throws Exception
+    public void canReadBytesAcrossChunkBoundaries() throws Exception
     {
         // Given
         byte[] inputBuffer = {
-                0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, // chunk 1 with size 10
-                0, 5, 1, 2, 3, 4, 5 // chunk 2 with size 5
+                0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,   // chunk 1 with size 10
+                0, 5, 1, 2, 3, 4, 5                     // chunk 2 with size 5
                 };
         InputStream in = new ByteArrayInputStream( inputBuffer );
         ChunkedInput input = new ChunkedInput();
@@ -98,10 +94,10 @@ public class ChunkedInputTest
         byte[] outputBuffer = new byte[15];
 
         // When
-        input.attempt( 10 );
+        input.hasMoreData();
 
         // Then
-        input.get( outputBuffer, 0, 15 );
-        assertThat( outputBuffer, equalTo( new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5 } ) );
+        input.readBytes( outputBuffer, 0, 15 );
+        assertThat( outputBuffer, equalTo( new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5} ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
@@ -40,7 +40,7 @@ public class ChunkedOutputTest
     public void shouldChunkSingleMessage() throws Throwable
     {
         // When
-        out.ensure( 3 ).put( (byte) 1 ).putShort( (short) 2 );
+        out.writeByte( (byte) 1 ).writeShort( (short) 2 );
         out.messageBoundaryHook().run();
         out.flush();
 
@@ -54,9 +54,9 @@ public class ChunkedOutputTest
     public void shouldChunkMessageSpanningMultipleChunks() throws Throwable
     {
         // When
-        out.ensure( 8 ).putLong( 1 )
-                .ensure( 8 ).putLong( 2 )
-                .ensure( 8 ).putLong( 3 );
+        out.writeLong( 1 )
+           .writeLong( 2 )
+           .writeLong( 3 );
         out.messageBoundaryHook().run();
         out.flush();
 
@@ -68,14 +68,14 @@ public class ChunkedOutputTest
     }
 
     @Test
-    public void shouldReserveSpaceForChunkHeaderWhenWriteDataToNewChunk() throws IOException
+    public void shouldReserveSpaceForChunkHeaderWhenWriteDataToNewChunk() throws Throwable
     {
         // Given 2 bytes left in buffer + chunk is closed
-        out.ensure( 10 ).put( new byte[10], 0, 10 );    // 2 (header) + 10
-        out.messageBoundaryHook().run();                // 2 (ending)
+        out.writeBytes( new byte[10], 0, 10 );  // 2 (header) + 10
+        out.messageBoundaryHook().run();        // 2 (ending)
 
         // When write 2 bytes
-        out.ensure( 2 ).putShort( (short) 33 );         // 2 (header) + 2
+        out.writeShort( (short) 33 );           // 2 (header) + 2
 
         // Then the buffer should auto flash if space left (2) is smaller than new data and chunk header (2 + 2)
         assertThat( writtenData.position(), equalTo( 14 ) );
@@ -84,9 +84,9 @@ public class ChunkedOutputTest
     }
 
     @Test
-    public void shouldSendOutDataWhoseSizeIsGreaterThanOutputBufferCapacity() throws IOException
+    public void shouldSendOutDataWhoseSizeIsGreaterThanOutputBufferCapacity() throws Throwable
     {
-        out.ensure( 16 ).put( new byte[16], 0, 16 ); // 2 + 16 is greater than the default max size 16
+        out.writeBytes( new byte[16], 0, 16 );  // 2 + 16 is greater than the default max size 16
         out.messageBoundaryHook().run();
         out.flush();
 
@@ -102,6 +102,7 @@ public class ChunkedOutputTest
             @Override
             public void write( int b ) throws IOException
             {
+                writtenData.put( (byte) b );
             }
 
             @Override

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
@@ -49,13 +49,14 @@ public class Neo4jRunner
     public static final String DEFAULT_URL = "neo4j://localhost:7687";
 
     private static Neo4jRunner globalInstance;
-    private static boolean externalServer = Boolean.getBoolean("neo4j.useExternalServer");
+    private static boolean externalServer = Boolean.getBoolean( "neo4j.useExternalServer" );
 
     private final String neo4jVersion = System.getProperty( "version", "neo4j-community-2.3.0-M01" );
     private final String neo4jLink = System.getProperty( "packageUri",
             "http://dist.neo4j.org/" + neo4jVersion + "-unix.tar.gz" );
     private final String remotingExtensionLink =
-            "http://m2.neo4j.org/service/local/artifact/maven/content?r=snapshots&g=org.neo4j.ndp&a=neo4j-ndp-kernelextension&v=LATEST";
+            "https://m2.neo4j.org/service/local/artifact/maven/content?r=snapshots&g=org.neo4j" +
+            ".ndp&a=neo4j-ndp-kernelextension&v=LATEST";
 
     private final File neo4jDir = new File( "./target/neo4j" );
     private final File neo4jHome = new File( neo4jDir, neo4jVersion );


### PR DESCRIPTION
Switched to channels in ChunkedInput&Output.
For input, instead of newing a new buffer every time a new chunk comes, we now write received data into a size-fixed buffer. If the incoming data size is greater than the buffer size, then we first read the amount of buffer size data and read more when the data in the buffer is consumed and more free space is available in the buffer.

Also refined PackInput&PackOutput interface according to the same changes in server.

Improved https://github.com/neo4j/neo4j-java-driver/pull/18