### PR TITLE
Deprecate TRUST_SIGNED_CERTIFICATES

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -25,7 +25,7 @@ import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.v1.util.Immutable;
 
 import static java.lang.System.getProperty;
-import static org.neo4j.driver.v1.Config.TrustStrategy.*;
+import static org.neo4j.driver.v1.Config.TrustStrategy.trustOnFirstUse;
 
 /**
  * A configuration class to config driver properties.
@@ -243,7 +243,7 @@ public class Config
         /**
          * Specify how to determine the authenticity of an encryption certificate provided by the Neo4j instance we are connecting to.
          * This defaults to {@link TrustStrategy#trustOnFirstUse(File)}.
-         * See {@link TrustStrategy#trustSignedBy(File)} for using certificate signatures instead to verify
+         * See {@link TrustStrategy#trustCustomCertificateSignedBy(File)} for using certificate signatures instead to verify
          * trust.
          * <p>
          * This is an important setting to understand, because unless we know that the remote server we have an encrypted connection to
@@ -290,11 +290,19 @@ public class Config
         public enum Strategy
         {
             TRUST_ON_FIRST_USE,
-            TRUST_SIGNED_CERTIFICATES
+            @Deprecated
+            TRUST_SIGNED_CERTIFICATES,
+            TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,
+            TRUST_SYSTEM_CA_SIGNED_CERTIFICATES
         }
 
         private final Strategy strategy;
         private final File certFile;
+
+        private TrustStrategy( Strategy strategy )
+        {
+            this( strategy, null );
+        }
 
         private TrustStrategy( Strategy strategy, File certFile )
         {
@@ -317,6 +325,15 @@ public class Config
         }
 
         /**
+         * Use {@link #trustCustomCertificateSignedBy(File)} instead.
+         */
+        @Deprecated
+        public static TrustStrategy trustSignedBy( File certFile )
+        {
+            return new TrustStrategy( Strategy.TRUST_SIGNED_CERTIFICATES, certFile );
+        }
+
+        /**
          * Only encrypted connections to Neo4j instances with certificates signed by a trusted certificate will be accepted.
          * The file specified should contain one or more trusted X.509 certificates.
          * <p>
@@ -326,9 +343,14 @@ public class Config
          * @param certFile the trusted certificate file
          * @return an authentication config
          */
