### PR TITLE
Should throw `SessionExpired` instead of `ConnectionFailure`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -40,6 +40,7 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.util.Function;
 
 import static java.lang.String.format;
@@ -420,7 +421,7 @@ public class RoutingDriver extends BaseDriver
             }
         }
 
-        throw new ConnectionFailureException( "Failed to connect to any read server" );
+        throw new SessionExpiredException( "Failed to connect to any read server" );
     }
 
     private Connection acquireWriteConnection()
@@ -439,7 +440,7 @@ public class RoutingDriver extends BaseDriver
             }
         }
 
-        throw new ConnectionFailureException( "Failed to connect to any write server" );
+        throw new SessionExpiredException( "Failed to connect to any write server" );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverStubTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverStubTest.java
@@ -372,7 +372,7 @@ public class RoutingDriverStubTest
             driver.session( AccessMode.READ );
             fail();
         }
-        catch ( ConnectionFailureException e )
+        catch ( SessionExpiredException e )
         {
             //ignore
         }


### PR DESCRIPTION
Whenever we run out of read or write servers the situation may still fix itself
on the next routing call so we should throw `SessionExpiredException` to indicate
to the user session acquisition should be retried.
