### PR TITLE
Close all connections on driver.close()

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -139,7 +139,7 @@ public class NetworkSession implements Session
     @Override
     public boolean isOpen()
     {
-        return isOpen.get();
+        return isOpen.get() && connection.isOpen();
     }
 
     @Override
@@ -176,10 +176,6 @@ public class NetworkSession implements Session
         try
         {
             connection.sync();
-        }
-        catch ( Throwable t )
-        {
-            throw t;
         }
         finally
         {
@@ -314,7 +310,7 @@ public class NetworkSession implements Session
 
     private void ensureSessionIsOpen()
     {
-        if ( !isOpen() )
+        if ( !isOpen.get() )
         {
             throw new ClientException(
                     "No more interaction with this session is allowed " +

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net.pooling;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.neo4j.driver.internal.util.Supplier;
+
+/**
+ * A blocking queue that also keeps track of connections that are acquired in order
+ * to facilitate termination of all connections.
+ */
+public class BlockingPooledConnectionQueue
+{
+    /** The backing queue, keeps track of connections currently in queue */
+    private final BlockingQueue<PooledConnection> queue;
+
+    /** Keeps track of acquired connections */
+    private final Set<PooledConnection> acquiredConnections =
+            Collections.newSetFromMap(new ConcurrentHashMap<PooledConnection, Boolean>());
+
+    public BlockingPooledConnectionQueue( int capacity )
+    {
+        this.queue = new LinkedBlockingQueue<>( capacity );
+    }
+
+    /**
+     * Offer a connections back to the queue
+     *
+     * @param pooledConnection the connection to put back to the queue
+     * @return <code>true</code> if connections was accepted otherwise <code>false</code>
+     */
+    public boolean offer( PooledConnection pooledConnection )
+    {
+        boolean offer = queue.offer( pooledConnection );
+        if ( offer )
+        {
+            acquiredConnections.remove( pooledConnection );
+        }
+        return offer;
+    }
+
+    public List<PooledConnection> toList()
+    {
+        return new ArrayList<>( queue );
+    }
+
+    public boolean isEmpty()
+    {
+        return queue.isEmpty();
+    }
+
+    public int size()
+    {
+        return queue.size();
+    }
+
+    public boolean contains( PooledConnection pooledConnection )
+    {
+        return queue.contains( pooledConnection );
+    }
+
+    /**
+     * Terminates all connections, both those that are currently in the queue as well
+     * as those that have been acquired.
+     */
+    public void terminate()
+    {
+        while ( !queue.isEmpty() )
+        {
+            PooledConnection conn = queue.poll();
+            if ( conn != null )
+            {
+                //close the underlying connection without adding it back to the queue
+                conn.dispose();
+            }
+        }
+        for ( PooledConnection pooledConnection : acquiredConnections )
+        {
+            pooledConnection.dispose();
+        }
+    }
+
+    /**
+     * Acquire connection or create a new one if the queue is empty
+     * @param supplier used to create a new connection if queue is empty
+     * @return a PooledConnection instance
+     */
+    public PooledConnection acquire( Supplier<PooledConnection> supplier )
+    {
+        PooledConnection poll = queue.poll();
+        if ( poll == null )
+        {
+            poll = supplier.get();
+        }
+        acquiredConnections.add( poll );
+        return poll;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.util.Consumer;
@@ -30,11 +29,11 @@ import org.neo4j.driver.v1.util.Function;
  */
 class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
 {
-    private final BlockingQueue<PooledConnection> connections;
+    private final BlockingPooledConnectionQueue connections;
     private final AtomicBoolean driverStopped;
     private final Function<PooledConnection, Boolean> validConnection;
 
-    PooledConnectionReleaseConsumer( BlockingQueue<PooledConnection> connections, AtomicBoolean driverStopped,
+    PooledConnectionReleaseConsumer( BlockingPooledConnectionQueue connections, AtomicBoolean driverStopped,
             Function<PooledConnection, Boolean> validConnection)
     {
         this.connections = connections;
@@ -67,11 +66,7 @@ class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
                 // which connection we get back, because other threads might be in the same situation as ours. It only
                 // matters that we added *a* connection that might not be observed by the loop, and that we dispose of
                 // *a* connection in response.
-                PooledConnection conn = connections.poll();
-                if ( conn != null )
-                {
-                    conn.dispose();
-                }
+                connections.terminate();
             }
         }
         else

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
@@ -30,44 +30,21 @@ import org.neo4j.driver.v1.util.Function;
 class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
 {
     private final BlockingPooledConnectionQueue connections;
-    private final AtomicBoolean driverStopped;
     private final Function<PooledConnection, Boolean> validConnection;
 
-    PooledConnectionReleaseConsumer( BlockingPooledConnectionQueue connections, AtomicBoolean driverStopped,
+    PooledConnectionReleaseConsumer( BlockingPooledConnectionQueue connections,
             Function<PooledConnection, Boolean> validConnection)
     {
         this.connections = connections;
-        this.driverStopped = driverStopped;
         this.validConnection = validConnection;
     }
 
     @Override
     public void accept( PooledConnection pooledConnection )
     {
-        if( driverStopped.get() )
+        if ( validConnection.apply( pooledConnection ) )
         {
-            // if the driver already closed, then no need to try to return to pool, just directly close this connection
-            pooledConnection.dispose();
-        }
-        else if ( validConnection.apply( pooledConnection ) )
-        {
-            boolean released = connections.offer( pooledConnection );
-            if( !released )
-            {
-                // if the connection could be put back to the pool, then we let the pool to manage it.
-                // Otherwise, we close the connection directly here.
-                pooledConnection.dispose();
-            }
-            else if ( driverStopped.get() )
-            {
-                // If our adding the pooledConnection to the queue was racing with the closing of the driver,
-                // then the loop where the driver is closing all available connections might not observe our newly
-                // added connection. Thus, we must attempt to remove a connection and dispose it. It doesn't matter
-                // which connection we get back, because other threads might be in the same situation as ours. It only
-                // matters that we added *a* connection that might not be observed by the loop, and that we dispose of
-                // *a* connection in response.
-                connections.terminate();
-            }
+            connections.offer( pooledConnection );
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -18,12 +18,9 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.ConnectionSettings;
@@ -35,6 +32,7 @@ import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Logging;
@@ -48,10 +46,10 @@ import static java.util.Collections.emptyList;
  * try to return the session into the session pool, however if we failed to return it back, either because the pool
  * is full or the pool is being cleaned on driver.close, then we directly close the connection attached with the
  * session.
- *
+ * <p>
  * The session is NOT meant to be thread safe, each thread should have an independent session and close it (return to
  * pool) when the work with the session has been done.
- *
+ * <p>
  * The driver is thread safe. Each thread could try to get a session from the pool and then return it to the pool
  * at the same time.
  */
@@ -60,7 +58,8 @@ public class SocketConnectionPool implements ConnectionPool
     /**
      * Pools, organized by server address.
      */
-    private final ConcurrentHashMap<BoltServerAddress,BlockingQueue<PooledConnection>> pools = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<BoltServerAddress,BlockingPooledConnectionQueue> pools =
+            new ConcurrentHashMap<>();
 
     private final Clock clock = Clock.SYSTEM;
 
@@ -73,7 +72,7 @@ public class SocketConnectionPool implements ConnectionPool
     private final AtomicBoolean stopped = new AtomicBoolean( false );
 
     public SocketConnectionPool( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
-                                 PoolSettings poolSettings, Logging logging )
+            PoolSettings poolSettings, Logging logging )
     {
         this.connectionSettings = connectionSettings;
         this.securityPlan = securityPlan;
@@ -94,41 +93,48 @@ public class SocketConnectionPool implements ConnectionPool
 
     private static Map<String,Value> tokenAsMap( AuthToken token )
     {
-        if( token instanceof InternalAuthToken )
+        if ( token instanceof InternalAuthToken )
         {
             return ((InternalAuthToken) token).toMap();
         }
         else
         {
-            throw new ClientException( "Unknown authentication token, `" + token + "`. Please use one of the supported " +
+            throw new ClientException(
+                    "Unknown authentication token, `" + token + "`. Please use one of the supported " +
                     "tokens from `" + AuthTokens.class.getSimpleName() + "`." );
         }
     }
 
     @Override
-    public Connection acquire( BoltServerAddress address )
+    public Connection acquire( final BoltServerAddress address )
     {
         if ( stopped.get() )
         {
             throw new IllegalStateException( "Pool has been closed, cannot acquire new values." );
         }
-        BlockingQueue<PooledConnection> connections = pool( address );
-        PooledConnection conn = connections.poll();
-        if ( conn == null )
+        final BlockingPooledConnectionQueue connections = pool( address );
+        Supplier<PooledConnection> supplier = new Supplier<PooledConnection>()
         {
-            conn = new PooledConnection( connect( address ), new
-                    PooledConnectionReleaseConsumer( connections, stopped, new PooledConnectionValidator( this, poolSettings ) ), clock );
-        }
+            @Override
+            public PooledConnection get()
+            {
+                return new PooledConnection( connect( address ), new
+                        PooledConnectionReleaseConsumer( connections, stopped,
+                        new PooledConnectionValidator( SocketConnectionPool.this, poolSettings ) ), clock );
+
+            }
+        };
+        PooledConnection conn = connections.acquire( supplier );
         conn.updateTimestamp();
         return conn;
     }
 
-    private BlockingQueue<PooledConnection> pool( BoltServerAddress address )
+    private BlockingPooledConnectionQueue pool( BoltServerAddress address )
     {
-        BlockingQueue<PooledConnection> pool = pools.get( address );
+        BlockingPooledConnectionQueue pool = pools.get( address );
         if ( pool == null )
         {
-            pool = new LinkedBlockingQueue<>(poolSettings.maxIdleConnectionPoolSize());
+            pool = new BlockingPooledConnectionQueue( poolSettings.maxIdleConnectionPoolSize() );
 
             if ( pools.putIfAbsent( address, pool ) != null )
             {
@@ -142,19 +148,13 @@ public class SocketConnectionPool implements ConnectionPool
     @Override
     public void purge( BoltServerAddress address )
     {
-        BlockingQueue<PooledConnection> connections = pools.remove( address );
+        BlockingPooledConnectionQueue connections = pools.remove( address );
         if ( connections == null )
         {
             return;
         }
-        while (!connections.isEmpty())
-        {
-            PooledConnection connection = connections.poll();
-            if ( connection != null)
-            {
-                connection.dispose();
-            }
-        }
+
+        connections.terminate();
     }
 
     @Override
@@ -166,41 +166,34 @@ public class SocketConnectionPool implements ConnectionPool
     @Override
     public void close()
     {
-        if( !stopped.compareAndSet( false, true ) )
+        if ( !stopped.compareAndSet( false, true ) )
         {
             // already closed or some other thread already started close
             return;
         }
 
-        for ( BlockingQueue<PooledConnection> pool : pools.values() )
+        for ( BlockingPooledConnectionQueue pool : pools.values() )
         {
-            while ( !pool.isEmpty() )
-            {
-                PooledConnection conn = pool.poll();
-                if ( conn != null )
-                {
-                    //close the underlying connection without adding it back to the queue
-                    conn.dispose();
-                }
-            }
+            pool.terminate();
         }
 
         pools.clear();
     }
 
+
     //for testing
-    public List<PooledConnection> connectionsForAddress(BoltServerAddress address)
+    public List<PooledConnection> connectionsForAddress( BoltServerAddress address )
     {
-        LinkedBlockingQueue<PooledConnection> pooledConnections =
-                (LinkedBlockingQueue<PooledConnection>) pools.get( address );
-        if (pooledConnections == null)
+        BlockingPooledConnectionQueue pooledConnections = pools.get( address );
+        if ( pooledConnections == null )
         {
             return emptyList();
         }
         else
         {
-            return new ArrayList<>( pooledConnections );
+            return pooledConnections.toList();
         }
     }
+
 
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net.pooling;
+
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.util.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BlockingPooledConnectionQueueTest
+{
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldCreateNewConnectionWhenEmpty()
+    {
+        // Given
+        PooledConnection connection = mock( PooledConnection.class );
+        Supplier<PooledConnection> supplier = mock( Supplier.class );
+        when( supplier.get() ).thenReturn( connection );
+        BlockingPooledConnectionQueue queue = new BlockingPooledConnectionQueue( 10 );
+
+        // When
+        queue.acquire( supplier );
+
+        // Then
+        verify( supplier ).get();
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldNotCreateNewConnectionWhenNotEmpty()
+    {
+        // Given
+        PooledConnection connection = mock( PooledConnection.class );
+        Supplier<PooledConnection> supplier = mock( Supplier.class );
+        when( supplier.get() ).thenReturn( connection );
+        BlockingPooledConnectionQueue queue = new BlockingPooledConnectionQueue( 1 );
+        queue.offer( connection );
+
+        // When
+        queue.acquire( supplier );
+
+        // Then
+        verify( supplier, never() ).get();
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldTerminateAllSeenConnections()
+    {
+        // Given
+        PooledConnection connection1 = mock( PooledConnection.class );
+        PooledConnection connection2 = mock( PooledConnection.class );
+        Supplier<PooledConnection> supplier = mock( Supplier.class );
+        when( supplier.get() ).thenReturn( connection1 );
+        BlockingPooledConnectionQueue queue = new BlockingPooledConnectionQueue( 2 );
+        queue.offer( connection1 );
+        queue.offer( connection2 );
+        assertThat( queue.size(), equalTo( 2 ) );
+
+        // When
+        queue.acquire( supplier );
+        assertThat( queue.size(), equalTo( 1 ) );
+        queue.terminate();
+
+        // Then
+        verify( connection1 ).dispose();
+        verify( connection2 ).dispose();
+    }
+
+    @Test
+    public void shouldNotAcceptWhenFull()
+    {
+        // Given
+        PooledConnection connection1 = mock( PooledConnection.class );
+        PooledConnection connection2 = mock( PooledConnection.class );
+        BlockingPooledConnectionQueue queue = new BlockingPooledConnectionQueue( 1 );
+
+        // Then
+        assertTrue(queue.offer( connection1 ));
+        assertFalse(queue.offer( connection2 ));
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
@@ -23,7 +23,6 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
@@ -73,7 +72,8 @@ public class ConnectionInvalidationTest
         PooledConnection conn = new PooledConnection( delegate, Consumers.<PooledConnection>noOp(), clock );
 
         // When/Then
-        BlockingQueue<PooledConnection> queue = mock( BlockingQueue.class );
+        BlockingPooledConnectionQueue
+                queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionValidator validator =
                 new PooledConnectionValidator( pool( true ), poolSettings );
 
@@ -81,7 +81,7 @@ public class ConnectionInvalidationTest
                 new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator);
         consumer.accept( conn );
 
-        verify( queue, never() ).add( conn );
+        verify( queue, never() ).offer( conn );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -99,7 +99,8 @@ public class ConnectionInvalidationTest
                 new PooledConnectionValidator( pool( true ), poolSettings );
 
         // When/Then
-        BlockingQueue<PooledConnection> queue = mock( BlockingQueue.class );
+        BlockingPooledConnectionQueue
+                queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
                 new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ),validator );
         consumer.accept( conn );
@@ -117,12 +118,13 @@ public class ConnectionInvalidationTest
         PooledConnectionValidator validator =
                 new PooledConnectionValidator( pool( true ), poolSettings );
         // When/Then
-        BlockingQueue<PooledConnection> queue = mock( BlockingQueue.class );
+        BlockingPooledConnectionQueue
+                queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
                 new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
         consumer.accept( conn );
 
-        verify( queue, never() ).add( conn );
+        verify( queue, never() ).offer( conn );
     }
 
     @Test
@@ -169,7 +171,8 @@ public class ConnectionInvalidationTest
 
         // Then
         assertTrue( conn.hasUnrecoverableErrors() );
-        BlockingQueue<PooledConnection> queue = mock( BlockingQueue.class );
+        BlockingPooledConnectionQueue
+                queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
                 new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
         consumer.accept( conn );
@@ -198,7 +201,8 @@ public class ConnectionInvalidationTest
         PoolSettings poolSettings = PoolSettings.defaultSettings();
         PooledConnectionValidator validator =
                 new PooledConnectionValidator( pool( true ), poolSettings );
-        BlockingQueue<PooledConnection> queue = mock( BlockingQueue.class );
+        BlockingPooledConnectionQueue
+                queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
                 new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
         consumer.accept( conn );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
@@ -78,7 +78,7 @@ public class ConnectionInvalidationTest
                 new PooledConnectionValidator( pool( true ), poolSettings );
 
         PooledConnectionReleaseConsumer consumer =
-                new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator);
+                new PooledConnectionReleaseConsumer( queue, validator);
         consumer.accept( conn );
 
         verify( queue, never() ).offer( conn );
@@ -102,7 +102,7 @@ public class ConnectionInvalidationTest
         BlockingPooledConnectionQueue
                 queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
-                new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ),validator );
+                new PooledConnectionReleaseConsumer( queue,validator );
         consumer.accept( conn );
 
         verify( queue ).offer( conn );
@@ -121,7 +121,7 @@ public class ConnectionInvalidationTest
         BlockingPooledConnectionQueue
                 queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
-                new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
+                new PooledConnectionReleaseConsumer( queue, validator );
         consumer.accept( conn );
 
         verify( queue, never() ).offer( conn );
@@ -174,7 +174,7 @@ public class ConnectionInvalidationTest
         BlockingPooledConnectionQueue
                 queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
-                new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
+                new PooledConnectionReleaseConsumer( queue, validator );
         consumer.accept( conn );
 
         verify( queue, never() ).offer( conn );
@@ -204,7 +204,7 @@ public class ConnectionInvalidationTest
         BlockingPooledConnectionQueue
                 queue = mock( BlockingPooledConnectionQueue.class );
         PooledConnectionReleaseConsumer consumer =
-                new PooledConnectionReleaseConsumer( queue, new AtomicBoolean( false ), validator );
+                new PooledConnectionReleaseConsumer( queue, validator );
         consumer.accept( conn );
 
         verify( queue ).offer( conn );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
@@ -20,8 +20,6 @@ package org.neo4j.driver.internal.net.pooling;
 
 import org.junit.Test;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.spi.Connection;
@@ -30,8 +28,8 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.Function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -64,7 +62,8 @@ public class PooledConnectionTest
     public void shouldDisposeConnectionIfNotValidConnection() throws Throwable
     {
         // Given
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(1);
+        final BlockingPooledConnectionQueue
+                pool = new BlockingPooledConnectionQueue(1);
 
         final boolean[] flags = {false};
 
@@ -94,7 +93,8 @@ public class PooledConnectionTest
     public void shouldReturnToThePoolIfIsValidConnectionAndIdlePoolIsNotFull() throws Throwable
     {
         // Given
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(1);
+        final BlockingPooledConnectionQueue
+                pool = new BlockingPooledConnectionQueue(1);
 
         final boolean[] flags = {false};
 
@@ -115,7 +115,7 @@ public class PooledConnectionTest
         pooledConnection.close();
 
         // Then
-        assertThat( pool, hasItem(pooledConnection) );
+        assertTrue( pool.contains(pooledConnection));
         assertThat( pool.size(), equalTo( 1 ) );
         assertThat( flags[0], equalTo( false ) );
     }
@@ -125,7 +125,8 @@ public class PooledConnectionTest
     public void shouldDisposeConnectionIfValidConnectionAndIdlePoolIsFull() throws Throwable
     {
         // Given
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(1);
+        final BlockingPooledConnectionQueue
+                pool = new BlockingPooledConnectionQueue(1);
 
         final boolean[] flags = {false};
 
@@ -148,7 +149,7 @@ public class PooledConnectionTest
         shouldBeClosedConnection.close();
 
         // Then
-        assertThat( pool, hasItem(pooledConnection) );
+        assertTrue( pool.contains(pooledConnection) );
         assertThat( pool.size(), equalTo( 1 ) );
         assertThat( flags[0], equalTo( true ) );
     }
@@ -163,7 +164,8 @@ public class PooledConnectionTest
         // session.close() -> well, close the connection directly without putting back to the pool
 
         // Given
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<>(1);
+        final BlockingPooledConnectionQueue
+                pool = new BlockingPooledConnectionQueue(1);
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
@@ -192,7 +194,8 @@ public class PooledConnectionTest
     {
         // Given
         final AtomicBoolean stopped = new AtomicBoolean( false );
-        final BlockingQueue<PooledConnection> pool = new LinkedBlockingQueue<PooledConnection>(1){
+        final BlockingPooledConnectionQueue
+                pool = new BlockingPooledConnectionQueue(1){
             public boolean offer(PooledConnection conn)
             {
                 stopped.set( true );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
@@ -68,8 +68,7 @@ public class PooledConnectionTest
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                new AtomicBoolean( false ), INVALID_CONNECTION );
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, INVALID_CONNECTION );
 
 
         PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
@@ -99,8 +98,7 @@ public class PooledConnectionTest
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                new AtomicBoolean( false ), VALID_CONNECTION );
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION );
 
                 PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
@@ -131,8 +129,7 @@ public class PooledConnectionTest
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                new AtomicBoolean( false ), VALID_CONNECTION);
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
         PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM );
         PooledConnection shouldBeClosedConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
@@ -164,13 +161,12 @@ public class PooledConnectionTest
         // session.close() -> well, close the connection directly without putting back to the pool
 
         // Given
-        final BlockingPooledConnectionQueue
-                pool = new BlockingPooledConnectionQueue(1);
+        final BlockingPooledConnectionQueue pool = new BlockingPooledConnectionQueue(1);
+        pool.terminate();
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                new AtomicBoolean( true ), VALID_CONNECTION);
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
         PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
@@ -193,25 +189,14 @@ public class PooledConnectionTest
     public void shouldDisposeConnectionIfPoolStoppedAfterPuttingConnectionBackToPool() throws Throwable
     {
         // Given
-        final AtomicBoolean stopped = new AtomicBoolean( false );
         final BlockingPooledConnectionQueue
-                pool = new BlockingPooledConnectionQueue(1){
-            public boolean offer(PooledConnection conn)
-            {
-                stopped.set( true );
-                // some clean work to close all connection in pool
-                boolean offer = super.offer( conn );
-                assertThat ( this.size(), equalTo( 1 ) );
-                // we successfully put the connection back to the pool
-                return offer;
-            }
-        };
+                pool = new BlockingPooledConnectionQueue(1);
+        pool.terminate();
         final boolean[] flags = {false};
 
         Connection conn = mock( Connection.class );
 
-        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool,
-                stopped , VALID_CONNECTION);
+        PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
         PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -23,13 +23,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import org.neo4j.driver.internal.logging.ConsoleLogging;
-import org.neo4j.driver.v1.*;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.util.TestNeo4j;
-
-import java.util.logging.Level;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -192,7 +195,7 @@ public class SessionIT
 
             tx.run("CALL test.driver.longRunningStatement({seconds})",
                     parameters( "seconds", 10 ) );
-            Thread.sleep( 1* 1000 );
+            Thread.sleep( 1000 );
             session.reset();
 
             exception.expect( ClientException.class );
@@ -215,7 +218,7 @@ public class SessionIT
         Session session = driver.session();
         session.run( "CALL test.driver.longRunningStatement({seconds})",
                 parameters( "seconds", 10 ) );
-        Thread.sleep( 1 * 1000 );
+        Thread.sleep( 1000 );
         session.reset();
 
         exception.expect( ClientException.class );
@@ -239,7 +242,7 @@ public class SessionIT
 
             StatementResult procedureResult = tx.run("CALL test.driver.longRunningStatement({seconds})",
                     parameters( "seconds", 10 ) );
-            Thread.sleep( 1* 1000 );
+            Thread.sleep( 1000 );
             session.reset();
 
             try
@@ -355,5 +358,19 @@ public class SessionIT
                 assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
             }
         }
+    }
+
+    @Test
+    public void shouldCloseSessionWhenDriverIsClosed() throws Throwable
+    {
+        // Given
+        Driver driver = GraphDatabase.driver( neo4j.uri() );
+        Session session = driver.session();
+
+        // When
+        driver.close();
+
+        // Then
+        assertFalse( session.isOpen() );
     }
 }


### PR DESCRIPTION
Connections/Sessions that were in flight, i.e. acquired from the pool, were not
closed when shutting down the driver, connections remained open until GC
happened. The expected behavior is that `driver.close()` closes down all
sessions it has created.
