### PR TITLE
Test for and handle failures on commit

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketResponseHandler.java
@@ -176,7 +176,10 @@ public class SocketResponseHandler implements MessageHandler
     public void handleIgnoredMessage()
     {
         StreamCollector collector = collectors.remove();
-        collector.done();
+        if (collector != null)
+        {
+            collector.done();
+        }
     }
 
     @Override


### PR DESCRIPTION
This fix allows the driver to gracefully handle failures when they occur at commit time rather than at execution time.
