### PR TITLE
Fix trust on first use for cluster

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -19,13 +19,6 @@
 
 package org.neo4j.driver.internal.security;
 
-import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.v1.*;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -33,6 +26,10 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 import static org.neo4j.driver.internal.util.CertificateTool.loadX509Cert;
 
@@ -68,13 +65,35 @@ public class SecurityPlan
     }
 
 
-    public static SecurityPlan forTrustOnFirstUse( File knownHosts, BoltServerAddress address, Logger logger )
+    public static SecurityPlan forTrustOnFirstUse( File knownHosts )
             throws IOException, KeyManagementException, NoSuchAlgorithmException
     {
-        SSLContext sslContext = SSLContext.getInstance( "TLS" );
-        sslContext.init( new KeyManager[0], new TrustManager[]{new TrustOnFirstUseTrustManager( address, knownHosts, logger )}, null );
+        Map<String,String> preLoadKnownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownHosts );
+        return new TrustOnFirstUseSecurityPlan( knownHosts, preLoadKnownHostsMap );
+    }
 
-        return new SecurityPlan( true, sslContext);
+    public static class TrustOnFirstUseSecurityPlan extends SecurityPlan
+    {
+        private final Map<String, String> trustOnFirstUseMap;
+        private final File knownHostsFile;
+
+        private TrustOnFirstUseSecurityPlan( File knownHostsFile, Map<String, String>
+                trustOnFirstUseMap )
+        {
+            super( true, null );
+            this.trustOnFirstUseMap = trustOnFirstUseMap;
+            this.knownHostsFile = knownHostsFile;
+        }
+
+        public Map<String, String> trustOnFirstUseMap()
+        {
+            return this.trustOnFirstUseMap;
+        }
+
+        public File knownHostFile()
+        {
+            return this.knownHostsFile;
+        }
     }
 
     public static SecurityPlan insecure()
@@ -85,7 +104,7 @@ public class SecurityPlan
     private final boolean requiresEncryption;
     private final SSLContext sslContext;
 
-    private SecurityPlan( boolean requiresEncryption, SSLContext sslContext)
+    private SecurityPlan( boolean requiresEncryption, SSLContext sslContext )
     {
         this.requiresEncryption = requiresEncryption;
         this.sslContext = sslContext;

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -27,6 +27,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -68,24 +69,23 @@ public class SecurityPlan
     public static SecurityPlan forTrustOnFirstUse( File knownHosts )
             throws IOException, KeyManagementException, NoSuchAlgorithmException
     {
-        Map<String,String> preLoadKnownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownHosts );
+        ConcurrentHashMap<String,String> preLoadKnownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownHosts );
         return new TrustOnFirstUseSecurityPlan( knownHosts, preLoadKnownHostsMap );
     }
 
     public static class TrustOnFirstUseSecurityPlan extends SecurityPlan
     {
-        private final Map<String, String> trustOnFirstUseMap;
+        private final ConcurrentHashMap<String, String> trustOnFirstUseMap;
         private final File knownHostsFile;
 
-        private TrustOnFirstUseSecurityPlan( File knownHostsFile, Map<String, String>
-                trustOnFirstUseMap )
+        private TrustOnFirstUseSecurityPlan( File knownHostsFile, ConcurrentHashMap<String, String> trustOnFirstUseMap )
         {
             super( true, null );
             this.trustOnFirstUseMap = trustOnFirstUseMap;
             this.knownHostsFile = knownHostsFile;
         }
 
-        public Map<String, String> trustOnFirstUseMap()
+        public ConcurrentHashMap<String, String> trustOnFirstUseMap()
         {
             return this.trustOnFirstUseMap;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManager.java
@@ -28,8 +28,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.X509TrustManager;
 
 import org.neo4j.driver.internal.util.BytePrinter;
@@ -54,11 +54,11 @@ public class TrustOnFirstUseTrustManager implements X509TrustManager
     private final File knownHostsFile;
 
     /** The map of server ip:port (in digits) and its known certificate we've registered */
-    private final Map<String, String> knownHosts;
+    private final ConcurrentHashMap<String, String> knownHosts;
     private final Logger logger;
     private final String serverId;
 
-    TrustOnFirstUseTrustManager( String serverId, File knownHosts, Map<String,String> preLoadedKnownHosts, Logger logger )
+    TrustOnFirstUseTrustManager( String serverId, File knownHosts, ConcurrentHashMap<String,String> preLoadedKnownHosts, Logger logger )
             throws IOException
     {
         this.logger = logger;
@@ -67,9 +67,9 @@ public class TrustOnFirstUseTrustManager implements X509TrustManager
         this.serverId = serverId;
     }
 
-    public static Map<String, String> createKnownHostsMap( File knownHostsFile ) throws IOException
+    public static ConcurrentHashMap<String, String> createKnownHostsMap( File knownHostsFile ) throws IOException
     {
-        Map<String, String> knownHosts = new HashMap<>();
+        ConcurrentHashMap<String, String> knownHosts = new ConcurrentHashMap<>();
         load( knownHostsFile, knownHosts );
         return knownHosts;
     }

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -34,7 +34,6 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.util.BiFunction;
 import org.neo4j.driver.v1.util.Function;
 
 import static java.lang.String.format;
@@ -222,8 +221,7 @@ public class GraphDatabase
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forSignedCertificates( config.trustStrategy().certFile() );
             case TRUST_ON_FIRST_USE:
-                return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile(),
-                        address, logger );
+                return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile() );
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + config.trustStrategy().strategy().name() );

