### PR TITLE
Drop connection/session peacefully on protocol violation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,3 @@ Java 8, because Neo4j-the-database needs it to run.
 
 If you are building on windows, you need to run install as admin so that Neo4j-the-database could be registered as a
 windows service and then be started and stopped correctly using its powershell scripts for windows.
-To be able to run powershell script on windows, you might need to enable running scripts on the system.
-This can for example be achieved by executing the following from an elevated PowerShell prompt:
-
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
@@ -154,6 +154,12 @@ public class SocketConnection implements Connection
         socket.stop();
     }
 
+    @Override
+    public boolean isOpen()
+    {
+        return socket.isOpen();
+    }
+
     private int nextRequestId()
     {
         return (requestCounter++);

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
@@ -222,6 +222,11 @@ public class SocketResponseHandler implements MessageHandler
         collectors.put( correlationId, collector );
     }
 
+    public boolean protocolViolationErrorOccurred()
+    {
+        return error != null && error.neo4jErrorCode().startsWith( "Neo.ClientError.Request" );
+    }
+
     public boolean serverFailureOccurred()
     {
         return error != null;

--- a/driver/src/main/java/org/neo4j/driver/internal/pool/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/pool/PooledConnection.java
@@ -100,7 +100,7 @@ public class PooledConnection implements Connection
         {
             delegate.sync();
         }
-        catch(RuntimeException e)
+        catch ( RuntimeException e )
         {
             onDelegateException( e );
         }
@@ -110,6 +110,12 @@ public class PooledConnection implements Connection
     public void close()
     {
         release.accept( this );
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return delegate.isOpen();
     }
 
     public boolean hasUnrecoverableErrors()
@@ -130,11 +136,17 @@ public class PooledConnection implements Connection
      */
     private void onDelegateException( RuntimeException e )
     {
-        if ( !isClientOrTransientError( e ) )
+        if ( !isClientOrTransientError( e ) || isProtocolViolationError( e ) )
         {
             unrecoverableErrorsOccurred = true;
         }
         throw e;
+    }
+
+    private boolean isProtocolViolationError(RuntimeException e )
+    {
+        return e instanceof Neo4jException
+               && ((Neo4jException) e).neo4jErrorCode().startsWith( "Neo.ClientError.Request" );
     }
 
     private boolean isClientOrTransientError( RuntimeException e )

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -59,4 +59,14 @@ public interface Connection extends AutoCloseable
 
     @Override
     void close();
+
+    /**
+     * Test if the underlying socket connection with the server is still open.
+     * When the socket connection with the server is closed,
+     * the connection cannot take on any task, but be {@link #close() closed} to release resources it occupies.
+     * Note: Invocation of {@link #close()} method would make this method to return false,
+     * however this method cannot indicate whether {@link #close()} is already be called or not.
+     * @return true if the socket connection with the server is open, otherwise false.
+     */
+    boolean isOpen();
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import static junit.framework.TestCase.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class InternalSessionTest
 {
@@ -40,6 +41,7 @@ public class InternalSessionTest
     {
         // Given
         Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( true );
         InternalSession sess = new InternalSession( mock );
 
         // When
@@ -54,6 +56,7 @@ public class InternalSessionTest
     {
         // Given
         Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( true );
         InternalSession sess = new InternalSession( mock );
         sess.beginTransaction();
 
@@ -69,6 +72,7 @@ public class InternalSessionTest
     {
         // Given
         Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( true );
         InternalSession sess = new InternalSession( mock );
         sess.beginTransaction().close();
 
@@ -84,6 +88,7 @@ public class InternalSessionTest
     {
         // Given
         Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( true );
         InternalSession sess = new InternalSession( mock );
         sess.beginTransaction();
 
@@ -99,6 +104,7 @@ public class InternalSessionTest
     {
         // Given
         Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( true );
         InternalSession sess = new InternalSession( mock );
         sess.beginTransaction().close();
 
@@ -107,5 +113,35 @@ public class InternalSessionTest
 
         // Then
         verify( mock ).sync();
+    }
+
+    @Test
+    public void shouldNotAllowMoreStatementsInSessionWhileConnectionClosed() throws Throwable
+    {
+        // Given
+        Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( false );
+        InternalSession sess = new InternalSession( mock );
+
+        // Expect
+        exception.expect( ClientException.class );
+
+        // When
+        sess.run( "whatever" );
+    }
+
+    @Test
+    public void shouldNotAllowMoreTransactionsInSessionWhileConnectionClosed() throws Throwable
+    {
+        // Given
+        Connection mock = mock( Connection.class );
+        when( mock.isOpen() ).thenReturn( false );
+        InternalSession sess = new InternalSession( mock );
+
+        // Expect
+        exception.expect( ClientException.class );
+
+        // When
+        sess.beginTransaction();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/pool/ConnectionInvalidationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/pool/ConnectionInvalidationTest.java
@@ -18,10 +18,10 @@
  */
 package org.neo4j.driver.internal.pool;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.io.IOException;
 
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -66,6 +66,13 @@ public class ConnectionInvalidationTest
     {
         assertRecoverable( new ClientException( "Neo.ClientError.General.ReadOnly", "Hello, world!" ) );
         assertRecoverable( new TransientException( "Neo.TransientError.General.ReadOnly", "Hello, world!" ) );
+    }
+
+    @Test
+    public void shouldInvalidateOnProtocolViolationExceptions() throws Throwable
+    {
+        assertUnrecoverable( new ClientException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
+        assertUnrecoverable( new ClientException( "Neo.ClientError.Request.Invalid", "Hello, world!" ) );
     }
 
     private void assertUnrecoverable( Neo4jException exception )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.driver.v1.integration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.driver.internal.connector.socket.SocketClient;
+import org.neo4j.driver.internal.connector.socket.SocketResponseHandler;
+import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.messaging.InitMessage;
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.util.TestNeo4j;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class SocketClientIT
+{
+    @Rule
+    public TestNeo4j neo4j = new TestNeo4j();
+
+    private SocketClient client = null;
+
+    @Before
+    public void setup()
+    {
+        URI url = URI.create( neo4j.address() );
+        client = new SocketClient( url.getHost(), url.getPort(), Config.defaultConfig(),
+                new DevNullLogger() );
+    }
+
+    @After
+    public void tearDown()
+    {
+        if( client != null )
+        {
+            client.stop();
+        }
+    }
+
+    @Test
+    public void shouldCloseConnectionWhenReceivingProtocolViolationError() throws Exception
+    {
+        // Given
+        List<Message> messages = new ArrayList<>( 2 );
+        messages.add( new InitMessage( "EvilClientV1_Hello" ) );
+        messages.add( new InitMessage( "EvilClientV1_World" ) );
+
+        SocketResponseHandler handler = mock( SocketResponseHandler.class );
+        when( handler.protocolViolationErrorOccurred() ).thenReturn( true );
+        when( handler.receivedResponses() ).thenReturn( 0, 1, 2 );
+        when( handler.serverFailure() ).thenReturn(
+                new ClientException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
+
+        // When & Then
+        client.start();
+        try
+        {
+            client.send( messages, handler );
+            fail( "The client should receive a protocol violation error" );
+        }
+        catch ( Exception e )
+        {
+            assertTrue( e instanceof ClientException );
+            assertThat( e.getMessage(), equalTo( "Hello, world!" ) );
+        }
+
+        assertThat( client.isOpen(), equalTo( false ) );
+        verify( handler, times(1) ).protocolViolationErrorOccurred();
+        verify( handler, times(1) ).receivedResponses();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
@@ -52,7 +52,7 @@ public class DumpMessage
         if ( args.length < 1 )
         {
             System.out.println( "Please specify PackStreamV1 messages " +
-                                "(or PackStreamV1 messages with chunk size and 00 00 ending) " +
+                                "(or PackStreamV1 messages in chunks) " +
                                 "that you want to unpack in hex strings. " );
             return;
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jWindowsInstaller.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jWindowsInstaller.java
@@ -86,6 +86,7 @@ public class Neo4jWindowsInstaller extends Neo4jInstaller
     {
         return runCommand(
                 "powershell.exe",
+                "-ExecutionPolicy", "RemoteSigned",
                 format( "Import-Module %s", new File( neo4jHomeDir, "bin/Neo4j-Management/Neo4j-Management.psm1" ).getAbsolutePath() ),
                 format( "; %s", cmd ) );
     }


### PR DESCRIPTION
Scenario:

```
C->S: RUN (&*()&&*%&^%I,
      PULL_ALL,...                   
```

Client sends to server a RUN message that cannot be understood by the server (unable to dechunk or unpack) and a PULL_ALL

`S->C: Neo.ClientError.Request, RST`  
Server sends back an error for RUN message and the wish to close this connection, without a reply to PULL_ALL

This PR makes sure that the client should close the connection/session immediately if the connection would be broken afterwards without waiting for any reply for PULL_ALL.
