### PR TITLE
Message boundary bug

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -178,7 +178,10 @@ public class BufferingChunkedInput implements PackInput
                             int bytesToRead = min( ctx.buffer.remaining(), ctx.remainingChunkSize );
                             copyBytes( ctx.buffer, ctx.scratchBuffer, bytesToRead );
                             ctx.remainingChunkSize -= bytesToRead;
-                            readNextPacket( ctx.channel, ctx.buffer );
+                            if ( !ctx.buffer.hasRemaining() )
+                            {
+                                readNextPacket( ctx.channel, ctx.buffer );
+                            }
                             return IN_CHUNK.read( ctx );
                         }
                         else
@@ -285,6 +288,8 @@ public class BufferingChunkedInput implements PackInput
          */
         private static void readNextPacket( ReadableByteChannel channel, ByteBuffer buffer ) throws IOException
         {
+            assert !buffer.hasRemaining();
+
             try
             {
                 buffer.clear();

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -97,243 +97,6 @@ public class BufferingChunkedInput implements PackInput
     }
 
 
-    /**
-     * Internal state machine used for reading data from the channel into the buffer.
-     */
-    private enum State
-    {
-        AWAITING_CHUNK
-                {
-                    @Override
-                    public State readChunkSize( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        if ( ctx.buffer.remaining() == 0 )
-                        {
-                            //buffer empty, block until you get at least at least one byte
-                            while ( ctx.buffer.remaining() == 0 )
-                            {
-                                readNextPacket( ctx.channel, ctx.buffer );
-                            }
-                            return AWAITING_CHUNK.readChunkSize( ctx );
-                        }
-                        else if ( ctx.buffer.remaining() >= 2 )
-                        {
-                            //enough space to read the whole chunk-size, store it and continue
-                            //to read the rest of the chunk
-                            ctx.remainingChunkSize = ctx.buffer.getShort() & 0xFFFF;
-                            return IN_CHUNK;
-                        }
-                        else
-                        {
-                            //only 1 byte in buffer, read that and continue
-                            //to read header
-                            int partialChunkSize = getUnsignedByteFromBuffer( ctx.buffer );
-                            ctx.remainingChunkSize = partialChunkSize << 8;
-                            return IN_HEADER.readChunkSize( ctx );
-                        }
-                    }
-
-                    @Override
-                    public State read( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        //read chunk size and then proceed to read the rest of the chunk.
-                        return readChunkSize( ctx ).read( ctx );
-                    }
-
-                    @Override
-                    public State peekByte( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        //read chunk size and then proceed to read the rest of the chunk.
-                        return readChunkSize( ctx ).peekByte( ctx );
-                    }
-                },
-        IN_CHUNK
-                {
-                    @Override
-                    public State readChunkSize( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        if ( ctx.remainingChunkSize == 0 )
-                        {
-                            //we are done reading the chunk, start reading the next one
-                            return AWAITING_CHUNK.readChunkSize( ctx );
-                        }
-                        else
-                        {
-                            //We should already have read the entire chunk size by now
-                            throw new IllegalStateException( "Chunk size has already been read" );
-                        }
-                    }
-
-                    @Override
-                    public State read( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        if ( ctx.remainingChunkSize == 0 )
-                        {
-                            //we are done reading the chunk, start reading the next one
-                            return AWAITING_CHUNK.read( ctx );
-                        }
-                        else if ( ctx.buffer.remaining() < ctx.scratchBuffer.remaining() )
-                        {
-                            //not enough room in buffer, store what is there and then fetch more data
-                            int bytesToRead = min( ctx.buffer.remaining(), ctx.remainingChunkSize );
-                            copyBytes( ctx.buffer, ctx.scratchBuffer, bytesToRead );
-                            ctx.remainingChunkSize -= bytesToRead;
-                            if ( !ctx.buffer.hasRemaining() )
-                            {
-                                readNextPacket( ctx.channel, ctx.buffer );
-                            }
-                            return IN_CHUNK.read( ctx );
-                        }
-                        else
-                        {
-                            //plenty of room in buffer, store it
-                            int bytesToRead = min( ctx.scratchBuffer.remaining(), ctx.remainingChunkSize );
-                            copyBytes( ctx.buffer, ctx.scratchBuffer, bytesToRead );
-                            ctx.remainingChunkSize -= bytesToRead;
-                            if ( ctx.scratchBuffer.remaining() == 0 )
-                            {
-                                //we have written all data that was asked for us
-                                return IN_CHUNK;
-                            }
-                            else
-                            {
-                                //Reached a msg boundary, proceed to next chunk
-                                return AWAITING_CHUNK.read( ctx );
-                            }
-                        }
-                    }
-
-                    @Override
-                    public State peekByte( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        if ( ctx.remainingChunkSize == 0 )
-                        {
-                            //we are done reading the chunk, start reading the next one
-                            return AWAITING_CHUNK.peekByte( ctx );
-                        }
-                        else if ( ctx.buffer.remaining() == 0 )
-                        {
-                            //no data in buffer, fill it up an try again
-                            readNextPacket( ctx.channel, ctx.buffer );
-                            return IN_CHUNK.peekByte( ctx );
-                        }
-                        else
-                        {
-                            return IN_CHUNK;
-                        }
-                    }
-                },
-        IN_HEADER
-                {
-                    @Override
-                    public State readChunkSize( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        if ( ctx.buffer.remaining() >= 1 )
-                        {
-                            //Now we have enough space to read the rest of the chunk size
-                            byte partialChunkSize = ctx.buffer.get();
-                            ctx.remainingChunkSize = ctx.remainingChunkSize | (partialChunkSize & 0xFF);
-                            return IN_CHUNK;
-                        }
-                        else
-                        {
-                            //Buffer is empty, fill it up and try again
-                            readNextPacket( ctx.channel, ctx.buffer );
-                            return IN_HEADER.readChunkSize( ctx );
-                        }
-                    }
-
-                    @Override
-                    public State read( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        throw new IllegalStateException( "Cannot read data while in progress of reading header" );
-                    }
-
-                    @Override
-                    public State peekByte( BufferingChunkedInput ctx ) throws IOException
-                    {
-                        throw new IllegalStateException( "Cannot read data while in progress of reading header" );
-                    }
-                };
-
-        /**
-         * Reads the size of the current incoming chunk.
-         * @param ctx A reference to the input.
-         * @return The next state.
-         * @throws IOException
-         */
-        public abstract State readChunkSize( BufferingChunkedInput ctx ) throws IOException;
-
-        /**
-         * Reads the current incoming chunk.
-         * @param ctx A reference to the input.
-         * @return The next state.
-         * @throws IOException
-         */
-        public abstract State read( BufferingChunkedInput ctx ) throws IOException;
-
-        /**
-         * Makes sure there is at least one byte in the buffer but doesn't consume it.
-         * @param ctx A reference to the input.
-         * @return The next state.
-         * @throws IOException
-         */
-        public abstract State peekByte( BufferingChunkedInput ctx ) throws IOException;
-
-        /**
-         * Read data from the underlying channel into the buffer.
-         * @param channel The channel to read from.
-         * @param buffer The buffer to read into
-         * @throws IOException
-         */
-        private static void readNextPacket( ReadableByteChannel channel, ByteBuffer buffer ) throws IOException
-        {
-            assert !buffer.hasRemaining();
-
-            try
-            {
-                buffer.clear();
-                int read = channel.read( buffer );
-                if ( read == -1 )
-                {
-                    throw new ClientException(
-                            "Connection terminated while receiving data. This can happen due to network " +
-                            "instabilities, or due to restarts of the database." );
-                }
-                buffer.flip();
-            }
-            catch ( ClosedByInterruptException e )
-            {
-                throw new ClientException(
-                        "Connection to the database was lost because someone called `interrupt()` on the driver " +
-                        "thread waiting for a reply. " +
-                        "This normally happens because the JVM is shutting down, but it can also happen because your " +
-                        "application code or some " +
-                        "framework you are using is manually interrupting the thread." );
-            }
-            catch ( IOException e )
-            {
-                String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
-                throw new ClientException(
-                        "Unable to process request: " + message + " buffer: \n" + BytePrinter.hex( buffer ), e );
-            }
-        }
-
-        /**
-         * Copy data from the buffer into the scratch buffer
-         */
-        private static void copyBytes( ByteBuffer from, ByteBuffer to, int bytesToRead )
-        {
-            //Use a temporary buffer and move over in one go
-            ByteBuffer temporaryBuffer = from.duplicate();
-            temporaryBuffer.limit( temporaryBuffer.position() + bytesToRead );
-            to.put( temporaryBuffer );
-
-            //move position so it looks like we have read from buffer
-            from.position( from.position() + bytesToRead );
-        }
-    }
-
     @Override
     public boolean hasMoreData() throws IOException
     {
@@ -393,7 +156,7 @@ public class BufferingChunkedInput implements PackInput
     @Override
     public byte peekByte() throws IOException
     {
-        state = state.peekByte( this );
+        peek();
         return buffer.get( buffer.position() );
     }
 
@@ -401,7 +164,6 @@ public class BufferingChunkedInput implements PackInput
     {
         return buffer.get() & 0xFF;
     }
-
 
     private boolean hasMoreDataUnreadInCurrentChunk()
     {
@@ -424,7 +186,7 @@ public class BufferingChunkedInput implements PackInput
             try
             {
                 // read message boundary
-                state.readChunkSize( BufferingChunkedInput.this );
+                readChunkSize( );
                 if ( remainingChunkSize != 0 )
                 {
                     throw new ClientException( "Expecting message complete ending '00 00', but got " +
@@ -457,7 +219,220 @@ public class BufferingChunkedInput implements PackInput
         assert (bytesToRead <= scratchBuffer.capacity());
         scratchBuffer.clear();
         scratchBuffer.limit( bytesToRead );
-        state = state.read( this );
+        read();
         scratchBuffer.flip();
     }
+
+    /**
+     * Internal state machine used for reading data from the channel into the buffer.
+     */
+    private enum State
+    {
+        AWAITING_CHUNK,
+        IN_CHUNK,
+        IN_HEADER,
+    }
+
+    private void read() throws IOException
+    {
+        while ( true )
+        {
+            switch ( state )
+            {
+            case AWAITING_CHUNK:
+                //read chunk size and then proceed to read the rest of the chunk.
+                readChunkSize();
+                break;
+
+            case IN_CHUNK:
+                if ( remainingChunkSize == 0 )
+                {
+                    //we are done reading the chunk, start reading the next one
+                    state = State.AWAITING_CHUNK;
+                }
+                else if ( buffer.remaining() < scratchBuffer.remaining() )
+                {
+                    //not enough room in buffer, store what is there and then fetch more data
+                    int bytesToRead = min( buffer.remaining(), remainingChunkSize );
+                    copyBytes( buffer, scratchBuffer, bytesToRead );
+                    remainingChunkSize -= bytesToRead;
+                    if ( !buffer.hasRemaining() )
+                    {
+                        readNextPacket( channel, buffer );
+                    }
+                }
+                else
+                {
+                    //plenty of room in buffer, store it
+                    int bytesToRead = min( scratchBuffer.remaining(), remainingChunkSize );
+                    copyBytes( buffer, scratchBuffer, bytesToRead );
+                    remainingChunkSize -= bytesToRead;
+                    if ( scratchBuffer.remaining() == 0 )
+                    {
+                        //we have written all data that was asked for us
+                        return;
+                    }
+                    else
+                    {
+                        //Reached a msg boundary, proceed to next chunk
+                        state = State.AWAITING_CHUNK;
+                    }
+                }
+                break;
+
+            case IN_HEADER:
+                throw new IllegalStateException( "Cannot read data while in progress of reading header" );
+            }
+        }
+    }
+
+    private void peek() throws IOException
+    {
+        while ( true )
+        {
+            switch ( state )
+            {
+            case AWAITING_CHUNK:
+                readChunkSize();
+                break;
+
+            case IN_CHUNK:
+                if ( remainingChunkSize == 0 )
+                {
+                    //we are done reading the chunk, start reading the next ones
+                    state = State.AWAITING_CHUNK;
+                }
+                else if ( buffer.remaining() == 0 )
+                {
+                    //no data in buffer, fill it up an try again
+                    readNextPacket( channel, buffer );
+                }
+                else
+                {
+                    return;
+                }
+                break;
+
+            case IN_HEADER:
+                throw new IllegalStateException( "Cannot read data while in progress of reading header" );
+            }
+        }
+    }
+
+    private void readChunkSize() throws IOException
+    {
+        while ( true )
+        {
+            switch ( state )
+            {
+            case AWAITING_CHUNK:
+                if ( buffer.remaining() == 0 )
+                {
+                    //buffer empty, block until you get at least at least one byte
+                    while ( buffer.remaining() == 0 )
+                    {
+                        readNextPacket( channel, buffer );
+                    }
+                }
+                else if ( buffer.remaining() >= 2 )
+                {
+                    //enough space to read the whole chunk-size, store it and continue
+                    //to read the rest of the chunk
+                    remainingChunkSize = buffer.getShort() & 0xFFFF;
+                    state = State.IN_CHUNK;
+                    return;
+                }
+                else
+                {
+                    //only 1 byte in buffer, read that and continue
+                    //to read header
+                    int partialChunkSize = getUnsignedByteFromBuffer( buffer );
+                    remainingChunkSize = partialChunkSize << 8;
+                    state = State.IN_HEADER;
+                }
+                break;
+            case IN_CHUNK:
+                if ( remainingChunkSize == 0 )
+                {
+                    //we are done reading the chunk, start reading the next one
+                    state = State.AWAITING_CHUNK;
+                }
+                else
+                {
+                    //We should already have read the entire chunk size by now
+                    throw new IllegalStateException( "Chunk size has already been read" );
+                }
+                break;
+            case IN_HEADER:
+                if ( buffer.remaining() >= 1 )
+                {
+                    //Now we have enough space to read the rest of the chunk size
+                    byte partialChunkSize = buffer.get();
+                    remainingChunkSize = remainingChunkSize | (partialChunkSize & 0xFF);
+                    state = State.IN_CHUNK;
+                    return;
+                }
+                else
+                {
+                    //Buffer is empty, fill it up and try again
+                    readNextPacket( channel, buffer );
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Read data from the underlying channel into the buffer.
+     * @param channel The channel to read from.
+     * @param buffer The buffer to read into
+     * @throws IOException
+     */
+    private static void readNextPacket( ReadableByteChannel channel, ByteBuffer buffer ) throws IOException
+    {
+        assert !buffer.hasRemaining();
+
+        try
+        {
+            buffer.clear();
+            int read = channel.read( buffer );
+            if ( read == -1 )
+            {
+                throw new ClientException(
+                        "Connection terminated while receiving data. This can happen due to network " +
+                        "instabilities, or due to restarts of the database." );
+            }
+            buffer.flip();
+        }
+        catch ( ClosedByInterruptException e )
+        {
+            throw new ClientException(
+                    "Connection to the database was lost because someone called `interrupt()` on the driver " +
+                    "thread waiting for a reply. " +
+                    "This normally happens because the JVM is shutting down, but it can also happen because your " +
+                    "application code or some " +
+                    "framework you are using is manually interrupting the thread." );
+        }
+        catch ( IOException e )
+        {
+            String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            throw new ClientException(
+                    "Unable to process request: " + message + " buffer: \n" + BytePrinter.hex( buffer ), e );
+        }
+    }
+
+    /**
+     * Copy data from the buffer into the scratch buffer
+     */
+    private static void copyBytes( ByteBuffer from, ByteBuffer to, int bytesToRead )
+    {
+        //Use a temporary buffer and move over in one go
+        ByteBuffer temporaryBuffer = from.duplicate();
+        temporaryBuffer.limit( temporaryBuffer.position() + bytesToRead );
+        to.put( temporaryBuffer );
+
+        //move position so it looks like we have read from buffer
+        from.position( from.position() + bytesToRead );
+    }
+
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputExhaustiveTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputExhaustiveTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.connector.socket;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BufferingChunkedInputExhaustiveTest
+{
+
+    @Test
+    public void shouldHandleAllMessageBoundaries() throws IOException
+    {
+        byte[] expected = new byte[256];
+        for ( int i = 0; i < 256; i++ )
+        {
+            expected[i] = (byte) (Byte.MIN_VALUE + i);
+        }
+
+        for ( int i = 0; i < 256; i++ )
+        {
+            BufferingChunkedInput input = new BufferingChunkedInput( splitChannel( expected, i ) );
+            byte[] dst = new byte[256];
+            input.readBytes( dst, 0, dst.length );
+
+            assertThat( dst, equalTo( expected ) );
+        }
+    }
+
+
+    ReadableByteChannel splitChannel( byte[] bytes, int split )
+    {
+        assert split >= 0 && split < bytes.length;
+        assert split <= Short.MAX_VALUE;
+        assert bytes.length <= Short.MAX_VALUE;
+
+        return packets( channel( bytes, 0, split ), channel( bytes, split, bytes.length ) );
+    }
+
+    ReadableByteChannel channel( byte[] bytes, int from, int to )
+    {
+        int size = to - from;
+        ByteBuffer packet = ByteBuffer.allocate( 4 + size );
+        packet.put( (byte) ((size >> 8) & 0xFF) );
+        packet.put( (byte) (size & 0xFF) );
+        for ( int i = from; i < to; i++ )
+        {
+            packet.put( bytes[i] );
+        }
+        packet.put( (byte) 0 );
+        packet.put( (byte) 0 );
+        packet.flip();
+
+        return asChannel( packet );
+    }
+
+    private ReadableByteChannel packets( final ReadableByteChannel... channels )
+    {
+
+        return new ReadableByteChannel()
+        {
+            private int index = 0;
+
+            @Override
+            public int read( ByteBuffer dst ) throws IOException
+            {
+                return channels[index++].read( dst );
+            }
+
+            @Override
+            public boolean isOpen()
+            {
+                return false;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+
+            }
+        };
+    }
+
+    private ReadableByteChannel asChannel( final ByteBuffer buffer )
+    {
+        return new ReadableByteChannel()
+        {
+            @Override
+            public int read( ByteBuffer dst ) throws IOException
+            {
+                int len = Math.min( dst.remaining(), buffer.remaining() );
+                for ( int i = 0; i < len; i++ )
+                {
+                    dst.put( buffer.get() );
+                }
+                return len;
+
+            }
+
+            @Override
+            public boolean isOpen()
+            {
+                return true;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+
+            }
+        };
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
@@ -55,7 +55,7 @@ public class BufferingChunkedInputFuzzTest
     public void messageSizeFuzzTest() throws IOException
     {
         int maxSize = 1 << 16;
-        Random random = new Random(11);
+        Random random = new Random();
         for ( int i = 0; i < 1000; i++)
         {
             int size = random.nextInt( maxSize  + 1);

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
@@ -23,11 +23,13 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Arrays;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class BufferingChunkedInputExhaustiveTest
+public class BufferingChunkedInputFuzzTest
 {
 
     @Test
@@ -49,6 +51,24 @@ public class BufferingChunkedInputExhaustiveTest
         }
     }
 
+    @Test
+    public void messageSizeFuzzTest() throws IOException
+    {
+        int maxSize = 1 << 16;
+        Random random = new Random();
+        for ( int i = 0; i < 1000; i++)
+        {
+            int size = random.nextInt( maxSize  + 1);
+            byte[] expected = new byte[size];
+            Arrays.fill(expected, (byte)42);
+            BufferingChunkedInput input = new BufferingChunkedInput( channel( expected, 0, size ) );
+
+            byte[] dst = new byte[size];
+            input.readBytes( dst, 0, size);
+
+            assertThat( dst, equalTo( expected ) );
+        }
+    }
 
     ReadableByteChannel splitChannel( byte[] bytes, int split )
     {

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputFuzzTest.java
@@ -55,7 +55,7 @@ public class BufferingChunkedInputFuzzTest
     public void messageSizeFuzzTest() throws IOException
     {
         int maxSize = 1 << 16;
-        Random random = new Random();
+        Random random = new Random(11);
         for ( int i = 0; i < 1000; i++)
         {
             int size = random.nextInt( maxSize  + 1);

--- a/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInputTest.java
@@ -93,6 +93,21 @@ public class BufferingChunkedInputTest
     }
 
     @Test
+    public void shouldReadBytesAcrossHeaders() throws IOException
+    {
+        // Given
+        BufferingChunkedInput input =
+                new BufferingChunkedInput( packets( packet( 0, 2, 1, 2, 0, 6), packet(3, 4, 5, 6, 7, 8, 0, 0 ) ) );
+
+        // When
+        byte[] dst = new byte[8];
+        input.readBytes(dst, 0, 8);
+
+        // Then
+        assertThat( dst, equalTo( new byte[]{1, 2, 3, 4, 5, 6, 7, 8} ) );
+    }
+
+    @Test
     public void shouldReadChunkWithSplitHeaderForBigMessages() throws IOException
     {
         // Given


### PR DESCRIPTION
When the last byte in the buffer is the next chunk size we should not fetch more data until that byte is also consumed. First commit fixes the actual issue whereas the second two handles other feedback.
- Do not delegate in the state machine since it might lead to stack overflow errors
- Better handling in `readBytes` for large messages

Note that this PR addresses the same issue https://github.com/neo4j/neo4j-java-driver/pull/169
