### PR TITLE
Avoid marking objects as both live and disposed

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/pool/ThreadCachingPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/pool/ThreadCachingPoolTest.java
@@ -18,17 +18,24 @@
  */
 package org.neo4j.driver.internal.pool;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumer;
@@ -36,15 +43,20 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ThreadCachingPoolTest
 {
     private final List<PooledObject> inUse = new LinkedList<>();
     private final List<PooledObject> inPool = new LinkedList<>();
     private final List<PooledObject> disposed = new LinkedList<>();
-
+    private final MethodHandle liveQueueGet = queueGetter( "live" );
+    private final MethodHandle disposedQueueGet = queueGetter( "disposed" );
+    private final ExecutorService executor = Executors.newFixedThreadPool( 10 );
     private static AtomicInteger IDGEN = new AtomicInteger();
 
     @Rule
@@ -127,7 +139,7 @@ public class ThreadCachingPoolTest
     {
         // Given
         ThreadCachingPool<PooledObject>
-                pool = new ThreadCachingPool<>( 4, trackAllocator, invalidIfIdIs(0), Clock.SYSTEM );
+                pool = new ThreadCachingPool<>( 4, trackAllocator, invalidIfIdIs( 0 ), Clock.SYSTEM );
 
         // And given we've allocated/releasd object with id 0 once (no validation on first allocation)
         // TODO: Is that the right thing to do? I assume the allocator will allocate healthy objects..
@@ -137,8 +149,8 @@ public class ThreadCachingPoolTest
         pool.acquire( 10, TimeUnit.SECONDS );
 
         // Then object with id 0 should've been disposed of, and we should have one live object with id 1
-        assertThat( inPool,   equalTo( none() ) );
-        assertThat( inUse,    equalTo( items( 1 ) ) );
+        assertThat( inPool, equalTo( none() ) );
+        assertThat( inUse, equalTo( items( 1 ) ) );
         assertThat( disposed, equalTo( items( 0 ) ) );
     }
 
@@ -171,8 +183,8 @@ public class ThreadCachingPoolTest
         val.invalidate().release();
 
         // Then
-        assertThat( inPool,   equalTo( none() ) );
-        assertThat( inUse,    equalTo( none() ) );
+        assertThat( inPool, equalTo( none() ) );
+        assertThat( inUse, equalTo( none() ) );
         assertThat( disposed, equalTo( items( val ) ) );
     }
 
@@ -191,9 +203,9 @@ public class ThreadCachingPoolTest
             try
             {
                 pool.acquire( 10, TimeUnit.SECONDS );
-                fail("Should not succeed at allocating any item here.");
+                fail( "Should not succeed at allocating any item here." );
             }
-            catch( ClientException e )
+            catch ( ClientException e )
             {
                 // Expected
             }
@@ -207,8 +219,8 @@ public class ThreadCachingPoolTest
         {
             pool.acquire( 10, TimeUnit.SECONDS );
         }
-        assertThat( inPool,   equalTo( none() ) );
-        assertThat( inUse,    equalTo( items( 0, 1, 2, 3 ) ) );
+        assertThat( inPool, equalTo( none() ) );
+        assertThat( inUse, equalTo( items( 0, 1, 2, 3 ) ) );
         assertThat( disposed, equalTo( none() ) ); // because allocation fails, onDispose is not called
     }
 
@@ -256,10 +268,88 @@ public class ThreadCachingPoolTest
         assertThat( inPool, equalTo( none() ) );
         assertThat( inUse, equalTo( items( 2, 3 ) ) );
         // only the first two items value onDispose called, since allocation fails after that
-        assertThat( disposed, equalTo( items( 0, 1) ) );
+        assertThat( disposed, equalTo( items( 0, 1 ) ) );
     }
 
