### PR TITLE
Fixed bitmasking error

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -88,6 +88,14 @@ public class BufferingChunkedInput implements PackInput
         this.state = State.AWAITING_CHUNK;
     }
 
+    /*
+     * Use only in tests
+     */
+    int remainingChunkSize()
+    {
+        return remainingChunkSize;
+    }
+
     /**
      * Internal state machine used for reading data from the channel into the buffer.
      */
@@ -220,7 +228,7 @@ public class BufferingChunkedInput implements PackInput
                         {
                             //Now we have enough space to read the rest of the chunk size
                             byte partialChunkSize = ctx.buffer.get();
-                            ctx.remainingChunkSize = (ctx.remainingChunkSize | partialChunkSize) & 0xFFFF;
+                            ctx.remainingChunkSize = ctx.remainingChunkSize | (partialChunkSize & 0xFF);
                             return IN_CHUNK;
                         }
                         else

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -96,6 +96,7 @@ public class BufferingChunkedInput implements PackInput
         return remainingChunkSize;
     }
 
+
     /**
      * Internal state machine used for reading data from the channel into the buffer.
      */
@@ -126,7 +127,7 @@ public class BufferingChunkedInput implements PackInput
                         {
                             //only 1 byte in buffer, read that and continue
                             //to read header
-                            byte partialChunkSize = ctx.buffer.get();
+                            int partialChunkSize = getUnsignedByteFromBuffer( ctx.buffer );
                             ctx.remainingChunkSize = partialChunkSize << 8;
                             return IN_HEADER.readChunkSize( ctx );
                         }
@@ -390,6 +391,12 @@ public class BufferingChunkedInput implements PackInput
         state = state.peekByte( this );
         return buffer.get( buffer.position() );
     }
+
+    static int getUnsignedByteFromBuffer( ByteBuffer buffer )
+    {
+        return buffer.get() & 0xFF;
+    }
+
 
     private boolean hasMoreDataUnreadInCurrentChunk()
     {

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputTest.java
@@ -104,11 +104,33 @@ public class BufferingChunkedInputTest
         assertThat( input.readByte(), equalTo( (byte) 1 ) );
         assertThat( input.remainingChunkSize(), equalTo( packetSize - 1 ) );
 
-        for ( int i = 1; i < 384; i++ )
+        for ( int i = 1; i < packetSize; i++ )
         {
             assertThat( input.readByte(), equalTo( (byte) 1 ) );
         }
         assertThat( input.remainingChunkSize(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void shouldReadChunkWithSplitHeaderForBigMessagesWhenInternalBufferHasOneByte() throws IOException
+    {
+        // Given
+        int packetSize = 32780;
+        BufferingChunkedInput input =
+                new BufferingChunkedInput( packets( packet( -128 ), packet( 12 ), fillPacket( packetSize, 1 ) ), 1);
+
+        // Then
+        assertThat( input.readByte(), equalTo( (byte) 1 ) );
+        assertThat( input.remainingChunkSize(), equalTo( packetSize - 1 ) );
+    }
+
+    @Test
+    public void shouldReadUnsignedByteFromBuffer() throws IOException
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( 1 );
+        buffer.put( (byte) -1 );
+        buffer.flip();
+        assertThat(BufferingChunkedInput.getUnsignedByteFromBuffer( buffer ), equalTo( 255 ));
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/ChunkedInputTest.java
@@ -18,6 +18,11 @@
  */
 package org.neo4j.driver.internal.connector.socket;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Matchers;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -25,11 +30,6 @@ import java.nio.channels.Channels;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.Matchers;
 
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.RecordingByteChannel;


### PR DESCRIPTION
For large message sizes whenever the header was split up between packets there
was a bitmasking error that calculated the chunksize wrong.
