### PR TITLE
timings and version

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.spi.Connection;
-import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Statement;
@@ -142,6 +142,12 @@ public class InternalSession implements Session
                 connection.close();
             }
         }
+    }
+
+    @Override
+    public String server()
+    {
+        return connection.server();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -82,12 +82,19 @@ public class InternalStatementResult implements StatementResult
                     keys = new ArrayList<>();
                 }
             }
+
+            @Override
+            public void resultAvailableAfter( long l )
+            {
+              pullAllResponseCollector.resultAvailableAfter( l );
+            }
         };
     }
 
     private StreamCollector newPullAllResponseCollector( Statement statement )
     {
         final SummaryBuilder summaryBuilder = new SummaryBuilder( statement );
+
         return new StreamCollector.NoOperationStreamCollector()
         {
             @Override
@@ -130,6 +137,12 @@ public class InternalStatementResult implements StatementResult
             public void done() {
                 summary = summaryBuilder.build();
                 done = true;
+            }
+
+            @Override
+            public void resultAvailableAfter(long l)
+            {
+                summaryBuilder.resultAvailableAfter( l );
             }
         };
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -144,6 +144,12 @@ public class InternalStatementResult implements StatementResult
             {
                 summaryBuilder.resultAvailableAfter( l );
             }
+
+            @Override
+            public void resultConsumedAfter(long l)
+            {
+                summaryBuilder.resultConsumedAfter( l );
+            }
         };
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -228,4 +228,10 @@ public class ConcurrencyGuardingConnection implements Connection
                                        "do that is to give each thread its own dedicated session." );
         }
     }
+
+    @Override
+    public String server()
+    {
+        return delegate.server();
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -47,6 +47,7 @@ public class SocketConnection implements Connection
     private final Queue<Message> pendingMessages = new LinkedList<>();
     private final SocketResponseHandler responseHandler;
     private AtomicBoolean interrupted = new AtomicBoolean( false );
+    private final StreamCollector.InitStreamCollector initStreamCollector = new StreamCollector.InitStreamCollector();
 
     private final SocketClient socket;
 
@@ -70,7 +71,7 @@ public class SocketConnection implements Connection
     @Override
     public void init( String clientName, Map<String,Value> authToken )
     {
-        queueMessage( new InitMessage( clientName, authToken ), StreamCollector.INIT );
+        queueMessage( new InitMessage( clientName, authToken ), initStreamCollector );
         sync();
     }
 
@@ -230,5 +231,11 @@ public class SocketConnection implements Connection
     public boolean isInterrupted()
     {
         return interrupted.get();
+    }
+
+    @Override
+    public String server()
+    {
+        return initStreamCollector.server(  );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
@@ -91,6 +91,7 @@ public class SocketResponseHandler implements MessageHandler
         collectProfile( collector, meta.get( "profile" ) );
         collectNotifications( collector, meta.get( "notifications" ) );
         collectResultAvailableAfter( collector, meta.get("result_available_after"));
+        collectResultConsumedAfter( collector, meta.get("result_consumed_after"));
         collector.doneSuccess();
     }
 
@@ -99,6 +100,14 @@ public class SocketResponseHandler implements MessageHandler
         if (resultAvailableAfter != null)
         {
             collector.resultAvailableAfter(resultAvailableAfter.asLong());
+        }
+    }
+
+    private void collectResultConsumedAfter( StreamCollector collector, Value resultConsumedAfter )
+    {
+        if (resultConsumedAfter != null)
+        {
+            collector.resultConsumedAfter(resultConsumedAfter.asLong());
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
@@ -84,6 +84,7 @@ public class SocketResponseHandler implements MessageHandler
     public void handleSuccessMessage( Map<String,Value> meta )
     {
         StreamCollector collector = collectors.remove();
+        collectServer( collector, meta.get( "server" ));
         collectFields( collector, meta.get( "fields" ) );
         collectType( collector, meta.get( "type" ) );
         collectStatistics( collector, meta.get( "stats" ) );
@@ -93,6 +94,14 @@ public class SocketResponseHandler implements MessageHandler
         collectResultAvailableAfter( collector, meta.get("result_available_after"));
         collectResultConsumedAfter( collector, meta.get("result_consumed_after"));
         collector.doneSuccess();
+    }
+
+    private void collectServer( StreamCollector collector, Value server )
+    {
+        if (server != null)
+        {
+            collector.server( server.asString() );
+        }
     }
 
     private void collectResultAvailableAfter( StreamCollector collector, Value resultAvailableAfter )

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketResponseHandler.java
@@ -90,7 +90,16 @@ public class SocketResponseHandler implements MessageHandler
         collectPlan( collector, meta.get( "plan" ) );
         collectProfile( collector, meta.get( "profile" ) );
         collectNotifications( collector, meta.get( "notifications" ) );
+        collectResultAvailableAfter( collector, meta.get("result_available_after"));
         collector.doneSuccess();
+    }
+
+    private void collectResultAvailableAfter( StreamCollector collector, Value resultAvailableAfter )
+    {
+        if (resultAvailableAfter != null)
+        {
+            collector.resultAvailableAfter(resultAvailableAfter.asLong());
+        }
     }
 
     private void collectNotifications( StreamCollector collector, Value notifications )

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
@@ -230,6 +230,12 @@ public class PooledConnection implements Connection
         return delegate.isInterrupted();
     }
 