--- a/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
@@ -29,9 +29,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Scanner;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
@@ -91,7 +90,7 @@ public class TrustOnFirstUseTrustManagerTest
         // Given
         BoltServerAddress knownServerAddress = new BoltServerAddress( knownServerIp, knownServerPort );
         Logger logger = mock(Logger.class);
-        Map<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
+        ConcurrentHashMap<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
         TrustOnFirstUseTrustManager manager =
                 new TrustOnFirstUseTrustManager( knownServerAddress.toString(), knownCertsFile, knownHostsMap, logger );
 
@@ -119,7 +118,7 @@ public class TrustOnFirstUseTrustManagerTest
         int newPort = 200;
         BoltServerAddress address = new BoltServerAddress( knownServerIp, newPort );
         Logger logger = mock(Logger.class);
-        Map<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
+        ConcurrentHashMap<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
         TrustOnFirstUseTrustManager manager =
                 new TrustOnFirstUseTrustManager( address.toString(), knownCertsFile, knownHostsMap, logger );
 
@@ -192,7 +191,7 @@ public class TrustOnFirstUseTrustManagerTest
         {
             TrustOnFirstUseTrustManager manager =
                     new TrustOnFirstUseTrustManager( new BoltServerAddress( knownServerIp, knownServerPort ).toString(),
-                            knownHostFile, new HashMap<String, String>(), mock( Logger.class ) );
+                            knownHostFile, new ConcurrentHashMap<String, String>(), mock( Logger.class ) );
             manager.checkServerTrusted( new X509Certificate[]{ knownCertificate}, null );
             fail( "Should have failed in write to certs" );
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
@@ -29,12 +29,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Scanner;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -88,8 +91,9 @@ public class TrustOnFirstUseTrustManagerTest
         // Given
         BoltServerAddress knownServerAddress = new BoltServerAddress( knownServerIp, knownServerPort );
         Logger logger = mock(Logger.class);
+        Map<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
         TrustOnFirstUseTrustManager manager =
-                new TrustOnFirstUseTrustManager( knownServerAddress, knownCertsFile, logger );
+                new TrustOnFirstUseTrustManager( knownServerAddress.toString(), knownCertsFile, knownHostsMap, logger );
 
         X509Certificate wrongCertificate = mock( X509Certificate.class );
         when( wrongCertificate.getEncoded() ).thenReturn( "fake certificate".getBytes() );
@@ -115,7 +119,9 @@ public class TrustOnFirstUseTrustManagerTest
         int newPort = 200;
         BoltServerAddress address = new BoltServerAddress( knownServerIp, newPort );
         Logger logger = mock(Logger.class);
