### PR TITLE
Handle applications not closing sessions better.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/LoggingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/LoggingResponseHandler.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.neo4j.driver.internal.spi.Logger;
 import org.neo4j.driver.v1.Value;
 
-import static org.neo4j.driver.internal.messaging.AckFailureMessage.ACK_FAILURE;
+import static org.neo4j.driver.internal.messaging.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.DiscardAllMessage.DISCARD_ALL;
 import static org.neo4j.driver.internal.messaging.IgnoredMessage.IGNORED;
 import static org.neo4j.driver.internal.messaging.PullAllMessage.PULL_ALL;
@@ -68,10 +68,10 @@ public class LoggingResponseHandler extends SocketResponseHandler
     }
 
     @Override
-    public void handleAckFailureMessage()
+    public void handleResetMessage()
     {
-        super.handleAckFailureMessage();
-        logger.debug( DEFAULT_DEBUG_LOGGING_FORMAT, ACK_FAILURE );
+        super.handleResetMessage();
+        logger.debug( DEFAULT_DEBUG_LOGGING_FORMAT, RESET );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
@@ -194,7 +194,7 @@ public class SocketResponseHandler implements MessageHandler
     }
 
     @Override
-    public void handleAckFailureMessage()
+    public void handleResetMessage()
     {
 
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageHandler.java
@@ -34,7 +34,7 @@ public interface MessageHandler
 
     void handleDiscardAllMessage() throws IOException;
 
-    void handleAckFailureMessage() throws IOException;
+    void handleResetMessage() throws IOException;
 
     // Responses
     void handleSuccessMessage( Map<String,Value> meta ) throws IOException;

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV1.java
@@ -59,7 +59,7 @@ import static org.neo4j.driver.v1.Values.value;
 public class PackStreamMessageFormatV1 implements MessageFormat
 {
     public final static byte MSG_INIT = 0x01;
-    public final static byte MSG_ACK_FAILURE = 0x0F;
+    public final static byte MSG_RESET = 0x0F;
     public final static byte MSG_RUN = 0x10;
     public final static byte MSG_DISCARD_ALL = 0x2F;
     public final static byte MSG_PULL_ALL = 0x3F;
@@ -152,9 +152,9 @@ public class PackStreamMessageFormatV1 implements MessageFormat
         }
 
         @Override
-        public void handleAckFailureMessage() throws IOException
+        public void handleResetMessage() throws IOException
         {
-            packer.packStructHeader( 0, MSG_ACK_FAILURE );
+            packer.packStructHeader( 0, MSG_RESET );
             onMessageComplete.run();
         }
 
@@ -429,9 +429,18 @@ public class PackStreamMessageFormatV1 implements MessageFormat
             case MSG_INIT:
                 unpackInitMessage( handler );
                 break;
+            case MSG_RESET:
+                unpackResetMessage( handler );
+                break;
             default:
                 throw new IOException( "Unknown message type: " + type );
             }
+        }
+
+        private void unpackResetMessage( MessageHandler handler ) throws IOException
+        {
+            handler.handleResetMessage();
+            onMessageComplete.run();
         }
 
         private void unpackInitMessage( MessageHandler handler ) throws IOException

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/ResetMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/ResetMessage.java
@@ -21,9 +21,10 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 
 /**
- * ACK_FAILURE request message
+ * RESET request message
  * <p>
- * Sent by clients to acknowledge receipt of failures sent by the server. This is required to
+ * Sent by clients to reset a session to a clean state - closing any open transaction or result streams.
+ * This also acknowledges receipt of failures sent by the server. This is required to
  * allow optimistic sending of multiple messages before responses have been received - pipelining.
  * <p>
  * When something goes wrong, we want the server to stop processing our already sent messages,
@@ -33,20 +34,20 @@ import java.io.IOException;
  * This message acts as a barrier after an error, informing the server that we've seen the error
  * message, and that messages that follow this one are safe to execute.
  */
