### PR TITLE
Fixes to driver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
 import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.neo4j.driver.v1.Values.value;
@@ -296,9 +297,9 @@ public class NetworkSession implements Session
     {
         if ( !connection.isOpen() )
         {
-            throw new ClientException( "The current session cannot be reused as the underlying connection with the " +
-                                       "server has been closed due to unrecoverable errors. " +
-                                       "Please close this session and retry your statement in another new session." );
+            throw new ConnectionFailureException( "The current session cannot be reused as the underlying connection with the " +
+                                                  "server has been closed due to unrecoverable errors. " +
+                                                  "Please close this session and retry your statement in another new session." );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -241,7 +241,7 @@ public class RoutingDriver extends BaseDriver
     //must be called from a synchronized method
     private boolean call( BoltServerAddress address, String procedureName, Consumer<Record> recorder )
     {
-        Connection acquire = null;
+        Connection acquire;
         Session session = null;
         try
         {
@@ -271,11 +271,6 @@ public class RoutingDriver extends BaseDriver
             {
                 session.close();
             }
-            if ( acquire != null )
-            {
-                acquire.close();
-            }
-
         }
         return true;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnection.java
@@ -19,7 +19,6 @@
 package org.neo4j.driver.internal.net.pooling;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
@@ -59,7 +58,6 @@ public class PooledConnection implements Connection
     private Runnable onError = null;
     private final Clock clock;
     private long lastUsed;
-    private final AtomicBoolean released = new AtomicBoolean( false );
 
     public PooledConnection( Connection delegate, Consumer<PooledConnection> release, Clock clock )
     {
@@ -69,9 +67,8 @@ public class PooledConnection implements Connection
         this.lastUsed = clock.millis();
     }
 
-    public void setInUse()
+    public void updateTimestamp()
     {
-        released.set(false);
         lastUsed = clock.millis();
     }
 
@@ -200,10 +197,7 @@ public class PooledConnection implements Connection
      */
     public void close()
     {
-        if ( released.compareAndSet( false, true ))
-        {
-            release.accept( this );
-        }
+        release.accept( this );
         // put the full logic of deciding whether to dispose the connection or to put it back to
         // the pool into the release object
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +40,8 @@ import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
+
+import static java.util.Collections.emptyList;
 
 /**
  * The pool is designed to buffer certain amount of free sessions into session pool. When closing a session, we first
@@ -115,7 +119,7 @@ public class SocketConnectionPool implements ConnectionPool
             conn = new PooledConnection( connect( address ), new
                     PooledConnectionReleaseConsumer( connections, stopped, new PooledConnectionValidator( this, poolSettings ) ), clock );
         }
-        conn.setInUse();
+        conn.updateTimestamp();
         return conn;
     }
 
@@ -182,6 +186,21 @@ public class SocketConnectionPool implements ConnectionPool
         }
 
         pools.clear();
+    }
+
+    //for testing
+    public List<PooledConnection> connectionsForAddress(BoltServerAddress address)
+    {
+        LinkedBlockingQueue<PooledConnection> pooledConnections =
+                (LinkedBlockingQueue<PooledConnection>) pools.get( address );
+        if (pooledConnections == null)
+        {
+            return emptyList();
+        }
+        else
+        {
+            return new ArrayList<>( pooledConnections );
+        }
     }
 
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -115,7 +115,7 @@ public class SocketConnectionPool implements ConnectionPool
             conn = new PooledConnection( connect( address ), new
                     PooledConnectionReleaseConsumer( connections, stopped, new PooledConnectionValidator( this, poolSettings ) ), clock );
         }
-        conn.updateUsageTimestamp();
+        conn.setInUse();
         return conn;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
@@ -41,13 +41,6 @@ public interface Collector
             throw new ClientException(
                     "Invalid server response message `FAILURE` received for client message `ACK_FAILURE`.", error );
         }
-
-        @Override
-        public void doneIgnored()
-        {
-            throw new ClientException(
-                    "Invalid server response message `IGNORED` received for client message `ACK_FAILURE`." );
-        }
     };
 
     class InitCollector extends NoOperationCollector

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -27,6 +27,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
 
 import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertNotNull;
@@ -121,7 +122,7 @@ public class NetworkSessionTest
         when( mock.isOpen() ).thenReturn( false );
 
         // Expect
-        exception.expect( ClientException.class );
+        exception.expect( ConnectionFailureException.class );
 
         // When
         sess.run( "whatever" );
@@ -134,7 +135,7 @@ public class NetworkSessionTest
         when( mock.isOpen() ).thenReturn( false );
 
         // Expect
-        exception.expect( ClientException.class );
+        exception.expect( ConnectionFailureException.class );
 
         // When
         sess.beginTransaction();

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -43,7 +43,6 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.summary.ResultSummary;
-import org.neo4j.driver.v1.util.BiFunction;
 import org.neo4j.driver.v1.util.Function;
 
 import static java.util.Arrays.asList;

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
@@ -120,39 +120,6 @@ public class PooledConnectionTest
         assertThat( flags[0], equalTo( false ) );
     }
 
-    @Test
-    public void shouldOnlyReturnOnceEventhougCloseIsBeingCalledMultipleTimes() throws Throwable
-    {
-        // Given
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(2);
-
-        final boolean[] flags = {false};
-
-        Connection conn = mock( Connection.class );
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                new AtomicBoolean( false ), VALID_CONNECTION );
-
-        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
-        {
-            @Override
-            public void dispose()
-            {
-                flags[0] = true;
-            }
-        };
-
-        // When
-        pooledConnection.close();
-        pooledConnection.close();
-        pooledConnection.close();
-        pooledConnection.close();
-        pooledConnection.close();
-
-        // Then
-        assertThat( pool, hasItem(pooledConnection) );
-        assertThat( pool.size(), equalTo( 1 ) );
-        assertThat( flags[0], equalTo( false ) );
-    }
 
     @Test
     public void shouldDisposeConnectionIfValidConnectionAndIdlePoolIsFull() throws Throwable

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
@@ -121,6 +121,40 @@ public class PooledConnectionTest
     }
 
     @Test
+    public void shouldOnlyReturnOnceEventhougCloseIsBeingCalledMultipleTimes() throws Throwable
+    {
+        // Given
+        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(2);
+
+        final boolean[] flags = {false};
+
+        Connection conn = mock( Connection.class );
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
+                new AtomicBoolean( false ), VALID_CONNECTION );
+
+        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+        {
+            @Override
+            public void dispose()
+            {
+                flags[0] = true;
+            }
+        };
+
+        // When
+        pooledConnection.close();
+        pooledConnection.close();
+        pooledConnection.close();
+        pooledConnection.close();
+        pooledConnection.close();
+
+        // Then
+        assertThat( pool, hasItem(pooledConnection) );
+        assertThat( pool.size(), equalTo( 1 ) );
+        assertThat( flags[0], equalTo( false ) );
+    }
+
+    @Test
     public void shouldDisposeConnectionIfValidConnectionAndIdlePoolIsFull() throws Throwable
     {
         // Given


### PR DESCRIPTION
- Don't fail if `ACK_FAILURE` is ignored
- Don't put the same connection back in the pool multiple times
- If connection is closed it is a `ConnectionFailureException`
