### PR TITLE
Fixed expect strust but get xx bug

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -408,11 +408,18 @@ public class BufferingChunkedInput implements PackInput
             int read = channel.read( buffer );
             if ( read == -1 )
             {
+                try
+                {
+                    channel.close();
+                }
+                catch ( IOException e )
+                {
+                    // best effort
+                }
                 throw new ClientException(
                         "Connection terminated while receiving data. This can happen due to network " +
                         "instabilities, or due to restarts of the database." );
             }
-            buffer.flip();
         }
         catch ( ClosedByInterruptException e )
         {
@@ -428,6 +435,10 @@ public class BufferingChunkedInput implements PackInput
             String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
             throw new ClientException(
                     "Unable to process request: " + message + " buffer: \n" + BytePrinter.hex( buffer ), e );
+        }
+        finally
+        {
+            buffer.flip();
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/BufferingChunkedInput.java
@@ -398,7 +398,7 @@ public class BufferingChunkedInput implements PackInput
      * @param buffer The buffer to read into
      * @throws IOException
      */
-    private static void readNextPacket( ReadableByteChannel channel, ByteBuffer buffer ) throws IOException
+    static void readNextPacket( ReadableByteChannel channel, ByteBuffer buffer ) throws IOException
     {
         assert !buffer.hasRemaining();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketUtils.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/connector/socket/SocketUtils.java
@@ -41,6 +41,14 @@ public final class SocketUtils
         {
             if (channel.read( buf ) < 0)
             {
+                try
+                {
+                    channel.close();
+                }
+                catch ( IOException e )
+                {
+                    // best effort
+                }
                 String bufStr = BytePrinter.hex( buf ).trim();
                 throw new ClientException( String.format(
                         "Connection terminated while receiving data. This can happen due to network " +
@@ -56,6 +64,14 @@ public final class SocketUtils
         {
             if (channel.write( buf ) < 0)
             {
+                try
+                {
+                    channel.close();
+                }
+                catch ( IOException e )
+                {
+                    // best effort
+                }
                 String bufStr = BytePrinter.hex( buf ).trim();
                 throw new ClientException( String.format(
                         "Connection terminated while sending data. This can happen due to network " +


### PR DESCRIPTION
that is caused by forgetting to flip a buffer back after connection error.
Close the socket channel directly if server already mark the end of the channel