+    @Override
+    public String server()
+    {
+        return delegate.server();
+    }
+
     public void dispose()
     {
         delegate.close();
@@ -280,7 +286,6 @@ public class PooledConnection implements Connection
 
     public long idleTime()
     {
-        long idleTime = clock.millis() - lastUsed;
-        return idleTime;
+        return clock.millis() - lastUsed;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -100,7 +100,7 @@ public interface Connection extends AutoCloseable
      * runnable. This is used in the driver to clean up resources associated with
      * the connection, like an open transaction.
      *
-     * @param runnable
+     * @param runnable To be run on error.
      */
     void onError( Runnable runnable );
 
@@ -117,4 +117,10 @@ public interface Connection extends AutoCloseable
      * @return true if the current session statement execution has been interrupted by another thread, otherwise false
      */
     boolean isInterrupted();
+
+    /**
+     * Returns the version of the server connected to.
+     * @return The version of the server connected to.
+     */
+    String server();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
@@ -50,15 +50,27 @@ public interface StreamCollector
         }
     };
 
-    StreamCollector INIT = new NoOperationStreamCollector()
+    class InitStreamCollector extends NoOperationStreamCollector
     {
+        private String server;
         @Override
         public void doneIgnored()
         {
             throw new ClientException(
                     "Invalid server response message `IGNORED` received for client message `INIT`." );
         }
-    };
+
+        @Override
+        public void server( String server )
+        {
+            this.server = server;
+        }
+
+        public String server()
+        {
+            return server;
+        }
+    }
 
     StreamCollector RESET = new ResetStreamCollector();
 
@@ -146,16 +158,13 @@ public interface StreamCollector
         }
 
         @Override
-        public void resultAvailableAfter( long l )
-        {
-
-        }
+        public void resultAvailableAfter( long l ) {}
 
         @Override
-        public void resultConsumedAfter( long l )
-        {
+        public void resultConsumedAfter( long l ) {}
 
-        }
+        @Override
+        public void server( String server ){}
     }
 
     // TODO: This should be modified to simply have head/record/tail methods
@@ -185,5 +194,7 @@ public interface StreamCollector
     void resultAvailableAfter( long l );
 
     void resultConsumedAfter( long l );
+
+    void server( String server );
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
@@ -150,6 +150,12 @@ public interface StreamCollector
         {
 
         }
+
+        @Override
+        public void resultConsumedAfter( long l )
+        {
+
+        }
     }
 
     // TODO: This should be modified to simply have head/record/tail methods
@@ -177,5 +183,7 @@ public interface StreamCollector
     void doneIgnored();
 
     void resultAvailableAfter( long l );
+
+    void resultConsumedAfter( long l );
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/StreamCollector.java
@@ -144,6 +144,12 @@ public interface StreamCollector
         {
             done();
         }
+
+        @Override
+        public void resultAvailableAfter( long l )
+        {
+
+        }
     }
 
     // TODO: This should be modified to simply have head/record/tail methods
@@ -169,5 +175,7 @@ public interface StreamCollector
     void doneFailure( Neo4jException error );
 
     void doneIgnored();
+
+    void resultAvailableAfter( long l );
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -20,18 +20,19 @@ package org.neo4j.driver.internal.summary;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.driver.internal.spi.StreamCollector;
+import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.Notification;
 import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
 import org.neo4j.driver.v1.summary.ResultSummary;
-import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.summary.StatementType;
 import org.neo4j.driver.v1.summary.SummaryCounters;
