### PR TITLE
Deprecate TOFU, add TRUST_ALL and remove E_NON_LOCAL

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -34,6 +35,16 @@ import static java.lang.String.format;
 
 public class RoutingDriver extends BaseDriver
 {
+    // Verify that a security plan is compatible with this driver, throwing an exception if not
+    private static SecurityPlan verifiedSecurityPlan( SecurityPlan securityPlan )
+    {
+        if ( !securityPlan.isRoutingCompatible() )
+        {
+            throw new IllegalArgumentException( "The chosen security plan is not compatible with a routing driver" );
+        }
+        return securityPlan;
+    }
+
     private final LoadBalancer loadBalancer;
 
     public RoutingDriver(
@@ -45,7 +56,7 @@ public class RoutingDriver extends BaseDriver
             Clock clock,
             Logging logging )
     {
-        super( contract, securityPlan, logging );
+        super( contract, verifiedSecurityPlan( securityPlan ), logging );
         this.loadBalancer = new LoadBalancer( settings, clock, log, connections, seedAddress );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
@@ -136,23 +136,4 @@ public class BoltServerAddress
         return port;
     }
 
-    /**
-     * Determine whether or not this address refers to the local machine. This
-     * will generally be true for "localhost" or "127.x.x.x".
-     *
-     * @return true if local, false otherwise
-     */
-    public boolean isLocal()
-    {
-        try
-        {
-            // confirmed to work as desired with both "localhost" and "127.x.x.x"
-            return InetAddress.getByName( host ).isLoopbackAddress();
-        }
-        catch ( UnknownHostException e )
-        {
-            // if it's unknown, it's not local so we can safely return false
-            return false;
-        }
-    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -294,7 +294,7 @@ public class SocketClient
 
             if (securityPlan.requiresEncryption())
             {
-                channel = new TLSSocketChannel( address, securityPlan, soChannel, logger );
+                channel = TLSSocketChannel.create( address, securityPlan, soChannel, logger );
             }
             else
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -59,7 +59,7 @@ public class SecurityPlan
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
         sslContext.init( new KeyManager[0], trustManagerFactory.getTrustManagers(), null );
 
-        return new SecurityPlan( true, sslContext);
+        return new SecurityPlan( true, sslContext );
     }
 
     public static SecurityPlan forSystemCertificates() throws NoSuchAlgorithmException, KeyStoreException

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -49,7 +49,7 @@ public class SecurityPlan
         return new SecurityPlan( true, sslContext, true );
     }
 
-    public static SecurityPlan forSignedCertificates( File certFile )
+    public static SecurityPlan forCustomCASignedCertificates( File certFile )
             throws GeneralSecurityException, IOException
     {
         // A certificate file is specified so we will load the certificates in the file
@@ -70,7 +70,7 @@ public class SecurityPlan
         return new SecurityPlan( true, sslContext, true );
     }
 
-    public static SecurityPlan forSystemCertificates() throws NoSuchAlgorithmException, KeyStoreException
+    public static SecurityPlan forSystemCASignedCertificates() throws NoSuchAlgorithmException, KeyStoreException
     {
         return new SecurityPlan( true, SSLContext.getDefault(), true );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -46,7 +46,7 @@ public class SecurityPlan
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
         sslContext.init( new KeyManager[0], new TrustManager[]{new TrustAllTrustManager()}, null );
 
-        return new SecurityPlan( true, sslContext );
+        return new SecurityPlan( true, sslContext, true );
     }
 
     public static SecurityPlan forSignedCertificates( File certFile )
@@ -67,12 +67,12 @@ public class SecurityPlan
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
         sslContext.init( new KeyManager[0], trustManagerFactory.getTrustManagers(), null );
 
-        return new SecurityPlan( true, sslContext );
+        return new SecurityPlan( true, sslContext, true );
     }
 
     public static SecurityPlan forSystemCertificates() throws NoSuchAlgorithmException, KeyStoreException
     {
-        return new SecurityPlan( true, SSLContext.getDefault() );
+        return new SecurityPlan( true, SSLContext.getDefault(), true );
     }
 
     @Deprecated
