### PR TITLE
Remove unused methods from Neo4jRunner

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/pool/InternalConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/pool/InternalConnectionPoolTest.java
@@ -53,7 +53,7 @@ public class InternalConnectionPoolTest
         Connector connector = connector( "bolt" );
         Config config = Config.build().withConnectionPoolSize( 1 ).toConfig();
         InternalConnectionPool pool = new InternalConnectionPool( singletonList( connector ),
-                Clock.SYSTEM, config );
+                Clock.SYSTEM, config, 100 );
 
         // When & Then
         pool.acquire( uri );
@@ -74,7 +74,7 @@ public class InternalConnectionPoolTest
         Connector connector = connector( "bolt" );
         Config config = Config.defaultConfig();
         InternalConnectionPool pool = new InternalConnectionPool( singletonList( connector ),
-                Clock.SYSTEM, config );
+                Clock.SYSTEM, config, 100 );
 
         Connection conn = pool.acquire( uri );
         conn.close();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionPoolIT.java
@@ -18,13 +18,13 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import java.util.LinkedList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
@@ -53,7 +53,7 @@ public class ConnectionPoolIT
         sessionGrabber.start();
 
         // When
-        neo4j.restartServerOnEmptyDatabase();
+        neo4j.restart();
 
         // Then we accept a hump with failing sessions, but demand that failures stop as soon as the server is back up.
         sessionGrabber.assertSessionsAvailableWithin( 60 );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SSLSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SSLSocketChannelIT.java
@@ -44,7 +44,6 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.ResultCursor;
 import org.neo4j.driver.v1.util.CertificateToolTest;
 import org.neo4j.driver.v1.util.Neo4jRunner;
-import org.neo4j.driver.v1.util.Neo4jSettings;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.junit.Assert.assertEquals;
@@ -59,7 +58,7 @@ import static org.mockito.Mockito.verify;
 public class SSLSocketChannelIT
 {
     @Rule
-    public TestNeo4j neo4j = new TestNeo4j( Neo4jSettings.DEFAULT.usingTLS( true ) );
+    public TestNeo4j neo4j = new TestNeo4j();
 
     @Test
     public void shouldPerformTLSHandshakeWithEmptyKnownCertsFile() throws Throwable

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
@@ -21,15 +21,14 @@ package org.neo4j.driver.v1.integration;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.Neo4jRunner;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Mainly concerned about the connection pool - we want to make sure that bad connections are evacuated from the
@@ -44,9 +43,6 @@ public class ServerKilledIT
     public void shouldRecoverFromServerRestart() throws Throwable
     {
         // Given
-        assumeTrue( neo4j.canControlServer() );
-
-        // And given we've spun up a few running sessions
         try ( Driver driver = GraphDatabase.driver( Neo4jRunner.DEFAULT_URL ) )
         {
             Session s1 = driver.session();
@@ -61,7 +57,7 @@ public class ServerKilledIT
             s4.close();
 
             // When
-            neo4j.restartServerOnEmptyDatabase();
+            neo4j.restart();
 
             // Then we should be able to start using sessions again, at most O(numSessions) session calls later
             // TODO: These should value evicted immediately, not show up as application-loggingLevel errors first

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/DriverStresser.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/DriverStresser.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.v1.ResultCursor;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.util.Neo4jRunner;
+import org.neo4j.driver.v1.util.Neo4jSettings;
 
 import static org.neo4j.driver.v1.Values.parameters;
 
@@ -57,7 +58,7 @@ public class DriverStresser
     public static void setup() throws Exception
     {
         server = Neo4jRunner.getOrCreateGlobalRunner();
-        server.startServerOnEmptyDatabase();
+        server.ensureRunning( Neo4jSettings.DEFAULT );
         driver = GraphDatabase.driver( "bolt://localhost" );
     }
 
@@ -88,7 +89,7 @@ public class DriverStresser
     public static void tearDown() throws Exception
     {
         driver.close();
-        server.stopServerIfRunning();
+        server.stop();
     }
 
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
@@ -44,17 +44,17 @@ public class TestNeo4jSession extends TestNeo4j implements Session
 
     public TestNeo4jSession( Neo4jResetMode resetMode )
     {
-        super( resetMode );
+        super();
     }
 
     public TestNeo4jSession( Neo4jSettings initialSettings )
     {
-        super( initialSettings );
+        super();
     }
 
     public TestNeo4jSession( Neo4jSettings initialSettings, Neo4jResetMode resetMode )
     {
-        super( initialSettings, resetMode );
+        super();
     }
 
     @Override


### PR DESCRIPTION
Add guard against running when another Neo4j instance is running.

The Neo4jRunner contained a lot of functionality that was not
used, with four separate code paths for starting Neo4j, which made
it somewhat complex to reason about how to prevent starting Neo4j
over an existing instance. This removes those unused code paths and
consolidates API usage to one main start path.
