### PR TITLE
Removed finalize from NetworkSession

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BaseDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BaseDriver.java
@@ -32,13 +32,15 @@ abstract class BaseDriver implements Driver
     private final static String DRIVER_LOG_NAME = "Driver";
 
     private final SecurityPlan securityPlan;
+    protected final SessionFactory sessionFactory;
     protected final Logger log;
 
     private AtomicBoolean closed = new AtomicBoolean( false );
 
-    BaseDriver( SecurityPlan securityPlan, Logging logging )
+    BaseDriver( SecurityPlan securityPlan, SessionFactory sessionFactory, Logging logging )
     {
         this.securityPlan = securityPlan;
+        this.sessionFactory = sessionFactory;
         this.log = logging.getLog( DRIVER_LOG_NAME );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
@@ -36,9 +36,10 @@ public class DirectDriver extends BaseDriver
             BoltServerAddress address,
             ConnectionPool connections,
             SecurityPlan securityPlan,
+            SessionFactory sessionFactory,
             Logging logging )
     {
-        super( securityPlan, logging );
+        super( securityPlan, sessionFactory, logging );
         this.address = address;
         this.connections = connections;
     }
@@ -46,7 +47,7 @@ public class DirectDriver extends BaseDriver
     @Override
     protected Session newSessionWithMode( AccessMode mode )
     {
-        return new NetworkSession( connections.acquire( address ) );
+        return sessionFactory.newInstance( connections.acquire( address ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -129,7 +129,7 @@ public class DriverFactory
 
     private static SessionFactory createSessionFactory( Config config )
     {
-        if ( LeakLoggingNetworkSessionFactory.leakLoggingEnabled() )
+        if ( config.logLeakedSessions() )
         {
             return new LeakLoggingNetworkSessionFactory( config.logging() );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Logger;
+
+import static java.lang.System.lineSeparator;
+
+class LeakLoggingNetworkSession extends NetworkSession
+{
+    private final Logger log;
+    private final String stackTrace;
+
+    LeakLoggingNetworkSession( Connection connection, Logger log )
+    {
+        super( connection );
+        this.log = log;
+        this.stackTrace = captureStackTrace();
+    }
+
+    @Override
+    protected void finalize() throws Throwable
+    {
+        logLeakIfNeeded();
+        super.finalize();
+    }
+
+    private void logLeakIfNeeded()
+    {
+        if ( isOpen() )
+        {
+            log.error( "Neo4j Session object leaked, please ensure that your application" +
+                       "calls the `close` method on Sessions before disposing of the objects.\n" +
+                       "Session was create at:\n" + stackTrace, null );
+        }
+    }
+
+    private static String captureStackTrace()
+    {
+        StringBuilder result = new StringBuilder();
+        StackTraceElement[] elements = Thread.currentThread().getStackTrace();
+        for ( StackTraceElement element : elements )
+        {
+            result.append( "\t" ).append( element ).append( lineSeparator() );
+        }
+        return result.toString();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.Session;
+
+public class LeakLoggingNetworkSessionFactory implements SessionFactory
+{
+    private static final String SYSTEM_PROPERTY_NAME = "org.neo4j.driver.logSessionLeaks";
+    private static final String LOGGER_NAME = "sessionLeak";
+
+    private final Logger logger;
+
+    public LeakLoggingNetworkSessionFactory( Logging logging )
+    {
+        this.logger = logging.getLog( LOGGER_NAME );
+    }
+
+    public static boolean leakLoggingEnabled()
+    {
+        String value = System.getProperty( SYSTEM_PROPERTY_NAME );
+        return Boolean.parseBoolean( value );
+    }
+
+    @Override
+    public Session newInstance( Connection connection )
+    {
+        return new LeakLoggingNetworkSession( connection, logger );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
@@ -23,22 +23,15 @@ import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
-public class LeakLoggingNetworkSessionFactory implements SessionFactory
+class LeakLoggingNetworkSessionFactory implements SessionFactory
 {
-    private static final String SYSTEM_PROPERTY_NAME = "org.neo4j.driver.logSessionLeaks";
     private static final String LOGGER_NAME = "sessionLeak";
 
     private final Logger logger;
 
-    public LeakLoggingNetworkSessionFactory( Logging logging )
+    LeakLoggingNetworkSessionFactory( Logging logging )
     {
         this.logger = logging.getLog( LOGGER_NAME );
-    }
-
-    public static boolean leakLoggingEnabled()
-    {
-        String value = System.getProperty( SYSTEM_PROPERTY_NAME );
-        return Boolean.parseBoolean( value );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -67,7 +67,7 @@ public class NetworkSession implements Session
     private ExplicitTransaction currentTransaction;
     private AtomicBoolean isOpen = new AtomicBoolean( true );
 
-    public NetworkSession( Connection connection )
+    NetworkSession( Connection connection )
     {
         this.connection = connection;
 
@@ -126,6 +126,7 @@ public class NetworkSession implements Session
         return cursor;
     }
 
+    @Override
     public synchronized void reset()
     {
         ensureSessionIsOpen();
@@ -253,18 +254,6 @@ public class NetworkSession implements Session
         ensureNoUnrecoverableError();
         ensureNoOpenTransactionBeforeOpeningTransaction();
         ensureConnectionIsOpen();
-    }
-
-    @Override
-    protected void finalize() throws Throwable
-    {
-        if ( isOpen.compareAndSet( true, false ) )
-        {
-            logger.error( "Neo4j Session object leaked, please ensure that your application calls the `close` " +
-                          "method on Sessions before disposing of the objects.", null );
-            connection.close();
-        }
-        super.finalize();
     }
 
     private void ensureNoUnrecoverableError()

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Session;
+
+public class NetworkSessionFactory implements SessionFactory
+{
+    @Override
+    public Session newInstance( Connection connection )
+    {
+        return new NetworkSession( connection );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Session;
 
-public class NetworkSessionFactory implements SessionFactory
+class NetworkSessionFactory implements SessionFactory
 {
     @Override
     public Session newInstance( Connection connection )

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -51,10 +51,11 @@ public class RoutingDriver extends BaseDriver
             BoltServerAddress seedAddress,
             ConnectionPool connections,
             SecurityPlan securityPlan,
+            SessionFactory sessionFactory,
             Clock clock,
             Logging logging )
     {
-        super( verifiedSecurityPlan( securityPlan ), logging );
+        super( verifiedSecurityPlan( securityPlan ), sessionFactory, logging );
         this.loadBalancer = new LoadBalancer( settings, clock, log, connections, seedAddress );
     }
 
@@ -62,7 +63,7 @@ public class RoutingDriver extends BaseDriver
     protected Session newSessionWithMode( AccessMode mode )
     {
         Connection connection = acquireConnection( mode );
-        NetworkSession networkSession = new NetworkSession( connection );
+        Session networkSession = sessionFactory.newInstance( connection );
         return new RoutingNetworkSession( networkSession, mode, connection.boltServerAddress(), loadBalancer );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Session;
+
+public interface SessionFactory
+{
+    Session newInstance( Connection connection );
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Session;
 
-public interface SessionFactory
+interface SessionFactory
 {
     Session newInstance( Connection connection );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -27,6 +27,8 @@ import org.neo4j.driver.v1.util.FileTools;
 
 import static java.lang.System.getProperty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ConfigTest
 {
@@ -84,6 +86,16 @@ public class ConfigTest
 
         // then
         assertEquals( -1, config.idleTimeBeforeConnectionTest() );
+    }
+
+    @Test
+    public void shouldTurnOnLeakedSessionsLogging()
+    {
+        // leaked sessions logging is turned off by default
+        assertFalse( Config.build().toConfig().logLeakedSessions() );
+
+        // it can be turned on using config
+        assertTrue( Config.build().withLeakedSessionsLogging().toConfig().logLeakedSessions() );
     }
 
     public static void deleteDefaultKnownCertFileIfExists()

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -121,14 +121,14 @@ public class DriverFactoryTest
 
         @Override
         DirectDriver createDirectDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                SecurityPlan securityPlan )
+                SecurityPlan securityPlan, SessionFactory sessionFactory )
         {
             throw new UnsupportedOperationException( "Can't create direct driver" );
         }
 
         @Override
         RoutingDriver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                RoutingSettings routingSettings, SecurityPlan securityPlan )
+                RoutingSettings routingSettings, SecurityPlan securityPlan, SessionFactory sessionFactory )
         {
             throw new UnsupportedOperationException( "Can't create routing driver" );
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.Session;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class LeakLoggingNetworkSessionFactoryTest
+{
+    @Test
+    public void createsLeakLoggingNetworkSessions()
+    {
+        SessionFactory factory = new LeakLoggingNetworkSessionFactory( mock( Logging.class ) );
+
+        Session session = factory.newInstance( mock( Connection.class ) );
+
+        assertThat( session, instanceOf( LeakLoggingNetworkSession.class ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Session;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class LeakLoggingNetworkSessionTest
+{
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Test
+    public void logsNothingDuringFinalizationIfClosed() throws Exception
+    {
+        Logger logger = mock( Logger.class );
+        Session session = new LeakLoggingNetworkSession( connectionMock( false ), logger );
+
+        finalize( session );
+
+        verifyZeroInteractions( logger );
+    }
+
+    @Test
+    public void logsMessageWithStacktraceDuringFinalizationIfLeaked() throws Exception
+    {
+        Logger logger = mock( Logger.class );
+        Session session = new LeakLoggingNetworkSession( connectionMock( true ), logger );
+
+        finalize( session );
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass( String.class );
+        verify( logger ).error( messageCaptor.capture(), any( Throwable.class ) );
+
+        assertEquals( 1, messageCaptor.getAllValues().size() );
+
+        String loggedMessage = messageCaptor.getValue();
+        assertThat( loggedMessage, startsWith( "Neo4j Session object leaked" ) );
+        assertThat( loggedMessage, containsString( "Session was create at" ) );
+        assertThat( loggedMessage, containsString(
+                getClass().getSimpleName() + "." + testName.getMethodName() )
+        );
+    }
+
+    private static void finalize( Session session ) throws Exception
+    {
+        Method finalizeMethod = session.getClass().getDeclaredMethod( "finalize" );
+        finalizeMethod.setAccessible( true );
+        finalizeMethod.invoke( session );
+    }
+
+    private static Connection connectionMock( boolean open )
+    {
+        Connection connection = mock( Connection.class );
+        when( connection.isOpen() ).thenReturn( open );
+        return connection;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Session;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class NetworkSessionFactoryTest
+{
+    @Test
+    public void createsNetworkSessions()
+    {
+        SessionFactory factory = new NetworkSessionFactory();
+
+        Session session = factory.newInstance( mock( Connection.class ) );
+
+        assertThat( session, instanceOf( NetworkSession.class ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -336,7 +336,8 @@ public class RoutingDriverTest
 
     private RoutingDriver driverWithPool( ConnectionPool pool )
     {
-        return new RoutingDriver( new RoutingSettings( 10, 5_000 ), SEED, pool, insecure(), clock, logging );
+        RoutingSettings settings = new RoutingSettings( 10, 5_000 );
+        return new RoutingDriver( settings, SEED, pool, insecure(), new NetworkSessionFactory(), clock, logging );
     }
 
     @SafeVarargs


### PR DESCRIPTION
It contained logic for closing opened underlying connection and logging info about the leak. Closing of resources in finalize is not reliable and overridden finalize can hurt when many sessions are garbage collected.

Commit also introduces a system property `org.neo4j.driver.logSessionLeaks` to enable logging of unclosed/leaked sessions and log stacktrace of where they were instantiated. This is meant to help with session leak investigations. So finalization overhead will be present only when problem is present and is being investigated.