### PR TITLE
Fix windows red tests

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedOutputTest.java
@@ -55,9 +55,9 @@ public class ChunkedOutputTest
         out.flush();
 
         // Then
-        assertThat( BytePrinter.hex( channel.getBytes() ),
-                equalTo( "00 08 00 00 00 00 00 00    00 01 00 08 00 00 00 00    " +
-                         "00 00 00 02 00 08 00 00    00 00 00 00 00 03 00 00\n" ) );
+        assertThat( BytePrinter.hex( channel.getBytes() ), equalTo( String.format(
+                "00 08 00 00 00 00 00 00    00 01 00 08 00 00 00 00    " +
+                "00 00 00 02 00 08 00 00    00 00 00 00 00 03 00 00%n" ) ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/util/FileTools.java
+++ b/driver/src/test/java/org/neo4j/driver/util/FileTools.java
@@ -128,6 +128,7 @@ public class FileTools
         }
 
         in.close();
+        out.flush();
         out.close();
 
         propFile.delete();


### PR DESCRIPTION
	-o line ending
	-o force to flush when closing an output stream