### PR TITLE
Fix the wrong chunk header size due to clear the whole buffer by mistake

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -287,7 +287,7 @@ public class BufferingChunkedInput implements PackInput
         {
             try
             {
-                buffer.clear();
+                buffer.compact();
                 int read = channel.read( buffer );
                 if ( read == -1 )
                 {


### PR DESCRIPTION
The situation where the issue arises:

When `IN_CHUNK`,

```
if (bytesToRead < readableBytesLeftInBuffer)
{
    read readable bytes left in buffer
    clear the buffer as we read all bytes already // wrong!!!
    ...
}
```

The problem is that there could be more bytes that do not belong to readable bytes left in the buffer, such as (part of) next chunk header!!
So instead of buffer.clear, use buffer.compact would solve this issue.
Tests should be needed to accept this PR.
