### PR TITLE
Add additional constructor to Statement to make it match `run` signature

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Statement.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Statement.java
@@ -44,15 +44,34 @@ public class Statement
     private final String text;
     private final Value parameters;
 
+    /**
+     * Create a new statement.
+     * @param text the statement text
+     * @param parameters the statement parameters
+     */
     public Statement( String text, Value parameters )
     {
         this.text = text;
         this.parameters = parameters == null ? Values.EmptyMap : parameters;
     }
 
+    /**
+     * Create a new statement.
+     * @param text the statement text
+     * @param parameters the statement parameters
+     */
+    public Statement( String text, Map<String, Object> parameters )
+    {
+        this( text, Values.value( parameters ) );
+    }
+
+    /**
+     * Create a new statement.
+     * @param text the statement text
+     */
     public Statement( String text )
     {
-        this( text, null );
+        this( text, Values.EmptyMap );
     }
 
     /**
@@ -85,6 +104,15 @@ public class Statement
      * @return a new statement with updated parameters
      */
     public Statement withParameters( Value newParameters )
+    {
+        return new Statement( text, newParameters );
+    }
+
+    /**
+     * @param newParameters the new statement's parameters
+     * @return a new statement with updated parameters
+     */
+    public Statement withParameters( Map<String, Object> newParameters )
     {
         return new Statement( text, newParameters );
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/StatementTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/StatementTest.java
@@ -20,6 +20,9 @@ package org.neo4j.driver.v1;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.v1.Values.parameters;
@@ -55,21 +58,6 @@ public class StatementTest
     }
 
     @Test
-    public void shouldConstructStatementWithNullParameters()
-    {
-        // given
-        String text = "MATCH (n) RETURN n";
-
-        // when
-        Statement statement = new Statement( text, null );
-
-        // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( Values.EmptyMap ) );
-    }
-
-
-    @Test
     public void shouldUpdateStatementText()
     {
         // when
@@ -96,6 +84,19 @@ public class StatementTest
         assertThat( statement.parameters(), equalTo( initialParameters ) );
     }
 
+    @Test
+    public void shouldReplaceMapParameters()
+    {
+        // when
+        String text = "MATCH (n) RETURN n";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put( "a", 1 );
+        Statement statement = new Statement( "MATCH (n) RETURN n" ).withParameters( parameters );
+
+        // then
+        assertThat( statement.text(), equalTo( text ) );
+        assertThat( statement.parameters(), equalTo( Values.value( parameters ) ) );
+    }
 
     @Test
     public void shouldUpdateStatementParameters()


### PR DESCRIPTION
99% of the time, users will have a `Map<String, Object>` for parameters, so make it easy to handle that without having to find `Values.value(..)`