-    private List<PooledObject> items( int ... objects )
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldNotHaveReferenceAsBothLiveAndDisposed() throws Throwable
+    {
+        // Given
+        final ThreadCachingPool<PooledObject>
+                pool = new ThreadCachingPool<>( 4, trackAllocator, checkInvalidateFlag, Clock.SYSTEM );
+
+        // This object will be cached in ThreadLocal
+        final PooledObject obj1 = pool.acquire( 10, TimeUnit.SECONDS );
+
+        //This will add another object to the live queue
+        assertTrue( acquireInSeparateThread( pool ) );
+
+        //Now we release the first object, meaning that it will be added
+        //to the live queue (as well as being cached as ThreadLocal in this thread)
+        obj1.release();
+        //Now we invalidate the object
+        obj1.invalidate();
+
+        // When
+        //Now the cached object is invalidated, we should now pick the object
+        //from the live objects created in the background thread
+        PooledObject obj2 = pool.acquire( 10, TimeUnit.SECONDS );
+
+        //THEN
+        assertThat( obj1.id, equalTo( 0 ) );
+        assertThat( obj2.id, equalTo( 1 ) );
+        BlockingQueue<Slot<PooledObject>> liveQueue = (BlockingQueue<Slot<PooledObject>>) liveQueueGet.invoke( pool );
+        BlockingQueue<Slot<PooledObject>> disposedQueue =
+                (BlockingQueue<Slot<PooledObject>>) disposedQueueGet.invoke( pool );
+
+        assertThat( disposedQueue, empty() );
+        assertThat( liveQueue, hasSize( 1 ) );
+        assertThat( liveQueue.poll( 10, TimeUnit.SECONDS ).value.id, equalTo( 0 ) );
+    }
+
+    private boolean acquireInSeparateThread( final ThreadCachingPool<PooledObject> pool ) throws InterruptedException
+    {
+        final AtomicBoolean succeeded = new AtomicBoolean( true );
+        executor.execute( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    PooledObject obj = pool.acquire( 10, TimeUnit.MINUTES );
+                    obj.release();
+                }
+                catch ( InterruptedException e )
+                {
+                    succeeded.set( false );
+                }
+            }
+        } );
+        executor.awaitTermination( 2, TimeUnit.SECONDS );
+        return succeeded.get();
+    }
+
+
+    //This is terrible hack, but I really want to keep the queues private in
+    //ThreadCachingPool
+    private static MethodHandle queueGetter( String name )
+    {
+        try
+        {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            Field value = ThreadCachingPool.class.getDeclaredField( name );
+            value.setAccessible( true );
+            return lookup.unreflectGetter( value );
+        }
+        catch ( NoSuchFieldException | IllegalAccessException e )
+        {
+            throw new AssertionError( e );
+        }
+    }
+
+    private List<PooledObject> items( int... objects )
     {
         List<PooledObject> out = new LinkedList<>();
         for ( int id : objects )
@@ -269,9 +359,9 @@ public class ThreadCachingPoolTest
         return out;
     }
 
-    private List<PooledObject> items( PooledObject ... objects )
+    private List<PooledObject> items( PooledObject... objects )
     {
-        return Arrays.asList(objects);
+        return Arrays.asList( objects );
     }
 
     private List<PooledObject> none()
@@ -305,7 +395,7 @@ public class ThreadCachingPoolTest
 
         public PooledObject( Consumer<PooledObject> release )
         {
-            this(IDGEN.getAndIncrement(), release);
+            this( IDGEN.getAndIncrement(), release );
         }
 
         public PooledObject( int id, Consumer<PooledObject> release )
