### PR TITLE
osgify artefact MANIFEST.MF (jar + sources)

### DIFF
--- a/driver/osgi.bnd
+++ b/driver/osgi.bnd
@@ -1,0 +1,9 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ !*.internal.*, \
+ *;version="${package-version}"
+
+Import-Package: \
+ *
+

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build.revision></build.revision>
-    <bundle.name>${project.groupId}</bundle.name>
+    <bundle.name>${project.groupId}.${project.artifactId}</bundle.name>
     <maven.build.timestamp.format>'v'yyyyMMdd-HHmm</maven.build.timestamp.format>
   </properties>
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,6 +6,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build.revision></build.revision>
+    <bundle.name>${project.groupId}</bundle.name>
+    <maven.build.timestamp.format>'v'yyyyMMdd-HHmm</maven.build.timestamp.format>
   </properties>
 
   <parent>
@@ -115,6 +117,16 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+              <archive>
+                  <manifestEntries>
+                      <Bundle-Name>${project.name} (Source)</Bundle-Name>
+                      <Bundle-SymbolicName>${bundle.name}.source</Bundle-SymbolicName>
+                      <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}</Bundle-Version>
+                      <Eclipse-SourceBundle>${bundle.name};version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}";roots:="."</Eclipse-SourceBundle>
+                  </manifestEntries>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -144,6 +156,7 @@
         <configuration>
           <archive>
             <index>true</index>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifest>
               <packageName>org/neo4j/driver</packageName>
             </manifest>
@@ -152,6 +165,47 @@
               <Implementation-Version>${project.version}-${build.revision}</Implementation-Version>
             </manifestEntries>
           </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.12</version>
+        <executions>
+            <execution>
+                <id>set-osgi-version</id>
+                <phase>validate</phase>
+                <goals>
+                    <goal>parse-version</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${bundle.name}</Bundle-SymbolicName>
+            <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}</Bundle-Version>
+            <_snapshot>${maven.build.timestamp}</_snapshot>
+            <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
+            <_removeheaders>Bnd-*,Private-Package</_removeheaders>
+            <_nouses>true</_nouses>
+            <!-- each module can override these defaults in their osgi.bnd file -->
+            <_include>-osgi.bnd</_include>
+          </instructions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
when applied the generated artefacts (jar + source-jar) will contain valid OSGi manifest headers to be consumed in OSGi environments / Eclipse


```
Manifest-Version: 1.0
Bundle-Description: Access to the Neo4j graph database through Java
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Package: org/neo4j/driver
Bundle-SymbolicName: org.neo4j.driver
Implementation-Version: 1.1-SNAPSHOT-${git.commit.id.abbrev}
Archiver-Version: Plexus Archiver
Bundle-ManifestVersion: 2
Include-Resource: license-header.txt=src/main/resources/license-header
 .txt
Import-Package: javax.net.ssl,javax.xml.bind,org.neo4j.driver.v1.excep
 tions;version="[1.1,2)",org.neo4j.driver.v1.exceptions.value;version=
 "[1.1,2)",org.neo4j.driver.v1.summary;version="[1.1,2)",org.neo4j.dri
 ver.v1.types;version="[1.1,2)",org.neo4j.driver.v1.util;version="[1.1
 ,2)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
Tool: Bnd-3.2.0.201605172007
Export-Package: org.neo4j.driver.v1;version="1.1.0",org.neo4j.driver.v
 1.exceptions;version="1.1.0",org.neo4j.driver.v1.exceptions.value;ver
 sion="1.1.0",org.neo4j.driver.v1.summary;version="1.1.0",org.neo4j.dr
 iver.v1.types;version="1.1.0",org.neo4j.driver.v1.util;version="1.1.0
 "
Bundle-Name: Neo4j Java Driver
Bundle-Version: 1.1.0.v20161129-2034
Created-By: Apache Maven Bundle Plugin
Build-Jdk: 1.8.0_112
```