### PR TITLE
Properly handle collections in `Values`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -35,12 +35,12 @@ import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.types.TypeSystem;
-import org.neo4j.driver.v1.util.Function;
 import org.neo4j.driver.v1.types.Entity;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
+import org.neo4j.driver.v1.types.TypeSystem;
+import org.neo4j.driver.v1.util.Function;
 
 /**
  * Utility for wrapping regular Java types and exposing them as {@link Value}
@@ -78,7 +78,7 @@ public abstract class Values
         if ( value instanceof Double ) { return value( (double) value ); }
         if ( value instanceof Float ) { return value( (float) value ); }
 
-        if ( value instanceof Collection<?> ) { return value( (List<Object>) value ); }
+        if ( value instanceof List<?> ) { return value( (List<Object>) value ); }
         if ( value instanceof Iterable<?> ) { return value( (Iterable<Object>) value ); }
         if ( value instanceof Map<?, ?> ) { return value( (Map<String,Object>) value ); }
 
@@ -171,12 +171,13 @@ public abstract class Values
         return new ListValue( values );
     }
 
-    public static Value value( List<Object> val )
+    public static Value value( List<Object> vals )
     {
-        Value[] values = new Value[val.size()];
-        for ( int i = 0; i < val.size(); i++ )
+        Value[] values = new Value[vals.size()];
+        int i = 0;
+        for ( Object val : vals )
         {
-            values[i] = value( val.get( i ) );
+            values[i++] = value( val );
         }
         return new ListValue( values );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -18,10 +18,13 @@
  */
 package org.neo4j.driver.internal;
 
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -241,6 +244,7 @@ public class ValuesTest
         assertThat( val.asList( ofObject() ), contains((Object)"hello", "world") );
     }
 
+    @SuppressWarnings( "unchecked" )
     @Test
     public void shouldMapMapOfString() throws Throwable
     {
@@ -252,5 +256,18 @@ public class ValuesTest
         // When/Then
         assertThat( val.asList( ofMap() ), contains(map, map) );
         assertThat( val.asList( ofObject() ), contains((Object)map, map) );
+    }
+
+    @Test
+    public void shouldHandleCollection() throws Throwable
+    {
+        // Given
+        Collection<String> collection = new ArrayDeque<>();
+        collection.add( "hello");
+        collection.add( "world");
+        Value val = value( collection );
+
+        // When/Then
+        assertThat( val.asList(), Matchers.<Object>containsInAnyOrder( "hello", "world" ));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ScalarTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ScalarTypeIT.java
@@ -54,7 +54,7 @@ public class ScalarTypeIT
     public static Collection<Object[]> typesToTest()
     {
         return Arrays.asList(
-                new Object[]{"RETURN 1 as v", Values.value( 1l )},
+                new Object[]{"RETURN 1 as v", Values.value( 1L )},
                 new Object[]{"RETURN 1.1 as v", Values.value( 1.1d )},
                 new Object[]{"RETURN 'hello' as v", Values.value( "hello" )},
                 new Object[]{"RETURN true as v", Values.value( true )},

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/StatementIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/StatementIT.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.v1.integration;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.neo4j.driver.v1.Record;
@@ -49,9 +50,9 @@ public class StatementIT
         assertThat( result.size(), equalTo( 3 ) );
 
         // And it should allow random access
-        assertThat( result.get( 0 ).get( "k" ).asLong(), equalTo( 1l ) );
-        assertThat( result.get( 1 ).get( "k" ).asLong(), equalTo( 2l ) );
-        assertThat( result.get( 2 ).get( "k" ).asLong(), equalTo( 3l ) );
+        assertThat( result.get( 0 ).get( "k" ).asLong(), equalTo( 1L ) );
+        assertThat( result.get( 1 ).get( "k" ).asLong(), equalTo( 2L ) );
+        assertThat( result.get( 2 ).get( "k" ).asLong(), equalTo( 3L ) );
 
         // And it should allow iteration
         long expected = 0;
@@ -60,7 +61,7 @@ public class StatementIT
             expected += 1;
             assertThat( value.get( "k" ), equalTo( Values.value( expected ) ) );
         }
-        assertThat( expected, equalTo( 3l ) );
+        assertThat( expected, equalTo( 3L ) );
     }
 
     @Test
@@ -68,6 +69,15 @@ public class StatementIT
     {
         // When
         session.run( "CREATE (n:FirstNode {name:{name}})", parameters( "name", "Steven" ) );
+
+        // Then nothing should've failed
+    }
+
+    @Test
+    public void shouldRunWithCollectionAsParameter() throws Throwable
+    {
+        // When
+        session.run( "RETURN {param}", parameters( "param", Collections.singleton( "FOO" ) ) );
 
         // Then nothing should've failed
     }


### PR DESCRIPTION
Previously we casted all collections to lists which broke with a
`ClassCastException` whenever a non-list collection was provided
as parameter. Also changed `value(List)` not to use random access
since it will be slow for everything but `ArrayList`.
