### PR TITLE
Make sessioin.reset thread-safe

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -170,7 +170,7 @@ class ExplicitTransaction implements Transaction
     }
 
     @Override
-    public StatementResult run( Statement statement )
+    public synchronized StatementResult run( Statement statement )
     {
         ensureNotFailed();
 
@@ -217,7 +217,7 @@ class ExplicitTransaction implements Transaction
         return InternalTypeSystem.TYPE_SYSTEM;
     }
 
-    public void markToClose()
+    public synchronized void markToClose()
     {
         state = State.FAILED;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -59,7 +59,6 @@ public class NetworkSession implements Session
 
     private ExplicitTransaction currentTransaction;
     private AtomicBoolean isOpen = new AtomicBoolean( true );
-    private AtomicBoolean markedToClose = new AtomicBoolean( false );
 
     NetworkSession( Connection connection, Logger logger )
     {
@@ -106,19 +105,17 @@ public class NetworkSession implements Session
 
     public void reset()
     {
+        ensureSessionIsOpen();
         ensureNoUnrecoverableError();
         ensureConnectionIsOpen();
 
-        if( markedToClose.compareAndSet( false, true ) )
-        {
-            connection.resetAsync();
-        }
+        connection.resetAsync();
     }
 
     @Override
     public boolean isOpen()
     {
-        return isOpen.get() && !markedToClose.get();
+        return isOpen.get();
     }
 
     @Override
@@ -206,6 +203,7 @@ public class NetworkSession implements Session
 
     private void ensureConnectionIsValidBeforeRunningSession()
     {
+        ensureSessionIsOpen();
         ensureNoUnrecoverableError();
         ensureNoOpenTransactionBeforeRunningSession();
         ensureConnectionIsOpen();
@@ -213,6 +211,7 @@ public class NetworkSession implements Session
 
     private void ensureConnectionIsValidBeforeOpeningTransaction()
     {
+        ensureSessionIsOpen();
         ensureNoUnrecoverableError();
         ensureNoOpenTransactionBeforeOpeningTransaction();
         ensureConnectionIsOpen();

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -109,6 +109,10 @@ public class NetworkSession implements Session
         ensureNoUnrecoverableError();
         ensureConnectionIsOpen();
 
+        if( currentTransaction != null )
+        {
+            currentTransaction.markToClose();
+        }
         connection.resetAsync();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -113,7 +113,7 @@ public class SocketConnection implements Connection
     }
 
     @Override
-    public void flush()
+    public synchronized void flush()
     {
         try
         {
@@ -180,7 +180,7 @@ public class SocketConnection implements Connection
         }
     }
 
-    private void queueMessage( Message msg, Collector collector )
+    private synchronized void queueMessage( Message msg, Collector collector )
     {
         pendingMessages.add( msg );
         responseHandler.appendResultCollector( collector );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.driver.internal.net;
 
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.neo4j.driver.internal.messaging.MessageHandler;
 import org.neo4j.driver.internal.spi.Collector;
@@ -39,7 +39,7 @@ import org.neo4j.driver.v1.util.Function;
 
 public class SocketResponseHandler implements MessageHandler
 {
-    private final Queue<Collector> collectors = new LinkedList<>();
+    private final Queue<Collector> collectors = new ConcurrentLinkedQueue<>();
 
     /** If a failure occurs, the error gets stored here */
     private Neo4jException error;

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -105,7 +105,8 @@ public class SessionIT
         final int killTimeout = 1; // 1s
         long startTime = -1, endTime;
 
-        try( final Session session = driver.session() )
+        final Session session = driver.session();
+        try
         {
             StatementResult result =
                     session.run( "CALL test.driver.longRunningStatement({seconds})",
@@ -123,12 +124,17 @@ public class SessionIT
         {
             endTime = System.currentTimeMillis();
             assertTrue( startTime > 0 );
-            assertTrue( endTime - startTime > killTimeout * 1000 ); // get killed by session.kill
+            assertTrue( endTime - startTime > killTimeout * 1000 ); // get reset by session.reset
             assertTrue( endTime - startTime < executionTimeout * 1000 / 2 ); // finished before execution finished
+            assertFalse( session.isOpen() );
         }
         catch ( Exception e )
         {
             fail( "Should be a Neo4jException" );
+        }
+        finally
+        {
+            session.close();
         }
     }
 
@@ -168,7 +174,7 @@ public class SessionIT
             assertThat( recordCount, greaterThan(1) );
 
             assertTrue( startTime > 0 );
-            assertTrue( endTime - startTime > killTimeout * 1000 ); // get killed by session.kill
+            assertTrue( endTime - startTime > killTimeout * 1000 ); // get reset by session.reset
             assertTrue( endTime - startTime < executionTimeout * 1000 / 2 ); // finished before execution finished
         }
     }
@@ -190,7 +196,7 @@ public class SessionIT
                 }
                 finally
                 {
-                    session.reset(); // kill the session after timeout
+                    session.reset(); // reset the session after timeout
                 }
             }
         } ).start();


### PR DESCRIPTION
- Sync on `enqueue` and `flush` to avoid sending `reset` and other messages at the same time. 
- Also changed response handler stream collector queue to be concurrent queue so that adding into the queue (sending) and removing from the queue (receiving) can be done safely concurrently.
- Keep `ack_fail` muted when `reset` is already send but not replied yet.
- Sync on `tx.markToClose` and `tx.run` to enforce no more statement in the current tx, if tx is already failed (reset).