@@ -82,21 +82,23 @@ public class SecurityPlan
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
         sslContext.init( new KeyManager[0], new TrustManager[]{new TrustOnFirstUseTrustManager( address, knownHosts, logger )}, null );
 
-        return new SecurityPlan( true, sslContext );
+        return new SecurityPlan( true, sslContext, false );
     }
 
     public static SecurityPlan insecure()
     {
-        return new SecurityPlan( false, null );
+        return new SecurityPlan( false, null, true );
     }
 
     private final boolean requiresEncryption;
     private final SSLContext sslContext;
+    private final boolean routingCompatible;
 
-    private SecurityPlan( boolean requiresEncryption, SSLContext sslContext)
+    private SecurityPlan( boolean requiresEncryption, SSLContext sslContext, boolean routingCompatible )
     {
         this.requiresEncryption = requiresEncryption;
         this.sslContext = sslContext;
+        this.routingCompatible = routingCompatible;
     }
 
     public boolean requiresEncryption()
@@ -104,7 +106,14 @@ public class SecurityPlan
         return requiresEncryption;
     }
 
+    public boolean isRoutingCompatible()
+    {
+        return routingCompatible;
+    }
 
-    public SSLContext sslContext() {return sslContext;}
+    public SSLContext sslContext()
+    {
+        return sslContext;
+    }
 
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -41,6 +41,14 @@ import static org.neo4j.driver.internal.util.CertificateTool.loadX509Cert;
  */
 public class SecurityPlan
 {
+    public static SecurityPlan forAllCertificates() throws GeneralSecurityException, IOException
+    {
+        SSLContext sslContext = SSLContext.getInstance( "TLS" );
+        sslContext.init( new KeyManager[0], new TrustManager[]{new TrustAllTrustManager()}, null );
+
+        return new SecurityPlan( true, sslContext );
+    }
+
     public static SecurityPlan forSignedCertificates( File certFile )
             throws GeneralSecurityException, IOException
     {
@@ -67,14 +75,14 @@ public class SecurityPlan
         return new SecurityPlan( true, SSLContext.getDefault() );
     }
 
-
+    @Deprecated
     public static SecurityPlan forTrustOnFirstUse( File knownHosts, BoltServerAddress address, Logger logger )
             throws IOException, KeyManagementException, NoSuchAlgorithmException
     {
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
         sslContext.init( new KeyManager[0], new TrustManager[]{new TrustOnFirstUseTrustManager( address, knownHosts, logger )}, null );
 
-        return new SecurityPlan( true, sslContext);
+        return new SecurityPlan( true, sslContext );
     }
 
     public static SecurityPlan insecure()

--- a/driver/src/main/java/org/neo4j/driver/internal/security/TrustAllTrustManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TrustAllTrustManager.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.driver.internal.security;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+
+public class TrustAllTrustManager implements X509TrustManager
+{
+    public void checkClientTrusted( X509Certificate[] chain, String authType ) throws CertificateException
+    {
+        throw new CertificateException( "All client connections to this client are forbidden." );
+    }
+
+    public void checkServerTrusted( X509Certificate[] chain, String authType ) throws CertificateException
+    {
+        // all fine, pass through
+    }
+
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return new X509Certificate[0];
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -167,7 +167,7 @@ public class Config
         private Logging logging = new JULogging( Level.INFO );
         private int maxIdleConnectionPoolSize = PoolSettings.DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
-        private EncryptionLevel encryptionLevel = EncryptionLevel.REQUIRED_NON_LOCAL;
+        private EncryptionLevel encryptionLevel = EncryptionLevel.REQUIRED;
         private TrustStrategy trustStrategy = trustAllCertificates();
         private RetryLogic retryLogic = RetryLogic.DEFAULT_RETRY_LOGIC;
         private int routingFailureLimit = 1;
@@ -368,10 +368,6 @@ public class Config
     {
         /** With this level, the driver will only connect to the server if it can do it without encryption. */
         NONE,
-
-        /** With this level, the driver will only connect to the server without encryption if local but with
-         * encryption otherwise. */
-        REQUIRED_NON_LOCAL,
 
         /** With this level, the driver will only connect to the server it if can do it with encryption. */
         REQUIRED

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -27,8 +27,7 @@ import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.internal.net.pooling.PoolSettings;
 import org.neo4j.driver.v1.util.Immutable;
 
-import static java.lang.System.getProperty;
-import static org.neo4j.driver.v1.Config.TrustStrategy.trustOnFirstUse;
+import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
 
 /**
  * A configuration class to config driver properties.
@@ -169,8 +168,7 @@ public class Config
         private int maxIdleConnectionPoolSize = PoolSettings.DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private EncryptionLevel encryptionLevel = EncryptionLevel.REQUIRED_NON_LOCAL;
-        private TrustStrategy trustStrategy = trustOnFirstUse(
-                new File( getProperty( "user.home" ), ".neo4j" + File.separator + "known_hosts" ) );
+        private TrustStrategy trustStrategy = trustAllCertificates();
         private RetryLogic retryLogic = RetryLogic.DEFAULT_RETRY_LOGIC;
         private int routingFailureLimit = 1;
         private long routingRetryDelayMillis = 5_000;
@@ -386,10 +384,16 @@ public class Config
     {
         public enum Strategy
         {
+            @Deprecated
             TRUST_ON_FIRST_USE,
+
             @Deprecated
             TRUST_SIGNED_CERTIFICATES,
+
+            TRUST_ALL_CERTIFICATES,
+
             TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,
+
             TRUST_SYSTEM_CA_SIGNED_CERTIFICATES
         }
 
@@ -445,9 +449,24 @@ public class Config
             return new TrustStrategy( Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, certFile );
         }
 
+        /**
+         *
+         * @return
+         */
         public static TrustStrategy trustSystemCertificates()
         {
             return new TrustStrategy( Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES );
+        }
+
+        /**
+         *
+         * @return
+         *
+         * @since 1.1
+         */
+        public static TrustStrategy trustAllCertificates()
+        {
+            return new TrustStrategy( Strategy.TRUST_ALL_CERTIFICATES );
         }
 
         /**
@@ -463,7 +482,10 @@ public class Config
          *
          * @param knownHostsFile a file where known certificates are stored.
          * @return an authentication config
+         *
+         * @deprecated in 1.1 in favour of {@link #trustAllCertificates()}
          */
+        @Deprecated
         public static TrustStrategy trustOnFirstUse( File knownHostsFile )
         {
             return new TrustStrategy( Strategy.TRUST_ON_FIRST_USE, knownHostsFile );

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -235,12 +235,12 @@ public class GraphDatabase
                 // intentional fallthrough
             // END OF DEPRECATED CASES //
 
-            case TRUST_ALL_CERTIFICATES:
-                return SecurityPlan.forAllCertificates();
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forCustomCASignedCertificates( config.trustStrategy().certFile() );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forSystemCASignedCertificates();
+            case TRUST_ALL_CERTIFICATES:
+                return SecurityPlan.forAllCertificates();
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + config.trustStrategy().strategy().name() );

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -40,7 +40,6 @@ import org.neo4j.driver.v1.util.Function;
 import static java.lang.String.format;
 import static org.neo4j.driver.internal.security.SecurityPlan.insecure;
 import static org.neo4j.driver.v1.Config.EncryptionLevel.REQUIRED;
-import static org.neo4j.driver.v1.Config.EncryptionLevel.REQUIRED_NON_LOCAL;
 
 /**
  * Creates {@link Driver drivers}, optionally letting you {@link #driver(URI, Config)} to configure them.
@@ -215,8 +214,7 @@ public class GraphDatabase
             throws GeneralSecurityException, IOException
     {
         Config.EncryptionLevel encryptionLevel = config.encryptionLevel();
-        boolean requiresEncryption = encryptionLevel.equals( REQUIRED ) ||
-                                     (encryptionLevel.equals( REQUIRED_NON_LOCAL ) && !address.isLocal());
+        boolean requiresEncryption = encryptionLevel.equals( REQUIRED );
 
         if ( requiresEncryption )
         {
@@ -240,9 +238,9 @@ public class GraphDatabase
             case TRUST_ALL_CERTIFICATES:
                 return SecurityPlan.forAllCertificates();
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlan.forSignedCertificates( config.trustStrategy().certFile() );
+                return SecurityPlan.forCustomCASignedCertificates( config.trustStrategy().certFile() );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlan.forSystemCertificates();
+                return SecurityPlan.forSystemCASignedCertificates();
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + config.trustStrategy().strategy().name() );

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -223,19 +223,26 @@ public class GraphDatabase
             Logger logger = config.logging().getLog( "session" );
             switch ( config.trustStrategy().strategy() )
             {
+
+            // DEPRECATED CASES //
+            case TRUST_ON_FIRST_USE:
+                logger.warn(
+                        "Option `TRUST_ON_FIRST_USE` has been deprecated and will be removed in a future " +
+                        "version of the driver. Please switch to use `TRUST_ALL_CERTIFICATES` instead." );
+                return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile(), address, logger );
             case TRUST_SIGNED_CERTIFICATES:
                 logger.warn(
                         "Option `TRUST_SIGNED_CERTIFICATE` has been deprecated and will be removed in a future " +
-                        "version " +
-                        "of the driver. Please switch to use `TRUST_CUSTOM_CA_SIGNED_CERTIFICATES` instead." );
-                //intentional fallthrough
+                        "version of the driver. Please switch to use `TRUST_CUSTOM_CA_SIGNED_CERTIFICATES` instead." );
+                // intentional fallthrough
+            // END OF DEPRECATED CASES //
+
+            case TRUST_ALL_CERTIFICATES:
+                return SecurityPlan.forAllCertificates();
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forSignedCertificates( config.trustStrategy().certFile() );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forSystemCertificates();
-            case TRUST_ON_FIRST_USE:
-                return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile(),
-                        address, logger );
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + config.trustStrategy().strategy().name() );

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -231,6 +231,8 @@ public class GraphDatabase
                 //intentional fallthrough
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlan.forSignedCertificates( config.trustStrategy().certFile() );
+            case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
+                return SecurityPlan.forSystemCertificates();
             case TRUST_ON_FIRST_USE:
                 return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile(),
                         address, logger );

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -45,8 +45,7 @@ public class ConfigTest
         Config.TrustStrategy authConfig = config.trustStrategy();
 
         // Then
-        assertEquals( authConfig.strategy(), Config.TrustStrategy.Strategy.TRUST_ON_FIRST_USE );
-        assertEquals( DEFAULT_KNOWN_HOSTS.getAbsolutePath(), authConfig.certFile().getAbsolutePath() );
+        assertEquals( authConfig.strategy(), Config.TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URI;
 
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Record;
@@ -33,6 +34,7 @@ import org.neo4j.driver.v1.util.StubServer;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.v1.Values.parameters;
+import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
 
 public class DirectDriverBoltKitTest
 {
@@ -45,7 +47,7 @@ public class DirectDriverBoltKitTest
         int x;
 
         // When
-        try ( Driver driver = GraphDatabase.driver( uri ) )
+        try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG ) )
         {
             try ( Session session = driver.session() )
             {

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
@@ -52,7 +52,9 @@ public class RoutingDriverBoltKitTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private static final Config config = Config.build().withLogging( new ConsoleLogging( Level.INFO ) ).toConfig();
+    private static final Config config = Config.build()
+            .withEncryptionLevel( Config.EncryptionLevel.NONE )
+            .withLogging( new ConsoleLogging( Level.INFO ) ).toConfig();
 
     @Test
     public void shouldHandleAcquireReadSession() throws IOException, InterruptedException, StubServer.ForceKilled

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -28,17 +28,6 @@ import static org.junit.Assert.*;
 public class BoltServerAddressTest
 {
     @Test
-    public void variantsOfLocalHostShouldResolveAsLocal() throws Exception
-    {
-        assertThat( new BoltServerAddress( "localhost", 7687 ).isLocal(), equalTo( true ) );
-        assertThat( new BoltServerAddress( "LocalHost", 7687 ).isLocal(), equalTo( true ) );
-        assertThat( new BoltServerAddress( "LOCALHOST", 7687 ).isLocal(), equalTo( true ) );
-        assertThat( new BoltServerAddress( "127.0.0.1", 7687 ).isLocal(), equalTo( true ) );
-        assertThat( new BoltServerAddress( "127.5.6.7", 7687 ).isLocal(), equalTo( true ) );
-        assertThat( new BoltServerAddress( "x", 7687 ).isLocal(), equalTo( false ) );
-    }
-
-    @Test
     public void defaultPortShouldBe7687()
     {
         assertThat( BoltServerAddress.DEFAULT_PORT, equalTo( 7687 ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseBoltKitTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
+
 public class GraphDatabaseBoltKitTest
 {
     @Test
@@ -41,7 +43,7 @@ public class GraphDatabaseBoltKitTest
         URI uri = URI.create( "bolt+routing://127.0.0.1:9001" );
 
         // When
-        Driver driver = GraphDatabase.driver( uri );
+        Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
 
         // Then
         assertThat( driver, instanceOf( RoutingDriver.class ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/EncryptionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/EncryptionIT.java
@@ -27,7 +27,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Config.EncryptionLevel.NONE;
 import static org.neo4j.driver.v1.Config.EncryptionLevel.REQUIRED;
-import static org.neo4j.driver.v1.Config.EncryptionLevel.REQUIRED_NON_LOCAL;
 
 public class EncryptionIT
 {
@@ -42,29 +41,6 @@ public class EncryptionIT
 
         // Then
         assertThat( driver.isEncrypted(), equalTo( false ) );
-
-        // When
-        Session session = driver.session();
-        StatementResult result = session.run( "RETURN 1" );
-
-        // Then
-        Record record = result.next();
-        int value = record.get( 0 ).asInt();
-        assertThat( value, equalTo( 1 ) );
-
-        // Finally
-        session.close();
-        driver.close();
-    }
-
-    @Test
-    public void shouldOperateWithRequiredNonLocalEncryption() throws Exception
-    {
-        // Given
-        Driver driver = GraphDatabase.driver( neo4j.uri(), Config.build().withEncryptionLevel( REQUIRED_NON_LOCAL ).toConfig() );
-
-        // Then
-        assertThat( driver.isEncrypted(), equalTo( !neo4j.address().isLocal() ) );
 
         // When
         Session session = driver.session();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.v1.integration;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
@@ -43,7 +44,8 @@ public class ServerKilledIT
     public void shouldRecoverFromServerRestart() throws Throwable
     {
         // Given
-        try ( Driver driver = GraphDatabase.driver( Neo4jRunner.DEFAULT_URI ) )
+        try ( Driver driver = GraphDatabase.driver( Neo4jRunner.DEFAULT_URI,
+                Config.build().withEncryptionLevel( Config.EncryptionLevel.NONE ).toConfig() ) )
         {
             Session s1 = driver.session();
             Session s2 = driver.session();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -117,7 +117,7 @@ public class TLSSocketChannelIT
             channel.connect( address.toSocketAddress() );
 
             // When
-            SecurityPlan securityPlan = SecurityPlan.forSignedCertificates( rootCert );
+            SecurityPlan securityPlan = SecurityPlan.forCustomCASignedCertificates( rootCert );
             TLSSocketChannel sslChannel = TLSSocketChannel.create( address, securityPlan, channel, logger );
             sslChannel.close();
 
@@ -144,7 +144,7 @@ public class TLSSocketChannelIT
             Logger logger = mock( Logger.class );
             SocketChannel channel = SocketChannel.open();
             channel.connect( new InetSocketAddress( "localhost", 7687 ) );
-            SecurityPlan securityPlan = SecurityPlan.forSystemCertificates();
+            SecurityPlan securityPlan = SecurityPlan.forSystemCASignedCertificates();
 
             // When
             try
@@ -235,7 +235,7 @@ public class TLSSocketChannelIT
         CertificateTool.saveX509Cert( aRandomCert, trustedCertFile );
 
         // When & Then
-        SecurityPlan securityPlan = SecurityPlan.forSignedCertificates( trustedCertFile );
+        SecurityPlan securityPlan = SecurityPlan.forCustomCASignedCertificates( trustedCertFile );
         TLSSocketChannel sslChannel = null;
         try
         {
@@ -267,7 +267,7 @@ public class TLSSocketChannelIT
 
         // When
         URI url = URI.create( "localhost:7687" );
-        SecurityPlan securityPlan = SecurityPlan.forSignedCertificates( Neo4jSettings.DEFAULT_TLS_CERT_FILE );
+        SecurityPlan securityPlan = SecurityPlan.forCustomCASignedCertificates( Neo4jSettings.DEFAULT_TLS_CERT_FILE );
         TLSSocketChannel sslChannel = TLSSocketChannel.create( address, securityPlan, channel, logger );
         sslChannel.close();
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -118,9 +118,7 @@ public class TLSSocketChannelIT
 
             // When
             SecurityPlan securityPlan = SecurityPlan.forSignedCertificates( rootCert );
-            TLSSocketChannel sslChannel =
-                    new TLSSocketChannel( address, securityPlan, channel, logger
-                    );
+            TLSSocketChannel sslChannel = TLSSocketChannel.create( address, securityPlan, channel, logger );
             sslChannel.close();
 
             // Then
@@ -152,7 +150,7 @@ public class TLSSocketChannelIT
             try
             {
                 TLSSocketChannel sslChannel =
-                        new TLSSocketChannel(address, securityPlan, channel, logger);
+                        TLSSocketChannel.create(address, securityPlan, channel, logger);
                 sslChannel.close();
             }
             catch ( SSLHandshakeException e )
@@ -188,7 +186,7 @@ public class TLSSocketChannelIT
         TLSSocketChannel sslChannel = null;
         try
         {
-            sslChannel = new TLSSocketChannel( address, securityPlan, channel, mock( Logger.class ) );
+            sslChannel = TLSSocketChannel.create( address, securityPlan, channel, mock( Logger.class ) );
             sslChannel.close();
         }
         catch ( SSLHandshakeException e )
@@ -241,7 +239,7 @@ public class TLSSocketChannelIT
         TLSSocketChannel sslChannel = null;
         try
         {
-            sslChannel = new TLSSocketChannel( neo4j.address(), securityPlan, channel, mock( Logger.class ) );
+            sslChannel = TLSSocketChannel.create( neo4j.address(), securityPlan, channel, mock( Logger.class ) );
             sslChannel.close();
         }
         catch ( SSLHandshakeException e )
@@ -270,7 +268,7 @@ public class TLSSocketChannelIT
         // When
         URI url = URI.create( "localhost:7687" );
         SecurityPlan securityPlan = SecurityPlan.forSignedCertificates( Neo4jSettings.DEFAULT_TLS_CERT_FILE );
-        TLSSocketChannel sslChannel = new TLSSocketChannel( address, securityPlan, channel, logger );
+        TLSSocketChannel sslChannel = TLSSocketChannel.create( address, securityPlan, channel, logger );
         sslChannel.close();
 
         // Then
@@ -335,7 +333,7 @@ public class TLSSocketChannelIT
 
         SecurityPlan securityPlan = SecurityPlan.forTrustOnFirstUse( knownCerts, address, new DevNullLogger() );
         TLSSocketChannel sslChannel =
-                new TLSSocketChannel( address, securityPlan, channel, logger );
+                TLSSocketChannel.create( address, securityPlan, channel, logger );
         sslChannel.close();
 
         // Then

--- a/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.neo4j.driver.v1.Config;
+
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -31,6 +33,9 @@ import static org.junit.Assert.fail;
 
 public class StubServer
 {
+    public static final Config INSECURE_CONFIG = Config.build()
+            .withEncryptionLevel( Config.EncryptionLevel.NONE ).toConfig();
+
     // This may be thrown if the driver has not been closed properly
     public static class ForceKilled extends Exception {}
 


### PR DESCRIPTION
- Adds `TRUST_ALL_CERTIFICATES` and sets as default trust mode
- Deprecates `TRUST_ON_FIRST_USE`
- Explicitly blocks `TRUST_ON_FIRST_USE` in combination with `bolt+routing`
- Removes `ENCRYPTION_NON_LOCAL`