### PR TITLE
Don't rely on unsupported configuration

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -34,10 +34,9 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-
 import static org.neo4j.driver.v1.AuthTokens.basic;
-import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.Values.ofValue;
+import static org.neo4j.driver.v1.Values.parameters;
 
 public class CredentialsIT
 {
@@ -90,7 +89,7 @@ public class CredentialsIT
     {
         neo4j.restartServerOnEmptyDatabase( Neo4jSettings.DEFAULT
                 .updateWith( Neo4jSettings.AUTH_ENABLED, "true" )
-                .updateWith( Neo4jSettings.AUTH_FILE, tempDir.newFile( "auth" ).getAbsolutePath() ));
+                .updateWith( Neo4jSettings.DATA_DIR, tempDir.getRoot().getAbsolutePath() ));
 
         Driver setPassword = GraphDatabase.driver( neo4j.address(), new InternalAuthToken(
                 parameters(

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
@@ -20,12 +20,12 @@ package org.neo4j.driver.v1.tck;
 
 import cucumber.api.CucumberOptions;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.driver.v1.util.Neo4jSettings;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 /**
@@ -35,21 +35,13 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 @CucumberOptions( features = {"target/resources/features"}, strict=true, tags={"~@in_dev", "~@db"}, format = {"pretty"})
 public class DriverComplianceIT
 {
+    @Rule
+    TemporaryFolder folder = new TemporaryFolder(  );
+
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();
 
     public DriverComplianceIT() throws IOException
     {
-    }
-
-    public static void updateEncryptionKeyAndCert( File key, File cert ) throws Exception
-    {
-        neo4j.restartServerOnEmptyDatabase(
-                Neo4jSettings.DEFAULT.usingEncryptionKeyAndCert( key, cert ) );
-    }
-
-    public static void useDefaultEncryptionKeyAndCert() throws Exception
-    {
-        neo4j.restartServerOnEmptyDatabase( Neo4jSettings.DEFAULT );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
@@ -31,8 +31,8 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Config.EncryptionLevel;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.CertificateToolTest.CertificateSigningRequestGenerator;
 import org.neo4j.driver.v1.util.CertificateToolTest.SelfSignedCertificateGenerator;
@@ -48,8 +48,7 @@ import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.internal.util.CertificateTool.saveX509Cert;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustOnFirstUse;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustSignedBy;
-import static org.neo4j.driver.v1.tck.DriverComplianceIT.updateEncryptionKeyAndCert;
-import static org.neo4j.driver.v1.tck.DriverComplianceIT.useDefaultEncryptionKeyAndCert;
+import static org.neo4j.driver.v1.tck.DriverComplianceIT.neo4j;
 import static org.neo4j.driver.v1.util.CertificateToolTest.generateSelfSignedCertificate;
 
 public class DriverSecurityComplianceSteps
@@ -117,7 +116,7 @@ public class DriverSecurityComplianceSteps
         generator.saveSelfSignedCertificate( cert );
         generator.savePrivateKey( key );
 
-        updateEncryptionKeyAndCert( key, cert );
+        neo4j.updateEncryptionKeyAndCert( key, cert );
 
     }
 
@@ -211,7 +210,7 @@ public class DriverSecurityComplianceSteps
         csrGenerator.savePrivateKey( key );
         saveX509Cert( signedCert, cert );
 
-        updateEncryptionKeyAndCert( key, cert );
+        neo4j.updateEncryptionKeyAndCert( key, cert );
     }
 
     @When( "^I connect via a TLS-enabled transport$" )
@@ -269,7 +268,7 @@ public class DriverSecurityComplianceSteps
     @After("@modifies_db_config")
     public void resetDbWithDefaultSettings() throws Throwable
     {
-        useDefaultEncryptionKeyAndCert();
+        neo4j.useDefaultEncryptionKeyAndCert();
     }
 
     private File tempFile(String prefix, String suffix) throws Throwable

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jInstaller.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jInstaller.java
@@ -18,11 +18,11 @@
  */
 package org.neo4j.driver.v1.util;
 
+import org.rauschig.jarchivelib.Archiver;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-
-import org.rauschig.jarchivelib.Archiver;
 
 import static org.neo4j.driver.v1.util.FileTools.extractTarball;
 import static org.neo4j.driver.v1.util.FileTools.streamFileTo;
@@ -49,7 +49,7 @@ public abstract class Neo4jInstaller
     public static final File neo4jDir = new File( "../target/neo4j" );
 
     public static final File neo4jHomeDir = new File( neo4jDir, version );
-    public static final File dbDir = new File( neo4jHomeDir, "data/graph.db" );
+    public static final File dbDir = new File( neo4jHomeDir, "data/databases/graph.db" );
 
     /**
      * download, untar/unzip

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
@@ -27,7 +27,7 @@ import static org.neo4j.driver.internal.util.Iterables.map;
 public class Neo4jSettings
 {
     public static final String AUTH_ENABLED = "dbms.security.auth_enabled";
-    public static final String AUTH_FILE = "unsupported.dbms.security.auth_store.location";
+    public static final String DATA_DIR = "dbms.directories.data";
 
     private static final String TLS_CERT_KEY = "dbms.security.tls_certificate_file";
     private static final String TLS_KEY_KEY = "dbms.security.tls_key_file";

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
@@ -28,21 +28,20 @@ public class Neo4jSettings
 {
     public static final String AUTH_ENABLED = "dbms.security.auth_enabled";
     public static final String DATA_DIR = "dbms.directories.data";
+    public static final String CERT_DIR = "dbms.directories.certificates";
 
-    private static final String TLS_CERT_KEY = "dbms.security.tls_certificate_file";
-    private static final String TLS_KEY_KEY = "dbms.security.tls_key_file";
+    private static final String DEFAULT_CERT_DIR = "certificates";
+    private static final String DEFAULT_TLS_CERT_PATH = DEFAULT_CERT_DIR + "/neo4j.cert";
+    private static final String DEFAULT_TLS_KEY_PATH = DEFAULT_CERT_DIR + "/neo4j.key";
 
-    private static final String DEFAULT_TLS_CERT_PATH = "conf/ssl/snakeoil.cert";
-    private static final String DEFAULT_TLS_KEY_PATH = "conf/ssl/snakeoil.key";
-
+    public static final File DEFAULT_TLS_KEY_FILE = new File( Neo4jInstaller.neo4jHomeDir, DEFAULT_TLS_KEY_PATH );
     public static final File DEFAULT_TLS_CERT_FILE = new File( Neo4jInstaller.neo4jHomeDir, DEFAULT_TLS_CERT_PATH );
 
 
     private final Map<String, String> settings;
 
     public static Neo4jSettings DEFAULT = new Neo4jSettings( map(
-            TLS_CERT_KEY, DEFAULT_TLS_CERT_PATH,
-            TLS_KEY_KEY, DEFAULT_TLS_KEY_PATH,
+            CERT_DIR, DEFAULT_CERT_DIR,
             AUTH_ENABLED, "false" ) );
 
     private Neo4jSettings( Map<String, String> settings )
@@ -84,14 +83,6 @@ public class Neo4jSettings
         Neo4jSettings that = (Neo4jSettings) o;
 
         return settings.equals( that.settings );
-    }
-
-    public Neo4jSettings usingEncryptionKeyAndCert( File key, File cert )
-    {
-        return updateWith( map(
-                TLS_CERT_KEY, cert.getAbsolutePath().replaceAll("\\\\", "/"),
-                TLS_KEY_KEY, key.getAbsolutePath().replaceAll("\\\\", "/")
-        ));
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4j.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4j.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
@@ -101,5 +103,17 @@ public class TestNeo4j implements TestRule
     {
         this.settings = settings;
         return this;
+    }
+
+    public void updateEncryptionKeyAndCert( File key, File cert ) throws Exception
+    {
+        Files.copy( key.toPath(), Neo4jSettings.DEFAULT_TLS_KEY_FILE.toPath(), StandardCopyOption.REPLACE_EXISTING );
+        Files.copy( cert.toPath(), Neo4jSettings.DEFAULT_TLS_CERT_FILE.toPath(), StandardCopyOption.REPLACE_EXISTING );
+        restartServerOnEmptyDatabase( Neo4jSettings.DEFAULT );
+    }
+
+    public void useDefaultEncryptionKeyAndCert() throws Exception
+    {
+        restartServerOnEmptyDatabase( Neo4jSettings.DEFAULT );
     }
 }


### PR DESCRIPTION
Instead of relying on `unsupported.dbms.security.auth_store.location`  to
control where the auth store is kept, we now use `dbms.directories.data`.
