### PR TITLE
TLS connections with the server

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -50,12 +50,16 @@ public class Config
     /** Connections that have been idle longer than this threshold will have a ping test performed on them. */
     private final long idleTimeBeforeConnectionTest;
 
+    private final boolean isTLSEnabled;
+
     private Config( ConfigBuilder builder )
     {
         this.logging = builder.logging;
 
         this.connectionPoolSize = builder.connectionPoolSize;
         this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
+
+        this.isTLSEnabled = builder.isTLSEnabled;
     }
 
     /**
@@ -86,6 +90,15 @@ public class Config
         return idleTimeBeforeConnectionTest;
     }
 
+    /**
+     * If TLS is enabled in all socket connections
+     * @return
+     */
+    public boolean isTLSEnabled()
+    {
+        return isTLSEnabled;
+    }
+
     public static ConfigBuilder build()
     {
         return new ConfigBuilder();
@@ -107,6 +120,7 @@ public class Config
         private Logging logging = new JULogging( Level.INFO );
         private int connectionPoolSize = 10;
         private long idleTimeBeforeConnectionTest = 200;
+        public boolean isTLSEnabled = false;
 
         private ConfigBuilder()
         {
@@ -145,6 +159,16 @@ public class Config
         public ConfigBuilder withMinIdleTimeBeforeConnectionTest( long milliSecond )
         {
             this.idleTimeBeforeConnectionTest = milliSecond;
+            return this;
+        }
+
+        /**
+         * Enable TLS in all connections with server
+         * @param value
+         */
+        public ConfigBuilder withTLSEnabled( boolean value )
+        {
+            this.isTLSEnabled = value;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver;
 
+import java.io.File;
 import java.util.logging.Level;
 
 import org.neo4j.driver.internal.logging.JULogging;
@@ -51,6 +52,7 @@ public class Config
     private final long idleTimeBeforeConnectionTest;
 
     private final boolean isTLSEnabled;
+    private final File trustedCertificate;
 
     private Config( ConfigBuilder builder )
     {
@@ -60,6 +62,7 @@ public class Config
         this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
 
         this.isTLSEnabled = builder.isTLSEnabled;
+        this.trustedCertificate = builder.trustedCertificate;
     }
 
     /**
@@ -99,6 +102,15 @@ public class Config
         return isTLSEnabled;
     }
 
+    /**
+     * Return the trusted certificate file. If it is not specified, then this method will return null.
+     * @return
+     */
+    public File trustedCertificate()
+    {
+        return trustedCertificate;
+    }
+
     public static ConfigBuilder build()
     {
         return new ConfigBuilder();
@@ -120,7 +132,8 @@ public class Config
         private Logging logging = new JULogging( Level.INFO );
         private int connectionPoolSize = 10;
         private long idleTimeBeforeConnectionTest = 200;
-        public boolean isTLSEnabled = false;
+        private boolean isTLSEnabled = false;
+        private File trustedCertificate = null;
 
         private ConfigBuilder()
         {
@@ -163,12 +176,29 @@ public class Config
         }
 
         /**
-         * Enable TLS in all connections with server
+         * Enable TLS in all connections with the server. When TLS enabled, if a trusted certificate is provided by
+         * invoking {@code withTrustedCertificate}, then only the connections with the trusted certificate will be
+         * accepted; if no certificated is provided, then we will trust the first certificate received from the server.
          * @param value
+         * @return this builder
          */
         public ConfigBuilder withTLSEnabled( boolean value )
         {
             this.isTLSEnabled = value;
+            return this;
+        }
+
+        /**
+         * Specify the certificate file where a trusted certificate is stored. (The file could contain multiple
+         * certificates. )
+         * If the certificate file is not provided, then default to trust the first certificate received from the
+         * server.
+         * @param cert
+         * @return this builder
+         */
+        public ConfigBuilder withTrustedCertificate( File cert )
+        {
+            this.trustedCertificate = cert;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/AllOrNothingChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/AllOrNothingChannel.java
@@ -21,20 +21,23 @@ package org.neo4j.driver.internal.connector.socket;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.SocketChannel;
 
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.util.BytePrinter;
 
 /**
- * Wraps a regular byte channel such that read and write will not return until the full buffers given have been sent or received, respectively.
+ * Wraps a regular socket channel such that read and write will not return until the full buffers given have been sent
+ * or received, respectively.
  */
 public class AllOrNothingChannel implements ByteChannel
 {
-    private final ByteChannel channel;
+    private final SocketChannel channel;
 
-    public AllOrNothingChannel( ByteChannel delegate ) throws IOException
+    public AllOrNothingChannel( SocketChannel channel ) throws IOException
     {
-        this.channel = delegate;
+        this.channel = channel;
+        this.channel.configureBlocking( true );
     }
 
     @Override
@@ -76,7 +79,7 @@ public class AllOrNothingChannel implements ByteChannel
     @Override
     public boolean isOpen()
     {
-        return true;
+        return channel.isOpen();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/LoggingByteChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/LoggingByteChannel.java
@@ -26,7 +26,8 @@ import org.neo4j.driver.internal.spi.Logger;
 import org.neo4j.driver.internal.util.BytePrinter;
 
 /**
- * Basically it is a wrapper to {@link AllOrNothingChannel} with logging enabled on bytes sent and received over the channel.
+ * Basically it is a wrapper to a {@link ByteChannel} with logging enabled to record bytes sent and received over the
+ * channel.
  */
 public class LoggingByteChannel implements ByteChannel
 {

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SSLSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SSLSocketChannel.java
@@ -1,0 +1,468 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SocketChannel;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLEngineResult.Status;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.internal.spi.Logger;
+import org.neo4j.driver.internal.util.BytePrinter;
+
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+
+/**
+ * A blocking SSL socket channel.
+ *
+ * When debugging, we could enable JSSE system debugging by setting system property:
+ * {@code -Djavax.net.debug=all} to get more information about handshake messages and other operations underway.
+ *
+ * References:
+ * http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#SSLENG
+ * http://docs.oracle.com/javase/1.5.0/docs/guide/security/jsse/JSSERefGuide.html#SSLENG
+ * http://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLEngine.html
+ */
+public class SSLSocketChannel implements ByteChannel
+{
+    private SocketChannel channel;      // The real channel the data is sent to and read from
+    private final Logger logger;
+
+    private SSLContext sslContext;
+    private SSLEngine sslEngine;
+
+    /** The buffer for network data */
+    private ByteBuffer cipherOut;
+    private ByteBuffer cipherIn;
+    /** The buffer for application data */
+    private ByteBuffer plainIn;
+    private ByteBuffer plainOut;
+
+    /** When enlarge the application and net buffer, this is the maximum buffer size that we could give */
+    private int bufferMax;
+
+    public SSLSocketChannel( String host, int port, SocketChannel channel, Logger logger )
+            throws GeneralSecurityException, IOException
+    {
+        logger.debug( "TLS connection enabled" );
+        this.logger = logger;
+        this.channel = channel;
+        this.channel.configureBlocking( true );
+
+        initSSLContext( host );
+        createSSLEngine( host, port );
+        createBuffers();
+        runSSLHandShake();
+        logger.debug( "TLS connection established" );
+    }
+
+    /** Used in internal tests only */
+    SSLSocketChannel( String host, int port, SocketChannel channel, Logger logger,
+            int appBufferSize, int netBufferSize )
+            throws GeneralSecurityException, IOException
+    {
+        logger.debug( "TLS connection enabled" );
+        this.logger = logger;
+        this.channel = channel;
+        this.channel.configureBlocking( true );
+
+        initSSLContext( host );
+        createSSLEngine( host, port );
+        createBuffers();
+        createBuffers( appBufferSize, netBufferSize ); // reset buffer size
+        runSSLHandShake();
+        logger.debug( "TLS connection established" );
+    }
+
+    /**
+     * A typical handshake on the client side might looks like:
+     * <table>
+     * <tr><td><b>Client</b></td><td><b>SSL/TLS message</b></td>          <td><b>HSStatus</b></td></tr>
+     * <tr><td>wrap()</td>          <td>ClientHello</td>                     <td>NEED_UNWRAP</td></tr>
+     * <tr><td>unwrap()</td>        <td>ServerHello/Cert/ServerHelloDone</td><td>NEED_WRAP</td></tr>
+     * <tr><td>wrap()</td>          <td>ClientKeyExchange</td>               <td>NEED_WRAP</td></tr>
+     * <tr><td>wrap()</td>          <td>ChangeCipherSpec</td>                <td>NEED_WRAP</td></tr>
+     * <tr><td>wrap()</td>          <td>Finished</td>                        <td>NEED_UNWRAP</td></tr>
+     * <tr><td>unwrap()</td>        <td>ChangeCipherSpec</td>                <td>NEED_UNWRAP</td></tr>
+     * <tr><td>unwrap()</td>        <td>Finished</td>                        <td>FINISHED</td></tr>
+     * </table>
+     *
+     * @throws IOException
+     */
+    private void runSSLHandShake() throws IOException
+    {
+        sslEngine.beginHandshake();
+        HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+        while ( handshakeStatus != FINISHED && handshakeStatus != NOT_HANDSHAKING )
+        {
+            switch ( handshakeStatus )
+            {
+            case NEED_TASK:
+                // Do the delegate task if there is some extra work such as checking the keystore during the handshake
+                handshakeStatus = runDelegatedTasks();
+                break;
+            case NEED_UNWRAP:
+                // Unwrap the ssl packet to get ssl handshake information
+                handshakeStatus = unwrap( null );
+                plainIn.clear();
+                break;
+            case NEED_WRAP:
+                // Wrap the app packet into an ssl packet to add ssl handshake information
+                handshakeStatus = wrap( plainOut );
+                break;
+            }
+        }
+
+        plainIn.clear();
+        plainOut.clear();
+    }
+
+    private HandshakeStatus runDelegatedTasks()
+    {
+        Runnable runnable;
+        while ( (runnable = sslEngine.getDelegatedTask()) != null )
+        {
+            runnable.run();
+        }
+        return sslEngine.getHandshakeStatus();
+    }
+
+    /**
+     * This method is mainly responsible for reading encrypted bytes from underlying socket channel and deciphering
+     * them.
+     *
+     * These deciphered data would be saved into {@code buffer} if it is specified (not null) and if its size is
+     * greater than the size of deciphered data.
+     * Otherwise, the deciphered bytes or the bytes that could not fit into {@code buffer} would be left in {@code
+     * plainIn} buffer.
+     *
+     * If the byes in {@code plaintIn} will not be used outside this method, we should always clear {@code
+     * plainIn} after each call to avoid wasting memory on it.
+     * <p>
+     * When working with this method, we should always put this method in a loop as there is no guarantee
+     * that deciphering would be carried out successfully in each call. The possible reasons that deciphering fails
+     * in a call could be requiring more bytes to decipher, too small buffers to hold all data, etc.
+     *
+     * To verify if deciphering is done successfully, we could check if any bytes has been read into {@code buffer},
+     * as the deciphered bytes will only be saved into {@code buffer} when deciphering is carried out successfully.
+     *
+     * @param buffer
+     * @return
+     * @throws IOException
+     */
+    private HandshakeStatus unwrap( ByteBuffer buffer ) throws IOException
+    {
+        HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+
+        /**
+         * This is the only place to read from the underlying channel
+         */
+        if ( channel.read( cipherIn ) < 0 )
+        {
+            throw new ClientException( "Failed to establish SSL socket connection." );
+        }
+        cipherIn.flip();
+
+        Status status = null;
+        do
+        {
+            status = sslEngine.unwrap( cipherIn, plainIn ).getStatus();
+            // Possible status here:
+            // OK - good
+            // BUFFER_OVERFLOW - we need to enlarge* plainIn
+            // BUFFER_UNDERFLOW - we need to enlarge* cipherIn and read more bytes from channel
+
+            /* In normal situations, enlarging buffers should happen very very rarely, as usually,
+             the initial size for application buffer and network buffer is greater than 1024 * 10,
+             and by using ChunkedInput and ChunkedOutput, the chunks are limited to 8192.
+             So we should not get any enlarging buffer request in most cases. */
+            switch ( status )
+            {
+            case OK:
+                plainIn.flip();
+                bufferCopy( plainIn, buffer );
+                plainIn.compact();
+                handshakeStatus = runDelegatedTasks();
+                break;
+            case BUFFER_OVERFLOW:
+                // Could attempt to drain the plainIn buffer of any already obtained
+                // data, but we'll just increase it to the size needed.
+                int curAppSize = plainIn.capacity();
+                int appSize = sslEngine.getSession().getApplicationBufferSize();
+                int newAppSize = appSize + plainIn.remaining();
+                if ( newAppSize > appSize * 2 )
+                {
+                    throw new ClientException(
+                            String.format( "Failed ro enlarge application buffer from %s to %s, as the maximum " +
+                                           "buffer size allowed is %s. The content in the buffer is: %s\n",
+                                    curAppSize, newAppSize, appSize * 2, BytePrinter.hex( plainIn ) ) );
+                }
+                ByteBuffer newPlainIn = ByteBuffer.allocateDirect( newAppSize );
+                newPlainIn.put( plainIn );
+                plainIn = newPlainIn;
+                logger.debug( "Enlarged application input buffer from %s to %s. " +
+                              "This operation should be a rare operation.", curAppSize, newAppSize );
+                // retry the operation.
+                break;
+            case BUFFER_UNDERFLOW:
+                int curNetSize = cipherIn.capacity();
+                int netSize = sslEngine.getSession().getPacketBufferSize();
+                // Resize buffer if needed.
+                if ( netSize > curNetSize )
+                {
+                    ByteBuffer newCipherIn = ByteBuffer.allocateDirect( netSize );
+                    newCipherIn.put( cipherIn );
+                    cipherIn = newCipherIn;
+                    logger.debug( "Enlarged network input buffer from %s to %s. " +
+                                  "This operation should be a rare operation.", curNetSize, netSize );
+                }
+                // Obtain more inbound network data for cipherIn,
+                // then retry the operation.
+                return handshakeStatus; // old status
+            default:
+                throw new ClientException( "Got unexpected status " + status );
+            }
+        }
+        while ( cipherIn.hasRemaining() ); /* Remember we are doing blocking reading.
+        We expect we should first handle all the data we've got and then decide what to do next. */
+
+        cipherIn.compact();
+        return handshakeStatus;
+    }
+
+    /**
+     * Encrypt the bytes given in {@code buffer} and write them out to the channel, when using this method, put it in
+     * a loop
+     *
+     * @param buffer contains the bytes to send to channel
+     * @return
+     * @throws IOException
+     */
+    private HandshakeStatus wrap( ByteBuffer buffer ) throws IOException
+    {
+        HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+        Status status = sslEngine.wrap( buffer, cipherOut ).getStatus();
+        // Possible status here:
+        // Ok - good
+        // BUFFER_OVERFLOW - we need to enlarge cipherOut to hold all ciphered data (should happen very rare)
+        // BUFFER_UNDERFLOW - we need to enlarge buffer (shouldn't happen)
+        switch ( status )
+        {
+        case OK:
+            handshakeStatus = runDelegatedTasks();
+            cipherOut.flip();
+            channel.write( cipherOut );
+            cipherOut.clear();
+            break;
+        case BUFFER_OVERFLOW:
+            // Enlarge the buffer and return the old status
+            int curNetSize = cipherOut.capacity();
+            int netSize = sslEngine.getSession().getPacketBufferSize();
+            if ( curNetSize >= netSize || buffer.capacity() > netSize )
+            {
+                // TODO
+                throw new ClientException(
+                        String.format( "Failed to enlarge network buffer from %s to %s. This is either because the " +
+                                       "new size is however less than the old size, or because the application " +
+                                       "buffer size %s is so big that the application data still cannot fit into the " +
+                                       "new network buffer.", curNetSize, netSize, buffer.capacity() ) );
+            }
+
+            cipherOut = ByteBuffer.allocateDirect( netSize );
+            logger.debug( "Enlarged network output buffer from %s to %s. " +
+                          "This operation should be a rare operation.", curNetSize, netSize );
+            break;
+        default:
+            throw new ClientException( "Got unexpected status " + status );
+        }
+        return handshakeStatus;
+    }
+
+    /**
+     * Copy the buffer content from one buffer to another.
+     * <pre>
+     * from: 0--------pos-----------------limit------cap
+     *                 |-data to be copied-|
+     * to:   0----pos------------------------limit---cap
+     *             |-data will be append after
+     * </pre>
+     * If {@code n = to.limit - to.pos, m = from.limit - from.pos}, then the amount of data will be copied
+     * {@code p = min(n, m)}.
+     * After the method call, the new position of {@code from.pos} will be {@code from.pos + p}, and similarly,
+     * the new position of {@code to.pos} will be {@code to.pos + p}
+     *
+     * @param from
+     * @param to
+     * @return
+     */
+    private int bufferCopy( ByteBuffer from, ByteBuffer to )
+    {
+        if ( from == null || to == null )
+        {
+            return 0;
+        }
+
+        int i;
+        for ( i = 0; to.remaining() > 0 && from.remaining() > 0; i++ )
+        {
+            to.put( from.get() );
+        }
+        return i;
+    }
+
+    /**
+     * Create network buffers and application buffers
+     *
+     * @throws IOException
+     */
+    private void createBuffers() throws IOException
+    {
+        SSLSession session = sslEngine.getSession();
+        int applicationBufferSize = session.getApplicationBufferSize();
+        int networkBufferSize = session.getPacketBufferSize();
+        bufferMax = Math.max( applicationBufferSize * 2, networkBufferSize * 2 );
+
+        createBuffers( applicationBufferSize, networkBufferSize );
+    }
+
+    void createBuffers( int appBufferSize, int netBufferSize )
+    {
+        plainOut = ByteBuffer.allocateDirect( appBufferSize );
+        plainIn = ByteBuffer.allocateDirect( appBufferSize );
+        cipherOut = ByteBuffer.allocateDirect( netBufferSize );
+        cipherIn = ByteBuffer.allocateDirect( netBufferSize );
+    }
+
+    /**
+     * Create SSLEngine with the SSLContext just created.
+     *
+     * @param host
+     * @param port
+     */
+    private void createSSLEngine( String host, int port )
+    {
+        sslEngine = sslContext.createSSLEngine( host, port );
+        sslEngine.setUseClientMode( true );
+    }
+
+    /**
+     * Using trust-on-first-use
+     */
+    private void initSSLContext( String host ) throws NoSuchAlgorithmException, IOException, KeyManagementException
+    {
+        sslContext = SSLContext.getInstance( "TLS" );
+
+        sslContext.init( new KeyManager[0], new TrustManager[]{new TrustOnFirstUseTrustManager( host )}, null );
+    }
+
+    @Override
+    public int read( ByteBuffer dst ) throws IOException
+    {
+        /**
+         * First try to read from plainBuffer.
+         * If not enough bytes left in plainBuffer,
+         * read encrypted data from underlying channel and put the deciphered data in the plain buffer.
+         * Return how many deciphered data that have been put dst.
+         */
+        int toRead = dst.remaining();
+        plainIn.flip();
+        if ( plainIn.remaining() >= toRead )
+        {
+            bufferCopy( plainIn, dst );
+            plainIn.compact();
+        }
+        else
+        {
+            dst.put( plainIn );             // Copy whatever left in the plainIn to dst
+            do
+            {
+                plainIn.clear();            // Clear plainIn
+                unwrap( dst );              // Read more data from the underline channel and save the data read into dst
+            }
+            while ( dst.remaining() > 0 );  // If enough bytes read then return otherwise continue reading from channel
+        }
+
+        return toRead;
+    }
+
+    @Override
+    public int write( ByteBuffer src ) throws IOException
+    {
+        /**
+         * Encrypt the plain text data in src buffer and write them into underlying channel.
+         * Return how many plain text data in src that have been written to the underlying channel.
+         */
+        int toWrite = src.remaining();
+        while ( src.remaining() > 0 )
+        {
+            wrap( src );
+        }
+        return toWrite;
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        plainOut.clear();
+        // Indicate that application is done with engine
+        sslEngine.closeOutbound();
+
+        while ( !sslEngine.isOutboundDone() )
+        {
+            // Get close message
+            SSLEngineResult res = sslEngine.wrap( plainOut, cipherOut );
+
+            // Check res statuses
+
+            // Send close message to peer
+            while ( cipherOut.hasRemaining() )
+            {
+                int num = channel.write( cipherOut );
+                if ( num == -1 )
+                {
+                    // handle closed channel
+                    break;
+                }
+            }
+        }
+        // Close transport
+        channel.close();
+        logger.debug( "TLS connection closed" );
+    }
+
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
@@ -25,6 +25,7 @@ import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.SocketChannel;
+import java.security.GeneralSecurityException;
 import java.util.List;
 
 import org.neo4j.driver.Config;
@@ -60,7 +61,7 @@ public class SocketClient
         try
         {
             logger.debug( "~~ [CONNECT] {0}:{1}.", host, port );
-            channel = SocketChannelFactory.create( host, port, logger );
+            channel = ChannelFactory.create( host, port, config.isTLSEnabled(), logger );
 
             protocol = negotiateProtocol();
             reader = protocol.reader();
@@ -68,14 +69,17 @@ public class SocketClient
         }
         catch ( ConnectException e )
         {
-            throw new ClientException( String.format( "Unable to connect to '%s' on port %s, " +
-                                                      "ensure the database is running and that there is a working " +
-                                                      "network " +
-                                                      "connection to it.", host, port ) );
+            throw new ClientException( String.format(
+                    "Unable to connect to '%s' on port %s, ensure the database is running and that there is a " +
+                    "working network connection to it.", host, port ) );
         }
         catch ( IOException e )
         {
             throw new ClientException( "Unable to process request: " + e.getMessage(), e );
+        }
+        catch ( GeneralSecurityException e )
+        {
+            throw new ClientException( "Unable to establish ssl connection with server: " + e.getMessage(), e );
         }
     }
 
@@ -104,26 +108,6 @@ public class SocketClient
         catch ( IOException e )
         {
             throw new ClientException( "Unable to close socket connection properly." + e.getMessage(), e );
-        }
-    }
-
-    private static class SocketChannelFactory
-    {
-        public static ByteChannel create( String host, int port, Logger logger ) throws IOException
-        {
-            SocketChannel channel = SocketChannel.open();
-            channel.setOption( StandardSocketOptions.SO_REUSEADDR, true );
-            channel.setOption( StandardSocketOptions.SO_KEEPALIVE, true );
-            channel.connect( new InetSocketAddress( host, port ) );
-
-            if( logger.isTraceEnabled() )
-            {
-                return new LoggingByteChannel( new AllOrNothingChannel( channel ), logger );
-            }
-            else
-            {
-                return new AllOrNothingChannel( channel );
-            }
         }
     }
 
@@ -168,5 +152,35 @@ public class SocketClient
     {
         int version = protocol == null ? -1 : protocol.version();
         return "SocketClient[protocolVersion=" + version + "]";
+    }
+
+    private static class ChannelFactory
+    {
+        public static ByteChannel create( String host, int port, boolean isTLSEnabled, Logger logger )
+                throws IOException, GeneralSecurityException
+        {
+            SocketChannel soChannel = SocketChannel.open();
+            soChannel.setOption( StandardSocketOptions.SO_REUSEADDR, true );
+            soChannel.setOption( StandardSocketOptions.SO_KEEPALIVE, true );
+            soChannel.connect( new InetSocketAddress( host, port ) );
+
+            ByteChannel channel = null;
+
+            if( isTLSEnabled )
+            {
+                channel = new SSLSocketChannel( host, port, soChannel, logger );
+            }
+            else
+            {
+                channel = new AllOrNothingChannel( soChannel );
+            }
+
+            if( logger.isTraceEnabled() )
+            {
+                channel = new LoggingByteChannel( channel, logger );
+            }
+
+            return channel;
+        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
@@ -168,7 +168,8 @@ public class SocketClient
 
             if( config.isTLSEnabled() )
             {
-                channel = new SSLSocketChannel( host, port, soChannel, logger, config.trustedCertificate() );
+                channel = new SSLSocketChannel( host, port, soChannel, logger,
+                        config.knownCerts(), config.trustedCert() );
             }
             else
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketClient.java
@@ -61,7 +61,7 @@ public class SocketClient
         try
         {
             logger.debug( "~~ [CONNECT] {0}:{1}.", host, port );
-            channel = ChannelFactory.create( host, port, config.isTLSEnabled(), logger );
+            channel = ChannelFactory.create( host, port, config, logger );
 
             protocol = negotiateProtocol();
             reader = protocol.reader();
@@ -156,7 +156,7 @@ public class SocketClient
 
     private static class ChannelFactory
     {
-        public static ByteChannel create( String host, int port, boolean isTLSEnabled, Logger logger )
+        public static ByteChannel create( String host, int port, Config config, Logger logger )
                 throws IOException, GeneralSecurityException
         {
             SocketChannel soChannel = SocketChannel.open();
@@ -166,9 +166,9 @@ public class SocketClient
 
             ByteChannel channel = null;
 
-            if( isTLSEnabled )
+            if( config.isTLSEnabled() )
             {
-                channel = new SSLSocketChannel( host, port, soChannel, logger );
+                channel = new SSLSocketChannel( host, port, soChannel, logger, config.trustedCertificate() );
             }
             else
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManager.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * References:
+ * http://stackoverflow.com/questions/6802421/how-to-compare-distinct-implementations-of-java-security-cert-x509certificate?answertab=votes#tab-top
+ */
+
+class TrustOnFirstUseTrustManager implements X509TrustManager
+{
+    /**
+     * A list of pairs (known_server_ip, certificate) are stored in this file.
+     * When establishing a SSL connection to a new server, we will save the server's IP and its certificate in this
+     * file.
+     * Then when we try to connect to a known server again, we will authenticate the server by checking if it provides
+     * the same certificate as the one saved in this file.
+     */
+    static final String KNOWN_CERTS_FILE_PATH = "known_certs";
+
+    /** The ip address of the server that we are currently connected to */
+    private final String ip;
+
+    /** The known certificate we've registered for this server */
+    private String cert;
+
+    TrustOnFirstUseTrustManager( String host ) throws IOException
+    {
+        // retrieve ip from host
+        InetAddress address = InetAddress.getByName( host );
+        this.ip = address.getHostAddress();
+
+        load();
+    }
+
+    /**
+     * Try to load the certificate form the file if the server we've connected is a known server.
+     *
+     * @throws IOException
+     */
+    private void load() throws IOException
+    {
+        File knownCertsFile = new File( KNOWN_CERTS_FILE_PATH );
+        if ( !knownCertsFile.exists() ) // it is fine if this file dose not exist
+        {
+            knownCertsFile.createNewFile();
+            return;
+        }
+
+        BufferedReader reader = new BufferedReader( new FileReader( knownCertsFile ) );
+        String line = null;
+        while ( (line = reader.readLine()) != null )
+        {
+            if ( line.contains( "," ) )
+            {
+                String[] strings = line.split( "," );
+                if ( strings[0].trim().equals( ip ) )
+                {
+                    // load the certificate
+                    cert = strings[1].trim();
+                    return;
+                }
+            }
+        }
+        reader.close();
+    }
+
+    /**
+     * Save a new (server_ip, cert) pair into knownCerts file
+     *
+     * @param cert
+     */
+    private void save( String cert ) throws IOException
+    {
+        this.cert = cert;
+
+        File knownCertsFile = new File( KNOWN_CERTS_FILE_PATH );
+        if ( !knownCertsFile.exists() ) // it is fine if this file dose not exist
+        {
+            knownCertsFile.createNewFile();
+        }
+
+        BufferedWriter writer = new BufferedWriter( new FileWriter( knownCertsFile, true ) );
+        writer.write( ip + "," + this.cert );
+        writer.newLine();
+        writer.close();
+    }
+
+    /*
+     * Disallow all client connection to this client
+     */
+    public void checkClientTrusted( X509Certificate[] chain, String authType )
+            throws CertificateException
+    {
+        throw new CertificateException( "All client connections to this client are forbidden." );
+    }
+
+    /*
+     * Trust the cert if it is seen first time for this server or it is the same with the one registered.
+     */
+    public void checkServerTrusted( X509Certificate[] chain, String authType )
+            throws CertificateException
+    {
+        X509Certificate certificate = chain[0];
+        byte[] encoded = certificate.getEncoded();
+
+        String cert = DatatypeConverter.printBase64Binary( encoded );
+
+        if ( this.cert == null )
+        {
+            try
+            {
+                save( cert );
+            }
+            catch ( IOException e )
+            {
+                throw new CertificateException( String.format(
+                        "Failed to save the server's ip and the certificate received from the server to file %s.\n" +
+                        "Server IP: %s\nReceived cert: %s",
+                        new File( KNOWN_CERTS_FILE_PATH ).getAbsolutePath(), ip, cert ), e );
+            }
+        }
+        else if ( !this.cert.equals( cert ) )
+        {
+            throw new CertificateException( String.format(
+                    "The certificate received from the server is different from the one we've known in file %s.\n" +
+                    "Expect cert: %s\nReceived cert: %s",
+                    new File( KNOWN_CERTS_FILE_PATH ).getAbsolutePath(), this.cert, cert ) );
+        }
+    }
+
+    /**
+     * No issuer is trusted.
+     */
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return new X509Certificate[0];
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManager.java
@@ -37,6 +37,8 @@ import javax.xml.bind.DatatypeConverter;
 
 class TrustOnFirstUseTrustManager implements X509TrustManager
 {
+    // TODO: discussion: do we really need the ip? Is it enough if we just create a trusted store from the first cert
+    // that we've got and trust the single cert?
     /**
      * A list of pairs (known_server_ip, certificate) are stored in this file.
      * When establishing a SSL connection to a new server, we will save the server's IP and its certificate in this

--- a/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import sun.security.provider.X509Factory;
+import sun.security.x509.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * A tool related to create, save, load certs, etc.
+ */
+public class CertificateTool
+{
+    /**
+     * Create a random certificate
+     *
+     * @return
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static X509Certificate genX509Cert() throws GeneralSecurityException, IOException
+    {
+        CertAndKeyGen certGen = new CertAndKeyGen( "RSA", "SHA1WithRSA", null );
+        certGen.generate( 1024 );
+
+        long validSecs = (long) 365 * 24 * 60 * 60; // valid for one year
+        X509Certificate cert = certGen.getSelfCertificate( new X500Name( "CN=NEO4J_JAVA_DRIVER" ), validSecs );
+        return cert;
+    }
+
+    /**
+     * Create a random certificate and save it into a file in X.509 format
+     *
+     * @param saveTo
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static void genX509Cert( File saveTo ) throws GeneralSecurityException, IOException
+    {
+        X509Certificate cert = genX509Cert();
+        saveX509Cert( cert, saveTo );
+    }
+
+    /**
+     * Save a certificate to a file. Remove all the content in the file if there is any before.
+     *
+     * @param cert
+     * @param certFile
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static void saveX509Cert( Certificate cert, File certFile ) throws GeneralSecurityException, IOException
+    {
+        saveX509Cert( new Certificate[]{cert}, certFile );
+    }
+
+    /**
+     * Save a list of certificates into a file
+     *
+     * @param certs
+     * @param certFile
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static void saveX509Cert( Certificate[] certs, File certFile ) throws GeneralSecurityException, IOException
+    {
+        BufferedWriter writer = new BufferedWriter( new FileWriter( certFile ) );
+
+        for ( int i = 0; i < certs.length; i++ )
+        {
+            String certStr = DatatypeConverter.printBase64Binary( certs[i].getEncoded() )
+                    .replaceAll( "(.{64})", "$1\n" );
+
+            writer.write( X509Factory.BEGIN_CERT );
+            writer.newLine();
+
+            writer.write( certStr );
+            writer.newLine();
+
+            writer.write( X509Factory.END_CERT );
+            writer.newLine();
+        }
+
+        writer.close();
+    }
+
+    /**
+     * Load the certificates written in X.509 format in a file to a key store.
+     *
+     * @param certFile
+     * @param keyStore
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static void loadX509Cert( File certFile, KeyStore keyStore ) throws GeneralSecurityException, IOException
+    {
+        BufferedInputStream inputStream = new BufferedInputStream( new FileInputStream( certFile ) );
+        CertificateFactory certFactory = CertificateFactory.getInstance( "X.509" );
+
+        int certCount = 0; // The file might contain multiple certs
+        while ( inputStream.available() > 0 )
+        {
+            Certificate cert = certFactory.generateCertificate( inputStream );
+            certCount++;
+            loadX509Cert( cert, "neo4j.javadriver.trustedcert." + certCount, keyStore );
+        }
+    }
+
+    /**
+     * Load a certificate to a key store with a name
+     *
+     * @param certAlias a name to identify different certificates
+     * @param cert
+     * @param keyStore
+     */
+    public static void loadX509Cert( Certificate cert, String certAlias, KeyStore keyStore ) throws KeyStoreException
+    {
+        keyStore.setCertificateEntry( certAlias, cert );
+    }
+}
+
+
+

--- a/driver/src/test/java/org/neo4j/driver/integration/SSLSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SSLSocketChannelIT.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.internal.connector.socket.SSLSocketChannel;
+import org.neo4j.driver.internal.connector.socket.SSLTestSocketChannel;
+import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.spi.Logger;
+import org.neo4j.driver.util.Neo4jRunner;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SSLSocketChannelIT
+{
+    private static TLSServer server;
+    @BeforeClass
+    public static void setup() throws IOException, InterruptedException
+    {
+        /* uncomment for JSSE debugging info */
+        // System.setProperty( "javax.net.debug", "all" );
+        // delete any certificate file that the client already know
+        server = new TLSServer();
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        if( server != null )
+        {
+            server.close();
+        }
+    }
+
+    @Test
+    public void shouldPerformTLSHandshake() throws Throwable
+    {
+        // Given
+        Logger logger = mock( Logger.class );
+        SocketChannel channel = SocketChannel.open();
+        channel.connect( new InetSocketAddress( "localhost", 7687 ) );
+
+        // When
+        SSLSocketChannel sslChannel =
+                new SSLSocketChannel( "localhost", 7687, channel, logger );
+        sslChannel.close();
+
+        // Then
+        verify( logger, atLeastOnce() ).debug( "TLS connection enabled" );
+        verify( logger, atLeastOnce() ).debug( "TLS connection established" );
+        verify( logger, atLeastOnce() ).debug( "TLS connection closed" );
+    }
+
+    @Test
+    public void shouldEnlargeBuffers() throws Throwable
+    {
+        // Given
+        final ArrayList<String> logs = new ArrayList<>();
+        Logger logger = new DevNullLogger()
+        {
+            @Override
+            public void debug( String format, Object... params )
+            {
+                logs.add( String.format( format, params ) );
+            }
+        };
+        SocketChannel channel = SocketChannel.open();
+        channel.connect( new InetSocketAddress( "localhost", 7687 ) );
+
+        // When & Then
+        SSLTestSocketChannel sslChannel =
+                new SSLTestSocketChannel( "localhost", 7687, channel, logger, 128, 128 );
+
+        assertEquals( 5, logs.size() );
+        assertTrue( logs.get( 0 ).equals( "TLS connection enabled" ) );
+        assertTrue( logs.get( 1 ).startsWith( "Enlarged network output buffer from 128 to" ) );
+        assertTrue( logs.get( 2 ).startsWith( "Enlarged application input buffer from 128 to" ) );
+        assertTrue( logs.get( 3 ).startsWith( "Enlarged network input buffer from 128 to" ) );
+        assertTrue( logs.get( 4 ).equals( "TLS connection established" ) );
+
+
+        // Then we will do the protocol handshake
+        // Reset the buffer to be a extreme small size
+        sslChannel.setBufferSize( 32, 32 );
+        ByteBuffer buf = ByteBuffer.wrap( new byte[]{
+                0, 0, 0, 1,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0} );
+        // Write the bytes to server
+        sslChannel.write( buf );
+
+        // Read the 0 0 0 1 from server in two read methods
+        buf.clear();
+        buf.limit( 2 );
+        sslChannel.read( buf );
+        buf.flip();
+        short proposal = buf.getShort();
+        assertEquals( 0, proposal );
+
+        buf.clear();
+        buf.limit( 2 );
+        sslChannel.read( buf );
+        buf.flip();
+        proposal = buf.getShort();
+        assertEquals( 1, proposal );
+
+        assertEquals( 7, logs.size() );
+        assertTrue( logs.get( 5 ).startsWith( "Enlarged network output buffer from 32 to" ) );
+        assertTrue( logs.get( 6 ).startsWith( "Enlarged network input buffer from 32 to" ) );
+
+        sslChannel.close();
+    }
+
+    @Test
+    public void shouldEstablishTLSConnection() throws Throwable
+    {
+        Driver driver = GraphDatabase.driver(
+                URI.create( Neo4jRunner.DEFAULT_URL ),
+                Config.build().withTLSEnabled( true ).toConfig() );
+
+        Result result = driver.session().run( "RETURN 1" );
+        assertTrue( result.next() );
+        assertEquals( 1, result.get( 0 ).javaInteger() );
+        assertFalse( result.next() );
+
+        driver.close();
+    }
+
+    private static class TLSServer
+    {
+        private Neo4jRunner server;
+
+        public TLSServer() throws IOException, InterruptedException
+        {
+            server = Neo4jRunner.getOrCreateGlobalServer();
+            server.enableTLS( true );
+        }
+
+        public void close()
+        {
+            server.enableTLS( false );
+        }
+
+    }
+
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
@@ -31,11 +31,11 @@ import org.neo4j.driver.internal.spi.Logger;
 public class SSLTestSocketChannel extends SSLSocketChannel
 {
 
-    public SSLTestSocketChannel( String host, int port, SocketChannel channel, Logger logger, File cert,
-            int appBufferSize, int netBufferSize )
+    public SSLTestSocketChannel( String host, int port, SocketChannel channel, Logger logger,
+            File knownCerts, File trustedCert, int appBufferSize, int netBufferSize )
             throws GeneralSecurityException, IOException
     {
-        super( host, port, channel, logger, cert, appBufferSize, netBufferSize );
+        super( host, port, channel, logger, knownCerts, trustedCert, appBufferSize, netBufferSize );
     }
 
     public void setBufferSize( int appBufferSize, int netBufferSize )

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.connector.socket;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
 import java.security.GeneralSecurityException;
@@ -30,11 +31,11 @@ import org.neo4j.driver.internal.spi.Logger;
 public class SSLTestSocketChannel extends SSLSocketChannel
 {
 
-    public SSLTestSocketChannel( String host, int port, SocketChannel channel, Logger logger,
+    public SSLTestSocketChannel( String host, int port, SocketChannel channel, Logger logger, File cert,
             int appBufferSize, int netBufferSize )
             throws GeneralSecurityException, IOException
     {
-        super( host, port, channel, logger, appBufferSize, netBufferSize );
+        super( host, port, channel, logger, cert, appBufferSize, netBufferSize );
     }
 
     public void setBufferSize( int appBufferSize, int netBufferSize )

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/SSLTestSocketChannel.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+import java.security.GeneralSecurityException;
+
+import org.neo4j.driver.internal.spi.Logger;
+
+/**
+ * SSLSocketChannel + size-changeable buffer
+ */
+public class SSLTestSocketChannel extends SSLSocketChannel
+{
+
+    public SSLTestSocketChannel( String host, int port, SocketChannel channel, Logger logger,
+            int appBufferSize, int netBufferSize )
+            throws GeneralSecurityException, IOException
+    {
+        super( host, port, channel, logger, appBufferSize, netBufferSize );
+    }
+
+    public void setBufferSize( int appBufferSize, int netBufferSize )
+    {
+        createBuffers( appBufferSize, netBufferSize );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/TrustOnFirstUseTrustManagerTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import junit.framework.TestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Scanner;
+import javax.xml.bind.DatatypeConverter;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TrustOnFirstUseTrustManagerTest
+{
+    @BeforeClass
+    public static void setup() throws Throwable
+    {
+        // create the cert file with one ip and some random cert in it
+        File certFile = new File( TrustOnFirstUseTrustManager.KNOWN_CERTS_FILE_PATH );
+        if ( certFile.exists() )
+        {
+            certFile.delete();
+        }
+        PrintWriter writer = new PrintWriter( certFile );
+        String knownIP = "1.2.3.4";
+        String knownCert = DatatypeConverter.printBase64Binary( "certificate".getBytes() );
+        writer.println( knownIP + "," + knownCert );
+        writer.close();
+    }
+
+    @AfterClass
+    public static void teardown()
+    {
+        new File( TrustOnFirstUseTrustManager.KNOWN_CERTS_FILE_PATH ).delete();
+    }
+
+    @Test
+    public void shouldLoadExistingCert() throws Throwable
+    {
+        TrustOnFirstUseTrustManager manager = new TrustOnFirstUseTrustManager( "1.2.3.4" );
+
+        X509Certificate x509Certificate = mock( X509Certificate.class );
+        when( x509Certificate.getEncoded() ).thenReturn( "fake certificate".getBytes() );
+        try
+        {
+            manager.checkServerTrusted( new X509Certificate[]{x509Certificate}, "authType" );
+            fail( "Should not trust the fake certificate" );
+        }
+        catch ( CertificateException e )
+        {
+            assertTrue( e.getMessage().startsWith(
+                    "The certificate received from the server is different from the one we've known in file" ) );
+        }
+    }
+
+
+    @Test
+    public void shouldSaveNewCert() throws Throwable
+    {
+        TrustOnFirstUseTrustManager manager = new TrustOnFirstUseTrustManager( "4.3.2.1" );
+
+        byte[] encoded = "certificate".getBytes();
+        String cert = DatatypeConverter.printBase64Binary( encoded );
+
+        X509Certificate x509Certificate = mock( X509Certificate.class );
+        when( x509Certificate.getEncoded() ).thenReturn( encoded );
+        try
+        {
+            manager.checkServerTrusted( new X509Certificate[]{x509Certificate}, "authType" );
+        }
+        catch ( CertificateException e )
+        {
+            fail( "Should trust the certificate the first time it is seen" );
+            e.printStackTrace();
+        }
+
+        File certFile = new File( TrustOnFirstUseTrustManager.KNOWN_CERTS_FILE_PATH );
+        Scanner reader = new Scanner( certFile );
+
+        String line;
+        assertTrue( reader.hasNextLine() );
+        line = reader.nextLine();
+        assertEquals( "1.2.3.4," + cert, line );
+        assertTrue( reader.hasNextLine() );
+        line = reader.nextLine();
+        TestCase.assertEquals( "4.3.2.1," + cert, line );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/util/CertificateToolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/util/CertificateToolTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.util;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+
+import org.neo4j.driver.internal.util.CertificateTool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.driver.internal.util.CertificateTool.genX509Cert;
+import static org.neo4j.driver.internal.util.CertificateTool.saveX509Cert;
+
+public class CertificateToolTest
+{
+    @Test
+    public void shouldLoadMultipleCertsIntoKeyStore() throws Throwable
+    {
+        // Given
+        File certFile = File.createTempFile( "3random", ".cer" );
+        certFile.deleteOnExit();
+
+        X509Certificate cert1 = genX509Cert();
+        X509Certificate cert2 = genX509Cert();
+        X509Certificate cert3 = genX509Cert();
+
+        saveX509Cert( new Certificate[] {cert1, cert2, cert3}, certFile );
+
+        KeyStore keyStore = KeyStore.getInstance( "JKS" );
+        keyStore.load( null, null );
+
+        // When
+        CertificateTool.loadX509Cert( certFile, keyStore );
+
+        // Then
+        Enumeration<String> aliases = keyStore.aliases();
+        assertTrue( aliases.hasMoreElements() );
+        assertTrue( aliases.nextElement().startsWith( "neo4j.javadriver.trustedcert" ) );
+        assertTrue( aliases.hasMoreElements() );
+        assertTrue( aliases.nextElement().startsWith( "neo4j.javadriver.trustedcert" ) );
+        assertTrue( aliases.hasMoreElements() );
+        assertTrue( aliases.nextElement().startsWith( "neo4j.javadriver.trustedcert" ) );
+        assertFalse( aliases.hasMoreElements() );
+    }
+
+}

--- a/driver/src/test/java/org/neo4j/driver/util/FileTools.java
+++ b/driver/src/test/java/org/neo4j/driver/util/FileTools.java
@@ -19,7 +19,10 @@
 package org.neo4j.driver.util;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Scanner;
 
 import static java.io.File.createTempFile;
 
@@ -50,5 +53,52 @@ public class FileTools
         tmp.delete();
         tmp.mkdir();
         return tmp;
+    }
+
+
+    public static void setProperty( File propFile, String name, String value ) throws FileNotFoundException
+    {
+        boolean foundProp = false;
+        Scanner in = new Scanner( propFile );
+
+        File newPropFile = new File( propFile.getParentFile(), "prop.tmp" );
+        PrintWriter out = new PrintWriter( newPropFile );
+
+        while ( in.hasNextLine() )
+        {
+            String line = in.nextLine();
+            if ( !line.trim().startsWith( "#" ) )
+            {
+                String[] tokens = line.split( "=" );
+                if ( tokens.length == 2 && tokens[0].equals( name ) )
+                {
+                    // found property and set it to the new value
+                    out.println( name + "=" + value );
+                    foundProp = true;
+                }
+                else
+                {
+                    // not the property that we are looking for, print it as original
+                    out.println( line );
+                }
+            }
+            else
+            {
+                // comments, print as original
+                out.println( line );
+            }
+        }
+
+        if ( !foundProp )
+        {
+            // add this as a new prop
+            out.println( name + "=" + value );
+        }
+
+        in.close();
+        out.close();
+
+        propFile.delete();
+        newPropFile.renameTo( propFile );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/FileToolsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/util/FileToolsTest.java
@@ -18,13 +18,17 @@
  */
 package org.neo4j.driver.util;
 
-import java.io.File;
-
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.Scanner;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.util.FileTools.tmpDir;
 
 public class FileToolsTest
@@ -45,6 +49,76 @@ public class FileToolsTest
             dir.delete();
         }
 
+    }
+
+    @Test
+    public void shouldAddPropertyAtBottom() throws FileNotFoundException
+    {
+        // Given
+        File propertyFile = createPropertyFile();
+
+        // When
+        FileTools.setProperty( propertyFile, "cat.name", "mimi" );
+
+        // Then
+        Scanner in = new Scanner( propertyFile );
+
+        try
+        {
+            assertEquals( "#Wow wow", in.nextLine() );
+            assertEquals( "Meow meow", in.nextLine() );
+            assertEquals( "color=black", in.nextLine() );
+            assertEquals( "cat.age=3", in.nextLine() );
+            assertEquals( "cat.name=mimi", in.nextLine() );
+
+            assertFalse( in.hasNextLine() );
+        }
+        finally
+        {
+            propertyFile.delete();
+        }
+    }
+
+    @Test
+    public void shouldResetPropertyAtTheSameLine() throws FileNotFoundException
+    {
+        // Given
+        File propertyFile = createPropertyFile();
+
+        // When
+        FileTools.setProperty( propertyFile, "color", "white" );
+
+        // Then
+        Scanner in = new Scanner( propertyFile );
+
+        try
+        {
+            assertEquals( "#Wow wow", in.nextLine() );
+            assertEquals( "Meow meow", in.nextLine() );
+            assertEquals( "color=white", in.nextLine() );
+            assertEquals( "cat.age=3", in.nextLine() );
+
+            assertFalse( in.hasNextLine() );
+        }
+        finally
+        {
+            propertyFile.delete();
+        }
+    }
+
+
+    private File createPropertyFile() throws FileNotFoundException
+    {
+        File propFile = new File( "Cat" );
+        PrintWriter out = new PrintWriter( propFile );
+
+        out.println( "#Wow wow" );
+        out.println( "Meow meow" );
+        out.println( "color=black" );
+        out.println( "cat.age=3" );
+
+        out.close();
+        return propFile;
     }
 
 }


### PR DESCRIPTION
Enabled the driver to establish TLS (handshake) and close TLS connections with the server
Ensured basic data transfer using TLS
Enabled the user to choose from no-TLS, TLS with `trust-first-cert`, and TLS with `only-trust-cert-provided`.