### PR TITLE
keys should never return null

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/summary/ResultBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/ResultBuilder.java
@@ -39,16 +39,17 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Collections.unmodifiableMap;
-
 import static org.neo4j.driver.internal.ParameterSupport.NO_PARAMETERS;
 
 public class ResultBuilder implements StreamCollector
 {
+    private final static List<String> NO_KEYS = new ArrayList<>();
+
     private final SummaryBuilder summaryBuilder;
 
     private List<Record> body = new ArrayList<>();
-    private List<String> keys = null;
-    private Map<String, Integer> keyIndexLookup = null;
+    private List<String> keys = NO_KEYS;
+    private Map<String,Integer> keyIndexLookup = null;
 
     public ResultBuilder( String statement, Map<String, Value> parameters )
     {
@@ -60,7 +61,7 @@ public class ResultBuilder implements StreamCollector
     @Override
     public void keys( String[] names )
     {
-        if ( keys == null )
+        if ( keys == NO_KEYS )
         {
             int numFields = names.length;
             if ( numFields == 0 )

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
@@ -78,4 +78,34 @@ public class InternalSessionTest
         // Then we should've gotten a transaction object back
         assertNotNull( tx );
     }
+
+    @Test
+    public void shouldNotBeAbleToUseSessionWhileOngoingTransaction() throws Throwable
+    {
+        // Given
+        Connection mock = mock( Connection.class );
+        InternalSession sess = new InternalSession( mock );
+        sess.beginTransaction();
+
+        // Expect
+        exception.expect( ClientException.class );
+
+        // When
+        sess.run( "whatever" );
+    }
+
+    @Test
+    public void shouldBeAbleToUseSessionAgainWhenTransactionIsClosed() throws Throwable
+    {
+        // Given
+        Connection mock = mock( Connection.class );
+        InternalSession sess = new InternalSession( mock );
+        sess.beginTransaction().close();
+
+        // When
+        sess.run( "whatever" );
+
+        // Then
+        verify( mock ).sync();
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ResultStreamIT.java
@@ -26,9 +26,9 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.TestNeo4jSession;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.driver.v1.Values.parameters;
 
 public class ResultStreamIT
@@ -108,5 +108,15 @@ public class ResultStreamIT
 
         // Then
         assertTrue( rs.value( "n" ).value( "age" ).isNull() );
+    }
+
+    @Test
+    public void shouldNotReturnNullKeysOnEmptyResult()
+    {
+        // Given
+        ResultCursor rs = session.run( "CREATE (n:Person {name:{name}})", parameters( "name", "Tom Hanks" ) );
+
+        // THEN
+        assertNotNull( rs.keys() );
     }
 }


### PR DESCRIPTION
For cypher statements that has no results, `resultCurson.keys` should return
an empty list rather than `null`.
