### PR TITLE
Setting up pull-request build for java-driver-repo on CI

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -157,11 +157,21 @@
             <version>2.1.13</version>
             <executions>
               <execution>
+                <id>generate-git-hash</id>
                 <goals>
                   <goal>revision</goal>
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <skipPoms>false</skipPoms>
+              <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+              <gitDescribe>
+                <dirty>-dirty</dirty>
+                <abbrev>7</abbrev>
+                <forceLongFormat>true</forceLongFormat>
+              </gitDescribe>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Fix the bug that git-commit-id-plugin cannot find .git directory on CI