-        public static TrustStrategy trustSignedBy( File certFile )
+        public static TrustStrategy trustCustomCertificateSignedBy( File certFile )
         {
-            return new TrustStrategy( Strategy.TRUST_SIGNED_CERTIFICATES, certFile );
+            return new TrustStrategy( Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, certFile );
+        }
+
+        public static TrustStrategy trustSystemCertifcates()
+        {
+            return new TrustStrategy( Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES );
         }
 
         /**
@@ -339,7 +361,7 @@ public class Config
          * Each time we reconnect to a known host, we verify that its certificate remains the same, guarding against attackers intercepting our communication.
          * <p>
          * Note that this approach is vulnerable to man-in-the-middle attacks the very first time you connect to a new Neo4j instance.
-         * If you do not trust the network you are connecting over, consider using {@link #trustSignedBy(File) signed certificates} instead, or manually adding the
+         * If you do not trust the network you are connecting over, consider using {@link #trustCustomCertificateSignedBy(File)}  signed certificates} instead, or manually adding the
          * trusted host line into the specified file.
          *
          * @param knownHostsFile a file where known certificates are stored.

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -69,13 +69,13 @@ public class ConfigTest
     {
         // Given
         File trustedCert = new File( "trusted_cert" );
-        Config config = Config.build().withTrustStrategy( Config.TrustStrategy.trustSignedBy( trustedCert ) ).toConfig();
+        Config config = Config.build().withTrustStrategy( Config.TrustStrategy.trustCustomCertificateSignedBy( trustedCert ) ).toConfig();
 
         // When
         Config.TrustStrategy authConfig = config.trustStrategy();
 
         // Then
-        assertEquals( authConfig.strategy(), Config.TrustStrategy.Strategy.TRUST_SIGNED_CERTIFICATES );
+        assertEquals( authConfig.strategy(), Config.TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES );
         assertEquals( trustedCert.getAbsolutePath(), authConfig.certFile().getAbsolutePath() );
     }
 
@@ -86,7 +86,7 @@ public class ConfigTest
         Config config = Config.build().withSessionLivenessCheckTimeout( 1337 ).toConfig();
 
         // then
-        assertThat( config.idleTimeBeforeConnectionTest(), equalTo( 1337l ) );
+        assertThat( config.idleTimeBeforeConnectionTest(), equalTo( 1337L ) );
     }
 
     public static void deleteDefaultKnownCertFileIfExists()

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
@@ -46,8 +46,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.internal.util.CertificateTool.saveX509Cert;
+import static org.neo4j.driver.v1.Config.TrustStrategy.trustCustomCertificateSignedBy;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustOnFirstUse;
-import static org.neo4j.driver.v1.Config.TrustStrategy.trustSignedBy;
 import static org.neo4j.driver.v1.tck.DriverComplianceIT.neo4j;
 import static org.neo4j.driver.v1.util.CertificateToolTest.generateSelfSignedCertificate;
 
@@ -199,7 +199,7 @@ public class DriverSecurityComplianceSteps
         driver = GraphDatabase.driver(
                 Neo4jRunner.DEFAULT_URL,
                 Config.build().withEncryptionLevel( EncryptionLevel.REQUIRED )
-                        .withTrustStrategy( trustSignedBy( rootCert ) ).toConfig() );
+                        .withTrustStrategy( trustCustomCertificateSignedBy( rootCert ) ).toConfig() );
 
         // generate certificate signing request and get a certificate signed by the root private key
         File cert = tempFile( "temp_cert", ".cert" );
@@ -223,7 +223,7 @@ public class DriverSecurityComplianceSteps
         driver = GraphDatabase.driver(
                 Neo4jRunner.DEFAULT_URL,
                 Config.build().withEncryptionLevel( EncryptionLevel.REQUIRED )
-                        .withTrustStrategy( trustSignedBy( Neo4jSettings.DEFAULT_TLS_CERT_FILE ) ).toConfig() );
+                        .withTrustStrategy( trustCustomCertificateSignedBy( Neo4jSettings.DEFAULT_TLS_CERT_FILE ) ).toConfig() );
     }
 
     // invalid cert
@@ -237,7 +237,7 @@ public class DriverSecurityComplianceSteps
         driver = GraphDatabase.driver(
                 Neo4jRunner.DEFAULT_URL,
                 Config.build().withEncryptionLevel( EncryptionLevel.REQUIRED )
-                        .withTrustStrategy( trustSignedBy( cert ) ).toConfig() );
+                        .withTrustStrategy( trustCustomCertificateSignedBy( cert ) ).toConfig() );
     }
 
     @And( "^I should get a helpful error explaining that no trusted certificate found$" )

--- a/examples/src/main/java/org/neo4j/docs/driver/Examples.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/Examples.java
@@ -239,7 +239,7 @@ public class Examples
         // tag::tls-signed[]
         Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic("neo4j", "neo4j"), Config.build()
                 .withEncryptionLevel( Config.EncryptionLevel.REQUIRED )
-                .withTrustStrategy( Config.TrustStrategy.trustSignedBy( new File( "/path/to/ca-certificate.pem") ) )
+                .withTrustStrategy( Config.TrustStrategy.trustCustomCertificateSignedBy( new File( "/path/to/ca-certificate.pem") ) )
                 .toConfig() );
         // end::tls-signed[]
 


### PR DESCRIPTION
`TRUST_SIGNED_CERTIFICATES` is behaving differently on different platforms. In
order to clean this up we deprecate it and replace with
- `TRUST_SYSTEM_CA_SIGNED_CERTIFICATES` which trusts the system defaults on the
  platform
- `TRUST_CUSTOM_CA_SIGNED_CERTIFICATES` which trusts a particular root
  certificate (can be a self-signed certificate for example)
