### PR TITLE
Automatically close on session.reset()

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -207,6 +207,12 @@ public class ConcurrencyGuardingConnection implements Connection
         delegate.resetAsync();
     }
 
+    @Override
+    public boolean isAckFailureMuted()
+    {
+        return delegate.isAckFailureMuted();
+    }
+
     private void markAsAvailable()
     {
         inUse.set( false );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -207,12 +207,6 @@ public class ConcurrencyGuardingConnection implements Connection
         delegate.resetAsync();
     }
 
-    @Override
-    public boolean isInterrupted()
-    {
-        return delegate.isInterrupted();
-    }
-
     private void markAsAvailable()
     {
         inUse.set( false );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
@@ -226,12 +226,6 @@ public class PooledConnection implements Connection
     }
 
     @Override
-    public boolean isInterrupted()
-    {
-        return delegate.isInterrupted();
-    }
-
-    @Override
     public String server()
     {
         return delegate.server();
@@ -260,7 +254,7 @@ public class PooledConnection implements Connection
         {
             unrecoverableErrorsOccurred = true;
         }
-        else if( !isInterrupted() )
+        else
         {
             ackFailure();
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
@@ -226,6 +226,12 @@ public class PooledConnection implements Connection
     }
 
     @Override
+    public boolean isAckFailureMuted()
+    {
+        return delegate.isAckFailureMuted();
+    }
+
+    @Override
     public String server()
     {
         return delegate.server();
@@ -254,7 +260,7 @@ public class PooledConnection implements Connection
         {
             unrecoverableErrorsOccurred = true;
         }
-        else
+        else if( !isAckFailureMuted() )
         {
             ackFailure();
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -114,6 +114,12 @@ public interface Connection extends AutoCloseable
     void resetAsync();
 
     /**
+     * Return true if ack_failure message is temporarily muted as the failure message will be acked using reset instead
+     * @return true if no ack_failre message should be sent when ackable failures are received.
+     */
+    boolean isAckFailureMuted();
+
+    /**
      * Returns the version of the server connected to.
      * @return The version of the server connected to.
      */

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -114,12 +114,6 @@ public interface Connection extends AutoCloseable
     void resetAsync();
 
     /**
-     * Return true if the current session statement execution has been interrupted by another thread, otherwise false.
-     * @return true if the current session statement execution has been interrupted by another thread, otherwise false
-     */
-    boolean isInterrupted();
-
-    /**
      * Returns the version of the server connected to.
      * @return The version of the server connected to.
      */

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
@@ -32,9 +32,11 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.util.TestNeo4jSession;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -215,24 +217,64 @@ public class TransactionIT
         // Then it wasn't the end of the world as we know it
     }
 
-    @Test
-    public void shouldHandleReset() throws Throwable
-    {
-            Transaction tx = session.beginTransaction();
-            tx.run( "UNWIND range(1,1) AS n RETURN n AS number" );
-            //TODO I believe there is a bug server side, if the RESET comes in
-            //too fast, stuff breaks
-            Thread.sleep( 100 );
-            session.reset();
-            tx = session.beginTransaction();
-            tx.run( "CREATE (n:FirstNode)" );
-            tx.success();
-            tx.close();
 
-            // Then the outcome of both statements should be visible
-            StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
-            long nodes = result.single().get( "count(n)" ).asLong();
-            assertThat( nodes, equalTo( 1L ) );
+    @Test
+    public void shouldThrowExceptionDueToNotConsumingResetFailure() throws Throwable
+    {
+        // Given
+        Transaction tx = session.beginTransaction();
+        tx.run( "UNWIND range(1,1) AS n RETURN n AS number" );
+        session.reset();
+
+        exception.expect( ClientException.class );
+        exception.expectMessage( startsWith(
+                "Failed to execute more statements as the session has been reset " +
+                "and an error has occurred due to the cancellation of executing the previous statement." ) );
+
+        // When & Then
+        tx = session.beginTransaction();
+    }
+
+    @Test
+    public void shouldBeAbleToRunMoreStatementAfterConsumingResetFailure() throws Throwable
+    {
+        Transaction tx = session.beginTransaction();
+        StatementResult failingResult = tx.run( "UNWIND range(1,1) AS n RETURN n AS number" );
+        session.reset();
+
+        exception.expect( TransientException.class );
+        exception.expectMessage( startsWith(
+                "The transaction has been terminated." ) );
+
+        failingResult.consume(); // fail with errors
+
+        tx = session.beginTransaction();
+        tx.run( "CREATE (n:FirstNode)" );
+        tx.success();
+        tx.close();
+
+        // Then the outcome of both statements should be visible
+        StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+        long nodes = result.single().get( "count(n)" ).asLong();
+        assertThat( nodes, equalTo( 1L ) );
+    }
+
+    @Test
+    public void shouldBeAbleToRunMoreStatementAfterEmptyReset() throws Throwable
+    {
+        // Given
+        session.reset();
+
+        // When
+        Transaction tx = session.beginTransaction();
+        tx.run( "CREATE (n:FirstNode)" );
+        tx.success();
+        tx.close();
+
+        // Then the outcome of both statements should be visible
+        StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+        long nodes = result.single().get( "count(n)" ).asLong();
+        assertThat( nodes, equalTo( 1L ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
@@ -142,7 +145,7 @@ public class TransactionIT
     public void shouldHandleNullParametersGracefully()
     {
         // When
-        session.run("match (n) return count(n)", (Value)null);
+        session.run( "match (n) return count(n)", (Value) null );
 
         // Then
         // pass - no exception thrown
@@ -155,7 +158,7 @@ public class TransactionIT
     {
         // GIVEN a successful query in a transaction
         Transaction tx = session.beginTransaction();
-        StatementResult result = tx.run("CREATE (n) RETURN n");
+        StatementResult result = tx.run( "CREATE (n) RETURN n" );
         result.consume();
         tx.success();
         tx.close();
@@ -164,7 +167,7 @@ public class TransactionIT
         exception.expect( ClientException.class );
 
         //WHEN running a malformed query in the original session
-        session.run("CREAT (n) RETURN n").consume();
+        session.run( "CREAT (n) RETURN n" ).consume();
     }
 
     @SuppressWarnings( "ConstantConditions" )
@@ -204,11 +207,102 @@ public class TransactionIT
         // When
         try ( Transaction tx = session.beginTransaction() )
         {
-            Map<String, Object> params = null;
+            Map<String,Object> params = null;
             tx.run( "CREATE (n:FirstNode)", params );
             tx.success();
         }
 
         // Then it wasn't the end of the world as we know it
+    }
+
+    @Test
+    public void shouldHandleReset() throws Throwable
+    {
+            Transaction tx = session.beginTransaction();
+            tx.run( "UNWIND range(1,1) AS n RETURN n AS number" );
+            //TODO I believe there is a bug server side, if the RESET comes in
+            //too fast, stuff breaks
+            Thread.sleep( 100 );
+            session.reset();
+            tx = session.beginTransaction();
+            tx.run( "CREATE (n:FirstNode)" );
+            tx.success();
+            tx.close();
+
+            // Then the outcome of both statements should be visible
+            StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+            long nodes = result.single().get( "count(n)" ).asLong();
+            assertThat( nodes, equalTo( 1L ) );
+    }
+
+    @Test
+    public void shouldHandleResetBeforeRun() throws Throwable
+    {
+        // Expect
+        exception.expect( ClientException.class );
+        exception.expectMessage( "Cannot run more statements in this transaction, because previous statements in the " +
+                                 "transaction has failed and the transaction has been rolled back. Please start a new" +
+                                 " transaction to run another statement." );
+        // When
+        Transaction tx = session.beginTransaction();
+        session.reset();
+        tx.run( "CREATE (n:FirstNode)" );
+    }
+
+    private Transaction globalTx = null;
+    @Test
+    public void shouldHandleResetFromMultipleThreads() throws Throwable
+    {
+        // When
+        ExecutorService runner = Executors.newFixedThreadPool( 2 );
+        runner.execute( new Runnable()
+
+        {
+            @Override
+            public void run()
+            {
+                globalTx = session.beginTransaction();
+                    globalTx.run( "CREATE (n:FirstNode)" );
+                try
+                {
+                    Thread.sleep( 1000 );
+                }
+                catch ( InterruptedException e )
+                {
+                    new AssertionError( e );
+                }
+
+                globalTx = session.beginTransaction();
+                globalTx.run( "CREATE (n:FirstNode)" );
+                globalTx.success();
+                globalTx.close();
+
+            }
+        } );
+        runner.execute( new Runnable()
+
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    Thread.sleep( 500 );
+                }
+                catch ( InterruptedException e )
+                {
+                    new AssertionError( e );
+                }
+
+                session.reset();
+            }
+        } );
+
+        runner.awaitTermination( 5, TimeUnit.SECONDS );
+
+        // Then the outcome of both statements should be visible
+        StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+        long nodes = result.single().get( "count(n)" ).asLong();
+        assertThat( nodes, equalTo( 1L ) );
     }
 }


### PR DESCRIPTION
In the event of a reset the transaction should be completely closed and the
session should be ready to create new transactions without explicitly closing
any transactions.
