### PR TITLE
Send INIT eagerly

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketConnection.java
@@ -67,6 +67,7 @@ public class SocketConnection implements Connection
     public void init( String clientName, Map<String,Value> authToken )
     {
         queueMessage( new InitMessage( clientName, authToken ), StreamCollector.NO_OP );
+        sync();
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -74,15 +74,12 @@ public class CredentialsIT
         String password = "secret";
         enableAuth( password );
 
-        Driver driver = GraphDatabase.driver( neo4j.address(), basic("thisisnotthepassword", password ) );
-        Session session = driver.session();
-
         // Expect
         exception.expect( ClientException.class );
         exception.expectMessage( "The client is unauthorized due to authentication failure." );
 
         // When
-        session.run( "RETURN 1" ).single().get(0);
+        GraphDatabase.driver( neo4j.address(), basic("thisisnotthepassword", password ) ).session();
     }
 
     private void enableAuth( String password ) throws Exception


### PR DESCRIPTION
There is no benefit of queuing the INIT message and it makes error handling
trickier.
