### PR TITLE
Add a TrustManager that trusts all certificates for testing purposes

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SSLContextFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SSLContextFactory.java
@@ -71,6 +71,9 @@ class SSLContextFactory
         case TRUST_ON_FIRST_USE:
             trustManagers = new TrustManager[]{new TrustOnFirstUseTrustManager( host, port, authConfig.certFile(), logger )};
             break;
+        case TRUST_ALL:
+            trustManagers = new TrustManager[]{new TrustAllTrustManager()};
+            break;
         default:
             throw new ClientException( "Unknown TLS authentication strategy: " + authConfig.strategy().name() );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustAllTrustManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/TrustAllTrustManager.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * References:
+ * http://stackoverflow.com/questions/6802421/how-to-compare-distinct-implementations-of-java-security-cert-x509certificate?answertab=votes#tab-top
+ */
+public class TrustAllTrustManager implements X509TrustManager
+{
+
+    /*
+     * Disallow all client connection to this client
+     */
+    public void checkClientTrusted( X509Certificate[] chain, String authType )
+            throws CertificateException
+    {
+        throw new CertificateException( "All client connections to this client are forbidden." );
+    }
+
+    /*
+     * Always trust the cert
+     */
+    public void checkServerTrusted( X509Certificate[] chain, String authType )
+            throws CertificateException
+    {
+        // trust everything
+    }
+
+    /**
+     * No issuer is trusted.
+     */
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return new X509Certificate[0];
+    }
+
+}

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -261,6 +261,7 @@ public class Config
     {
         public enum Strategy
         {
+        	TRUST_ALL,
             TRUST_ON_FIRST_USE,
             TRUST_SIGNED_CERTIFICATES
         }
@@ -320,6 +321,16 @@ public class Config
         public static TrustStrategy trustOnFirstUse( File knownHostsFile )
         {
             return new TrustStrategy( Strategy.TRUST_ON_FIRST_USE, knownHostsFile );
+        }
+        
+        /**
+         * Trust all Neo4j instances. ONLY USE THIS FOR TESTING PURPOSES.
+         * 
+         * @return an authentication config
+         */
+        public static TrustStrategy trustAll()
+        {
+            return new TrustStrategy( Strategy.TRUST_ALL, null );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/TrustAllTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/TrustAllTrustManagerTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.junit.Test;
+
+public class TrustAllTrustManagerTest
+{
+
+    @Test
+    public void shouldTrustAllCerts() throws Throwable
+    {
+        // Given
+    	TrustAllTrustManager manager = new TrustAllTrustManager();
+
+        X509Certificate firstCertificate = mock( X509Certificate.class );
+        when( firstCertificate.getEncoded() ).thenReturn( "fake certificate number 1".getBytes() );
+
+        X509Certificate secondCertificate = mock( X509Certificate.class );
+        when( secondCertificate.getEncoded() ).thenReturn( "fake certificate number 2".getBytes() );
+
+        // When & Then
+        try
+        {
+            manager.checkServerTrusted( new X509Certificate[]{firstCertificate}, null );
+            manager.checkServerTrusted( new X509Certificate[]{secondCertificate}, null );
+        }
+        catch ( CertificateException e )
+        {
+        	fail( "Should trust all fake certificates" );
+        }
+    }
+
+}


### PR DESCRIPTION
InProcessServer changes the server certificate on each restart, so none of the current strategies fit (without cumbersome scripting work, that is).
