### PR TITLE
Remove server when failing on session acquisition

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingNetworkSession.java
@@ -75,6 +75,11 @@ public class RoutingNetworkSession extends NetworkSession
         }
     }
 
+    public BoltServerAddress address()
+    {
+        return connection.address();
+    }
+
     static Neo4jException filterFailureToWrite( ClientException e, AccessMode mode, RoutingErrorHandler onError,
             BoltServerAddress address )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingStatementResult.java
@@ -192,4 +192,8 @@ public class RoutingStatementResult implements StatementResult
         }
     }
 
+    public BoltServerAddress address()
+    {
+        return address;
+    }
 }


### PR DESCRIPTION
We were only checking for connection failures on running and consuming the
results, however there might also be a connection failure on session acquisition.
By not properly removing the server on session-acquisition failures we end up
in a scenario where we constantly retry to connect to that endpoint.
