### PR TITLE
Removed ping

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -50,8 +50,8 @@ public class SocketConnection implements Connection
 {
     private final Queue<Message> pendingMessages = new LinkedList<>();
     private final SocketResponseHandler responseHandler;
-    private AtomicBoolean isInterrupted = new AtomicBoolean( false );
-    private AtomicBoolean isAckFailureMuted = new AtomicBoolean( false );
+    private final AtomicBoolean isInterrupted = new AtomicBoolean( false );
+    private final AtomicBoolean isAckFailureMuted = new AtomicBoolean( false );
     private InternalServerInfo serverInfo;
 
     private final SocketClient socket;
@@ -66,10 +66,19 @@ public class SocketConnection implements Connection
         this.socket.start();
     }
 
-    // for mocked socket testing
-    SocketConnection( SocketClient socket, Logger logger )
+    /**
+     * Create new connection backed by the given socket.
+     * <p>
+     * <b>Note:</b> this constructor should be used <b>only</b> for testing.
+     *
+     * @param socket the socket to use for network interactions.
+     * @param serverInfo the info about server this connection points to.
+     * @param logger the logger.
+     */
+    public SocketConnection( SocketClient socket, InternalServerInfo serverInfo, Logger logger )
     {
         this.socket = socket;
+        this.serverInfo = serverInfo;
         this.logger = logger;
         this.responseHandler = createResponseHandler( logger );
         this.socket.start();

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
@@ -21,38 +21,20 @@ package org.neo4j.driver.internal.net.pooling;
 
 public class PoolSettings
 {
-    public static PoolSettings defaultSettings()
-    {
-        return new PoolSettings( DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE, DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST );
-    }
-
     public static final int DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE = 10;
-    public static final long DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST = 200;
 
     /**
      * Maximum number of idle connections per pool.
      */
     private final int maxIdleConnectionPoolSize;
 
-    /**
-     * Connections that have been idle longer than this threshold will have a ping test performed on them.
-     */
-    private final long idleTimeBeforeConnectionTest;
-
-    public PoolSettings( int maxIdleConnectionPoolSize, long idleTimeBeforeConnectionTest )
+    public PoolSettings( int maxIdleConnectionPoolSize )
     {
         this.maxIdleConnectionPoolSize = maxIdleConnectionPoolSize;
-        this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTest;
     }
 
     public int maxIdleConnectionPoolSize()
     {
         return maxIdleConnectionPoolSize;
     }
-
-    public long idleTimeBeforeConnectionTest()
-    {
-        return idleTimeBeforeConnectionTest;
-    }
-
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal.net.pooling;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.net.BoltServerAddress;
@@ -113,10 +112,11 @@ public class SocketConnectionPool implements ConnectionPool
             @Override
             public PooledConnection get()
             {
-                return new PooledConnection( connect( address ), new
-                        PooledConnectionReleaseConsumer( connections,
-                        new PooledConnectionValidator( SocketConnectionPool.this, poolSettings ) ), clock );
-
+                PooledConnectionValidator connectionValidator =
+                        new PooledConnectionValidator( SocketConnectionPool.this );
+                PooledConnectionReleaseConsumer releaseConsumer =
+                        new PooledConnectionReleaseConsumer( connections, connectionValidator );
+                return new PooledConnection( connect( address ), releaseConsumer, clock );
             }
         };
         PooledConnection conn = connections.acquire( supplier );

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -51,9 +51,6 @@ public class Config
 
     private final int maxIdleConnectionPoolSize;
 
-    /** Connections that have been idle longer than this threshold will have a ping test performed on them. */
-    private final long idleTimeBeforeConnectionTest;
-
     /** Level of encryption we need to adhere to */
     private final EncryptionLevel encryptionLevel;
 
@@ -68,7 +65,6 @@ public class Config
         this.logging = builder.logging;
 
         this.maxIdleConnectionPoolSize = builder.maxIdleConnectionPoolSize;
-        this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
 
         this.encryptionLevel = builder.encryptionLevel;
         this.trustStrategy = builder.trustStrategy;
@@ -107,11 +103,15 @@ public class Config
     /**
      * Pooled connections that have been unused for longer than this timeout will be tested before they are
      * used again, to ensure they are still live.
+     *
      * @return idle time in milliseconds
+     * @deprecated pooled sessions are automatically checked for validity before being returned to the pool. This
+     * method will always return <code>-1</code> and will be possibly removed in future.
      */
+    @Deprecated
     public long idleTimeBeforeConnectionTest()
     {
-        return idleTimeBeforeConnectionTest;
+        return -1;
     }
 
     /**
@@ -159,7 +159,6 @@ public class Config
     {
         private Logging logging = new JULogging( Level.INFO );
         private int maxIdleConnectionPoolSize = PoolSettings.DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
-        private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private EncryptionLevel encryptionLevel = EncryptionLevel.REQUIRED;
         private TrustStrategy trustStrategy = trustAllCertificates();
         private int routingFailureLimit = 1;
@@ -229,10 +228,12 @@ public class Config
          *
          * @param timeout minimum idle time in milliseconds
          * @return this builder
+         * @deprecated pooled sessions are automatically checked for validity before being returned to the pool.
+         * This setting will be ignored and possibly removed in future.
          */
+        @Deprecated
         public ConfigBuilder withSessionLivenessCheckTimeout( long timeout )
         {
-            this.idleTimeBeforeConnectionTest = timeout;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabase.java
@@ -177,9 +177,7 @@ public class GraphDatabase
         }
 
         // Establish pool settings
-        PoolSettings poolSettings = new PoolSettings(
-                config.maxIdleConnectionPoolSize(),
-                config.idleTimeBeforeConnectionTest() );
+        PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize() );
 
         // And finally, construct the driver proper
         ConnectionPool connectionPool =

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -26,9 +26,7 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.util.FileTools;
 
 import static java.lang.System.getProperty;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class ConfigTest
 {
@@ -79,13 +77,13 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldConfigureMinIdleTime() throws Throwable
+    public void shouldIgnoreLivenessCheckTimeoutSetting() throws Throwable
     {
         // when
         Config config = Config.build().withSessionLivenessCheckTimeout( 1337 ).toConfig();
 
         // then
-        assertThat( config.idleTimeBeforeConnectionTest(), equalTo( 1337L ) );
+        assertEquals( -1, config.idleTimeBeforeConnectionTest() );
     }
 
     public static void deleteDefaultKnownCertFileIfExists()

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.SuccessMessage;
+import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.summary.ServerInfo;
@@ -48,7 +49,7 @@ public class SocketConnectionTest
     {
         // Given
         SocketClient socket = mock( SocketClient.class );
-        SocketConnection conn = new SocketConnection( socket, mock( Logger.class ) );
+        SocketConnection conn = new SocketConnection( socket, mock( InternalServerInfo.class ), mock( Logger.class ) );
 
         when( socket.address() ).thenReturn( BoltServerAddress.from( URI.create( "http://neo4j.com:9000" ) ) );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net.pooling;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import java.io.IOException;
+import java.util.Queue;
+
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.net.SocketClient;
+import org.neo4j.driver.internal.net.SocketConnection;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.summary.InternalServerInfo;
+import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.Consumers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
+import static org.neo4j.driver.internal.messaging.ResetMessage.RESET;
+import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
+
+public class PooledConnectionValidatorTest
+{
+    @Test
+    public void resetAndSyncValidConnection()
+    {
+        Connection connection = mock( Connection.class );
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = newValidatorWithMockedPool();
+        boolean connectionIsValid = validator.apply( pooledConnection );
+
+        assertTrue( connectionIsValid );
+
+        InOrder inOrder = inOrder( connection );
+        inOrder.verify( connection ).reset();
+        inOrder.verify( connection ).sync();
+    }
+
+    @Test
+    public void sendsSingleResetMessageForValidConnection() throws IOException
+    {
+        SocketClient socket = mock( SocketClient.class );
+        InternalServerInfo serverInfo = new InternalServerInfo( LOCAL_DEFAULT, "v1" );
+        Connection connection = new SocketConnection( socket, serverInfo, DEV_NULL_LOGGER );
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = newValidatorWithMockedPool();
+        boolean connectionIsValid = validator.apply( pooledConnection );
+
+        assertTrue( connectionIsValid );
+
+        ArgumentCaptor<Queue<Message>> captor = messagesCaptor();
+        verify( socket ).send( captor.capture() );
+        assertEquals( 1, captor.getAllValues().size() );
+        Queue<Message> messages = captor.getValue();
+        assertEquals( 1, messages.size() );
+        assertEquals( RESET, messages.peek() );
+    }
+
+    private static PooledConnection newPooledConnection( Connection connection )
+    {
+        return new PooledConnection( connection, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
+    }
+
+    private static PooledConnectionValidator newValidatorWithMockedPool()
+    {
+        return new PooledConnectionValidator( connectionPoolMock() );
+    }
+
+    private static ConnectionPool connectionPoolMock()
+    {
+        ConnectionPool pool = mock( ConnectionPool.class );
+        when( pool.hasAddress( any( BoltServerAddress.class ) ) ).thenReturn( true );
+        return pool;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static ArgumentCaptor<Queue<Message>> messagesCaptor()
+    {
+        return (ArgumentCaptor) ArgumentCaptor.forClass( Queue.class );
+    }
+}

--- a/driver/src/test/resources/acquire_endpoints.script
+++ b/driver/src/test/resources/acquire_endpoints.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 
 C: RUN "CALL dbms.cluster.routing.getServers" {}

--- a/driver/src/test/resources/dead_server.script
+++ b/driver/src/test/resources/dead_server.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 !: AUTO RUN "BEGIN" {}
 

--- a/driver/src/test/resources/discover_servers.script
+++ b/driver/src/test/resources/discover_servers.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 
 C: RUN "CALL dbms.cluster.routing.getServers" {}

--- a/driver/src/test/resources/failed_discovery.script
+++ b/driver/src/test/resources/failed_discovery.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 
 C: RUN "CALL dbms.cluster.routing.getServers" {}

--- a/driver/src/test/resources/non_discovery_server.script
+++ b/driver/src/test/resources/non_discovery_server.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 
 C: RUN "CALL dbms.cluster.routing.getServers" {}

--- a/driver/src/test/resources/not_able_to_write_server.script
+++ b/driver/src/test/resources/not_able_to_write_server.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 !: AUTO RUN "ROLLBACK" {}
 !: AUTO RUN "BEGIN" {}

--- a/driver/src/test/resources/read_server.script
+++ b/driver/src/test/resources/read_server.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 !: AUTO RUN "ROLLBACK" {}
 !: AUTO RUN "BEGIN" {}

--- a/driver/src/test/resources/return_x.script
+++ b/driver/src/test/resources/return_x.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 
 C: RUN "RETURN {x}" {"x": 1}

--- a/driver/src/test/resources/write_server.script
+++ b/driver/src/test/resources/write_server.script
@@ -1,6 +1,5 @@
 !: AUTO INIT
 !: AUTO RESET
-!: AUTO RUN "RETURN 1 // JavaDriver poll to test connection" {}
 !: AUTO PULL_ALL
 !: AUTO RUN "ROLLBACK" {}
 !: AUTO RUN "BEGIN" {}


### PR DESCRIPTION
Previously ping query (`RETURN 1`) was executed on each `Session#close()`. This was intended to verify the underlying connection and decide if it should be returned to the pool or not.

Running such ping is not quite necessary because we already execute `RESET` and `SYNC` before that. Combination of `RESET` and `SYNC` guarantees to send at least one message and thus validates the connection. Also query `RETURN 1` made database start transaction and possibly do planning, this work seem unnecessary.

This commit removes ping and adds tests to verify that we actually send messages to socket during pooled connection validation.