### PR TITLE
Adding new API for accessing records and mapped values with a default value

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
@@ -25,6 +25,7 @@ import java.util.NoSuchElementException;
 
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.value.InternalValue;
+import org.neo4j.driver.internal.types.InternalMapAccessorWithDefaultValue;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
@@ -36,7 +37,7 @@ import static org.neo4j.driver.internal.util.Format.formatPairs;
 import static org.neo4j.driver.v1.Values.ofObject;
 import static org.neo4j.driver.v1.Values.ofValue;
 
-public class InternalRecord implements Record
+public class InternalRecord extends InternalMapAccessorWithDefaultValue implements Record
 {
     private final List<String> keys;
     private final Value[] values;

--- a/driver/src/main/java/org/neo4j/driver/internal/types/InternalMapAccessorWithDefaultValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/types/InternalMapAccessorWithDefaultValue.java
@@ -1,0 +1,344 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.types;
+
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.internal.AsValue;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.types.Entity;
+import org.neo4j.driver.v1.types.MapAccessorWithDefaultValue;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Relationship;
+import org.neo4j.driver.v1.util.Function;
+
+public abstract class InternalMapAccessorWithDefaultValue implements MapAccessorWithDefaultValue
+{
+    public abstract Value get( String key );
+
+    @Override
+    public Value get( String key, Value defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Value get( Value value, Value defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return ((AsValue) value).asValue();
+        }
+    }
+
+    @Override
+    public Object get( String key, Object defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Object get(Value value, Object defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asObject();
+        }
+    }
+
+    @Override
+    public Number get( String key, Number defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Number get( Value value, Number defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asNumber();
+        }
+    }
+
+    @Override
+    public Entity get( String key, Entity defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Entity get( Value value, Entity defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asEntity();
+        }
+    }
+
+    @Override
+    public Node get( String key, Node defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Node get( Value value, Node defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asNode();
+        }
+    }
+
+    @Override
+    public Path get( String key, Path defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Path get( Value value, Path defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asPath();
+        }
+    }
+
+    @Override
+    public Relationship get( String key, Relationship defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Relationship get( Value value, Relationship defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asRelationship();
+        }
+    }
+
+    @Override
+    public List<Object> get( String key, List<Object> defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private List<Object> get( Value value, List<Object> defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return  value.asList();
+        }
+    }
+
+    @Override
+    public  <T> List<T> get( String key, List<T> defaultValue, Function<Value,T> mapFunc )
+    {
+        return get( get( key ), defaultValue, mapFunc );
+    }
+
+    private <T> List<T> get( Value value, List<T> defaultValue, Function<Value, T> mapFunc )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asList( mapFunc );
+        }
+    }
+
+    @Override
+    public Map<String, Object> get( String key, Map<String,Object> defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private Map<String, Object> get( Value value, Map<String, Object> defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asMap();
+        }
+    }
+
+    @Override
+    public <T> Map<String, T> get( String key, Map<String,T> defaultValue, Function<Value,T> mapFunc )
+    {
+        return get( get( key ), defaultValue, mapFunc );
+    }
+
+    private <T>Map<String, T> get( Value value, Map<String, T> defaultValue, Function<Value, T> mapFunc )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asMap( mapFunc );
+        }
+    }
+
+    @Override
+    public int get( String key, int defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private int get( Value value, int defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asInt();
+        }
+    }
+
+    @Override
+    public long get( String key, long defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private long get( Value value, long defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asLong();
+        }
+    }
+
+    @Override
+    public boolean get( String key, boolean defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private boolean get( Value value, boolean defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asBoolean();
+        }
+    }
+
+    @Override
+    public String get( String key, String defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private String get( Value value, String defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asString();
+        }
+    }
+
+    @Override
+    public float get( String key, float defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private float get( Value value, float defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asFloat();
+        }
+    }
+
+    @Override
+    public double get( String key, double defaultValue )
+    {
+        return get( get( key ), defaultValue );
+    }
+
+    private double get( Value value, double defaultValue )
+    {
+        if( value.equals( Values.NULL ) )
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return value.asDouble();
+        }
+    }
+
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.value;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.internal.types.InternalMapAccessorWithDefaultValue;
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.internal.types.TypeRepresentation;
 import org.neo4j.driver.v1.Value;