-public class AckFailureMessage implements Message
+public class ResetMessage implements Message
 {
-    public static final AckFailureMessage ACK_FAILURE = new AckFailureMessage();
+    public static final ResetMessage RESET = new ResetMessage();
 
     @Override
     public void dispatch( MessageHandler handler ) throws IOException
     {
-        handler.handleAckFailureMessage();
+        handler.handleResetMessage();
     }
 
     @Override
     public String toString()
     {
-        return "[ACK_FAILURE]";
+        return "[RESET]";
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/pool/InternalConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/pool/InternalConnectionPool.java
@@ -92,7 +92,7 @@ public class InternalConnectionPool implements ConnectionPool
     {
         try
         {
-            PooledConnection conn = pool( sessionURI ).acquire( 30, TimeUnit.SECONDS );
+            Connection conn = pool( sessionURI ).acquire( 30, TimeUnit.SECONDS );
             if( conn == null )
             {
                 throw new ClientException(

--- a/driver/src/main/java/org/neo4j/driver/internal/pool/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/pool/PooledConnection.java
@@ -94,6 +94,19 @@ public class PooledConnection implements Connection
     }
 
     @Override
+    public void reset( StreamCollector collector )
+    {
+        try
+        {
+            delegate.reset( collector );
+        }
+        catch ( RuntimeException e )
+        {
+            onDelegateException( e );
+        }
+    }
+
+    @Override
     public void sync()
     {
         try
@@ -109,6 +122,9 @@ public class PooledConnection implements Connection
     @Override
     public void close()
     {
+        // In case this session has an open result or transaction or something,
+        // make sure it's reset to a nice state before we reuse it.
+        reset( StreamCollector.NO_OP );
         release.accept( this );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -53,6 +53,12 @@ public interface Connection extends AutoCloseable
     void pullAll( StreamCollector collector );
 
     /**
+     * Queue a reset action, output will be handed to the collector once the pull starts. This will
+     * close the stream once its completed, allowing another {@link #run(String, java.util.Map, StreamCollector) run}
+     */
+    void reset( StreamCollector collector );
+
+    /**
      * Ensure all outstanding actions are carried out on the server.
      */
     void sync();

--- a/driver/src/main/java/org/neo4j/driver/v1/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Driver.java
@@ -74,11 +74,13 @@ public class Driver implements AutoCloseable
 {
     private final ConnectionPool connections;
     private final URI url;
+    private final Config config;
 
     public Driver( URI url, Config config )
     {
         this.url = url;
         this.connections = new InternalConnectionPool( config );
+        this.config = config;
     }
 
     /**
@@ -88,11 +90,7 @@ public class Driver implements AutoCloseable
      */
     public Session session()
     {
-        return new InternalSession( connections.acquire( url ) );
-        // TODO a ConnectionPool per URL
-        // ConnectionPool connections = new InternalConnectionPool( logging, url );
-        // And to value a connection from the pool could be
-        // connections.acquire();
+        return new InternalSession( connections.acquire( url ), config.logging().getLog( "session" ) );
     }
 
     /**

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalSessionTest.java
@@ -22,12 +22,21 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.Logger;
+import org.neo4j.driver.internal.spi.StreamCollector;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static junit.framework.TestCase.assertNotNull;
+import static org.jsoup.helper.Validate.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,13 +45,15 @@ public class InternalSessionTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+    private final Connection mock = mock( Connection.class );
+    private InternalSession sess = new InternalSession( mock, new DevNullLogger() );
+
     @Test
     public void shouldSyncOnRun() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( true );
-        InternalSession sess = new InternalSession( mock );
+        InternalSession sess = new InternalSession( mock, new DevNullLogger() );
 
         // When
         sess.run( "whatever" );
@@ -55,9 +66,7 @@ public class InternalSessionTest
     public void shouldNotAllowNewTxWhileOneIsRunning() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( true );
-        InternalSession sess = new InternalSession( mock );
         sess.beginTransaction();
 
         // Expect
@@ -71,9 +80,7 @@ public class InternalSessionTest
     public void shouldBeAbleToOpenTxAfterPreviousIsClosed() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( true );
-        InternalSession sess = new InternalSession( mock );
         sess.beginTransaction().close();
 
         // When
@@ -87,9 +94,7 @@ public class InternalSessionTest
     public void shouldNotBeAbleToUseSessionWhileOngoingTransaction() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( true );
-        InternalSession sess = new InternalSession( mock );
         sess.beginTransaction();
 
         // Expect
@@ -103,9 +108,7 @@ public class InternalSessionTest
     public void shouldBeAbleToUseSessionAgainWhenTransactionIsClosed() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( true );
-        InternalSession sess = new InternalSession( mock );
         sess.beginTransaction().close();
 
         // When
@@ -119,9 +122,7 @@ public class InternalSessionTest
     public void shouldNotAllowMoreStatementsInSessionWhileConnectionClosed() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( false );
-        InternalSession sess = new InternalSession( mock );
 
         // Expect
         exception.expect( ClientException.class );
@@ -134,14 +135,89 @@ public class InternalSessionTest
     public void shouldNotAllowMoreTransactionsInSessionWhileConnectionClosed() throws Throwable
     {
         // Given
-        Connection mock = mock( Connection.class );
         when( mock.isOpen() ).thenReturn( false );
-        InternalSession sess = new InternalSession( mock );
 
         // Expect
         exception.expect( ClientException.class );
 
         // When
         sess.beginTransaction();
+    }
+
+    @Test
+    public void shouldWarnAndCloseOnLeak() throws Throwable
+    {
+        // Given
+        CloseTrackingConnection connection = new CloseTrackingConnection();
+        Logger logger = spy( Logger.class );
+
+        // When
+        new InternalSession( connection, logger );
+
+        // Then
+        long deadline = System.currentTimeMillis() + 1000 * 30;
+        while ( !connection.closeCalled.get() )
+        {
+            System.gc();
+            if ( System.currentTimeMillis() > deadline )
+            {
+                fail( "Expected unclosed session object to close its inner connection on finalize." );
+            }
+        }
+
+        verify( logger ).error( "Neo4j Session object leaked, please ensure that your application calls the `close` method on Sessions before disposing of the objects.", null );
+    }
+
+    private static class CloseTrackingConnection implements Connection
+    {
+        AtomicBoolean closeCalled = new AtomicBoolean();
+
+        @Override
+        public void init( String clientName )
+        {
+
+        }
+
+        @Override
+        public void run( String statement, Map<String,Value> parameters, StreamCollector collector )
+        {
+
+        }
+
+        @Override
+        public void discardAll()
+        {
+
+        }
+
+        @Override
+        public void pullAll( StreamCollector collector )
+        {
+
+        }
+
+        @Override
+        public void reset( StreamCollector collector )
+        {
+
+        }
+
+        @Override
+        public void sync()
+        {
+
+        }
+
+        @Override
+        public void close()
+        {
+            closeCalled.set( true );
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return true;
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/LoggingResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/LoggingResponseHandlerTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import org.junit.Test;
 
 import org.neo4j.driver.internal.logging.DevNullLogger;
-import org.neo4j.driver.internal.messaging.AckFailureMessage;
+import org.neo4j.driver.internal.messaging.ResetMessage;
 import org.neo4j.driver.internal.messaging.DiscardAllMessage;
 import org.neo4j.driver.internal.messaging.FailureMessage;
 import org.neo4j.driver.internal.messaging.IgnoredMessage;
@@ -103,11 +103,11 @@ public class LoggingResponseHandlerTest
     public void shouldLogAckFailureMessage() throws Throwable
     {
         // When
-        handler.handleAckFailureMessage();
+        handler.handleResetMessage();
 
         // Then
-        assertEquals( "S: [ACK_FAILURE]", log );
-        assertEquals( format( new AckFailureMessage() ), log );
+        assertEquals( "S: [RESET]", log );
+        assertEquals( format( new ResetMessage() ), log );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -63,6 +63,7 @@ public class MessageFormatTest
         assertSerializes( new DiscardAllMessage() );
         assertSerializes( new IgnoredMessage() );
         assertSerializes( new FailureMessage( "Neo.Banana.Bork.Birk", "Hello, world!" ) );
+        assertSerializes( new ResetMessage() );
         assertSerializes( new InitMessage( "JavaDriver/1.0.0" ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/CaptureStdOut.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/CaptureStdOut.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class CaptureStdOut
+{
+    private ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+    private ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+
+    public AutoCloseable capture()
+    {
+        final PrintStream stdOut = System.out;
+        final PrintStream stdErr = System.err;
+        System.setOut( new PrintStream( capturedOut ) );
+        System.setErr( new PrintStream( capturedErr ) );
+        return new AutoCloseable()
+        {
+            @Override
+            public void close() throws Exception
+            {
+                System.setOut( stdOut );
+                System.setErr( stdErr );
+            }
+        };
+    }
+
+    public List<String> out()
+    {
+        return lines( capturedOut );
+    }
+
+    public List<String> err()
+    {
+        return lines( capturedErr );
+    }
+
+    private List<String> lines( ByteArrayOutputStream buff )
+    {
+        try
+        {
+            return asList( buff.toString( "utf-8" ).split( System.getProperty("line.separator") ));
+        }
+        catch ( UnsupportedEncodingException e )
+        {
+            throw new AssertionError( e );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.driver.internal.connector.socket.ChunkedInput;
-import org.neo4j.driver.internal.messaging.AckFailureMessage;
+import org.neo4j.driver.internal.messaging.ResetMessage;
 import org.neo4j.driver.internal.messaging.DiscardAllMessage;
 import org.neo4j.driver.internal.messaging.FailureMessage;
 import org.neo4j.driver.internal.messaging.IgnoredMessage;
@@ -332,9 +332,9 @@ public class DumpMessage
         }
 
         @Override
-        public void handleAckFailureMessage()
+        public void handleResetMessage()
         {
-            outcome.add( new AckFailureMessage() );
+            outcome.add( new ResetMessage() );
         }
 
         @Override


### PR DESCRIPTION
- Introduces basic finalizer to the InternalSession object, which closes
  the underlying connection if the session was not closed by the user,
  and prints a warning to stderr.
