### PR TITLE
Proper handling for empty result

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -249,6 +249,12 @@ public class RoutingDriver extends BaseDriver
             session = sessionProvider.apply( acquire );
 
             StatementResult records = session.run( format( "CALL %s", procedureName ) );
+            //got a result but was empty
+            if (!records.hasNext()) {
+                forget( address );
+                return false;
+            }
+            //consume the results
             while ( records.hasNext() )
             {
                 recorder.accept( records.next() );

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverStubTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverStubTest.java
@@ -106,21 +106,24 @@ public class RoutingDriverStubTest
         assertThat( server.exitStatus(), equalTo( 0 ) );
     }
 
-
     @Test
     public void shouldHandleEmptyResponse() throws IOException, InterruptedException, StubServer.ForceKilled
     {
         // Given
         StubServer server = StubServer.start( "handle_empty_response.script" , 9001 );
         URI uri = URI.create( "bolt+routing://127.0.0.1:9001" );
-        try ( RoutingDriver driver = (RoutingDriver) GraphDatabase.driver( uri, config ) )
+
+        // When
+        try
         {
-            Set<BoltServerAddress> servers = driver.routingServers();
-            assertThat( servers, hasSize( 0 ) );
-            assertFalse( driver.connectionPool().hasAddress( address( 9001 ) ) );
+            GraphDatabase.driver( uri, config );
+            fail();
+        } catch ( ServiceUnavailableException e )
+        {
+            //ignore
         }
 
-        // Finally
+        // Then
         assertThat( server.exitStatus(), equalTo( 0 ) );
     }
 


### PR DESCRIPTION
When server returns an empty list on routing we should just throw a
`ServiceUnavailableException`.