-import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.exceptions.ClientException;
 
 public class SummaryBuilder implements StreamCollector
 {
@@ -42,6 +43,7 @@ public class SummaryBuilder implements StreamCollector
     private Plan plan = null;
     private ProfiledPlan profile;
     private List<Notification> notifications = null;
+    private long resultAvailableAfter;
 
     public SummaryBuilder( Statement statement )
     {
@@ -148,6 +150,12 @@ public class SummaryBuilder implements StreamCollector
         // intentionally empty
     }
 
+    @Override
+    public void resultAvailableAfter( long l )
+    {
+      this.resultAvailableAfter = l;
+    }
+
     public ResultSummary build()
     {
         return new ResultSummary()
@@ -198,6 +206,12 @@ public class SummaryBuilder implements StreamCollector
             public List<Notification> notifications()
             {
                 return notifications == null ? new ArrayList<Notification>() : notifications;
+            }
+
+            @Override
+            public long resultAvailableAfter( TimeUnit timeUnit )
+            {
+                return timeUnit.convert( resultAvailableAfter, TimeUnit.MILLISECONDS );
             }
         };
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -163,6 +163,12 @@ public class SummaryBuilder implements StreamCollector
         this.resultConsumedAfter = l;
     }
 
+    @Override
+    public void server( String server )
+    {
+        // intentionally empty
+    }
+
     public ResultSummary build()
     {
         return new ResultSummary()

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -43,8 +43,8 @@ public class SummaryBuilder implements StreamCollector
     private Plan plan = null;
     private ProfiledPlan profile;
     private List<Notification> notifications = null;
-    private long resultAvailableAfter;
-    private long resultConsumedAfter;
+    private long resultAvailableAfter = -1L;
+    private long resultConsumedAfter = -1L;
 
     public SummaryBuilder( Statement statement )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -44,6 +44,7 @@ public class SummaryBuilder implements StreamCollector
     private ProfiledPlan profile;
     private List<Notification> notifications = null;
     private long resultAvailableAfter;
+    private long resultConsumedAfter;
 
     public SummaryBuilder( Statement statement )
     {
@@ -156,6 +157,12 @@ public class SummaryBuilder implements StreamCollector
       this.resultAvailableAfter = l;
     }
 
+    @Override
+    public void resultConsumedAfter( long l )
+    {
+        this.resultConsumedAfter = l;
+    }
+
     public ResultSummary build()
     {
         return new ResultSummary()
@@ -212,6 +219,12 @@ public class SummaryBuilder implements StreamCollector
             public long resultAvailableAfter( TimeUnit timeUnit )
             {
                 return timeUnit.convert( resultAvailableAfter, TimeUnit.MILLISECONDS );
+            }
+
+            @Override
+            public long resultConsumedAfter( TimeUnit timeUnit )
+            {
+                return timeUnit.convert( resultConsumedAfter, TimeUnit.MILLISECONDS );
             }
         };
     }

--- a/driver/src/main/java/org/neo4j/driver/v1/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Session.java
@@ -75,4 +75,10 @@ public interface Session extends Resource, StatementRunner
      */
     @Override
     void close();
+
+    /**
+     * Returns a string telling which version of the server the session is connected to.
+     * @return The server version of <code>null</code> if not available.
+     */
+    String server();
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/summary/ResultSummary.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/summary/ResultSummary.java
@@ -19,9 +19,10 @@
 package org.neo4j.driver.v1.summary;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import org.neo4j.driver.v1.util.Immutable;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.util.Immutable;
 
 /**
  * The result summary of running a statement. The result summary interface can be used to investigate
@@ -90,4 +91,12 @@ public interface ResultSummary
      * notifications produced while executing the statement.
      */
     List<Notification> notifications();
+
+    /**
+     * The time it took the server to make the result available for consumption.
+     *
+     * @param unit The unit of the duration.
+     * @return The time it took for the server to have the result available in the provided time unit.
+     */
+    long resultAvailableAfter( TimeUnit unit );
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/summary/ResultSummary.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/summary/ResultSummary.java
@@ -99,4 +99,12 @@ public interface ResultSummary
      * @return The time it took for the server to have the result available in the provided time unit.
      */
     long resultAvailableAfter( TimeUnit unit );
+
+    /**
+     * The time it took the server to consume the result.
+     *
+     * @param unit The unit of the duration.
+     * @return The time it took for the server to consume the result in the provided time unit.
+     */
+    long resultConsumedAfter( TimeUnit unit );
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -34,7 +34,6 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -171,19 +170,6 @@ public class SessionIT
             assertTrue( startTime > 0 );
             assertTrue( endTime - startTime > killTimeout * 1000 ); // get killed by session.kill
             assertTrue( endTime - startTime < executionTimeout * 1000 / 2 ); // finished before execution finished
