### PR TITLE
More friendly error when user tries to WRITE in a READ session.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ClusterDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ClusterDriver.java
@@ -286,7 +286,7 @@ public class ClusterDriver extends BaseDriver
     @Override
     public Session session( final AccessMode mode )
     {
-        return new ClusteredNetworkSession( acquireConnection( mode ),
+        return new ClusteredNetworkSession( mode, acquireConnection( mode ),
                 new ClusteredErrorHandler()
                 {
                     @Override

--- a/driver/src/test/java/org/neo4j/driver/internal/ClusteredReadStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ClusteredReadStatementResultTest.java
@@ -18,52 +18,33 @@
  */
 package org.neo4j.driver.internal;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
-import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import static org.neo4j.driver.v1.AccessMode.READ;
 
-@RunWith(Parameterized.class)
-public class ClusteredStatementResultTest
+public class ClusteredReadStatementResultTest
 {
     private static final BoltServerAddress LOCALHOST = new BoltServerAddress( "localhost", 7687 );
     private StatementResult delegate = mock( StatementResult.class );
     private ClusteredErrorHandler onError = mock( ClusteredErrorHandler.class );
-    private final AccessMode accessMode;
-
-    @Parameterized.Parameters(name = "accessMode-{0}")
-    public static Collection<AccessMode> data()
-    {
-        return Arrays.asList( AccessMode.values() );
-    }
-
-    public ClusteredStatementResultTest( AccessMode accessMode )
-    {
-        this.accessMode = accessMode;
-    }
 
     @Test
-    public void shouldHandleConnectionFailureOnConsume()
+    public void shouldHandleWriteFailureOnConsume()
     {
         // Given
-        when( delegate.consume() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.consume() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -71,23 +52,23 @@ public class ClusteredStatementResultTest
             result.consume();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnHasNext()
+    public void shouldHandleWriteFailureOnHasNext()
     {
         // Given
-        when( delegate.hasNext() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.hasNext() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -95,23 +76,23 @@ public class ClusteredStatementResultTest
             result.hasNext();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnKeys()
+    public void shouldHandleWriteFailureOnKeys()
     {
         // Given
-        when( delegate.keys() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.keys() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -119,23 +100,23 @@ public class ClusteredStatementResultTest
             result.keys();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnList()
+    public void shouldHandleWriteFailureOnList()
     {
         // Given
-        when( delegate.list() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.list() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -143,23 +124,23 @@ public class ClusteredStatementResultTest
             result.list();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnNext()
+    public void shouldHandleWriteFailureOnNext()
     {
         // Given
-        when( delegate.next() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.next() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -167,23 +148,23 @@ public class ClusteredStatementResultTest
             result.next();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnPeek()
+    public void shouldHandleWriteFailureOnPeek()
     {
         // Given
-        when( delegate.peek() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.peek() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -191,23 +172,23 @@ public class ClusteredStatementResultTest
             result.peek();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnSingle()
+    public void shouldHandleWriteFailureOnSingle()
     {
         // Given
-        when( delegate.single() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.single() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, READ, LOCALHOST, onError );
 
         // When
         try
@@ -215,13 +196,12 @@ public class ClusteredStatementResultTest
             result.single();
             fail();
         }
-        catch ( SessionExpiredException e )
+        catch ( ClientException e )
         {
             //ignore
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/ClusteredWriteStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ClusteredWriteStatementResultTest.java
@@ -18,17 +18,11 @@
  */
 package org.neo4j.driver.internal;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 
 import static org.junit.Assert.fail;
@@ -37,33 +31,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import static org.neo4j.driver.v1.AccessMode.WRITE;
 
-@RunWith(Parameterized.class)
-public class ClusteredStatementResultTest
+public class ClusteredWriteStatementResultTest
 {
     private static final BoltServerAddress LOCALHOST = new BoltServerAddress( "localhost", 7687 );
     private StatementResult delegate = mock( StatementResult.class );
     private ClusteredErrorHandler onError = mock( ClusteredErrorHandler.class );
-    private final AccessMode accessMode;
-
-    @Parameterized.Parameters(name = "accessMode-{0}")
-    public static Collection<AccessMode> data()
-    {
-        return Arrays.asList( AccessMode.values() );
-    }
-
-    public ClusteredStatementResultTest( AccessMode accessMode )
-    {
-        this.accessMode = accessMode;
-    }
 
     @Test
-    public void shouldHandleConnectionFailureOnConsume()
+    public void shouldHandleWriteFailureOnConsume()
     {
         // Given
-        when( delegate.consume() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.consume() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -77,17 +60,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnHasNext()
+    public void shouldHandleWriteFailureOnHasNext()
     {
         // Given
-        when( delegate.hasNext() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.hasNext() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -101,17 +85,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnKeys()
+    public void shouldHandleWriteFailureOnKeys()
     {
         // Given
-        when( delegate.keys() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.keys() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -125,17 +110,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnList()
+    public void shouldHandleWriteFailureOnList()
     {
         // Given
-        when( delegate.list() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.list() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -149,17 +135,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnNext()
+    public void shouldHandleWriteFailureOnNext()
     {
         // Given
-        when( delegate.next() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.next() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -173,17 +160,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnPeek()
+    public void shouldHandleWriteFailureOnPeek()
     {
         // Given
-        when( delegate.peek() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.peek() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -197,17 +185,18 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 
     @Test
-    public void shouldHandleConnectionFailureOnSingle()
+    public void shouldHandleWriteFailureOnSingle()
     {
         // Given
-        when( delegate.single() ).thenThrow( new ConnectionFailureException( "oh no" ) );
+        when( delegate.single() )
+                .thenThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) );
         ClusteredStatementResult result =
-                new ClusteredStatementResult( delegate, accessMode, LOCALHOST, onError );
+                new ClusteredStatementResult( delegate, WRITE, LOCALHOST, onError );
 
         // When
         try
@@ -221,7 +210,7 @@ public class ClusteredStatementResultTest
         }
 
         // Then
-        verify( onError ).onConnectionFailure( LOCALHOST );
+        verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
 }


### PR DESCRIPTION
Common error codes returned by the server indicate that the user
attempted (and failed) to write. If the user was using a READ
session we can give tell them directly that the problem is their fault.
