### PR TITLE
Do not instantiate new objects for each BooleanValue

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -201,7 +201,7 @@ public class Values
 
     public static Value value( final boolean val )
     {
-        return new BooleanValue( val );
+        return BooleanValue.fromBoolean( val );
     }
 
     public static Value value( final char val )

--- a/driver/src/main/java/org/neo4j/driver/v1/internal/value/BooleanValue.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/internal/value/BooleanValue.java
@@ -18,49 +18,27 @@
  */
 package org.neo4j.driver.v1.internal.value;
 
-public class BooleanValue extends ValueAdapter
+public abstract class BooleanValue extends ValueAdapter
 {
-    private final boolean val;
 
-    public BooleanValue( boolean val )
+
+    private BooleanValue() {
+        //do nothing
+    }
+
+    public static BooleanValue TRUE = new TrueValue();
+
+    public static BooleanValue FALSE = new FalseValue();
+
+    public static BooleanValue fromBoolean( boolean value )
     {
-        this.val = val;
+        return value ? TRUE : FALSE;
     }
 
     @Override
-    public boolean javaBoolean()
+    public int hashCode()
     {
-        return val;
-    }
-
-    @Override
-    public String javaString()
-    {
-        return val ? "true" : "false";
-    }
-
-    @Override
-    public int javaInteger()
-    {
-        return val ? 1 : 0;
-    }
-
-    @Override
-    public long javaLong()
-    {
-        return val ? 1 : 0;
-    }
-
-    @Override
-    public float javaFloat()
-    {
-        return val ? 1 : 0;
-    }
-
-    @Override
-    public double javaDouble()
-    {
-        return val ? 1 : 0;
+        return Boolean.hashCode( javaBoolean() );
     }
 
     @Override
@@ -69,27 +47,90 @@ public class BooleanValue extends ValueAdapter
         return true;
     }
 
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
+
+    private static class TrueValue extends BooleanValue {
+        @Override
+        public boolean javaBoolean()
         {
             return true;
         }
-        if ( o == null || getClass() != o.getClass() )
+
+        @Override
+        public String javaString()
+        {
+            return"true";
+        }
+        @Override
+        public int javaInteger()
+        {
+            return 1;
+        }
+
+        @Override
+        public long javaLong()
+        {
+            return 1L;
+        }
+
+        @Override
+        public float javaFloat()
+        {
+            return 1f;
+        }
+
+        @Override
+        public double javaDouble()
+        {
+            return 1d;
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            return obj == TRUE;
+        }
+    }
+
+    private static class FalseValue extends BooleanValue {
+        @Override
+        public boolean javaBoolean()
         {
             return false;
         }
 
-        BooleanValue values = (BooleanValue) o;
+        @Override
+        public String javaString()
+        {
+            return "false";
+        }
+        @Override
+        public int javaInteger()
+        {
+            return 0;
+        }
 
-        return val == values.val;
+        @Override
+        public long javaLong()
+        {
+            return 0L;
+        }
 
-    }
+        @Override
+        public float javaFloat()
+        {
+            return 0f;
+        }
 
-    @Override
-    public int hashCode()
-    {
-        return javaInteger();
+        @Override
+        public double javaDouble()
+        {
+            return 0d;
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            return obj == FALSE;
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/internal/value/BooleanValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/internal/value/BooleanValueTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.driver.v1.internal.value.BooleanValue.FALSE;
+import static org.neo4j.driver.v1.internal.value.BooleanValue.TRUE;
 
 public class BooleanValueTest
 {
@@ -31,7 +33,7 @@ public class BooleanValueTest
     public void testBooleanTrue() throws Exception
     {
         // Given
-        BooleanValue value = new BooleanValue( true );
+        BooleanValue value = TRUE;
 
         // Then
         assertThat( value.javaBoolean(), equalTo( true ) );
@@ -45,7 +47,7 @@ public class BooleanValueTest
     public void testBooleanFalse() throws Exception
     {
         // Given
-        BooleanValue value = new BooleanValue( false );
+        BooleanValue value = FALSE;
 
         // Then
         assertThat( value.javaBoolean(), equalTo( false ) );
@@ -59,7 +61,7 @@ public class BooleanValueTest
     public void testIsBoolean() throws Exception
     {
         // Given
-        BooleanValue value = new BooleanValue( true );
+        BooleanValue value = TRUE;
 
         // Then
         assertThat( value.isBoolean(), equalTo( true ) );
@@ -69,8 +71,8 @@ public class BooleanValueTest
     public void testEquals() throws Exception
     {
         // Given
-        BooleanValue firstValue = new BooleanValue( true );
-        BooleanValue secondValue = new BooleanValue( true );
+        BooleanValue firstValue = TRUE;
+        BooleanValue secondValue = TRUE;
 
         // Then
         assertThat( firstValue, equalTo( secondValue ) );
@@ -80,7 +82,7 @@ public class BooleanValueTest
     public void testHashCode() throws Exception
     {
         // Given
-        BooleanValue value = new BooleanValue( true );
+        BooleanValue value = TRUE;
 
         // Then
         assertThat( value.hashCode(), notNullValue() );


### PR DESCRIPTION
Instead of instantiating new objects, use constants `TRUE` and `FALSE`
instead.