### PR TITLE
Ensure all URI examples contain an explicit port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ available.
 
 Connect to a Neo4j 3.0.0+ database:
 
-    Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic( "neo4j", "neo4j" ) );
+    Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic( "neo4j", "neo4j" ) );
     
     try ( Session session = driver.session() )
     {

--- a/driver/src/main/javadoc/overview.html
+++ b/driver/src/main/javadoc/overview.html
@@ -13,7 +13,7 @@ If you are using Java, this is generally the interface you'd use to integrate Ne
 
 <p>Once you have the driver and a connector on your classpath, you can establish sessions with Neo4j.</p>
 
-<pre><code>Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic( "neo4j", "p4ssw0rd" ) );
+<pre><code>Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic( "neo4j", "p4ssw0rd" ) );
 try( Session session = driver.session() )
 {
     StatementResult result = session.run( "RETURN 'hello, world!'" );

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
@@ -42,7 +42,7 @@ public class DirectDriverTest
     public void shouldUseDefaultPortIfMissing()
     {
         // Given
-        URI uri = URI.create( "bolt://localhost" );
+        URI uri = URI.create( "bolt://localhost:7687" );
 
         // When
         DirectDriver driver = (DirectDriver) GraphDatabase.driver( uri );

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/DriverStresser.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/DriverStresser.java
@@ -58,7 +58,7 @@ public class DriverStresser
     {
         server = Neo4jRunner.getOrCreateGlobalRunner();
         server.ensureRunning( Neo4jSettings.TEST_SETTINGS );
-        driver = GraphDatabase.driver( "bolt://localhost" );
+        driver = GraphDatabase.driver( "bolt://localhost:7687" );
     }
 
     static class Worker

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/ErrorReportingSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/ErrorReportingSteps.java
@@ -186,7 +186,7 @@ public class ErrorReportingSteps
     @And( "^I get a session from the driver and close the driver$" )
     public void iGetASessionFromTheDriver() throws Throwable
     {
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost" ) )
+        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:7687" ) )
         {
             transactionRunner = new TransactionRunner( driver.session() );
         }
@@ -228,7 +228,7 @@ public class ErrorReportingSteps
     @Given( "^I have a driver with fixed pool size of (\\d+)$" )
     public void iHaveADriverWithFixedPoolSizeOf( int poolSize ) throws Throwable
     {
-        smallDriver = GraphDatabase.driver( "bolt://localhost", Config.build().withMaxSessions( poolSize ).toConfig() );
+        smallDriver = GraphDatabase.driver( "bolt://localhost:7687", Config.build().withMaxSessions( poolSize ).toConfig() );
     }
 
     @And( "^I try to get a session$" )

--- a/examples/src/main/java/org/neo4j/docs/driver/Examples.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/Examples.java
@@ -41,7 +41,7 @@ public class Examples
     public static Driver constructDriver() throws Exception
     {
         // tag::construct-driver[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic("neo4j", "neo4j") );
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic("neo4j", "neo4j") );
         // end::construct-driver[]
 
         return driver;
@@ -51,7 +51,7 @@ public class Examples
     {
         // tag::configuration[]
         Driver driver = GraphDatabase.driver(
-                "bolt://localhost",
+                "bolt://localhost:7687",
                 AuthTokens.basic("neo4j", "neo4j"),
                 Config.build().withMaxSessions( 10 ).toConfig() );
         // end::configuration[]
@@ -215,7 +215,7 @@ public class Examples
     public static Driver requireEncryption() throws Exception
     {
         // tag::tls-require-encryption[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic("neo4j", "neo4j"),
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic("neo4j", "neo4j"),
                 Config.build().withEncryptionLevel( Config.EncryptionLevel.REQUIRED ).toConfig() );
         // end::tls-require-encryption[]
 
@@ -225,7 +225,7 @@ public class Examples
     public static Driver trustOnFirstUse() throws Exception
     {
         // tag::tls-trust-on-first-use[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic("neo4j", "neo4j"), Config.build()
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic("neo4j", "neo4j"), Config.build()
                 .withEncryptionLevel( Config.EncryptionLevel.REQUIRED )
                 .withTrustStrategy( Config.TrustStrategy.trustOnFirstUse( new File( "/path/to/neo4j_known_hosts" ) ) )
                 .toConfig() );
@@ -237,7 +237,7 @@ public class Examples
     public static Driver trustSignedCertificates() throws Exception
     {
         // tag::tls-signed[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic("neo4j", "neo4j"), Config.build()
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic("neo4j", "neo4j"), Config.build()
                 .withEncryptionLevel( Config.EncryptionLevel.REQUIRED )
                 .withTrustStrategy( Config.TrustStrategy.trustCustomCertificateSignedBy( new File( "/path/to/ca-certificate.pem") ) )
                 .toConfig() );
@@ -249,7 +249,7 @@ public class Examples
     public static Driver connectWithAuthDisabled() throws Exception
     {
         // tag::connect-with-auth-disabled[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost",
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687",
                 Config.build().withEncryptionLevel( Config.EncryptionLevel.REQUIRED ).toConfig() );
         // end::connect-with-auth-disabled[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/MinimalWorkingExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/MinimalWorkingExample.java
@@ -28,7 +28,7 @@ public class MinimalWorkingExample
     public static void minimalWorkingExample() throws Exception
     {
         // tag::minimal-example[]
-        Driver driver = GraphDatabase.driver( "bolt://localhost", AuthTokens.basic( "neo4j", "neo4j" ) );
+        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic( "neo4j", "neo4j" ) );
         Session session = driver.session();
 
         session.run( "CREATE (a:Person {name:'Arthur', title:'King'})" );

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -86,7 +86,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             Examples.statement( session );
@@ -101,7 +101,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             Examples.statementWithoutParameters( session );
@@ -116,7 +116,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             session.run( "MATCH (n) DETACH DELETE n" );
@@ -134,7 +134,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-              Driver driver = GraphDatabase.driver( "bolt://localhost" );
+              Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
               Session session = driver.session() )
         {
             session.run( "MATCH (n) DETACH DELETE n" );
@@ -152,7 +152,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             session.run( "MATCH (n) DETACH DELETE n" );
@@ -172,7 +172,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" ) )
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" ) )
         {
             try ( Session setup = driver.session() )
             {
@@ -192,7 +192,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-              Driver driver = GraphDatabase.driver( "bolt://localhost" );
+              Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
               Session session = driver.session() )
         {
             exception.expect(RuntimeException.class);
@@ -203,7 +203,7 @@ public class ExamplesIT
     @Test
     public void transactionCommit() throws Throwable
     {
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost" );
+        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             session.run( "MATCH (n) DETACH DELETE n" );
@@ -218,7 +218,7 @@ public class ExamplesIT
     @Test
     public void transactionRollback() throws Throwable
     {
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost" );
+        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             session.run( "MATCH (n) DETACH DELETE n" );
@@ -236,7 +236,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             Examples.resultSummary( session );
@@ -253,7 +253,7 @@ public class ExamplesIT
     {
         StdIOCapture stdIO = new StdIOCapture();
         try ( AutoCloseable captured = stdIO.capture();
-                Driver driver = GraphDatabase.driver( "bolt://localhost" );
+                Driver driver = GraphDatabase.driver( "bolt://localhost:7687" );
                 Session session = driver.session() )
         {
             Examples.notifications( session );


### PR DESCRIPTION
For docs, the port should always be specified explicitly. We should not encourage "default port" style usage. This is because the port(s) used will regularly vary from default within many production cases and the explicit case is therefore more generally helpful.