-        }
-    }
-
-    @Test
-    public void shouldShowServerVersion() throws Throwable
-    {
-        // Given
-        try( Driver driver = GraphDatabase.driver( neo4j.uri() ) )
-        {
-            try ( Session session = driver.session() )
-            {
-                assertNotNull( session.server() );
-            }
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -48,7 +49,7 @@ public class SessionIT
     public void shouldKnowSessionIsClosed() throws Throwable
     {
         // Given
-        try( Driver driver =  GraphDatabase.driver( neo4j.uri() ); )
+        try( Driver driver =  GraphDatabase.driver( neo4j.uri() ) )
         {
             Session session = driver.session();
 
@@ -170,6 +171,19 @@ public class SessionIT
             assertTrue( startTime > 0 );
             assertTrue( endTime - startTime > killTimeout * 1000 ); // get killed by session.kill
             assertTrue( endTime - startTime < executionTimeout * 1000 / 2 ); // finished before execution finished
+        }
+    }
+
+    @Test
+    public void shouldShowServerVersion() throws Throwable
+    {
+        // Given
+        try( Driver driver = GraphDatabase.driver( neo4j.uri() ) )
+        {
+            try ( Session session = driver.session() )
+            {
+                assertNotNull( session.server() );
+            }
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
@@ -74,6 +74,7 @@ public class SummaryIT
         assertFalse( summary.hasProfile() );
         assertThat( summary, equalTo( result.consume() ) );
         assertThat( summary.resultAvailableAfter( TimeUnit.MILLISECONDS ), greaterThan( 0L ) );
+        assertThat( summary.resultConsumedAfter( TimeUnit.MILLISECONDS ), greaterThan( 0L ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
@@ -22,6 +22,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
@@ -71,6 +73,7 @@ public class SummaryIT
         assertFalse( summary.hasPlan() );
         assertFalse( summary.hasProfile() );
         assertThat( summary, equalTo( result.consume() ) );
+        assertThat( summary.resultAvailableAfter( TimeUnit.MILLISECONDS ), greaterThan( 0L ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/util/ServerVersion.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/ServerVersion.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Integer.compare;
+
+public class ServerVersion
+{
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    private static final Pattern PATTERN =
+            Pattern.compile("Neo4j/(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?");
+
+    private ServerVersion( int major, int minor, int patch )
+    {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+    public static final ServerVersion v3_1_0 = new ServerVersion(3, 1, 0);
+    public static final ServerVersion v3_0_0 = new ServerVersion(3, 1, 0);
+
+    public static ServerVersion version( String server )
+    {
+        if ( server == null )
+        {
+            return new ServerVersion( 3, 0, 0 );
+        }
+        else
+        {
+            Matcher matcher = PATTERN.matcher( server );
+            if ( matcher.matches() )
+            {
+                int major = Integer.valueOf( matcher.group( 1 ) );
+                int minor = Integer.valueOf( matcher.group( 2 ) );
+                String patchString = matcher.group( 3 );
+                int patch = 0;
+                if ( patchString != null && !patchString.isEmpty() )
+                {
+                    patch = Integer.valueOf( patchString );
+                }
+                return new ServerVersion( major, minor, patch );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Cannot parse " + server );
+            }
+        }
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        ServerVersion that = (ServerVersion) o;
+
+        if ( major != that.major )
+        { return false; }
+        if ( minor != that.minor )
+        { return false; }
+        return patch == that.patch;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + patch;
+        return result;
+    }
+
+    public boolean greaterThan(ServerVersion other)
+    {
+        return compareTo( other ) > 0;
+    }
+
+    public boolean greaterThanOrEqual(ServerVersion other)
+    {
+        return compareTo( other ) >= 0;
+    }
+
+    public boolean lessThan(ServerVersion other)
+    {
+        return compareTo( other ) < 0;
+    }
+
+    public boolean lessThanOrEqual(ServerVersion other)
+    {
+        return compareTo( other ) <= 0;
+    }
+
+    private int compareTo( ServerVersion o )
+    {
+        int c = compare( major, o.major );
+        if (c == 0)
+        {
+            c = compare( minor, o.minor );
+            if (c == 0)
+            {
+                c = compare( patch, o.patch );
+            }
+        }
+
+        return c;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
@@ -24,11 +24,11 @@ import org.junit.runners.model.Statement;
 import java.util.Map;
 
 import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.types.TypeSystem;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.types.TypeSystem;
 
 /**
  * A little utility for integration testing, this provides tests with a session they can work with.
@@ -92,6 +92,12 @@ public class TestNeo4jSession extends TestNeo4j implements Session
     public void close()
     {
         throw new UnsupportedOperationException( "Disallowed on this test session" );
+    }
+
+    @Override
+    public String server()
+    {
+        return realSession.server();
     }
 
     @Override


### PR DESCRIPTION
Exposes `resultAvailableAfter` and `resultConsumedAfter` on `ResultSummary` and `server` on `Session`. 
