### PR TITLE
Basic infrastructure for causal cluster integration tests

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/util/Iterables.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Iterables.java
@@ -52,6 +52,21 @@ public class Iterables
         return list;
     }
 
+    public static <T> T single( Iterable<T> it )
+    {
+        Iterator<T> iterator = it.iterator();
+        if ( !iterator.hasNext() )
+        {
+            throw new IllegalArgumentException( "Given iterable is empty" );
+        }
+        T result = iterator.next();
+        if ( iterator.hasNext() )
+        {
+            throw new IllegalArgumentException( "Given iterable contains more than one element: " + it );
+        }
+        return result;
+    }
+
     public static Map<String, String> map( String ... alternatingKeyValue )
     {
         Map<String, String> out = new HashMap<>();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- * <p>
+ *
  * This file is part of Neo4j.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.integration;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.cc.Cluster;
+import org.neo4j.driver.v1.util.cc.ClusterMember;
+import org.neo4j.driver.v1.util.cc.ClusterRule;
+
+public class CausalClusteringIT
+{
+    private static final long DEFAULT_TIMEOUT_MS = 15_000;
+
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule();
+
+    @Test
+    public void shouldExecuteReadAndWritesWhenDriverSuppliedWithAddressOfLeader() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+
+        ClusterMember leader = cluster.leaderTx( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.run( "CREATE CONSTRAINT ON (p:Person) ASSERT p.name is UNIQUE" );
+            }
+        } );
+
+        executeWriteAndReadThroughBolt( leader );
+    }
+
+    private int executeWriteAndReadThroughBolt( ClusterMember member ) throws TimeoutException, InterruptedException
+    {
+        try ( Driver driver = GraphDatabase.driver( member.getRoutingUri(), clusterRule.getDefaultAuthToken() ) )
+        {
+            return inExpirableSession( driver, createWritableSession(), executeWriteAndRead() );
+        }
+    }
+
+    private Function<Driver,Session> createWritableSession()
+    {
+        return new Function<Driver,Session>()
+        {
+            @Override
+            public Session apply( Driver driver )
+            {
+                return driver.session( AccessMode.WRITE );
+            }
+        };
+    }
+
+    private Function<Session,Integer> executeWriteAndRead()
+    {
+        return new Function<Session,Integer>()
+        {
+            @Override
+            public Integer apply( Session session )
+            {
+                session.run( "MERGE (n:Person {name: 'Jim'})" ).consume();
+                Record record = session.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
+                return record.get( "count" ).asInt();
+            }
+        };
+    }
+
+    private <T> T inExpirableSession( Driver driver, Function<Driver,Session> acquirer, Function<Session,T> op )
+            throws TimeoutException, InterruptedException
+    {
+        long endTime = System.currentTimeMillis() + DEFAULT_TIMEOUT_MS;
+
+        do
+        {
+            try ( Session session = acquirer.apply( driver ) )
+            {
+                return op.apply( session );
+            }
+            catch ( SessionExpiredException e )
+            {
+                // role might have changed; try again;
+            }
+        }
+        while ( System.currentTimeMillis() < endTime );
+
+        throw new TimeoutException( "Transaction did not succeed in time" );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- *
+ * <p>
  * This file is part of Neo4j.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,19 +21,30 @@ package org.neo4j.driver.v1.integration;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.net.URI;
 import java.util.concurrent.TimeoutException;
 
-import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.util.Function;
 import org.neo4j.driver.v1.util.cc.Cluster;
 import org.neo4j.driver.v1.util.cc.ClusterMember;
 import org.neo4j.driver.v1.util.cc.ClusterRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class CausalClusteringIT
 {
@@ -47,24 +58,147 @@ public class CausalClusteringIT
     {
         Cluster cluster = clusterRule.getCluster();
 
-        ClusterMember leader = cluster.leaderTx( new Consumer<Session>()
-        {
-            @Override
-            public void accept( Session session )
-            {
-                session.run( "CREATE CONSTRAINT ON (p:Person) ASSERT p.name is UNIQUE" );
-            }
-        } );
+        int count = executeWriteAndReadThroughBolt( cluster.leader() );
 
-        executeWriteAndReadThroughBolt( leader );
+        assertEquals( 1, count );
+    }
+
+    @Test
+    public void shouldExecuteReadAndWritesWhenDriverSuppliedWithAddressOfFollower() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+
+        int count = executeWriteAndReadThroughBolt( cluster.anyFollower() );
+
+        assertEquals( 1, count );
+    }
+
+    @Test
+    public void sessionCreationShouldFailIfCallingDiscoveryProcedureOnEdgeServer() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+
+        ClusterMember readReplica = cluster.anyReadReplica();
+        try
+        {
+            createDriver( readReplica.getRoutingUri() );
+            fail( "Should have thrown an exception using a read replica address for routing" );
+        }
+        catch ( ServiceUnavailableException ex )
+        {
+            assertEquals( "Could not perform discovery. No routing servers available.", ex.getMessage() );
+        }
+    }
+
+    // Ensure that Bookmarks work with single instances using a driver created using a bolt[not+routing] URI.
+    @Test
+    public void bookmarksShouldWorkWithDriverPinnedToSingleServer() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+        ClusterMember leader = cluster.leader();
+
+        try ( Driver driver = createDriver( leader.getBoltUri() ) )
+        {
+            String bookmark = inExpirableSession( driver, createSession(), new Function<Session,String>()
+            {
+                @Override
+                public String apply( Session session )
+                {
+                    try ( Transaction tx = session.beginTransaction() )
+                    {
+                        tx.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Alistair" ) );
+                        tx.success();
+                    }
+
+                    return session.lastBookmark();
+                }
+            } );
+
+            assertNotNull( bookmark );
+
+            try ( Session session = driver.session();
+                  Transaction tx = session.beginTransaction( bookmark ) )
+            {
+                Record record = tx.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
+                assertEquals( 1, record.get( "count" ).asInt() );
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    public void shouldUseBookmarkFromAReadSessionInAWriteSession() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+        ClusterMember leader = cluster.leader();
+
+        try ( Driver driver = createDriver( leader.getBoltUri() ) )
+        {
+            inExpirableSession( driver, createWritableSession(), new Function<Session,Void>()
+            {
+                @Override
+                public Void apply( Session session )
+                {
+                    session.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Jim" ) );
+                    return null;
+                }
+            } );
+
+            final String bookmark;
+            try ( Session session = driver.session( AccessMode.READ ) )
+            {
+                try ( Transaction tx = session.beginTransaction() )
+                {
+                    tx.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
+                    tx.success();
+                }
+
+                bookmark = session.lastBookmark();
+            }
+
+            assertNotNull( bookmark );
+
+            inExpirableSession( driver, createWritableSession(), new Function<Session,Void>()
+            {
+                @Override
+                public Void apply( Session session )
+                {
+                    try ( Transaction tx = session.beginTransaction( bookmark ) )
+                    {
+                        tx.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Alistair" ) );
+                        tx.success();
+                    }
+
+                    return null;
+                }
+            } );
+
+            try ( Session session = driver.session() )
+            {
+                Record record = session.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
+                assertEquals( 2, record.get( "count" ).asInt() );
+            }
+        }
     }
 
     private int executeWriteAndReadThroughBolt( ClusterMember member ) throws TimeoutException, InterruptedException
     {
-        try ( Driver driver = GraphDatabase.driver( member.getRoutingUri(), clusterRule.getDefaultAuthToken() ) )
+        try ( Driver driver = createDriver( member.getRoutingUri() ) )
         {
             return inExpirableSession( driver, createWritableSession(), executeWriteAndRead() );
         }
+    }
+
+    private Function<Driver,Session> createSession()
+    {
+        return new Function<Driver,Session>()
+        {
+            @Override
+            public Session apply( Driver driver )
+            {
+                return driver.session();
+            }
+        };
     }
 
     private Function<Driver,Session> createWritableSession()
@@ -112,5 +246,23 @@ public class CausalClusteringIT
         while ( System.currentTimeMillis() < endTime );
 
         throw new TimeoutException( "Transaction did not succeed in time" );
+    }
+
+    private Driver createDriver( URI boltUri )
+    {
+        Logging devNullLogging = new Logging()
+        {
+            @Override
+            public Logger getLog( String name )
+            {
+                return DevNullLogger.DEV_NULL_LOGGER;
+            }
+        };
+
+        Config config = Config.build()
+                .withLogging( devNullLogging )
+                .toConfig();
+
+        return GraphDatabase.driver( boltUri, clusterRule.getDefaultAuthToken(), config );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -159,14 +159,7 @@ public class Neo4jRunner
     private int runCommand( String... cmd ) throws IOException
     {
         ProcessBuilder pb = new ProcessBuilder().inheritIO();
-        Map<String,String> env = System.getenv();
-        pb.environment().put( "JAVA_HOME",
-                // This driver is built to work with multiple java versions.
-                // Neo4j, however, works with a specific version of Java. This allows
-                // specifying which Java version to use for Neo4j separately from which
-                // version to use for the driver tests.
-                env.containsKey( "NEO4J_JAVA" ) ? env.get( "NEO4J_JAVA" ) :
-                System.getProperties().getProperty( "java.home" ) );
+        ProcessEnvConfigurator.configure( pb );
         if( NEORUN_START_ARGS != null )
         {
             // overwrite the env var in the sub process if the system property is specified

--- a/driver/src/test/java/org/neo4j/driver/v1/util/ProcessEnvConfigurator.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/ProcessEnvConfigurator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util;
+
+import java.util.Map;
+
+public final class ProcessEnvConfigurator
+{
+    /**
+     * Name of environment variable used by the Neo4j database.
+     */
+    private static final String JAVA_HOME = "JAVA_HOME";
+    /**
+     * Name of environment variable to be used for the Neo4j database, defined by the build system.
+     */
+    private static final String NEO4J_JAVA = "NEO4J_JAVA";
+
+    private ProcessEnvConfigurator()
+    {
+    }
+
+    public static void configure( ProcessBuilder processBuilder )
+    {
+        processBuilder.environment().put( JAVA_HOME, determineJavaHome() );
+    }
+
+    /**
+     * This driver is built to work with multiple java versions. Neo4j, however, works with a specific version of
+     * Java. This allows specifying which Java version to use for Neo4j separately from which version to use for
+     * the driver tests.
+     * <p>
+     * This method determines which java home to use based on present environment variables.
+     *
+     * @return path to the java home.
+     */
+    private static String determineJavaHome()
+    {
+        Map<String,String> environment = System.getenv();
+
+        String definedJava = environment.get( NEO4J_JAVA );
+        if ( definedJava != null )
+        {
+            return definedJava;
+        }
+
+        return System.getProperties().getProperty( "java.home" );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- * <p>
+ *
  * This file is part of Neo4j.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+
+import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
+
+public class Cluster
+{
+    private static final String ADMIN_USER = "neo4j";
+
+    private final Path path;
+    private final String password;
+    private final Set<ClusterMember> members;
+
+    public Cluster( Path path, String password )
+    {
+        this( path, password, Collections.<ClusterMember>emptySet() );
+    }
+
+    public Cluster( Path path, String password, Set<ClusterMember> members )
+    {
+        this.path = Objects.requireNonNull( path );
+        this.password = password;
+        this.members = createMembers( password, members );
+    }
+
+    Cluster withMembers( Set<ClusterMember> newMembers )
+    {
+        return new Cluster( path, password, newMembers );
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public ClusterMember leaderTx( Consumer<Session> tx )
+    {
+        // todo: handle leader switches
+        ClusterMember leader = findLeader();
+        try ( Driver driver = createDriver( leader.getBoltUri(), password );
+              Session session = driver.session() )
+        {
+            tx.accept( session );
+        }
+
+        return leader;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Cluster{" +
+               "path=" + path +
+               ", members=" + members +
+               "}";
+    }
+
+    private static Set<ClusterMember> createMembers( String password, Set<ClusterMember> givenMembers )
+    {
+        if ( givenMembers.isEmpty() )
+        {
+            return givenMembers;
+        }
+
+        Set<ClusterMember> expectedMembers = new HashSet<>( givenMembers );
+        Set<ClusterMember> actualMembers = new HashSet<>();
+
+        try ( Driver driver = createDriver( password, givenMembers ) )
+        {
+            // todo: add some timeout
+            while ( !expectedMembers.isEmpty() )
+            {
+                try ( Session session = driver.session( AccessMode.READ ) )
+                {
+                    StatementResult result = session.run( "call dbms.cluster.overview()" );
+                    for ( Record record : result.list() )
+                    {
+                        URI boltUri = extractBoltUri( record );
+
+                        ClusterMember member = findByBoltUri( boltUri, expectedMembers );
+                        if ( member != null )
+                        {
+                            ClusterMemberRole role = extractRole( record );
+                            ClusterMember actualMember = member.withRole( role );
+                            actualMembers.add( actualMember );
+                            expectedMembers.remove( member );
+                        }
+                    }
+                }
+            }
+        }
+
+
+        return actualMembers;
+    }
+
+    private ClusterMember findLeader()
+    {
+        try ( Driver driver = createDriver( password, members );
+              Session session = driver.session( AccessMode.READ ) )
+        {
+            StatementResult result = session.run( "call dbms.cluster.overview()" );
+            for ( Record record : result.list() )
+            {
+                ClusterMemberRole role = extractRole( record );
+                if ( role == ClusterMemberRole.LEADER )
+                {
+                    URI boltUri = extractBoltUri( record );
+                    ClusterMember leader = findByBoltUri( boltUri, members );
+                    if ( leader == null )
+                    {
+                        throw new IllegalStateException( "Unknown leader: '" + boltUri + "'\n" + this );
+                    }
+                    return leader;
+                }
+            }
+        }
+        throw new IllegalStateException( "Unable to find leader.\n" + this );
+    }
+
+    private static Driver createDriver( String password, Set<ClusterMember> members )
+    {
+        if ( members.isEmpty() )
+        {
+            throw new IllegalArgumentException( "No members, can't create driver" );
+        }
+
+        ClusterMember firstMember = members.iterator().next();
+        URI boltUri = firstMember.getBoltUri();
+        return createDriver( boltUri, password );
+    }
+
+    private static Driver createDriver( URI boltUri, String password )
+    {
+        return GraphDatabase.driver( boltUri, AuthTokens.basic( ADMIN_USER, password ), driverConfig() );
+    }
+
+    private static URI extractBoltUri( Record record )
+    {
+        List<Object> addresses = record.get( "addresses" ).asList();
+        String boltUriString = (String) addresses.get( 0 );
+        return URI.create( boltUriString );
+    }
+
+    private static ClusterMemberRole extractRole( Record record )
+    {
+        String roleString = record.get( "role" ).asString();
+        return ClusterMemberRole.valueOf( roleString.toUpperCase() );
+    }
+
+    private static ClusterMember findByBoltUri( URI boltUri, Set<ClusterMember> members )
+    {
+        for ( ClusterMember member : members )
+        {
+            if ( member.getBoltUri().equals( boltUri ) )
+            {
+                return member;
+            }
+        }
+        return null;
+    }
+
+    private static Config driverConfig()
+    {
+        // try to build config for a very lightweight driver
+        return Config.build()
+                .withTrustStrategy( trustAllCertificates() )
+                .withEncryptionLevel( Config.EncryptionLevel.NONE )
+                .withMaxIdleSessions( 1 )
+                .withSessionLivenessCheckTimeout( TimeUnit.HOURS.toMillis( 1 ) )
+                .toConfig();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
@@ -25,6 +25,8 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import org.neo4j.driver.v1.util.ProcessEnvConfigurator;
+
 import static java.lang.System.lineSeparator;
 
 final class ClusterControl
@@ -75,6 +77,7 @@ final class ClusterControl
         try
         {
             ProcessBuilder processBuilder = new ProcessBuilder().command( command );
+            ProcessEnvConfigurator.configure( processBuilder );
             return executeAndGetStdOut( processBuilder );
         }
         catch ( IOException e )

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
@@ -35,7 +35,7 @@ final class ClusterControl
     {
     }
 
-    static boolean boltKitAvailable()
+    static boolean boltKitClusterAvailable()
     {
         try
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
@@ -37,7 +37,7 @@ final class ClusterControl
     {
         try
         {
-            executeCommand( "neoctrl-cluster", "-h" );
+            executeCommand( "neoctrl-cluster", "--help" );
             return true;
         }
         catch ( ClusterControlException e )
@@ -46,11 +46,12 @@ final class ClusterControl
         }
     }
 
-    static void installCluster( String neo4jVersion, int cores, int readReplicas, String password, Path path )
+    static void installCluster( String neo4jVersion, int cores, int readReplicas, String password, int port,
+            Path path )
     {
         executeCommand( "neoctrl-cluster", "install",
-                "-c", String.valueOf( cores ), "-r", String.valueOf( readReplicas ),
-                "-p", password,
+                "--cores", String.valueOf( cores ), "--read-replicas", String.valueOf( readReplicas ),
+                "--password", password, "--initial-port", String.valueOf( port ),
                 neo4jVersion, path.toString() );
     }
 
@@ -66,7 +67,7 @@ final class ClusterControl
 
     static void killCluster( Path path )
     {
-        executeCommand( "neoctrl-cluster", "stop", "-k", path.toString() );
+        executeCommand( "neoctrl-cluster", "stop", "--kill", path.toString() );
     }
 
     private static String executeCommand( String... command )

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControl.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static java.lang.System.lineSeparator;
+
+final class ClusterControl
+{
+    private ClusterControl()
+    {
+    }
+
+    static boolean boltKitAvailable()
+    {
+        try
+        {
+            executeCommand( "neoctrl-cluster", "-h" );
+            return true;
+        }
+        catch ( ClusterControlException e )
+        {
+            return false;
+        }
+    }
+
+    static void installCluster( String neo4jVersion, int cores, int readReplicas, String password, Path path )
+    {
+        executeCommand( "neoctrl-cluster", "install",
+                "-c", String.valueOf( cores ), "-r", String.valueOf( readReplicas ),
+                "-p", password,
+                neo4jVersion, path.toString() );
+    }
+
+    static String startCluster( Path path )
+    {
+        return executeCommand( "neoctrl-cluster", "start", path.toString() );
+    }
+
+    static void stopCluster( Path path )
+    {
+        executeCommand( "neoctrl-cluster", "stop", path.toString() );
+    }
+
+    static void killCluster( Path path )
+    {
+        executeCommand( "neoctrl-cluster", "stop", "-k", path.toString() );
+    }
+
+    private static String executeCommand( String... command )
+    {
+        try
+        {
+            ProcessBuilder processBuilder = new ProcessBuilder().command( command );
+            return executeAndGetStdOut( processBuilder );
+        }
+        catch ( IOException e )
+        {
+            throw new ClusterControlException( "Error running command " + Arrays.toString( command ), e );
+        }
+        catch ( InterruptedException e )
+        {
+            Thread.currentThread().interrupt();
+            throw new ClusterControlException( "Interrupted while waiting for command " +
+                                               Arrays.toString( command ), e );
+        }
+    }
+
+    private static String executeAndGetStdOut( ProcessBuilder processBuilder )
+            throws IOException, InterruptedException
+    {
+        Process process = processBuilder.start();
+        int exitCode = process.waitFor();
+        String stdOut = asString( process.getInputStream() );
+        String stdErr = asString( process.getErrorStream() );
+        if ( exitCode != 0 )
+        {
+            throw new ClusterControlException( "Non-zero exit code\nSTDOUT:\n" + stdOut + "\nSTDERR:\n" + stdErr );
+        }
+        return stdOut;
+    }
+
+    private static String asString( InputStream input )
+    {
+        StringBuilder result = new StringBuilder();
+        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( input ) ) )
+        {
+            String line;
+            while ( (line = reader.readLine()) != null )
+            {
+                result.append( line ).append( lineSeparator() );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new ClusterControlException( "Unable to read from stream", e );
+        }
+        return result.toString();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControlException.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControlException.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterControlException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+class ClusterControlException extends RuntimeException
+{
+    ClusterControlException( String message )
+    {
+        super( message );
+    }
+
+    ClusterControlException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- * <p>
+ *
  * This file is part of Neo4j.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- *
+ * <p>
  * This file is part of Neo4j.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,26 +26,12 @@ import static java.util.Objects.requireNonNull;
 public class ClusterMember
 {
     private final URI boltUri;
-    private final URI httpUri;
     private final Path path;
-    private final ClusterMemberRole role;
 
-    public ClusterMember( URI boltUri, URI httpUri, Path path )
-    {
-        this( boltUri, httpUri, path, ClusterMemberRole.UNKNOWN );
-    }
-
-    public ClusterMember( URI boltUri, URI httpUri, Path path, ClusterMemberRole role )
+    public ClusterMember( URI boltUri, Path path )
     {
         this.boltUri = requireNonNull( boltUri );
-        this.httpUri = requireNonNull( httpUri );
         this.path = requireNonNull( path );
-        this.role = requireNonNull( role );
-    }
-
-    public ClusterMember withRole( ClusterMemberRole role )
-    {
-        return new ClusterMember( boltUri, httpUri, path, role );
     }
 
     public URI getBoltUri()
@@ -58,19 +44,9 @@ public class ClusterMember
         return URI.create( boltUri.toString().replace( "bolt://", "bolt+routing://" ) );
     }
 
-    public URI getHttpUri()
-    {
-        return httpUri;
-    }
-
     public Path getPath()
     {
         return path;
-    }
-
-    public ClusterMemberRole getRole()
-    {
-        return role;
     }
 
     @Override
@@ -78,9 +54,7 @@ public class ClusterMember
     {
         return "ClusterMember{" +
                "boltUri=" + boltUri +
-               ", httpUri=" + httpUri +
                ", path=" + path +
-               ", role=" + role +
                "}";
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -25,6 +25,9 @@ import static java.util.Objects.requireNonNull;
 
 public class ClusterMember
 {
+    private static final String SIMPLE_SCHEME = "bolt://";
+    private static final String ROUTING_SCHEME = "bolt+routing://";
+
     private final URI boltUri;
     private final Path path;
 
@@ -41,7 +44,7 @@ public class ClusterMember
 
     public URI getRoutingUri()
     {
-        return URI.create( boltUri.toString().replace( "bolt://", "bolt+routing://" ) );
+        return URI.create( boltUri.toString().replace( SIMPLE_SCHEME, ROUTING_SCHEME ) );
     }
 
     public Path getPath()

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClusterMember
+{
+    private final URI boltUri;
+    private final URI httpUri;
+    private final Path path;
+    private final ClusterMemberRole role;
+
+    public ClusterMember( URI boltUri, URI httpUri, Path path )
+    {
+        this( boltUri, httpUri, path, ClusterMemberRole.UNKNOWN );
+    }
+
+    public ClusterMember( URI boltUri, URI httpUri, Path path, ClusterMemberRole role )
+    {
+        this.boltUri = requireNonNull( boltUri );
+        this.httpUri = requireNonNull( httpUri );
+        this.path = requireNonNull( path );
+        this.role = requireNonNull( role );
+    }
+
+    public ClusterMember withRole( ClusterMemberRole role )
+    {
+        return new ClusterMember( boltUri, httpUri, path, role );
+    }
+
+    public URI getBoltUri()
+    {
+        return boltUri;
+    }
+
+    public URI getRoutingUri()
+    {
+        return URI.create( boltUri.toString().replace( "bolt://", "bolt+routing://" ) );
+    }
+
+    public URI getHttpUri()
+    {
+        return httpUri;
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public ClusterMemberRole getRole()
+    {
+        return role;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ClusterMember{" +
+               "boltUri=" + boltUri +
+               ", httpUri=" + httpUri +
+               ", path=" + path +
+               ", role=" + role +
+               "}";
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
@@ -20,7 +20,6 @@ package org.neo4j.driver.v1.util.cc;
 
 public enum ClusterMemberRole
 {
-    UNKNOWN,
     LEADER,
     FOLLOWER,
     READ_REPLICA

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMemberRole.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+public enum ClusterMemberRole
+{
+    UNKNOWN,
+    LEADER,
+    FOLLOWER,
+    READ_REPLICA
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+import org.junit.rules.ExternalResource;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.AuthTokens;
+
+import static java.lang.System.err;
+import static org.junit.Assume.assumeTrue;
+
+public class ClusterRule extends ExternalResource
+{
+    private static final Path CLUSTER_DIR = Paths.get( "target", "test-cluster" ).toAbsolutePath();
+    private static final String PASSWORD = "test";
+
+    public Cluster getCluster()
+    {
+        return SharedCluster.get();
+    }
+
+    public AuthToken getDefaultAuthToken()
+    {
+        return AuthTokens.basic( "neo4j", PASSWORD );
+    }
+
+    @Override
+    protected void before() throws Throwable
+    {
+        assumeTrue( "BoltKit unavailable", ClusterControl.boltKitAvailable() );
+
+        if ( !SharedCluster.exists() )
+        {
+            try
+            {
+                delete( CLUSTER_DIR );
+                // todo: get version from env
+                SharedCluster.install( "3.1.0-M13-beta3", 3, 0, PASSWORD, CLUSTER_DIR );
+                SharedCluster.start();
+            }
+            finally
+            {
+                addShutdownHookToStopCluster();
+            }
+        }
+    }
+
+    private static void addShutdownHookToStopCluster()
+    {
+        Runtime.getRuntime().addShutdownHook( new Thread()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    SharedCluster.kill();
+                    delete( CLUSTER_DIR );
+                }
+                catch ( Throwable t )
+                {
+                    err.println( "Cluster stopping shutdown hook failed" );
+                    t.printStackTrace();
+                }
+            }
+        } );
+    }
+
+    private static void delete( final Path path )
+    {
+        try
+        {
+            if ( !Files.exists( path ) )
+            {
+                return;
+            }
+
+            Files.walkFileTree( path, new SimpleFileVisitor<Path>()
+            {
+                @Override
+                public FileVisitResult visitFile( Path file, BasicFileAttributes attributes ) throws IOException
+                {
+                    Files.delete( file );
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory( Path dir, IOException error ) throws IOException
+                {
+                    if ( error != null )
+                    {
+                        return FileVisitResult.TERMINATE;
+                    }
+                    Files.delete( dir );
+                    return FileVisitResult.CONTINUE;
+                }
+            } );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Unable to delete '" + path + "'", e );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
@@ -38,6 +38,7 @@ public class ClusterRule extends ExternalResource
 {
     private static final Path CLUSTER_DIR = Paths.get( "target", "test-cluster" ).toAbsolutePath();
     private static final String PASSWORD = "test";
+    private static final int INITIAL_PORT = 20_000;
 
     public Cluster getCluster()
     {
@@ -60,7 +61,7 @@ public class ClusterRule extends ExternalResource
             {
                 delete( CLUSTER_DIR );
                 // todo: get version from env
-                SharedCluster.install( "3.1.0-M13-beta3", 3, 2, PASSWORD, CLUSTER_DIR );
+                SharedCluster.install( "3.1.0-M13-beta3", 3, 2, PASSWORD, INITIAL_PORT, CLUSTER_DIR );
                 SharedCluster.start();
             }
             finally

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
@@ -60,7 +60,7 @@ public class ClusterRule extends ExternalResource
             {
                 delete( CLUSTER_DIR );
                 // todo: get version from env
-                SharedCluster.install( "3.1.0-M13-beta3", 3, 0, PASSWORD, CLUSTER_DIR );
+                SharedCluster.install( "3.1.0-M13-beta3", 3, 2, PASSWORD, CLUSTER_DIR );
                 SharedCluster.start();
             }
             finally
@@ -68,6 +68,12 @@ public class ClusterRule extends ExternalResource
                 addShutdownHookToStopCluster();
             }
         }
+    }
+
+    @Override
+    protected void after()
+    {
+        getCluster().cleanUp();
     }
 
     private static void addShutdownHookToStopCluster()

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterUnavailableException.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterUnavailableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterUnavailableException.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterUnavailableException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+class ClusterUnavailableException extends Exception
+{
+    ClusterUnavailableException( String message )
+    {
+        super( message );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -40,6 +40,12 @@ final class SharedCluster
         return clusterInstance;
     }
 
+    static void remove()
+    {
+        assertClusterExists();
+        clusterInstance = null;
+    }
+
     static boolean exists()
     {
         return clusterInstance != null;

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.util.cc;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.lang.System.lineSeparator;
+
+final class SharedCluster
+{
+    private static Cluster clusterInstance;
+
+    private SharedCluster()
+    {
+    }
+
+    static Cluster get()
+    {
+        assertClusterExists();
+        return clusterInstance;
+    }
+
+    static boolean exists()
+    {
+        return clusterInstance != null;
+    }
+
+    static void install( String neo4jVersion, int cores, int readReplicas, String password, Path path )
+    {
+        assertClusterDoesNotExist();
+        ClusterControl.installCluster( neo4jVersion, cores, readReplicas, password, path );
+        clusterInstance = new Cluster( path, password );
+    }
+
+    static void start()
+    {
+        assertClusterExists();
+        String output = ClusterControl.startCluster( clusterInstance.getPath() );
+        Set<ClusterMember> members = parseStartCommandOutput( output );
+        clusterInstance = clusterInstance.withMembers( members );
+    }
+
+    static void stop()
+    {
+        assertClusterExists();
+        ClusterControl.stopCluster( clusterInstance.getPath() );
+    }
+
+    static void kill()
+    {
+        assertClusterExists();
+        ClusterControl.killCluster( clusterInstance.getPath() );
+    }
+
+    private static Set<ClusterMember> parseStartCommandOutput( String output )
+    {
+        Set<ClusterMember> result = new HashSet<>();
+
+        String[] lines = output.split( lineSeparator() );
+        for ( String line : lines )
+        {
+            String[] clusterMemberSplit = line.split( " " );
+            if ( clusterMemberSplit.length != 3 )
+            {
+                throw new IllegalArgumentException(
+                        "Wrong start command output. " +
+                        "Expected to have 'http_uri bolt_uri path' in line '" + line + "'" );
+            }
+
+            URI httpUri = URI.create( clusterMemberSplit[0] );
+            URI boltUri = URI.create( clusterMemberSplit[1] );
+            Path path = Paths.get( clusterMemberSplit[1] );
+
+            result.add( new ClusterMember( boltUri, httpUri, path ) );
+        }
+
+        if ( result.isEmpty() )
+        {
+            throw new IllegalStateException( "No cluster members" );
+        }
+
+        return result;
+    }
+
+    private static void assertClusterExists()
+    {
+        if ( clusterInstance == null )
+        {
+            throw new IllegalStateException( "Shared cluster does not exist" );
+        }
+    }
+
+    private static void assertClusterDoesNotExist()
+    {
+        if ( clusterInstance != null )
+        {
+            throw new IllegalStateException( "Shared cluster already exists" );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- * <p>
+ *
  * This file is part of Neo4j.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,10 +45,10 @@ final class SharedCluster
         return clusterInstance != null;
     }
 
-    static void install( String neo4jVersion, int cores, int readReplicas, String password, Path path )
+    static void install( String neo4jVersion, int cores, int readReplicas, String password, int port, Path path )
     {
         assertClusterDoesNotExist();
-        ClusterControl.installCluster( neo4jVersion, cores, readReplicas, password, path );
+        ClusterControl.installCluster( neo4jVersion, cores, readReplicas, password, port, path );
         clusterInstance = new Cluster( path, password );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -52,12 +52,21 @@ final class SharedCluster
         clusterInstance = new Cluster( path, password );
     }
 
-    static void start()
+    static void start() throws ClusterUnavailableException
     {
         assertClusterExists();
         String output = ClusterControl.startCluster( clusterInstance.getPath() );
         Set<ClusterMember> members = parseStartCommandOutput( output );
-        clusterInstance = clusterInstance.withMembers( members );
+
+        try
+        {
+            clusterInstance = clusterInstance.withMembers( members );
+        }
+        catch ( ClusterUnavailableException e )
+        {
+            kill();
+            throw e;
+        }
     }
 
     static void stop()

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
- *
+ * <p>
  * This file is part of Neo4j.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -87,11 +87,10 @@ final class SharedCluster
                         "Expected to have 'http_uri bolt_uri path' in line '" + line + "'" );
             }
 
-            URI httpUri = URI.create( clusterMemberSplit[0] );
             URI boltUri = URI.create( clusterMemberSplit[1] );
             Path path = Paths.get( clusterMemberSplit[1] );
 
-            result.add( new ClusterMember( boltUri, httpUri, path ) );
+            result.add( new ClusterMember( boltUri, path ) );
         }
 
         if ( result.isEmpty() )


### PR DESCRIPTION
This PR adds some basic infrastructure to install/start/stop/query shared causal cluster and moves couple ITs from https://github.com/neo4j/neo4j codebase.

Missing functionality:
 - download specified/latest neo4j package
 - add cores and read replicas dynamically
 - stop/kill individual cluster members (simulate leader switches)

These items and corresponding tests will be covered in future PRs.