@@ -362,7 +452,7 @@ public class ThreadCachingPoolTest
         @Override
         public PooledObject allocate( Consumer<PooledObject> release )
         {
-            if( creationException != null )
+            if ( creationException != null )
             {
                 throw creationException;
             }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.stress;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.util.TestNeo4j;
+
+import static java.util.Arrays.asList;
+import static org.neo4j.driver.v1.GraphDatabase.driver;
+
+public class SessionPoolingStressIT
+{
+    @Rule
+    public TestNeo4j neo4j = new TestNeo4j();
+
+    private static final int N_THREADS = 10;
+    private final ExecutorService executor = Executors.newFixedThreadPool( N_THREADS );
+    private static final List<String> QUERIES = asList( "RETURN 1295 + 42", "UNWIND range(1,10000) AS x CREATE (n {prop:x}) DELETE n " );
+    private static final int MAX_TIME = 10000;
+    private final AtomicBoolean hasFailed = new AtomicBoolean( false );
+
+
+    @Test
+    public void shouldWorkFine() throws InterruptedException
+    {
+        Driver driver = driver( neo4j.address(),
+                Config.build()
+                        .withEncryptionLevel( Config.EncryptionLevel.NONE )
+                        .withMaxSessions( N_THREADS + 1 ).toConfig() );
+
+        doWork( driver );
+        executor.awaitTermination( MAX_TIME + (int)(MAX_TIME * 0.2), TimeUnit.MILLISECONDS );
+    }
+
+    private void doWork( final Driver driver )
+    {
+        for ( int i = 0; i < N_THREADS; i++ )
+        {
+            executor.execute( new Worker( driver ) );
+        }
+    }
+
+    private class Worker implements Runnable
+    {
+        private final Random random = ThreadLocalRandom.current();
+        private final Driver driver;
+
+        public Worker( Driver driver )
+        {
+            this.driver = driver;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                long deadline = System.currentTimeMillis() + MAX_TIME;
+                for (;;)
+                {
+                    for ( String query : QUERIES )
+                    {
+                        runQuery( query );
+                    }
+                    long left = deadline - System.currentTimeMillis();
+                    if ( left <= 0 )
+                    {
+                        break;
+                    }
+                }
+            }
+            catch ( Throwable e )
+            {
+                e.printStackTrace();
+                hasFailed.set( true );
+            }
+        }
+
+        private void runQuery( String query ) throws InterruptedException
+        {
+            try ( Session session = driver.session() )
+            {
+                StatementResult run = session.run( query );
+                Thread.sleep( random.nextInt( 100 ) );
+                run.consume();
+                Thread.sleep( random.nextInt( 100 ) );
+            }
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/ThreadCachingPoolStressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/ThreadCachingPoolStressTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.stress;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.driver.internal.pool.Allocator;
+import org.neo4j.driver.internal.pool.ThreadCachingPool;
+import org.neo4j.driver.internal.pool.ValidationStrategy;
+import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+
+import static org.junit.Assert.assertFalse;
+
+public class ThreadCachingPoolStressTest
+{
+    private static final int WORKER_THREADS = 10;
+    public static final long TOTAL_MAX_TIME = 10000L;
+    private final ExecutorService executor = Executors.newFixedThreadPool( WORKER_THREADS );
+    private final AtomicBoolean hasFailed = new AtomicBoolean( false );
+
+    @Test
+    public void shouldWorkFine() throws InterruptedException
+    {
+        // Given
+        ThreadCachingPool<PooledObject>
+                pool =
+                new ThreadCachingPool<>( WORKER_THREADS, new TestAllocator(), checkInvalidateFlag, Clock.SYSTEM );
+        // When
+        doStuffInTheBackground( pool );
+        executor.awaitTermination( TOTAL_MAX_TIME, TimeUnit.MILLISECONDS );
+        // Then
+
+        assertFalse( hasFailed.get() );
+    }
+
+    private void doStuffInTheBackground( final ThreadCachingPool<PooledObject> pool )
+    {
+        for ( int i = 0; i < WORKER_THREADS; i++ )
+        {
+            executor.execute( new Worker( pool ) );
+        }
+    }
+
+    private class PooledObject
+    {
+        private boolean valid = true;
+        private final Consumer<PooledObject> release;
+
+        private PooledObject( Consumer<PooledObject> release )
+        {
+            this.release = release;
+        }
+
+        void close()
+        {
+            release.accept( this );
+        }
+
+        public void invalidate()
+        {
+            this.valid = false;
+        }
+    }
+
+    private class TestAllocator implements Allocator<PooledObject>
+    {
+
+        @Override
+        public PooledObject allocate( Consumer<PooledObject> release ) throws Neo4jException
+        {
+            return new PooledObject( release );
+        }
+
+        @Override
+        public void onDispose( PooledObject o )
+        {
+
+        }
+
+        @Override
+        public void onAcquire( PooledObject o )
+        {
+
+        }
+    }
+
+    private final ValidationStrategy<PooledObject> checkInvalidateFlag = new ValidationStrategy<PooledObject>()
+    {
+        @Override
+        public boolean isValid( PooledObject value, long idleTime )
+        {
+            return value.valid;
+        }
+    };
+
+    private class Worker implements Runnable
+    {
+        private final ThreadLocalRandom random;
+        private final double probabilityToRelease;
+        private final double probabilityToInvalidate;
+        private final ThreadCachingPool<PooledObject> pool;
+        private final long timeToRun;
+
+        public Worker( ThreadCachingPool<PooledObject> pool )
+        {
+            this.pool = pool;
+            this.random = ThreadLocalRandom.current();
+            this.probabilityToRelease = 0.5;
+            this.probabilityToInvalidate = 0.5;
+            this.timeToRun = random.nextLong( TOTAL_MAX_TIME );
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                long deadline = timeToRun + System.currentTimeMillis();
+                for (; ; )
+                {
+                    PooledObject object = pool.acquire( random.nextInt( 1 ), TimeUnit.SECONDS );
+                    if ( object != null )
+                    {
+
+
+                        Thread.sleep( random.nextInt( 100 ) );
+                        object.close();
+                        if ( random.nextDouble() < probabilityToInvalidate )
+                        {
+                            Thread.sleep( random.nextInt( 100 ) );
+                            object.invalidate();
+                        }
+                    }
+                    Thread.sleep( random.nextInt( 100 ) );
+
+                    long timeLeft = deadline - System.currentTimeMillis();
+                    if ( timeLeft <= 0 )
+                    {
+                        break;
+                    }
+                }
+            }
+            catch ( Throwable e )
+            {
+                e.printStackTrace();
+                hasFailed.set( true );
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the `ThreadCachingPool` whenever an object is picked from the
`ThreadLocal` we cannot add it to the `disposed` queue directly since the
object will already be present in the `live` queue (or will be on release). Doing
that means that the object will be present both in the  `live` and `disposed`
queue and also means that on reallocation we can multiple copies of the same
reference and can lead to that the `live` queue blows up in size.