-        TrustOnFirstUseTrustManager manager = new TrustOnFirstUseTrustManager( address, knownCertsFile, logger );
+        Map<String,String> knownHostsMap = TrustOnFirstUseTrustManager.createKnownHostsMap( knownCertsFile );
+        TrustOnFirstUseTrustManager manager =
+                new TrustOnFirstUseTrustManager( address.toString(), knownCertsFile, knownHostsMap, logger );
 
         String fingerprint = fingerprint( knownCertificate );
 
@@ -125,6 +131,7 @@ public class TrustOnFirstUseTrustManagerTest
         // Then no exception should've been thrown, and we should've logged that we now trust this certificate
         verify(logger).warn( "Adding %s as known and trusted certificate for %s.", fingerprint, "1.2.3.4:200" );
 
+        assertThat(knownHostsMap.get( address.toString() ), equalTo( fingerprint ) );
         // And the file should contain the right info
         Scanner reader = new Scanner( knownCertsFile );
 
@@ -159,7 +166,7 @@ public class TrustOnFirstUseTrustManagerTest
         // When & Then
         try
         {
-            new TrustOnFirstUseTrustManager( new BoltServerAddress( knownServerIp, knownServerPort ), knownHostFile, null );
+            TrustOnFirstUseTrustManager.createKnownHostsMap( knownHostFile );
             fail( "Should have failed in load certs" );
         }
         catch( IOException e )
@@ -177,14 +184,15 @@ public class TrustOnFirstUseTrustManagerTest
     {
         // Given
         File knownHostFile = mock( File.class );
-        when( knownHostFile.exists() ).thenReturn( false /*skip reading*/, true );
+        when( knownHostFile.exists() ).thenReturn( true );
         when( knownHostFile.canWrite() ).thenReturn( false );
 
         // When & Then
         try
         {
             TrustOnFirstUseTrustManager manager =
-                    new TrustOnFirstUseTrustManager( new BoltServerAddress( knownServerIp, knownServerPort ), knownHostFile, mock( Logger.class ) );
+                    new TrustOnFirstUseTrustManager( new BoltServerAddress( knownServerIp, knownServerPort ).toString(),
+                            knownHostFile, new HashMap<String, String>(), mock( Logger.class ) );
             manager.checkServerTrusted( new X509Certificate[]{ knownCertificate}, null );
             fail( "Should have failed in write to certs" );
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -34,13 +34,17 @@ import java.nio.channels.SocketChannel;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLHandshakeException;
 
-import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.security.TLSSocketChannel;
-import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.v1.*;
 import org.neo4j.driver.internal.util.CertificateTool;
-
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.util.CertificateToolTest;
 import org.neo4j.driver.v1.util.Neo4jRunner;
 import org.neo4j.driver.v1.util.Neo4jSettings;
@@ -184,7 +188,7 @@ public class TLSSocketChannelIT
         createFakeServerCertPairInKnownCerts( address, knownCerts );
 
         // When & Then
-        SecurityPlan securityPlan = SecurityPlan.forTrustOnFirstUse( knownCerts, address, new DevNullLogger() );
+        SecurityPlan securityPlan = SecurityPlan.forTrustOnFirstUse( knownCerts );
         TLSSocketChannel sslChannel = null;
         try
         {
@@ -333,7 +337,7 @@ public class TLSSocketChannelIT
 
         // When
 
-        SecurityPlan securityPlan = SecurityPlan.forTrustOnFirstUse( knownCerts, address, new DevNullLogger() );
+        SecurityPlan securityPlan = SecurityPlan.forTrustOnFirstUse( knownCerts );
         TLSSocketChannel sslChannel =
                 new TLSSocketChannel( address, securityPlan, channel, logger );
         sslChannel.close();


### PR DESCRIPTION
The driver creates a serverId-fingerprint map and pass this map to be shared by all connections. Each connection creates its own sslContext and trustManager at the connection starts. All connections refer to the map when getting/adding a server fingerprint to the file
