### PR TITLE
Uniform handling of ENCRYPTION_NON_LOCAL

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
@@ -35,7 +35,7 @@ public class BoltServerAddress
     public static final int DEFAULT_PORT = 7687;
     public static final BoltServerAddress LOCAL_DEFAULT = new BoltServerAddress( "localhost", DEFAULT_PORT );
     private static final Pattern LOCALHOST =
-            Pattern.compile( "^(localhost|127(\\.\\d+){3})$", Pattern.CASE_INSENSITIVE );
+            Pattern.compile( "^localhost$|^127(\\.\\d+){3}$|^(?:0*\\:)*?:?0*1$", Pattern.CASE_INSENSITIVE );
 
 
     public static BoltServerAddress from( URI uri )
@@ -61,7 +61,7 @@ public class BoltServerAddress
 
     public BoltServerAddress( String host )
     {
-        int colon = host.indexOf( ':' );
+        int colon = host.lastIndexOf( ':' );
         if ( colon >= 0 )
         {
             this.port = Integer.parseInt( host.substring( colon + 1 ) );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.neo4j.driver.internal.net;
 
 import java.net.InetAddress;
@@ -24,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
@@ -34,6 +34,9 @@ public class BoltServerAddress
 {
     public static final int DEFAULT_PORT = 7687;
     public static final BoltServerAddress LOCAL_DEFAULT = new BoltServerAddress( "localhost", DEFAULT_PORT );
+    private static final Pattern LOCALHOST =
+            Pattern.compile( "^(localhost|127(\\.\\d+){3})$", Pattern.CASE_INSENSITIVE );
+
 
     public static BoltServerAddress from( URI uri )
     {
@@ -100,7 +103,7 @@ public class BoltServerAddress
 
     public SocketAddress toSocketAddress()
     {
-        if (socketAddress == null)
+        if ( socketAddress == null )
         {
             socketAddress = new InetSocketAddress( host, port );
         }
@@ -138,21 +141,12 @@ public class BoltServerAddress
 
     /**
      * Determine whether or not this address refers to the local machine. This
-     * will generally be true for "localhost" or "127.x.x.x".
+     * will be true for "localhost" or "127.x.x.x".
      *
      * @return true if local, false otherwise
      */
     public boolean isLocal()
     {
-        try
-        {
-            // confirmed to work as desired with both "localhost" and "127.x.x.x"
-            return InetAddress.getByName( host ).isLoopbackAddress();
-        }
-        catch ( UnknownHostException e )
-        {
-            // if it's unknown, it's not local so we can safely return false
-            return false;
-        }
+        return LOCALHOST.matcher( host ).matches();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
@@ -68,6 +68,34 @@ public class DirectDriverTest
 
     }
 
+    @Test
+    public void shouldConnectWithIPv6WithExplicitPort()
+    {
+        // Given
+        URI uri = URI.create( "bolt://[::1]:7688" );
+
+        // When
+        DirectDriver driver = (DirectDriver) GraphDatabase.driver( uri );
+
+        // Then
+        BoltServerAddress address = driver.server();
+        assertThat( address.port(), equalTo(7688 ) );
+    }
+
+    @Test
+    public void shouldConnectWithIPv6WithImplicitPort()
+    {
+        // Given
+        URI uri = URI.create( "bolt://[::1]" );
+
+        // When
+        DirectDriver driver = (DirectDriver) GraphDatabase.driver( uri );
+
+        // Then
+        BoltServerAddress address = driver.server();
+        assertThat( address.port(), equalTo( BoltServerAddress.DEFAULT_PORT ) );
+    }
+
     @Ignore
     public void shouldBeAbleRunCypher() throws StubServer.ForceKilled, InterruptedException, IOException
     {

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -20,16 +20,23 @@
 package org.neo4j.driver.internal.net;
 
 import org.junit.Test;
-import org.neo4j.driver.internal.net.BoltServerAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class BoltServerAddressTest
 {
     @Test
     public void variantsOfLocalHostShouldResolveAsLocal() throws Exception
     {
+        assertThat( new BoltServerAddress( "::1", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0:0:0:0:0:0:0:1", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0::1", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0:0:0::1", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0000::0001", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0000:0:0000::0001", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0000:0:0000::1", 7687 ).isLocal(), equalTo( true ) );
+        assertThat( new BoltServerAddress( "0000:0000:0000:0000:0000:0000:0000:0001", 7687 ).isLocal(), equalTo( true ) );
         assertThat( new BoltServerAddress( "localhost", 7687 ).isLocal(), equalTo( true ) );
         assertThat( new BoltServerAddress( "LocalHost", 7687 ).isLocal(), equalTo( true ) );
         assertThat( new BoltServerAddress( "LOCALHOST", 7687 ).isLocal(), equalTo( true ) );
@@ -48,6 +55,15 @@ public class BoltServerAddressTest
     public void portShouldUseDefaultIfNotSupplied()
     {
         assertThat( new BoltServerAddress( "localhost" ).port(), equalTo( BoltServerAddress.DEFAULT_PORT ) );
+    }
+
+    @Test
+    public void shouldHandleIPv6String()
+    {
+        BoltServerAddress address = new BoltServerAddress( "[2001:0db8:0000:0000:0000:ff00:0042:8329]:1234" );
+
+        assertThat(address.host(), equalTo( "[2001:0db8:0000:0000:0000:ff00:0042:8329]" ));
+        assertThat(address.port(), equalTo( 1234));
     }
 
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -32,6 +32,7 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.util.Neo4jSettings;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -100,6 +101,18 @@ public class SessionIT
 
             // Then
             assertFalse( session.isOpen() );
+        }
+    }
+
+    @Test
+    public void shouldConnectWithIpv6() throws Throwable
+    {
+        neo4j.restart( Neo4jSettings.TEST_SETTINGS.updateWith( Neo4jSettings.BOLT_CONNECTOR, "[::1]:7687" ) );
+        // Given
+        try ( Driver driver = GraphDatabase.driver("bolt://[::1]");
+              Session session = driver.session())
+            {
+            assertThat( session.run( "RETURN 11" ).single().get( 0 ).asLong(), equalTo(11L));
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jSettings.java
@@ -19,11 +19,14 @@
 package org.neo4j.driver.v1.util;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
 
 import static org.neo4j.driver.internal.util.Iterables.map;
 
@@ -33,6 +36,7 @@ public class Neo4jSettings
     public static final String DATA_DIR = "dbms.directories.data";
     public static final String CERT_DIR = "dbms.directories.certificates";
     public static final String IMPORT_DIR = "dbms.directories.import";
+    public static final String BOLT_CONNECTOR = "dbms.connector.bolt.address";
 
     private static final String DEFAULT_IMPORT_DIR = "import";
     private static final String DEFAULT_CERT_DIR = "certificates";
@@ -52,12 +56,27 @@ public class Neo4jSettings
             CERT_DIR, DEFAULT_CERT_DIR,
             DATA_DIR, DEFAULT_DATA_DIR,
             IMPORT_DIR, DEFAULT_IMPORT_DIR,
-            AUTH_ENABLED, "false" ), Collections.<String>emptySet() );
+            AUTH_ENABLED, "false",
+            BOLT_CONNECTOR, Neo4jRunner.DEFAULT_ADDRESS.toString()
+    ), Collections.<String>emptySet() );
 
     private Neo4jSettings( Map<String, String> settings, Set<String> excludes )
     {
         this.settings = settings;
         this.excludes = excludes;
+    }
+
+    public BoltServerAddress boltConnectorAddress()
+    {
+        String s = settings.get( BOLT_CONNECTOR );
+        if (s == null)
+        {
+            return Neo4jRunner.DEFAULT_ADDRESS;
+        }
+        else
+        {
+            return BoltServerAddress.from( URI.create( "bolt://" + s ));
+        }
     }
 
     public Map<String, String> propertiesMap()


### PR DESCRIPTION
Although the old check, which looked for a loopback address was in someway
_more correct_. We want a well-defined uniform across driver. So the driver
will only consider a connection to be local if it matches `localhost`,
`127.x.y.z`, or `::1` (and variants thereof)