@@ -40,7 +41,7 @@ import static org.neo4j.driver.internal.value.InternalValue.Format.VALUE_ONLY;
 import static org.neo4j.driver.v1.Values.ofValue;
 import static org.neo4j.driver.v1.Values.ofObject;
 
-public abstract class ValueAdapter implements InternalValue
+public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue implements InternalValue
 {
     @Override
     public Value asValue()

--- a/driver/src/main/java/org/neo4j/driver/v1/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Record.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
+import org.neo4j.driver.v1.types.MapAccessorWithDefaultValue;
 import org.neo4j.driver.v1.util.Function;
 import org.neo4j.driver.v1.util.Immutable;
 import org.neo4j.driver.v1.util.Pair;
@@ -39,7 +40,7 @@ import org.neo4j.driver.v1.util.Pair;
  * @since 1.0
  */
 @Immutable
-public interface Record
+public interface Record extends MapAccessorWithDefaultValue
 {
     /**
      * Retrieve the keys of the underlying map

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.v1.exceptions.value.LossyCoercion;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 import org.neo4j.driver.v1.types.Entity;
 import org.neo4j.driver.v1.types.MapAccessor;
+import org.neo4j.driver.v1.types.MapAccessorWithDefaultValue;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
@@ -86,7 +87,7 @@ import org.neo4j.driver.v1.util.Immutable;
  * @since 1.0
  */
 @Immutable
-public interface Value extends MapAccessor
+public interface Value extends MapAccessor, MapAccessorWithDefaultValue
 {
     /**
      * If the underlying value is a collection type, return the number of values in the collection.

--- a/driver/src/main/java/org/neo4j/driver/v1/types/MapAccessorWithDefaultValue.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/types/MapAccessorWithDefaultValue.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.types;
+
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.util.Function;
+
+/**
+ * Provides methods to access the value of an underlying unordered map by key.
+ * When calling the methods, a user need to provides a default value, which will be given back if no match found by
+ * the key provided.
+ * The default value also servers the purpose of specifying the return type of the value found in map by key.
+ * If the type of the value found A differs from the type of the default value B, a cast from A to B would happen
+ * automatically. Note: Error might arise if the cast from A to B is not possible.
+ */
+public interface MapAccessorWithDefaultValue
+{
+    /**
+     * Retrieve the value with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the value
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the value found by the key or the default value if no such key exists
+     */
+    Value get( String key, Value defaultValue );
+
+    /**
+     * Retrieve the object with the given key.
+     * If no object found by the key, then the default object provided would be returned.
+     * @param key the key of the object
+     * @param defaultValue the default object that would be returned if no object found by the key in the map
+     * @return the object found by the key or the default object if no such key exists
+     */
+    Object get( String key, Object defaultValue );
+
+    /**
+     * Retrieve the number with the given key.
+     * If no number found by the key, then the default number provided would be returned.
+     * @param key the key of the number
+     * @param defaultValue the default number that would be returned if no number found by the key in the map
+     * @return the number found by the key or the default number if no such key exists
+     */
+    Number get( String key, Number defaultValue );
+
+    /**
+     * Retrieve the entity with the given key.
+     * If no entity found by the key, then the default entity provided would be returned.
+     * @param key the key of the entity
+     * @param defaultValue the default entity that would be returned if no entity found by the key in the map
+     * @return the entity found by the key or the default entity if no such key exists
+     */
+    Entity get( String key, Entity defaultValue );
+
+    /**
+     * Retrieve the node with the given key.
+     * If no node found by the key, then the default node provided would be returned.
+     * @param key the key of the node
+     * @param defaultValue the default node that would be returned if no node found by the key in the map
+     * @return the node found by the key or the default node if no such key exists
+     */
+    Node get( String key, Node defaultValue );
+
+    /**
+     * Retrieve the path with the given key.
+     * If no path found by the key, then the default path provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default path that would be returned if no path found by the key in the map
+     * @return the path found by the key or the default path if no such key exists
+     */
+    Path get( String key, Path defaultValue );
+
+    /**
+     * Retrieve the value with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the value found by the key or the default value if no such key exists
+     */
+    Relationship get( String key, Relationship defaultValue );
+
+    /**
+     * Retrieve the list of objects with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the value
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the list of objects found by the key or the default value if no such key exists
+     */
+    List<Object> get( String key, List<Object> defaultValue );
+
+    /**
+     * Retrieve the list of objects with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the value
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the list of objects found by the key or the default value if no such key exists
+     */
+    /**
+     * Retrieve the list with the given key.
+     * If no value found by the key, then the default list provided would be returned.
+     * @param key the key of the value
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @param mapFunc the map function that defines how to map each element of the list from {@link Value} to T
+     * @param <T> the type of the elements in the returned list
+     * @return the converted list found by the key or the default list if no such key exists
+     */
+    <T> List<T> get( String key, List<T> defaultValue, Function<Value,T> mapFunc );
+
+    /**
+     * Retrieve the map with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the map found by the key or the default value if no such key exists
+     */
+    Map<String, Object> get( String key, Map<String,Object> defaultValue );
+
+    /**
+     * Retrieve the map with the given key.
+     * If no value found by the key, then the default map provided would be returned.
+     * @param key the key of the value
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @param mapFunc the map function that defines how to map each value in map from {@link Value} to T
+     * @param <T> the type of the values in the returned map
+     * @return the converted map found by the key or the default map if no such key exists.
+     */
+    <T> Map<String, T> get( String key, Map<String,T> defaultValue, Function<Value,T> mapFunc );
+
+    /**
+     * Retrieve the java integer with the given key.
+     * If no integer found by the key, then the default integer provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default integer that would be returned if no integer found by the key in the map
+     * @return the integer found by the key or the default integer if no such key exists
+     */
+    int get( String key, int defaultValue );
+
+    /**
+     * Retrieve the java long number with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the java long number found by the key or the default value if no such key exists
+     */
+    long get( String key, long defaultValue );
+
+    /**
+     * Retrieve the java boolean with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the java boolean found by the key or the default value if no such key exists
+     */
+    boolean get( String key, boolean defaultValue );
+
+    /**
+     * Retrieve the java string with the given key.
+     * If no string found by the key, then the default string provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default string that would be returned if no string found by the key in the map
+     * @return the string found by the key or the default string if no such key exists
+     */
+    String get( String key, String defaultValue );
+
+    /**
+     * Retrieve the java float number with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the java float number found by the key or the default value if no such key exists
+     */
+    float get( String key, float defaultValue );
+
+    /**
+     * Retrieve the java double number with the given key.
+     * If no value found by the key, then the default value provided would be returned.
+     * @param key the key of the property
+     * @param defaultValue the default value that would be returned if no value found by the key in the map
+     * @return the java double number found by the key or the default value if no such key exists
+     */
+    double get( String key, double defaultValue );
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.internal.value.BooleanValue;
+import org.neo4j.driver.internal.value.FloatValue;
+import org.neo4j.driver.internal.value.IntegerValue;
+import org.neo4j.driver.internal.value.ListValue;
+import org.neo4j.driver.internal.value.MapValue;
+import org.neo4j.driver.internal.value.NodeValue;
+import org.neo4j.driver.internal.value.NullValue;
+import org.neo4j.driver.internal.value.PathValue;
+import org.neo4j.driver.internal.value.RelationshipValue;
+import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.types.Entity;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Relationship;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.driver.v1.Values.ofInteger;
+import static org.neo4j.driver.v1.Values.value;
+
+public class InternalMapAccessorWithDefaultValueTest
+{
+    private static final String wrongKey = "wrong_key";
+
+    @Test
+    public void shouldGetValueFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        // Scalar Values
+        assertThat( record.get( "NullValue", NullValue.NULL ), equalTo( NullValue.NULL ) );
+        assertThat( record.get( wrongKey, NullValue.NULL ), equalTo( NullValue.NULL ) );
+
+        assertThat( record.get( "BooleanValue", BooleanValue.FALSE ), equalTo( ( Value ) BooleanValue.TRUE ) );
+        assertThat( record.get( wrongKey, BooleanValue.FALSE ), equalTo( ( Value ) BooleanValue.FALSE ) );
+
+        assertThat( record.get( "StringValue", new StringValue( "" ) ),
+                equalTo( ( Value ) new StringValue( "hello world" ) ) );
+        assertThat( record.get( wrongKey, new StringValue( "" ) ), equalTo( ( Value ) new StringValue( "" ) ) );
+
+        assertThat( record.get( "IntegerValue", new IntegerValue( -1 ) ), equalTo( ( Value ) new IntegerValue( 11 ) ) );
+        assertThat( record.get( wrongKey, new IntegerValue( -1 ) ), equalTo( ( Value ) new IntegerValue( -1 ) ) );
+
+        assertThat( record.get( "FloatValue", new FloatValue( 1.1 ) ), equalTo( ( Value ) new FloatValue( 2.2 ) ) );
+        assertThat( record.get( wrongKey, new FloatValue( 1.1 ) ), equalTo( ( Value ) new FloatValue( 1.1 ) ) );
+
+        // List
+        assertThat( record.get( "ListValue", new ListValue() ),
+                equalTo( (Value) new ListValue( new IntegerValue( 1 ), new IntegerValue( 2 ) ) ) );
+        assertThat( record.get( wrongKey, new ListValue() ), equalTo( (Value) new ListValue() ) );
+
+        // Map
+        Value defaultMapValue = new MapValue( new HashMap<String,Value>() );
+        Value realMapValue = new MapValue( createMap() );
+        assertThat( record.get( "MapValue", defaultMapValue ), equalTo( realMapValue ) );
+        assertThat( record.get( wrongKey, defaultMapValue ), equalTo( defaultMapValue ) );
+
+        // Path
+        Value defaultPathValue = new PathValue( new InternalPath(
+                new InternalNode( 0L ),
+                new InternalRelationship( 0L, 0L, 1L, "T" ),
+                new InternalNode( 1L ) ) );
+        Value realPathValue = new PathValue( createPath() );
+        assertThat( record.get( "PathValue", defaultPathValue ), equalTo( realPathValue ) );
+        assertThat( record.get( wrongKey, defaultPathValue ), equalTo( defaultPathValue ) );
+
+        // Node
+        Value defaultNodeValue = new NodeValue( new InternalNode( 0L ) );
+        Value realNodeValue = new NodeValue( createNode() );
+        assertThat( record.get( "NodeValue", defaultNodeValue ), equalTo( realNodeValue ) );
+        assertThat( record.get( wrongKey, defaultNodeValue ), equalTo( defaultNodeValue ) );
+
+        // Rel
+        Value defaultRelValue = new RelationshipValue( new InternalRelationship( 0L, 0L, 1L, "T" ) );
+        Value realRelValue = new RelationshipValue( createRel() );
+        assertThat( record.get( "RelValue", defaultRelValue ), equalTo( realRelValue ) );
+        assertThat( record.get( wrongKey, defaultRelValue ), equalTo( defaultRelValue ) );
+    }
+
+    @Test
+    public void shouldGetObjectFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        // IntegerValue.asObject returns Long
+        assertThat( record.get( "IntegerValue", (Object) 3 ), equalTo( (Object) new Long( 11 ) ) );
+        assertThat( record.get( wrongKey, (Object) 3 ), equalTo( (Object) new Integer( 3 ) ) );
+    }
+
+    @Test
+    public void shouldGetNumberFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        // IntegerValue.asNumber returns Long
+        assertThat( record.get( "IntegerValue", (Number) 3 ), equalTo( (Object) new Long( 11 ) ) );
+        assertThat( record.get( wrongKey, (Number) 3 ), equalTo( (Object) new Integer( 3 ) ) );
+    }
+
+    @Test
+    public void shouldGetEntityFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Entity defaultNodeEntity = new InternalNode( 0L );
+        assertThat( record.get( "NodeValue", defaultNodeEntity ), equalTo( (Entity) createNode() ) );
+        assertThat( record.get( wrongKey, defaultNodeEntity ), equalTo( defaultNodeEntity ) );
+
+        Entity defaultRelEntity = new InternalRelationship( 0L, 0L, 1L, "T" );
+        assertThat( record.get( "RelValue", defaultRelEntity ), equalTo( (Entity) createRel() ) );
+        assertThat( record.get( wrongKey, defaultRelEntity ), equalTo( defaultRelEntity ) );
+    }
+
+    @Test
+    public void shouldGetNodeFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Node defaultNode = new InternalNode( 0L );
+        assertThat( record.get( "NodeValue", defaultNode ), equalTo( createNode() ) );
+        assertThat( record.get( wrongKey, defaultNode ), equalTo( defaultNode ) );
+    }
+
+    @Test
+    public void shouldGetRelFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Relationship defaultRel = new InternalRelationship( 0L, 0L, 1L, "T" );
+        assertThat( record.get( "RelValue", defaultRel ), equalTo( createRel() ) );
+        assertThat( record.get( wrongKey, defaultRel ), equalTo( defaultRel ) );
+    }
+
+    @Test
+    public void shouldGetPathFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Path defaultPath = new InternalPath(
+                new InternalNode( 0L ),
+                new InternalRelationship( 0L, 0L, 1L, "T" ),
+                new InternalNode( 1L ) );
+        assertThat( record.get( "PathValue", defaultPath ), equalTo( createPath() ) );
+        assertThat( record.get( wrongKey, defaultPath ), equalTo( defaultPath ) );
+    }
+
+    @Test
+    public void shouldGetListOfObjectsFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        List<Object> defalutValue = new ArrayList<>();
+        // List of java objects, therefore IntegerValue will be converted to Long
+        assertThat( record.get( "ListValue", defalutValue ), equalTo( asList( (Object) 1L, 2L ) ) );
+        assertThat( record.get( wrongKey, defalutValue ), equalTo( defalutValue ) );
+    }
+
+    @Test
+    public void shouldGetListOfTFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+        List<Integer> defaultValue = new ArrayList<>();
+
+        assertThat( record.get( "ListValue", defaultValue, ofInteger() ), equalTo( asList( 1, 2 ) ) );
+        assertThat( record.get( wrongKey, defaultValue, ofInteger() ), equalTo( defaultValue ) );
+    }
+
+    @Test
+    public void shouldGetMapOfStringObjectFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put( "key1", 1L );
+        expected.put( "key2", 2L );
+        Map<String,Object> defaultValue = new HashMap<>();
+
+        assertThat( record.get( "MapValue", defaultValue ), equalTo( expected ) );
+        assertThat( record.get( wrongKey, defaultValue ), equalTo( defaultValue ) );
+    }
+
+    @Test
+    public void shouldGetMapOfStringTFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put( "key1", 1 );
+        expected.put( "key2", 2 );
+        Map<String,Integer> defaultValue = new HashMap<>();
+
+        assertThat( record.get( "MapValue", defaultValue, ofInteger() ), equalTo( expected ) );
+        assertThat( record.get( wrongKey, defaultValue, ofInteger() ), equalTo( defaultValue ) );
+    }
+
+    @Test
+    public void shouldGetPrimitiveTypesFromRecord() throws Throwable
+    {
+        Record record = createRecord();
+
+        // boolean
+        assertThat( record.get( "BooleanValue", false ), equalTo( true ) );
+        assertThat( record.get( wrongKey, false ), equalTo( false ) );
+
+        // string
+        assertThat( record.get( "StringValue", "" ), equalTo( "hello world" ) );
+        assertThat( record.get( wrongKey, "" ), equalTo( "" ) );
+
+        // int
+        assertThat( record.get( "IntegerValue", 3 ), equalTo( 11 ) );
+        assertThat( record.get( wrongKey, 3 ), equalTo( 3 ) );
+
+        // long
+        assertThat( record.get( "IntegerValue", 4L ), equalTo( 11L ) );
+        assertThat( record.get( wrongKey, 4L ), equalTo( 4L ) );
+
+        // float
+        assertThat( record.get( "float", 1F ), equalTo( 0.1F ) );
+        assertThat( record.get( wrongKey, 1F ), equalTo(  1F ) );
+
+        // double
+        assertThat( record.get( "FloatValue", 1.1 ), equalTo( 2.2 ) );
+        assertThat( record.get( wrongKey, 1.1 ), equalTo(  1.1 ) );
+    }
+
+    @Test
+    public void shouldGetFromMap() throws Throwable
+    {
+        MapValue mapValue = new MapValue( createMap() );
+        assertThat( mapValue.get( "key1", 0L ), equalTo( 1L ) );
+        assertThat( mapValue.get( "key2", 0 ), equalTo( 2 ) );
+        assertThat( mapValue.get( wrongKey, "" ), equalTo( "" ) );
+    }
+
+    @Test
+    public void shouldGetFromNode() throws Throwable
+    {
+        Map<String,Value> props = new HashMap<>();
+        props.put( "k1", value( 43 ) );
+        props.put( "k2", value( "hello world" ) );
+        NodeValue nodeValue = new NodeValue( new InternalNode( 42L, Collections.singletonList( "L" ), props ) );
+
+        assertThat( nodeValue.get( "k1", 0 ), equalTo( 43 ) );
+        assertThat( nodeValue.get( "k2", "" ), equalTo( "hello world" ) );
+        assertThat( nodeValue.get( wrongKey, 0L ), equalTo( 0L ) );
+    }
+
+    @Test
+    public void shouldGetFromRel() throws Throwable
+    {
+        Map<String,Value> props = new HashMap<>();
+        props.put( "k1", value( 43 ) );
+        props.put( "k2", value( "hello world" ) );
+        RelationshipValue relValue = new RelationshipValue( new InternalRelationship( 0L, 0L, 1L, "T", props ) );
+
+        assertThat( relValue.get( "k1", 0 ), equalTo( 43 ) );
+        assertThat( relValue.get( "k2", "" ), equalTo( "hello world" ) );
+        assertThat( relValue.get( wrongKey, 0L ), equalTo( 0L ) );
+    }
+
+    private Path createPath()
+    {
+        return new InternalPath(
+                new InternalNode( 42L ),
+                new InternalRelationship( 43L, 42L, 44L, "T" ),
+                new InternalNode( 44L ) );
+    }
+
+    private Node createNode()
+    {
+        return new InternalNode( 1L );
+    }
+
+    private Relationship createRel()
+    {
+        return new InternalRelationship( 1L, 1L, 2L, "T" );
+    }
+
+    private Map<String, Value> createMap()
+    {
+        Map<String, Value> map = new HashMap<>();
+        map.put( "key1", new IntegerValue( 1 ) );
+        map.put( "key2", new IntegerValue( 2 ) );
+        return map;
+    }
+
+    private Record createRecord()
+    {
+        Map<String, Value> map = createMap();
+        Path path = createPath();
+        Node node = createNode();
+        Relationship rel = createRel();
+
+        List<String> keys = asList(
+                "NullValue",
+                "BooleanValue",
+                "StringValue",
+                "IntegerValue",
+                "FloatValue",
+                "ListValue",
+                "MapValue",
+                "PathValue",
+                "NodeValue",
+                "RelValue",
+                "float"
+        );
+        Value[] values = new Value[]{
+                NullValue.NULL,
+                BooleanValue.TRUE,
+                new StringValue( "hello world" ),
+                new IntegerValue( 11 ),
+                new FloatValue( 2.2 ),
+                new ListValue( new IntegerValue( 1 ), new IntegerValue( 2 ) ),
+                new MapValue( map ),
+                new PathValue( path ),
+                new NodeValue( node ),
+                new RelationshipValue( rel ),
+                Values.value( 0.1F )
+        };
+        Record record = new InternalRecord( keys, values );
+        return record;
+    }
+
+}


### PR DESCRIPTION
This change enables 
`record.get( "key", defalutValue )`
and
`node.get( "propKey", defalutPropValue )`
`rel.get( "propKey", defalutPropValue )`
where defalutValue could be the types that we've defined `asXX` method already
