### PR TITLE
Proper handling of cluster failures for transactions

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ClusterView.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ClusterView.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.ConcurrentRoundRobinSet;
+import org.neo4j.driver.v1.Logger;
+
+/**
+ * Defines a snapshot view of the cluster.
+ */
+class ClusterView
+{
+    private final static Comparator<BoltServerAddress> COMPARATOR = new Comparator<BoltServerAddress>()
+    {
+        @Override
+        public int compare( BoltServerAddress o1, BoltServerAddress o2 )
+        {
+            int compare = o1.host().compareTo( o2.host() );
+            if ( compare == 0 )
+            {
+                compare = Integer.compare( o1.port(), o2.port() );
+            }
+
+            return compare;
+        }
+    };
+
+    private static final int MIN_ROUTERS = 1;
+
+    private final ConcurrentRoundRobinSet<BoltServerAddress> routingServers =
+            new ConcurrentRoundRobinSet<>( COMPARATOR );
+    private final ConcurrentRoundRobinSet<BoltServerAddress> readServers =
+            new ConcurrentRoundRobinSet<>( COMPARATOR );
+    private final ConcurrentRoundRobinSet<BoltServerAddress> writeServers =
+            new ConcurrentRoundRobinSet<>( COMPARATOR );
+    private final Clock clock;
+    private final long expires;
+    private final Logger log;
+
+    public ClusterView( long expires, Clock clock, Logger log )
+    {
+        this.expires = expires;
+        this.clock = clock;
+        this.log = log;
+    }
+
+    public void addRouter( BoltServerAddress router )
+    {
+        this.routingServers.add( router );
+    }
+
+    public boolean isStale()
+    {
+        return expires < clock.millis() ||
+               routingServers.size() <= MIN_ROUTERS ||
+               readServers.isEmpty() ||
+               writeServers.isEmpty();
+    }
+
+    Set<BoltServerAddress> all()
+    {
+        HashSet<BoltServerAddress> all =
+                new HashSet<>( routingServers.size() + readServers.size() + writeServers.size() );
+        all.addAll( routingServers );
+        all.addAll( readServers );
+        all.addAll( writeServers );
+        return all;
+    }
+
+
+    public BoltServerAddress nextRouter()
+    {
+        return routingServers.hop();
+    }
+
+    public BoltServerAddress nextReader()
+    {
+        return readServers.hop();
+    }
+
+    public BoltServerAddress nextWriter()
+    {
+        return writeServers.hop();
+    }
+
+    public void addReaders( List<BoltServerAddress> addresses )
+    {
+        readServers.addAll( addresses );
+    }
+
+    public void addWriters( List<BoltServerAddress> addresses )
+    {
+        writeServers.addAll( addresses );
+    }
+
+    public void addRouters( List<BoltServerAddress> addresses )
+    {
+        routingServers.addAll( addresses );
+    }
+
+    public void remove( BoltServerAddress address )
+    {
+        if ( routingServers.remove( address ) )
+        {
+            log.debug( "Removing %s from routers", address.toString() );
+        }
+        if ( readServers.remove( address ) )
+        {
+            log.debug( "Removing %s from readers", address.toString() );
+        }
+        if ( writeServers.remove( address ) )
+        {
+            log.debug( "Removing %s from writers", address.toString() );
+        }
+    }
+
+    public boolean removeWriter( BoltServerAddress address )
+    {
+        return writeServers.remove( address );
+    }
+
+    public int numberOfRouters()
+    {
+        return routingServers.size();
+    }
+
+    public int numberOfReaders()
+    {
+        return readServers.size();
+    }
+
+    public int numberOfWriters()
+    {
+        return writeServers.size();
+    }
+
+    public Set<BoltServerAddress> routingServers()
+    {
+        return Collections.unmodifiableSet( routingServers );
+    }
+
+    public Set<BoltServerAddress> readServers()
+    {
+        return Collections.unmodifiableSet( readServers );
+    }
+
+    public Set<BoltServerAddress> writeServers()
+    {
+        return Collections.unmodifiableSet( writeServers );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -242,7 +242,8 @@ public class RoutingDriver extends BaseDriver
     @Override
     public Session session( final AccessMode mode )
     {
-        return new RoutingNetworkSession( mode, acquireConnection( mode ),
+        Connection connection = acquireConnection( mode );
+        return new RoutingNetworkSession( new NetworkSession( connection ), mode, connection.address(),
                 new RoutingErrorHandler()
                 {
                     @Override

--- a/driver/src/test/java/org/neo4j/driver/internal/ClusterViewTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ClusterViewTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.v1.Logger;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ClusterViewTest
+{
+
+    @Test
+    public void shouldRoundRobinAmongRoutingServers()
+    {
+        // Given
+        ClusterView clusterView = new ClusterView( 5L, mock( Clock.class ), mock( Logger.class ) );
+
+        // When
+        clusterView.addRouters( asList( address("host1"), address( "host2" ), address( "host3" )));
+
+        // Then
+        assertThat(clusterView.nextRouter(), equalTo(address( "host1" )));
+        assertThat(clusterView.nextRouter(), equalTo(address( "host2" )));
+        assertThat(clusterView.nextRouter(), equalTo(address( "host3" )));
+        assertThat(clusterView.nextRouter(), equalTo(address( "host1" )));
+    }
+
+    @Test
+    public void shouldRoundRobinAmongReadServers()
+    {
+        // Given
+        ClusterView clusterView = new ClusterView( 5L, mock( Clock.class ), mock( Logger.class ) );
+
+        // When
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+
+        // Then
+        assertThat(clusterView.nextReader(), equalTo(address( "host1" )));
+        assertThat(clusterView.nextReader(), equalTo(address( "host2" )));
+        assertThat(clusterView.nextReader(), equalTo(address( "host3" )));
+        assertThat(clusterView.nextReader(), equalTo(address( "host1" )));
+    }
+
+    @Test
+    public void shouldRoundRobinAmongWriteServers()
+    {
+        // Given
+        ClusterView clusterView = new ClusterView( 5L, mock( Clock.class ), mock( Logger.class ) );
+
+        // When
+        clusterView.addWriters( asList( address("host1"), address( "host2" ), address( "host3" )));
+
+        // Then
+        assertThat(clusterView.nextWriter(), equalTo(address( "host1" )));
+        assertThat(clusterView.nextWriter(), equalTo(address( "host2" )));
+        assertThat(clusterView.nextWriter(), equalTo(address( "host3" )));
+        assertThat(clusterView.nextWriter(), equalTo(address( "host1" )));
+    }
+
+    @Test
+    public void shouldRemoveServer()
+    {
+        // Given
+        ClusterView clusterView = new ClusterView( 5L, mock( Clock.class ), mock( Logger.class ) );
+
+        clusterView.addRouters( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addWriters( asList( address("host2"), address( "host4" )));
+
+        // When
+        clusterView.remove( address( "host2" ) );
+
+        // Then
+        assertThat(clusterView.routingServers(), containsInAnyOrder(address( "host1" ), address( "host3" )));
+        assertThat(clusterView.readServers(), containsInAnyOrder(address( "host1" ), address( "host3" )));
+        assertThat(clusterView.writeServers(), containsInAnyOrder(address( "host4" )));
+        assertThat(clusterView.all(), containsInAnyOrder( address( "host1" ), address( "host3" ), address( "host4" ) ));
+    }
+
+    @Test
+    public void shouldBeStaleIfExpired()
+    {
+        // Given
+        Clock clock = mock( Clock.class );
+        when(clock.millis()).thenReturn( 6L );
+        ClusterView clusterView = new ClusterView( 5L, clock, mock( Logger.class ) );
+        clusterView.addRouters( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addWriters( asList( address("host2"), address( "host4" )));
+
+        // Then
+        assertTrue(clusterView.isStale());
+    }
+
+    @Test
+    public void shouldNotBeStaleIfNotExpired()
+    {
+        // Given
+        Clock clock = mock( Clock.class );
+        when(clock.millis()).thenReturn( 4L );
+        ClusterView clusterView = new ClusterView( 5L, clock, mock( Logger.class ) );
+        clusterView.addRouters( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addWriters( asList( address("host2"), address( "host4" )));
+
+        // Then
+        assertFalse(clusterView.isStale());
+    }
+
+    @Test
+    public void shouldBeStaleIfOnlyOneRouter()
+    {
+        // Given
+        Clock clock = mock( Clock.class );
+        when(clock.millis()).thenReturn( 4L );
+        ClusterView clusterView = new ClusterView( 5L, clock, mock( Logger.class ) );
+        clusterView.addRouters( singletonList( address( "host1" ) ) );
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+        clusterView.addWriters( asList( address("host2"), address( "host4" )));
+
+        // When
+
+        // Then
+        assertTrue(clusterView.isStale());
+    }
+
+    @Test
+    public void shouldBeStaleIfNoReader()
+    {
+        // Given
+        Clock clock = mock( Clock.class );
+        when(clock.millis()).thenReturn( 4L );
+        ClusterView clusterView = new ClusterView( 5L, clock, mock( Logger.class ) );
+        clusterView.addRouters( singletonList( address( "host1" ) ) );
+        clusterView.addWriters( asList( address("host2"), address( "host4" )));
+
+        // Then
+        assertTrue(clusterView.isStale());
+    }
+
+    @Test
+    public void shouldBeStaleIfNoWriter()
+    {
+        // Given
+        Clock clock = mock( Clock.class );
+        when(clock.millis()).thenReturn( 4L );
+        ClusterView clusterView = new ClusterView( 5L, clock, mock( Logger.class ) );
+        clusterView.addRouters( singletonList( address( "host1" ) ) );
+        clusterView.addReaders( asList( address("host1"), address( "host2" ), address( "host3" )));
+
+        // Then
+        assertTrue(clusterView.isStale());
+    }
+
+    private BoltServerAddress address(String host)
+    {
+        return new BoltServerAddress( host );
+    }
+
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -254,7 +254,7 @@ public class RoutingDriverTest
         final Session session = mock( Session.class );
         when( session.run( GET_SERVERS ) ).thenReturn(
                 getServers( asList( "localhost:1111", "localhost:1112" ),
-                        asList( "localhost:2222", "localhost:2223", "localhost:2223" ),
+                        asList( "localhost:2222", "localhost:2223", "localhost:2224" ),
                         singletonList( "localhost:3333" ) ) );
 
         // When
@@ -267,8 +267,8 @@ public class RoutingDriverTest
 
         // Then
         assertThat(read1.address(), equalTo(boltAddress( "localhost", 2222 )));
-        assertThat(read2.address(), equalTo(boltAddress( "localhost", 2222 )));
-        assertThat(read3.address(), equalTo(boltAddress( "localhost", 2222 )));
+        assertThat(read2.address(), equalTo(boltAddress( "localhost", 2223 )));
+        assertThat(read3.address(), equalTo(boltAddress( "localhost", 2224 )));
         assertThat(read4.address(), equalTo(boltAddress( "localhost", 2222 )));
 
     }
@@ -280,7 +280,7 @@ public class RoutingDriverTest
         final Session session = mock( Session.class );
         when( session.run( GET_SERVERS ) ).thenReturn(
                 getServers( asList( "localhost:1111", "localhost:1112" ),
-                        singletonList( "localhost:3333" ),  asList( "localhost:2222", "localhost:2223", "localhost:2223" ) ) );
+                        singletonList( "localhost:3333" ),  asList( "localhost:2222", "localhost:2223", "localhost:2224" ) ) );
 
         // When
         RoutingDriver routingDriver = forSession( session );
@@ -292,8 +292,8 @@ public class RoutingDriverTest
 
         // Then
         assertThat(write1.address(), equalTo(boltAddress( "localhost", 2222 )));
-        assertThat(write2.address(), equalTo(boltAddress( "localhost", 2222 )));
-        assertThat(write3.address(), equalTo(boltAddress( "localhost", 2222 )));
+        assertThat(write2.address(), equalTo(boltAddress( "localhost", 2223 )));
+        assertThat(write3.address(), equalTo(boltAddress( "localhost", 2224 )));
         assertThat(write4.address(), equalTo(boltAddress( "localhost", 2222 )));
 
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingNetworkSessionTest.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.AccessMode;
-import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
@@ -68,7 +68,8 @@ public class RoutingNetworkSessionTest
                 when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
 
         RoutingNetworkSession result =
-                new RoutingNetworkSession( AccessMode.WRITE, connection, onError );
+                new RoutingNetworkSession( new NetworkSession( connection ), AccessMode.WRITE, connection.address(),
+                        onError );
 
         // When
         try
@@ -94,7 +95,8 @@ public class RoutingNetworkSessionTest
         doThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ).
                 when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
         RoutingNetworkSession session =
-                new RoutingNetworkSession( AccessMode.WRITE, connection, onError );
+                new RoutingNetworkSession( new NetworkSession(connection), AccessMode.WRITE, connection.address(),
+                        onError );
 
         // When
         try
@@ -120,7 +122,7 @@ public class RoutingNetworkSessionTest
         doThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ).
                 when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
         RoutingNetworkSession session =
-                new RoutingNetworkSession( AccessMode.READ, connection, onError );
+                new RoutingNetworkSession( new NetworkSession( connection ), AccessMode.READ, connection.address(), onError );
 
         // When
         try
@@ -144,7 +146,7 @@ public class RoutingNetworkSessionTest
         doThrow( toBeThrown ).
                 when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
         RoutingNetworkSession session =
-                new RoutingNetworkSession( AccessMode.WRITE, connection, onError );
+                new RoutingNetworkSession( new NetworkSession( connection ), AccessMode.WRITE, connection.address(), onError );
 
         // When
         try
@@ -169,7 +171,8 @@ public class RoutingNetworkSessionTest
                 when( connection ).sync();
 
         RoutingNetworkSession session =
-                new RoutingNetworkSession( AccessMode.WRITE, connection, onError );
+                new RoutingNetworkSession( new NetworkSession( connection ),  AccessMode.WRITE, connection.address(),
+                        onError );
 
         // When
         try
@@ -194,7 +197,7 @@ public class RoutingNetworkSessionTest
         doThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ).when( connection ).sync();
 
         RoutingNetworkSession session =
-                new RoutingNetworkSession( AccessMode.WRITE, connection, onError );
+                new RoutingNetworkSession( new NetworkSession( connection ), AccessMode.WRITE, connection.address(), onError );
 
         // When
         try
@@ -211,4 +214,69 @@ public class RoutingNetworkSessionTest
         verify( onError ).onWriteFailure( LOCALHOST );
         verifyNoMoreInteractions( onError );
     }
+
+    @Test
+    public void shouldDelegateLastBookmark()
+    {
+        // Given
+        Session inner = mock( Session.class );
+        RoutingNetworkSession session =
+                new RoutingNetworkSession( inner, AccessMode.WRITE, connection.address(), onError );
+
+
+        // When
+        session.lastBookmark();
+
+        // Then
+        verify( inner ).lastBookmark();
+    }
+
+    @Test
+    public void shouldDelegateReset()
+    {
+        // Given
+        Session inner = mock( Session.class );
+        RoutingNetworkSession session =
+                new RoutingNetworkSession( inner, AccessMode.WRITE, connection.address(), onError );
+
+
+        // When
+        session.reset();
+
+        // Then
+        verify( inner ).reset();
+    }
+
+    @Test
+    public void shouldDelegateIsOpen()
+    {
+        // Given
+        Session inner = mock( Session.class );
+        RoutingNetworkSession session =
+                new RoutingNetworkSession( inner, AccessMode.WRITE, connection.address(), onError );
+
+
+        // When
+        session.isOpen();
+
+        // Then
+        verify( inner ).isOpen();
+    }
+
+    @Test
+    public void shouldDelegateServer()
+    {
+        // Given
+        Session inner = mock( Session.class );
+        RoutingNetworkSession session =
+                new RoutingNetworkSession( inner, AccessMode.WRITE, connection.address(), onError );
+
+
+        // When
+        session.server();
+
+        // Then
+        verify( inner ).server();
+    }
+
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Map;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.Collector;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class RoutingTransactionTest
+{
+    private static final BoltServerAddress LOCALHOST = new BoltServerAddress( "localhost", 7687 );
+    private Connection connection;
+    private RoutingErrorHandler onError;
+    private Runnable cleanup;
+
+    private Answer<Void> throwingAnswer( final Throwable throwable )
+    {
+        return new Answer<Void>()
+        {
+            @Override
+            public Void answer( InvocationOnMock invocationOnMock ) throws Throwable
+            {
+                String statement = (String) invocationOnMock.getArguments()[0];
+                if ( statement.equals( "BEGIN" ) )
+                {
+                    return null;
+                }
+                else
+                {
+                    throw throwable;
+                }
+            }
+        };
+    }
+
+    @Before
+    public void setUp()
+    {
+        connection = mock( Connection.class );
+        when( connection.address() ).thenReturn( LOCALHOST );
+        when( connection.isOpen() ).thenReturn( true );
+        onError = mock( RoutingErrorHandler.class );
+        cleanup = mock( Runnable.class );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleConnectionFailures()
+    {
+        // Given
+
+        doAnswer( throwingAnswer( new ConnectionFailureException( "oh no" ) ) )
+                .when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
+
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.READ, LOCALHOST,
+                        onError );
+
+        // When
+        try
+        {
+            tx.run( "CREATE ()" );
+            fail();
+        }
+        catch ( SessionExpiredException e )
+        {
+            //ignore
+        }
+
+        // Then
+        verify( onError ).onConnectionFailure( LOCALHOST );
+        verifyNoMoreInteractions( onError );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleWriteFailuresInWriteAccessMode()
+    {
+        // Given
+        doAnswer( throwingAnswer( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ) )
+                .when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
+
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        try
+        {
+            tx.run( "CREATE ()" );
+            fail();
+        }
+        catch ( SessionExpiredException e )
+        {
+            //ignore
+        }
+
+        // Then
+        verify( onError ).onWriteFailure( LOCALHOST );
+        verifyNoMoreInteractions( onError );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleWriteFailuresInReadAccessMode()
+    {
+        // Given
+        doAnswer( throwingAnswer( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ) )
+                .when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.READ,
+                        connection.address(), onError );
+
+        // When
+        try
+        {
+            tx.run( "CREATE ()" );
+            fail();
+        }
+        catch ( ClientException e )
+        {
+            //ignore
+        }
+        verifyNoMoreInteractions( onError );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldRethrowNonWriteFailures()
+    {
+        // Given
+        ClientException toBeThrown = new ClientException( "code", "oh no!" );
+        doAnswer( throwingAnswer( toBeThrown ) )
+                .when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        try
+        {
+            tx.run( "CREATE ()" );
+            fail();
+        }
+        catch ( ClientException e )
+        {
+            assertThat( e, is( toBeThrown ) );
+        }
+
+        // Then
+        verifyZeroInteractions( onError );
+    }
+
+    @Test
+    public void shouldHandleConnectionFailuresOnClose()
+    {
+        // Given
+        doThrow( new ConnectionFailureException( "oh no" ) ).
+                when( connection ).sync();
+
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        try
+        {
+            tx.close();
+            fail();
+        }
+        catch ( SessionExpiredException e )
+        {
+            //ignore
+        }
+
+        // Then
+        verify( onError ).onConnectionFailure( LOCALHOST );
+        verifyNoMoreInteractions( onError );
+    }
+
+    @Test
+    public void shouldHandleWriteFailuresOnClose()
+    {
+        // Given
+        doThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ).when( connection ).sync();
+
+        RoutingTransaction tx =
+                new RoutingTransaction( new ExplicitTransaction( connection, cleanup ), AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        try
+        {
+            tx.close();
+            fail();
+        }
+        catch ( SessionExpiredException e )
+        {
+            //ignore
+        }
+
+        // Then
+        verify( onError ).onWriteFailure( LOCALHOST );
+        verifyNoMoreInteractions( onError );
+    }
+
+
+    @Test
+    public void shouldDelegateSuccess()
+    {
+        // Given
+        Transaction inner = mock( Transaction.class );
+        RoutingTransaction tx =
+                new RoutingTransaction(inner, AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        tx.success();
+
+        // Then
+        verify( inner ).success();
+    }
+
+    @Test
+    public void shouldDelegateFailure()
+    {
+        // Given
+        Transaction inner = mock( Transaction.class );
+        RoutingTransaction tx =
+                new RoutingTransaction(inner, AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        tx.failure();
+
+        // Then
+        verify( inner ).failure();
+    }
+
+    @Test
+    public void shouldDelegateIsOpen()
+    {
+        // Given
+        Transaction inner = mock( Transaction.class );
+        RoutingTransaction tx =
+                new RoutingTransaction(inner, AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        tx.isOpen();
+
+        // Then
+        verify( inner ).isOpen();
+    }
+
+    @Test
+    public void shouldDelegateTypesystem()
+    {
+        // Given
+        Transaction inner = mock( Transaction.class );
+        RoutingTransaction tx =
+                new RoutingTransaction(inner, AccessMode.WRITE,
+                        connection.address(), onError );
+
+        // When
+        tx.typeSystem();
+
+        // Then
+        verify( inner ).typeSystem();
+    }
+}

--- a/driver/src/test/resources/not_able_to_write_server.script
+++ b/driver/src/test/resources/not_able_to_write_server.script
@@ -2,6 +2,9 @@
 !: AUTO RESET
 !: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+!: AUTO PULL_ALL
 
 C: RUN "CREATE ()" {}
 C: PULL_ALL

--- a/driver/src/test/resources/read_server.script
+++ b/driver/src/test/resources/read_server.script
@@ -2,6 +2,8 @@
 !: AUTO RESET
 !: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
 
 C: RUN "MATCH (n) RETURN n.name" {}
    PULL_ALL

--- a/driver/src/test/resources/write_server.script
+++ b/driver/src/test/resources/write_server.script
@@ -2,6 +2,8 @@
 !: AUTO RESET
 !: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
 
 C: RUN "CREATE (n {name:'Bob'})" {}
    PULL_ALL


### PR DESCRIPTION
We weren't checking for the cluster failures when running on transactions.
All operations should check for leader-switches and connection failures and
handle them appropriately.
