### PR TITLE
added driver.close() to README to prevent parked threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Connect to a Neo4j 3.0.0+ database
     
     session.close();
     
+    driver.close();
+
 # Building
 
 ## Java version


### PR DESCRIPTION
Not closing the Driver will lead to threads not being closed.
In the Neo4j instance neo4j.Session-XXX theads will stay in PARK state.

To prevent users for blowing up their Neo4j instance I've added it to the Readme
