### PR TITLE
Handle all failures from getServers

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ClusterDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ClusterDriver.java
@@ -180,21 +180,15 @@ public class ClusterDriver extends BaseDriver
                 connections.purge( remove );
             }
         }
-        catch ( ClientException ex )
+        catch ( Exception ex )
         {
-            if ( ex.code().equals( "Neo.ClientError.Procedure.ProcedureNotFound" ) )
-            {
-                //no procedure there, not much to do, stick with what we've got
-                //this may happen because server is running in standalone mode
-                this.close();
-                throw new ServiceUnavailableException(
-                        String.format( "Server %s couldn't perform discovery",
-                                address == null ? "`UNKNOWN`" : address.toString() ), ex );
-            }
-            else
-            {
-                throw ex;
-            }
+            //discovery failed, not much to do, stick with what we've got
+            //this may happen because server is running in standalone mode
+            this.close();
+            throw new ServiceUnavailableException(
+                    String.format( "Server %s couldn't perform discovery",
+                            address == null ? "`UNKNOWN`" : address.toString() ), ex );
+
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/ClusterDriverStubTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ClusterDriverStubTest.java
@@ -406,24 +406,29 @@ public class ClusterDriverStubTest
     @Test
     public void shouldFailOnNonDiscoverableServer() throws IOException, InterruptedException, StubServer.ForceKilled
     {
-        // When
-        StubServer server = StubServer.start( resource( "non_discovery_server.script" ), 9001 );
+        //Expect
+        exception.expect( ServiceUnavailableException.class );
 
+        // Given
+        StubServer.start( resource( "non_discovery_server.script" ), 9001 );
         URI uri = URI.create( "bolt+routing://127.0.0.1:9001" );
-        boolean failed = false;
-        //noinspection EmptyTryBlock
-        try
-        {
-            GraphDatabase.driver( uri, config );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            failed = true;
-        }
-        assertTrue( failed );
 
-        // Finally
-        assertThat( server.exitStatus(), equalTo( 0 ) );
+        // When
+        GraphDatabase.driver( uri, config );
+    }
+
+    @Test
+    public void shouldFailRandomFailureInGetServers() throws IOException, InterruptedException, StubServer.ForceKilled
+    {
+        //Expect
+        exception.expect( ServiceUnavailableException.class );
+
+        // Given
+        StubServer.start( resource( "failed_discovery.script" ), 9001 );
+        URI uri = URI.create( "bolt+routing://127.0.0.1:9001" );
+
+        // When
+        GraphDatabase.driver( uri, config );
     }
 
     @Test

--- a/driver/src/test/resources/failed_discovery.script
+++ b/driver/src/test/resources/failed_discovery.script
@@ -1,0 +1,11 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
+S: IGNORED
+C: ACK_FAILURE
+S: SUCCESS {}


### PR DESCRIPTION
It doesn't really matter what kind of failures that happens
in `getServers`, to the user they should all be presented as
a SessionUnavailableException so that the user can retry with
another server.
