### PR TITLE
Fix off-by-one error in max routing failures

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -199,7 +199,7 @@ public final class LoadBalancer implements RoutingErrorHandler, AutoCloseable
                     return cluster;
                 }
             }
-            if ( ++failures > settings.maxRoutingFailures )
+            if ( ++failures >= settings.maxRoutingFailures )
             {
                 throw new ServiceUnavailableException( NO_ROUTERS_AVAILABLE );
             }

--- a/driver/src/test/java/org/neo4j/driver/internal/EventHandler.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/EventHandler.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal;
 
+import org.hamcrest.Matcher;
+
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
@@ -31,8 +33,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.hamcrest.Matcher;
 
 import org.neo4j.driver.internal.util.MatcherFactory;
 import org.neo4j.driver.v1.EventLogger;
@@ -110,7 +110,7 @@ public final class EventHandler
     {
         synchronized ( events )
         {
-            assertThat( events, (Matcher) count( matcher, count ) );
+            assertThat( "Unexpected count " + count, events, (Matcher) count( matcher, count ) );
         }
     }
 


### PR DESCRIPTION
Previously `LoadBalancer` retried routing table lookup one time more than the configured amount. Relevant setting is `routingFailureLimit`.