### PR TITLE
Check when only one router left

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -306,7 +306,7 @@ public class RoutingDriverTest
             @Override
             public Record single() throws NoSuchRecordException
             {
-                return null;
+                return next();
             }
 
             @Override


### PR DESCRIPTION
Waiting until we completely run out of routing servers is too late, we must always rediscover when
we only have one known router left.

Also simplifies the routing code somewhat.
