### PR TITLE
fix JavaDoc in StatementResult to reference Records instead of Values

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResult.java
@@ -122,8 +122,7 @@ public interface StatementResult extends Iterator<Record>
      *
      * Calling this method exhausts the result.
      *
-     * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
-     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param mapFunction a function to map from Record to T. See {@link Records} for some predefined functions.
      * @param <T> the type of result list elements
      * @return list of all mapped remaining immutable records
      */


### PR DESCRIPTION
The JavaDoc for StatementResult.list(Function<Record,T>) currently references the "Values" class for its parameter mapFunction. Since that parameter is for a Function from Record to T, it should mention "Records" instead.

That JavaDoc confused me while using the method, and it took a while to find the Records-class. Using Records, one could use "Values", as in `statementResult.list(Records.column("n", Values.ofNode()))`, but at least "Records" should be mentioned in the original JavaDoc.
