### PR TITLE
Better handling of closed driver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BaseDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BaseDriver.java
@@ -16,19 +16,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.neo4j.driver.internal;
 
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.Session;
 
 abstract class BaseDriver implements Driver
 {
+    private final static String DRIVER_LOG_NAME = "Driver";
+
     private final SecurityPlan securityPlan;
     protected final Logger log;
-    private final static String DRIVER_LOG_NAME = "Driver";
+
+    private final ReentrantReadWriteLock closedLock = new ReentrantReadWriteLock();
+    private boolean closed;
 
     BaseDriver( SecurityPlan securityPlan, Logging logging )
     {
@@ -37,8 +44,68 @@ abstract class BaseDriver implements Driver
     }
 
     @Override
-    public boolean isEncrypted()
+    public final boolean isEncrypted()
     {
-        return securityPlan.requiresEncryption();
+        closedLock.readLock().lock();
+        try
+        {
+            assertOpen();
+            return securityPlan.requiresEncryption();
+        }
+        finally
+        {
+            closedLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public final Session session()
+    {
+        return session( AccessMode.WRITE );
+    }
+
+    @Override
+    public final Session session( AccessMode mode )
+    {
+        closedLock.readLock().lock();
+        try
+        {
+            assertOpen();
+            return newSessionWithMode( mode );
+        }
+        finally
+        {
+            closedLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public final void close()
+    {
+        closedLock.writeLock().lock();
+        try
+        {
+            if ( !closed )
+            {
+                closeResources();
+            }
+        }
+        finally
+        {
+            closed = true;
+            closedLock.writeLock().unlock();
+        }
+    }
+
+    protected abstract Session newSessionWithMode( AccessMode mode );
+
+    protected abstract void closeResources();
+
+    private void assertOpen()
+    {
+        if ( closed )
+        {
+            throw new IllegalStateException( "This driver instance has already been closed" );
+        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
@@ -44,19 +44,13 @@ public class DirectDriver extends BaseDriver
     }
 
     @Override
-    public Session session()
+    protected Session newSessionWithMode( AccessMode mode )
     {
         return new NetworkSession( connections.acquire( address ) );
     }
 
     @Override
-    public Session session( AccessMode ignore )
-    {
-        return session();
-    }
-
-    @Override
-    public void close()
+    protected void closeResources()
     {
         try
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -59,16 +59,11 @@ public class RoutingDriver extends BaseDriver
     }
 
     @Override
-    public Session session()
-    {
-        return session( AccessMode.WRITE );
-    }
-
-    @Override
-    public Session session( final AccessMode mode )
+    protected Session newSessionWithMode( AccessMode mode )
     {
         Connection connection = acquireConnection( mode );
-        return new RoutingNetworkSession( new NetworkSession( connection ), mode, connection.boltServerAddress(), loadBalancer );
+        NetworkSession networkSession = new NetworkSession( connection );
+        return new RoutingNetworkSession( networkSession, mode, connection.boltServerAddress(), loadBalancer );
     }
 
     private Connection acquireConnection( AccessMode role )
@@ -85,7 +80,7 @@ public class RoutingDriver extends BaseDriver
     }
 
     @Override
-    public void close()
+    protected void closeResources()
     {
         try
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/DriverCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/DriverCloseIT.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import org.neo4j.driver.internal.logging.ConsoleLogging;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.util.StubServer;
+import org.neo4j.driver.v1.util.TestNeo4j;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith( Enclosed.class )
+public class DriverCloseIT
+{
+    public abstract static class DriverCloseITBase
+    {
+        protected abstract Driver createDriver();
+
+        @Test
+        public void isEncryptedThrowsForClosedDriver()
+        {
+            Driver driver = createDriver();
+
+            driver.close();
+
+            try
+            {
+                driver.isEncrypted();
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( IllegalStateException.class ) );
+            }
+        }
+
+        @Test
+        public void sessionThrowsForClosedDriver()
+        {
+            Driver driver = createDriver();
+
+            driver.close();
+
+            try
+            {
+                driver.session();
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( IllegalStateException.class ) );
+            }
+        }
+
+        @Test
+        public void sessionWithModeThrowsForClosedDriver()
+        {
+            Driver driver = createDriver();
+
+            driver.close();
+
+            try
+            {
+                driver.session( AccessMode.WRITE );
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( IllegalStateException.class ) );
+            }
+        }
+
+        @Test
+        public void closeClosedDriver()
+        {
+            Driver driver = createDriver();
+
+            driver.close();
+            driver.close();
+            driver.close();
+        }
+    }
+
+    public static class DirectDriverCloseIT extends DriverCloseITBase
+    {
+        @ClassRule
+        public static TestNeo4j neo4j = new TestNeo4j();
+
+        @Override
+        protected Driver createDriver()
+        {
+            return GraphDatabase.driver( neo4j.uri() );
+        }
+
+        @Test
+        public void useSessionAfterDriverIsClosed()
+        {
+            Driver driver = createDriver();
+            Session session = driver.session();
+
+            driver.close();
+
+            try
+            {
+                session.run( "create ()" );
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( ServiceUnavailableException.class ) );
+            }
+        }
+    }
+
+    public static class RoutingDriverCloseIT extends DriverCloseITBase
+    {
+        private StubServer router;
+
+        @Before
+        public void setUp() throws Exception
+        {
+            router = StubServer.start( "acquire_endpoints.script", 9001 );
+        }
+
+        @After
+        public void tearDown() throws Exception
+        {
+            router.exitStatus();
+        }
+
+        @Override
+        protected Driver createDriver()
+        {
+            Config config = Config.build()
+                    .withEncryptionLevel( Config.EncryptionLevel.NONE )
+                    .withLogging( new ConsoleLogging( Level.OFF ) )
+                    .toConfig();
+
+            return GraphDatabase.driver( "bolt+routing://127.0.0.1:9001", config );
+        }
+
+        @Test
+        public void useSessionAfterDriverIsClosed() throws Exception
+        {
+            StubServer readServer = StubServer.start( "read_server.script", 9005 );
+
+            Driver driver = createDriver();
+
+            try ( Session session = driver.session( AccessMode.READ ) )
+            {
+                List<Record> records = session.run( "MATCH (n) RETURN n.name" ).list();
+                assertEquals( 3, records.size() );
+            }
+
+            Session session = driver.session( AccessMode.READ );
+
+            driver.close();
+
+            try
+            {
+                session.run( "MATCH (n) RETURN n.name" );
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e.getCause(), instanceOf( ServiceUnavailableException.class ) );
+            }
+
+            assertEquals( 0, readServer.exitStatus() );
+        }
+    }
+}


### PR DESCRIPTION
It was previously possible to use closed driver instance, obtain sessions from it and run queries. This was seen to cause problems in multi-threaded scenarios when some worker threads try to use driver, which was concurrently closed by other worker.
 This commit makes driver track if it is closed or not and throw exceptions if on every interaction when closed. Thrown exception is `IllegalStateException`. Actuall `#close()` method can be called multiple times and is a no-op for already closed driver.