### PR TITLE
Only read message ending after all bytes in message content have been read

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
@@ -62,6 +62,7 @@ public class ConsoleLogging implements Logging
     public static class ConsoleLogger extends JULogger
     {
         private final ConsoleHandler handler;
+
         public ConsoleLogger( String name, Level level )
         {
             super( name, level );

--- a/driver/src/main/java/org/neo4j/driver/internal/util/BytePrinter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/BytePrinter.java
@@ -226,7 +226,11 @@ public class BytePrinter
             for ( int i = offset; i < offset + length; i++ )
             {
                 print( bytes.get( i ), out );
-                if ( (i - offset + 1) % 8 == 0 )
+                if ( i == offset + length - 1 )
+                {
+                    // no pending blanks
+                }
+                else if ( (i - offset + 1) % 8 == 0 )
                 {
                     out.print( "    " );
                 }
@@ -241,7 +245,5 @@ public class BytePrinter
         {
             throw new RuntimeException( e );
         }
-
-
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -36,7 +36,6 @@ import org.neo4j.driver.internal.SimpleNode;
 import org.neo4j.driver.internal.SimplePath;
 import org.neo4j.driver.internal.SimpleRelationship;
 import org.neo4j.driver.internal.connector.socket.ChunkedOutput;
-import org.neo4j.driver.internal.packstream.BufferedChannelOutput;
 import org.neo4j.driver.internal.packstream.PackStream;
 import org.neo4j.driver.util.DumpMessage;
 
@@ -142,7 +141,9 @@ public class MessageFormatTest
     {
         ByteArrayInputStream input = new ByteArrayInputStream( bytes );
         MessageFormat.Reader reader = format.newReader( Channels.newChannel( input ) );
-        return DumpMessage.unpack( reader );
+        ArrayList<Message> messages = new ArrayList<>();
+        DumpMessage.unpack( messages, reader );
+        return messages;
     }
 
 }

--- a/driver/src/test/java/org/neo4j/driver/util/DumpMessage.java
+++ b/driver/src/test/java/org/neo4j/driver/util/DumpMessage.java
@@ -20,8 +20,11 @@ package org.neo4j.driver.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.driver.Value;
@@ -36,23 +39,24 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.MessageHandler;
 import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
-import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1.NoOpRunnable;
 import org.neo4j.driver.internal.messaging.PullAllMessage;
 import org.neo4j.driver.internal.messaging.RecordMessage;
 import org.neo4j.driver.internal.messaging.RunMessage;
 import org.neo4j.driver.internal.messaging.SuccessMessage;
-import org.neo4j.driver.internal.packstream.BufferedChannelInput;
+import org.neo4j.driver.internal.packstream.PackInput;
+import org.neo4j.driver.internal.util.BytePrinter;
 
 import static org.neo4j.driver.internal.util.BytePrinter.hexStringToBytes;
 
 public class DumpMessage
 {
-    public static void main( String[] args ) throws IOException
+    public static void main( String[] args )
     {
-        if( args.length <= 1)
+        if ( args.length < 1 )
         {
-            System.out.println( "Please specify the PackStreamV1 message (without chunk size and 00 00 ending) " +
-                                "that you want to unpack in hex strings");
+            System.out.println( "Please specify PackStreamV1 messages " +
+                                "(or PackStreamV1 messages with chunk size and 00 00 ending) " +
+                                "that you want to unpack in hex strings. " );
             return;
         }
         StringBuilder hexStr = new StringBuilder();
@@ -67,12 +71,25 @@ public class DumpMessage
         ArrayList<Message> messages = null;
         try
         {
+            // first try to interpret as a message with chunk header and 00 00 ending
             messages = unpackPackStreamV1WithHeader( bytes );
         }
-        catch ( Exception e )
+        catch ( IOException e )
         {
-            System.out.println( e.toString() );
-            messages = unpackPackStreamV1Message( bytes );
+            // fall back to interpret as a message without chunk header and 00 00 ending
+            try
+            {
+                messages = unpackPackStreamV1Message( bytes );
+            }
+            catch ( IOException ee )
+            {
+                // If both of them failed, then print the debug info for both of them.
+                System.err.println( "Failed to interpret the given hex string." );
+                e.printStackTrace();
+
+                ee.printStackTrace();
+                return;
+            }
         }
 
         for ( Message message : messages )
@@ -83,91 +100,278 @@ public class DumpMessage
 
     public static ArrayList<Message> unpackPackStreamV1WithHeader( byte[] bytes ) throws IOException
     {
-        ByteArrayInputStream input = new ByteArrayInputStream( bytes );
-        ChunkedInput chunkedInput = new ChunkedInput( Channels.newChannel( input ) );
-        PackStreamMessageFormatV1.Reader reader =
-                new PackStreamMessageFormatV1.Reader( chunkedInput, chunkedInput.messageBoundaryHook() );
-        ArrayList<Message> messages = unpack( reader );
-        return messages;
+        ArrayList<Message> messages = new ArrayList<>();
+        ByteArrayChunkedInput chunkedInput = new ByteArrayChunkedInput( bytes );
+        try
+        {
+            PackStreamMessageFormatV1.Reader reader =
+                    new PackStreamMessageFormatV1.Reader( chunkedInput, chunkedInput.messageBoundaryHook() );
+            unpack( messages, reader );
+            return messages;
+        }
+        catch ( Exception e )
+        {
+            int offset = chunkedInput.prePos;
+            throw new IOException(
+                    "Error when interpreting the message as PackStreamV1 message with chunk size and 00 00 ending:" +
+                    "\nMessage interpreted : " + messages +
+                    "\n" + BytePrinter.hexInOneLine( ByteBuffer.wrap( bytes ), 0, bytes.length ) + /* all bytes */
+                    "\n" + padLeft( offset ) /* the indicator of the error place*/, e );
+        }
     }
 
     public static ArrayList<Message> unpackPackStreamV1Message( byte[] bytes ) throws IOException
     {
-        ByteArrayInputStream input = new ByteArrayInputStream( bytes );
-        BufferedChannelInput bufferedChannelInput = new BufferedChannelInput( 1024*8, Channels.newChannel( input ) );
-        PackStreamMessageFormatV1.Reader reader =
-                new PackStreamMessageFormatV1.Reader( bufferedChannelInput, new NoOpRunnable() );
-        ArrayList<Message> messages = unpack( reader );
+        ArrayList<Message> messages = new ArrayList<>();
+        byte[] bytesWithHeadTail = putBytesInOneChunk( bytes );
+        ByteArrayChunkedInput chunkedInput = new ByteArrayChunkedInput( bytesWithHeadTail );
 
-        return messages;
-    }
-
-    public static ArrayList<Message> unpack( MessageFormat.Reader reader ) throws IOException
-    {
-        final ArrayList<Message> outcome = new ArrayList<>();
         try
         {
-            reader.read( new MessageHandler()
+            PackStreamMessageFormatV1.Reader reader =
+                    new PackStreamMessageFormatV1.Reader( chunkedInput, chunkedInput.messageBoundaryHook() );
+            unpack( messages, reader );
+            return messages;
+        }
+        catch ( Exception e )
+        {
+            int offset = chunkedInput.prePos - 2; // not including the chunk size
+            throw new IOException(
+                    "Error when interpreting the message as PackStream message:" +
+                    "\nMessage interpreted : " + messages +
+                    "\n" + BytePrinter.hexInOneLine( ByteBuffer.wrap( bytes ), 0, bytes.length ) + /* all bytes */
+                    "\n" + padLeft( offset ) /* the indicator of the error place*/, e );
+        }
+    }
+
+    private static String padLeft( int offset )
+    {
+        StringBuilder output = new StringBuilder();
+        for ( int i = 0; i < offset; i++ )
+        {
+            output.append( "  " );
+            if ( (i + 1) % 8 == 0 )
             {
-                @Override
-                public void handlePullAllMessage()
-                {
-                    outcome.add( new PullAllMessage() );
-                }
+                output.append( "    " );
+            }
+            else
+            {
+                output.append( " " );
+            }
+        }
+        output.append( "^" );
+        return output.toString();
+    }
 
-                @Override
-                public void handleInitializeMessage( String clientNameAndVersion ) throws IOException
-                {
-                    outcome.add( new InitializeMessage( clientNameAndVersion ) );
-                }
+    private static byte[] putBytesInOneChunk( byte[] bytes )
+    {
+        byte[] bytesWithHeadAndTail = new byte[bytes.length + 2 + 2]; // 2 for head and 2 for tail
+        bytesWithHeadAndTail[0] = (byte) (bytes.length >>> 8);
+        bytesWithHeadAndTail[1] = (byte) bytes.length;
+        for ( int i = 0; i < bytes.length; i++ )
+        {
+            bytesWithHeadAndTail[i + 2] = bytes[i];
+        }
+        return bytesWithHeadAndTail;
+    }
 
-                @Override
-                public void handleRunMessage( String statement, Map<String,Value> parameters )
-                {
-                    outcome.add( new RunMessage( statement, parameters ) );
-                }
-
-                @Override
-                public void handleDiscardAllMessage()
-                {
-                    outcome.add( new DiscardAllMessage() );
-                }
-
-                @Override
-                public void handleAckFailureMessage()
-                {
-                    outcome.add( new AckFailureMessage() );
-                }
-
-                @Override
-                public void handleSuccessMessage( Map<String,Value> meta )
-                {
-                    outcome.add( new SuccessMessage( meta ) );
-                }
-
-                @Override
-                public void handleRecordMessage( Value[] fields )
-                {
-                    outcome.add( new RecordMessage( fields ) );
-                }
-
-                @Override
-                public void handleFailureMessage( String code, String message )
-                {
-                    outcome.add( new FailureMessage( code, message ) );
-                }
-
-                @Override
-                public void handleIgnoredMessage()
-                {
-                    outcome.add( new IgnoredMessage() );
-                }
-            } );
+    public static List<Message> unpack( List<Message> outcome, MessageFormat.Reader reader )
+            throws IOException
+    {
+        try
+        {
+            do
+            {
+                reader.read( new MessageRecordedMessageHandler( outcome ) );
+            }
+            while ( reader.hasNext() );
         }
         catch ( Neo4jException e )
         {
             throw e;
         }
         return outcome;
+    }
+
+    /**
+     *  This class modified {@link ChunkedInput} to accept a byte array as input and keep track of how many bytes we
+     *  have read from the input byte array.
+     */
+    private static class ByteArrayChunkedInput implements PackInput
+    {
+        private int prePos;
+        private int curPos;
+        private final int size;
+
+        private final ChunkedInput delegate;
+
+        public ByteArrayChunkedInput( byte[] bytes )
+        {
+            prePos = curPos = 0;
+            size = bytes.length;
+            ByteArrayInputStream input = new ByteArrayInputStream( bytes );
+            ReadableByteChannel ch = Channels.newChannel( input );
+            this.delegate = new ChunkedInput( ch )
+            {
+                @Override
+                protected int readChunkSize() throws IOException
+                {
+                    prePos = curPos;
+                    int chunkSize = super.readChunkSize();
+                    curPos += 2;
+                    return chunkSize;
+                }
+            };
+        }
+
+        @Override
+        public boolean hasMoreData() throws IOException
+        {
+            return curPos < size;
+        }
+
+        @Override
+        public byte readByte()
+        {
+            prePos = curPos;
+            byte read = delegate.readByte();
+            curPos += 1;
+            return read;
+        }
+
+        @Override
+        public short readShort()
+        {
+            prePos = curPos;
+            short read = delegate.readShort();
+            curPos += 2;
+            return read;
+        }
+
+        @Override
+        public int readInt()
+        {
+            prePos = curPos;
+            int read = delegate.readInt();
+            curPos += 4;
+            return read;
+        }
+
+        @Override
+        public long readLong()
+        {
+            prePos = curPos;
+            long read = delegate.readLong();
+            curPos += 8;
+            return read;
+        }
+
+        @Override
+        public double readDouble()
+        {
+            prePos = curPos;
+            double read = delegate.readDouble();
+            curPos += 8;
+            return read;
+        }
+
+        @Override
+        public PackInput readBytes( byte[] into, int offset, int toRead )
+        {
+            prePos = curPos;
+            PackInput packInput = delegate.readBytes( into, offset, toRead );
+            curPos += toRead;
+            return packInput;
+        }
+
+        @Override
+        public byte peekByte()
+        {
+            return delegate.peekByte();
+        }
+
+        public Runnable messageBoundaryHook()
+        {
+            // the method will call readChunkSize method so no need to +2
+            final Runnable runnable = delegate.messageBoundaryHook();
+            return new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    prePos = curPos;
+                    runnable.run();
+                }
+            };
+        }
+
+    }
+
+    /**
+     * All the interpreted messages will be appended to the input message array even if an error happens when
+     * decoding other messages latter.
+     */
+    private static class MessageRecordedMessageHandler implements MessageHandler
+    {
+        private final List<Message> outcome;
+
+        public MessageRecordedMessageHandler( List<Message> outcome )
+        {
+            this.outcome = outcome;
+        }
+
+        @Override
+        public void handlePullAllMessage()
+        {
+            outcome.add( new PullAllMessage() );
+        }
+
+        @Override
+        public void handleInitializeMessage( String clientNameAndVersion ) throws IOException
+        {
+            outcome.add( new InitializeMessage( clientNameAndVersion ) );
+        }
+
+        @Override
+        public void handleRunMessage( String statement, Map<String,Value> parameters )
+        {
+            outcome.add( new RunMessage( statement, parameters ) );
+        }
+
+        @Override
+        public void handleDiscardAllMessage()
+        {
+            outcome.add( new DiscardAllMessage() );
+        }
+
+        @Override
+        public void handleAckFailureMessage()
+        {
+            outcome.add( new AckFailureMessage() );
+        }
+
+        @Override
+        public void handleSuccessMessage( Map<String,Value> meta )
+        {
+            outcome.add( new SuccessMessage( meta ) );
+        }
+
+        @Override
+        public void handleRecordMessage( Value[] fields )
+        {
+            outcome.add( new RecordMessage( fields ) );
+        }
+
+        @Override
+        public void handleFailureMessage( String code, String message )
+        {
+            outcome.add( new FailureMessage( code, message ) );
+        }
+
+        @Override
+        public void handleIgnoredMessage()
+        {
+            outcome.add( new IgnoredMessage() );
+        }
     }
 }


### PR DESCRIPTION
Fix a bug where the ChunkedInput will try to read message ending 00 00 from channel when more bytes left unread in the message content buffer.
Refined DumpMessage error message when decoding messages from hex string to plain text