### PR TITLE
Better internal error handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectDriver.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -46,7 +47,14 @@ public class DirectDriver extends BaseDriver
     @Override
     protected Session newSessionWithMode( AccessMode mode )
     {
-        return new NetworkSession( connections.acquire( address ) );
+        try
+        {
+            return new NetworkSession( connections.acquire( address ) );
+        }
+        catch ( InternalException e )
+        {
+            throw e.publicException();
+        }
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -119,7 +119,7 @@ public class DriverFactory
         PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize() );
         Connector connector = new SocketConnector( connectionSettings, securityPlan, config.logging() );
 
-        return new SocketConnectionPool( poolSettings, connector, Clock.SYSTEM, config.logging() );
+        return new SocketConnectionPool( poolSettings, connector, config.logging() );
     }
 
     private static SecurityPlan createSecurityPlan( BoltServerAddress address, Config config )

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/BoltProtocolException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/BoltProtocolException.java
@@ -16,43 +16,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging;
+package org.neo4j.driver.internal.exceptions;
 
-import java.io.IOException;
-
-import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
 
 /**
- * IGNORED response message
- * <p>
- * Sent by the server to signal that an operation has been ignored.
- * Terminates response sequence.
+ * Any error that related to some unexpected use of Bolt protocol, including failed to encode/decode between bolt
+ * message and binary, unexpected message replied etc.
  */
-public class IgnoredMessage implements Message
+public class BoltProtocolException extends InternalException
 {
-    public static final IgnoredMessage IGNORED = new IgnoredMessage();
-
-    @Override
-    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
+    public BoltProtocolException( String msg )
     {
-        handler.handleIgnoredMessage();
+        super( msg );
+    }
+
+    public BoltProtocolException( String msg, Throwable error )
+    {
+        super( msg, error );
+    }
+
+    public BoltProtocolException( String msg, InternalException error )
+    {
+        super( msg, error.publicException() );
     }
 
     @Override
-    public String toString()
+    public Neo4jException publicException()
     {
-        return "IGNORED {}";
-    }
-
-    @Override
-    public boolean equals( Object obj )
-    {
-        return obj != null && obj.getClass() == getClass();
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return 1;
+        return new ClientException( getMessage(), getCause() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/ConnectionException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/ConnectionException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+
+/**
+ * This error indicates that a socket connection is broken due to errors.
+ *
+ * When seeing this error, the socket connection should be closed.
+ * While the driver should recover from this error, after the network is good for connection again.
+ *
+ * For a routing client, the client should consider to remove the server from routing table,
+ * as the server probably no long available or not ready/authed to serve the client.
+ */
+public class ConnectionException extends InternalException
+{
+    public ConnectionException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    public ConnectionException( String msg, InternalException error )
+    {
+        super( msg, error.getCause() );
+    }
+
+    public ConnectionException( String msg )
+    {
+        super( msg );
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return new ServiceUnavailableException( getMessage(), getCause() );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/FailedToUpdateRoutingException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/FailedToUpdateRoutingException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+
+/**
+ * Only used in {@link org.neo4j.driver.internal.RoutingDriver} regarding {@link org.neo4j.driver.internal.cluster.LoadBalancer}
+ * failed to update routing table.
+ *
+ * The reason of failing could be interrupted during update/connection terminated during update/no router to use for
+ * updating and so on.
+ *
+ * This error will end up in {@link org.neo4j.driver.v1.exceptions.ServiceUnavailableException} as failing to update
+ * routing table means the driver failed to connect to the cluster and can no longer server routing
+ */
+public class FailedToUpdateRoutingException extends InternalException
+{
+    public FailedToUpdateRoutingException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    public FailedToUpdateRoutingException( String msg )
+    {
+        super( msg );
+    }
+
+    public FailedToUpdateRoutingException( String msg, InternalException error )
+    {
+        super( msg, error );
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return new ServiceUnavailableException( getMessage(), getCause() );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+
+/**
+ * Internal checked exceptions.
+ * This exception should never be visible to a driver user in anyway.
+ *
+ * The internal error should be casted to a public error in {@link org.neo4j.driver.v1.exceptions} with
+ * {@link #publicException()} method call before it reaches to a driver end user.
+ */
+public abstract class InternalException extends Exception
+{
+    public InternalException()
+    {}
+
+    public InternalException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    public InternalException( String msg )
+    {
+        super( msg );
+    }
+
+    public abstract Neo4jException publicException();
+
+    public boolean isUnrecoverableError()
+    {
+        return true;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/InvalidOperationException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/InvalidOperationException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+
+/**
+ * Any error that happens due to mis-use of this driver, such as connecting to a port that does not support Bolt
+ * protocol, or connecting to a server whose version is not compatible with this driver.
+ *
+ * This error normally requires a restart of a driver and change config correctly to recover.
+ *
+ * <p>
+ * This error is very similar to {@link UnsupportedOperationException} which this error is a checked error.
+ * </p>
+ */
+public class InvalidOperationException extends InternalException
+{
+    public InvalidOperationException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    public InvalidOperationException( String msg )
+    {
+        super( msg );
+    }
+
+    public InvalidOperationException( String msg, InternalException error )
+    {
+        super( msg, error.publicException() );
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return new ClientException( this.getMessage(), this.getCause() );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/ServerNeo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/ServerNeo4jException.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.driver.internal.exceptions;
 
 import org.neo4j.driver.v1.exceptions.ClientException;

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/ServerNeo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/ServerNeo4jException.java
@@ -1,0 +1,65 @@
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.DatabaseException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.TransientException;
+
+/**
+ * This exception represents an exception that is passed from the server.
+ * When using bolt driver with a server, the server might return a failure message indicating something is wrong to
+ * run a statement. The failure message could be mapped into a {@link org.neo4j.driver.v1.exceptions.Neo4jException}.
+ *
+ * This {@link ServerNeo4jException} wrap around the {@link org.neo4j.driver.v1.exceptions.Neo4jException} to make it
+ * a checked exception so that we could keep track of it when it is passed internally. Then when we surface this
+ * exception to the user, we will map it back to {@link org.neo4j.driver.v1.exceptions.Neo4jException}.
+ */
+public class ServerNeo4jException extends InternalException
+{
+    private final Neo4jException error;
+
+    public ServerNeo4jException( String code, String message )
+    {
+        String[] parts = code.split( "\\." );
+        String classification = parts[1];
+        switch ( classification )
+        {
+        case "ClientError":
+            error = new ClientException( code, message );
+            break;
+        case "TransientError":
+            error = new TransientException( code, message );
+            break;
+        default:
+            error = new DatabaseException( code, message );
+            break;
+        }
+    }
+
+    public ServerNeo4jException( Neo4jException error )
+    {
+        this.error = error;
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return error;
+    }
+
+    public boolean isProtocolViolationError()
+    {
+        return error != null && error.code().startsWith( "Neo.ClientError.Request" );
+    }
+
+    private boolean isDatabaseError()
+    {
+        return error != null && error instanceof DatabaseException;
+    }
+
+    @Override
+    public boolean isUnrecoverableError()
+    {
+        return isDatabaseError() || isProtocolViolationError();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/TLSConnectionException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/TLSConnectionException.java
@@ -16,21 +16,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging;
+package org.neo4j.driver.internal.exceptions;
 
-import java.io.IOException;
-
-import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
 
 /**
- * Base class for all protocol messages.
+ * Any error that related to failing establish tls connections with the server
  */
-public interface Message
+public class TLSConnectionException extends InternalException
 {
-    /**
-     * @throws IOException failed to read/write to the socket
-     * @throws BoltProtocolException if the handler failed to handle this message
-     */
-    void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException;
+    public TLSConnectionException( String msg )
+    {
+        super( msg );
+    }
 
+    public TLSConnectionException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return new ClientException( this.getMessage(), this.getCause() );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/FailureMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/FailureMessage.java
@@ -20,6 +20,8 @@ package org.neo4j.driver.internal.messaging;
 
 import java.io.IOException;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+
 import static java.lang.String.format;
 
 /**
@@ -41,7 +43,7 @@ public class FailureMessage implements Message
     }
 
     @Override
-    public void dispatch( MessageHandler handler ) throws IOException
+    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
     {
         handler.handleFailureMessage( code, message );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/InitMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/InitMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Value;
 
 import static java.lang.String.format;
@@ -42,7 +43,7 @@ public class InitMessage implements Message
     }
 
     @Override
-    public void dispatch( MessageHandler handler ) throws IOException
+    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
     {
         handler.handleInitMessage( userAgent, authToken );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+
 public interface MessageFormat
 {
     interface Writer
     {
-        Writer write( Message msg ) throws IOException;
+        Writer write( Message msg ) throws IOException, BoltProtocolException;
 
         Writer flush() throws IOException;
 
@@ -40,7 +42,7 @@ public interface MessageFormat
          */
         boolean hasNext() throws IOException;
 
-        void read( MessageHandler handler ) throws IOException;
+        void read( MessageHandler handler ) throws IOException, BoltProtocolException;
 
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageHandler.java
@@ -21,14 +21,15 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Value;
 
 public interface MessageHandler
 {
     // Requests
-    void handleInitMessage( String clientNameAndVersion, Map<String,Value> authToken ) throws IOException;
+    void handleInitMessage( String clientNameAndVersion, Map<String,Value> authToken ) throws IOException, BoltProtocolException;
 
-    void handleRunMessage( String statement, Map<String,Value> parameters ) throws IOException;
+    void handleRunMessage( String statement, Map<String,Value> parameters ) throws IOException, BoltProtocolException;
 
     void handlePullAllMessage() throws IOException;
 
@@ -39,12 +40,12 @@ public interface MessageHandler
     void handleAckFailureMessage() throws IOException;
 
     // Responses
-    void handleSuccessMessage( Map<String,Value> meta ) throws IOException;
+    void handleSuccessMessage( Map<String,Value> meta ) throws IOException, BoltProtocolException;
 
-    void handleRecordMessage( Value[] fields ) throws IOException;
+    void handleRecordMessage( Value[] fields ) throws IOException, BoltProtocolException;
 
-    void handleFailureMessage( String code, String message ) throws IOException;
+    void handleFailureMessage( String code, String message ) throws IOException, BoltProtocolException;
 
-    void handleIgnoredMessage() throws IOException;
+    void handleIgnoredMessage() throws IOException, BoltProtocolException;
 
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/RecordMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/RecordMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Value;
 
 public class RecordMessage implements Message
@@ -33,7 +34,7 @@ public class RecordMessage implements Message
     }
 
     @Override
-    public void dispatch( MessageHandler handler ) throws IOException
+    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
     {
         handler.handleRecordMessage( fields );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/RunMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/RunMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Value;
 
 import static java.lang.String.format;
@@ -43,7 +44,7 @@ public class RunMessage implements Message
     }
 
     @Override
-    public void dispatch( MessageHandler handler ) throws IOException
+    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
     {
         handler.handleRunMessage( statement, parameters );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/SuccessMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/SuccessMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Value;
 
 import static java.lang.String.format;
@@ -41,7 +42,7 @@ public class SuccessMessage implements Message
     }
 
     @Override
-    public void dispatch( MessageHandler handler ) throws IOException
+    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
     {
         handler.handleSuccessMessage( metadata );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -21,6 +21,10 @@ package org.neo4j.driver.internal.net;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Logger;
@@ -46,6 +50,7 @@ public class ConcurrencyGuardingConnection implements Connection
 
     @Override
     public void init( String clientName, Map<String,Value> authToken )
+            throws ConnectionException, ServerNeo4jException, InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -60,7 +65,7 @@ public class ConcurrencyGuardingConnection implements Connection
 
     @Override
     public void run( String statement, Map<String,Value> parameters,
-            Collector collector )
+            Collector collector ) throws InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -74,7 +79,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void discardAll( Collector collector )
+    public void discardAll( Collector collector ) throws InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -88,7 +93,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void pullAll( Collector collector )
+    public void pullAll( Collector collector ) throws InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -102,7 +107,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void reset()
+    public void reset() throws InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -131,6 +136,7 @@ public class ConcurrencyGuardingConnection implements Connection
 
     @Override
     public void sync()
+            throws ConnectionException, ServerNeo4jException, InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -144,7 +150,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void flush()
+    public void flush() throws ConnectionException, InvalidOperationException, BoltProtocolException
     {
         try
         {
@@ -158,7 +164,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void receiveOne()
+    public void receiveOne() throws ConnectionException, ServerNeo4jException, BoltProtocolException
     {
         try
         {
@@ -172,7 +178,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void close()
+    public void close() throws InvalidOperationException
     {
         // It is fine to call close concurrently with this connection being used somewhere else.
         // This could happen when driver is closed while there still exist sessions that do some work.
@@ -186,27 +192,9 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void onError( Runnable runnable )
-    {
-        delegate.onError( runnable );
-    }
-
-    @Override
-    public boolean hasUnrecoverableErrors()
-    {
-        return delegate.hasUnrecoverableErrors();
-    }
-
-    @Override
-    public void resetAsync()
+    public void resetAsync() throws ConnectionException, InvalidOperationException, BoltProtocolException
     {
         delegate.resetAsync();
-    }
-
-    @Override
-    public boolean isAckFailureMuted()
-    {
-        return delegate.isAckFailureMuted();
     }
 
     private void markAsAvailable()

--- a/driver/src/main/java/org/neo4j/driver/internal/net/LoggingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/LoggingResponseHandler.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.net;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Value;
 
@@ -97,14 +98,14 @@ public class LoggingResponseHandler extends SocketResponseHandler
     }
 
     @Override
-    public void handleFailureMessage( String code, String message )
+    public void handleFailureMessage( String code, String message ) throws BoltProtocolException
     {
         logger.debug("S: FAILURE %s \"%s\"", code, message );
         super.handleFailureMessage( code, message );
     }
 
     @Override
-    public void handleIgnoredMessage()
+    public void handleIgnoredMessage() throws BoltProtocolException
     {
         logger.debug( DEFAULT_DEBUG_LOGGING_FORMAT, IGNORED );
         super.handleIgnoredMessage();

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
@@ -21,6 +21,10 @@ package org.neo4j.driver.internal.net;
 import java.util.Map;
 
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
@@ -46,6 +50,7 @@ public class SocketConnector implements Connector
 
     @Override
     public final Connection connect( BoltServerAddress address )
+            throws InvalidOperationException, ConnectionException, BoltProtocolException, ServerNeo4jException
     {
         Connection connection = createConnection( address, securityPlan, logging );
 
@@ -57,10 +62,10 @@ public class SocketConnector implements Connector
         {
             connection.init( connectionSettings.userAgent(), tokenAsMap( connectionSettings.authToken() ) );
         }
-        catch ( Throwable initError )
+        catch ( BoltProtocolException | ConnectionException | ServerNeo4jException | InvalidOperationException e )
         {
             connection.close();
-            throw initError;
+            throw e;
         }
 
         return connection;
@@ -72,6 +77,7 @@ public class SocketConnector implements Connector
      * <b>This method is package-private only for testing</b>
      */
     Connection createConnection( BoltServerAddress address, SecurityPlan securityPlan, Logging logging )
+            throws ConnectionException, InvalidOperationException
     {
         return new SocketConnection( address, securityPlan, logging );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionFactory.java
@@ -16,43 +16,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging;
-
-import java.io.IOException;
+package org.neo4j.driver.internal.net.pooling;
 
 import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
+import org.neo4j.driver.internal.spi.PooledConnection;
 
-/**
- * IGNORED response message
- * <p>
- * Sent by the server to signal that an operation has been ignored.
- * Terminates response sequence.
- */
-public class IgnoredMessage implements Message
+public interface PooledConnectionFactory
 {
-    public static final IgnoredMessage IGNORED = new IgnoredMessage();
-
-    @Override
-    public void dispatch( MessageHandler handler ) throws IOException, BoltProtocolException
-    {
-        handler.handleIgnoredMessage();
-    }
-
-    @Override
-    public String toString()
-    {
-        return "IGNORED {}";
-    }
-
-    @Override
-    public boolean equals( Object obj )
-    {
-        return obj != null && obj.getClass() == getClass();
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return 1;
-    }
+    PooledConnection newInstance()
+            throws ConnectionException, InvalidOperationException, ServerNeo4jException, BoltProtocolException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseManager.java
@@ -18,31 +18,30 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.util.Function;
 
 /**
- * The responsibility of the PooledConnectionReleaseConsumer is to release valid connections
+ * The responsibility of the {@link PooledConnectionReleaseManager} is to release valid connections
  * back to the connections queue.
  */
-class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
+public class PooledConnectionReleaseManager implements PooledConnectionReleaser
 {
     private final BlockingPooledConnectionQueue connections;
-    private final Function<PooledConnection, Boolean> validConnection;
+    private final Function<PooledConnection, Boolean> connectionValidator;
 
-    PooledConnectionReleaseConsumer( BlockingPooledConnectionQueue connections,
-            Function<PooledConnection, Boolean> validConnection)
+    protected PooledConnectionReleaseManager( BlockingPooledConnectionQueue conns,
+            Function<PooledConnection,Boolean> validator )
     {
-        this.connections = connections;
-        this.validConnection = validConnection;
+        this.connections = conns;
+        this.connectionValidator = validator;
     }
 
     @Override
-    public void accept( PooledConnection pooledConnection )
+    public void accept( PooledConnection pooledConnection ) throws InvalidOperationException
     {
-        if ( validConnection.apply( pooledConnection ) )
+        if ( connectionValidator.apply( pooledConnection ) )
         {
             connections.offer( pooledConnection );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaser.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaser.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.driver.internal.net.pooling;
 
 import org.neo4j.driver.internal.exceptions.InvalidOperationException;

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaser.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaser.java
@@ -1,0 +1,13 @@
+package org.neo4j.driver.internal.net.pooling;
+
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.spi.PooledConnection;
+
+/**
+ * The responsibility of the {@link PooledConnectionReleaser} is to release valid connections
+ * back to the connections queue.
+ */
+public interface PooledConnectionReleaser
+{
+    void accept( PooledConnection pooledConnection ) throws InvalidOperationException;
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidator.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidator.java
@@ -19,9 +19,10 @@
 package org.neo4j.driver.internal.net.pooling;
 
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.util.Function;
 
-class PooledConnectionValidator implements Function<PooledConnection,Boolean>
+class PooledConnectionValidator implements Function<PooledConnection, Boolean>
 {
     private final ConnectionPool pool;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -18,15 +18,18 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.Connector;
-import org.neo4j.driver.internal.util.Clock;
-import org.neo4j.driver.internal.util.Supplier;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logging;
 
 /**
@@ -46,43 +49,40 @@ public class SocketConnectionPool implements ConnectionPool
     /**
      * Pools, organized by server address.
      */
-    private final ConcurrentHashMap<BoltServerAddress,BlockingPooledConnectionQueue> pools =
-            new ConcurrentHashMap<>();
 
     private final AtomicBoolean closed = new AtomicBoolean();
+    private final ConcurrentHashMap<BoltServerAddress,BlockingPooledConnectionQueue> pools = new ConcurrentHashMap<>();
 
     private final PoolSettings poolSettings;
     private final Connector connector;
-    private final Clock clock;
     private final Logging logging;
 
-    public SocketConnectionPool( PoolSettings poolSettings, Connector connector, Clock clock, Logging logging )
+    public SocketConnectionPool( PoolSettings poolSettings, Connector connector, Logging logging )
     {
         this.poolSettings = poolSettings;
         this.connector = connector;
-        this.clock = clock;
         this.logging = logging;
     }
 
     @Override
-    public Connection acquire( final BoltServerAddress address )
+    public PooledConnection acquire( final BoltServerAddress address )
+            throws ConnectionException, InvalidOperationException, ServerNeo4jException, BoltProtocolException
     {
         assertNotClosed();
 
         final BlockingPooledConnectionQueue connections = pool( address );
-        Supplier<PooledConnection> supplier = new Supplier<PooledConnection>()
+        PooledConnectionFactory pooledConnectionFactory = new PooledConnectionFactory()
         {
             @Override
-            public PooledConnection get()
+            public PooledConnection newInstance()
+                    throws ConnectionException, ServerNeo4jException, InvalidOperationException, BoltProtocolException
             {
-                PooledConnectionValidator connectionValidator =
-                        new PooledConnectionValidator( SocketConnectionPool.this );
-                PooledConnectionReleaseConsumer releaseConsumer =
-                        new PooledConnectionReleaseConsumer( connections, connectionValidator );
-                return new PooledConnection( connector.connect( address ), releaseConsumer, clock );
+                PooledConnectionReleaser releaseManager =
+                        new SocketConnectionPoolPooledConnectionReleaseManager( connections );
+                return new PooledSocketConnection( connector.connect( address ), releaseManager );
             }
         };
-        PooledConnection conn = connections.acquire( supplier );
+        PooledConnection conn = connections.acquire( pooledConnectionFactory );
 
         if ( closed.get() )
         {
@@ -90,8 +90,50 @@ public class SocketConnectionPool implements ConnectionPool
             throw poolClosedException();
         }
 
-        conn.updateTimestamp();
         return conn;
+    }
+
+    @Override
+    public void purge( BoltServerAddress address ) throws InvalidOperationException
+    {
+        BlockingPooledConnectionQueue connections = pools.remove( address );
+        if ( connections != null )
+        {
+            connections.terminate();
+        }
+    }
+
+    @Override
+    public boolean hasAddress( BoltServerAddress address )
+    {
+        return pools.containsKey( address );
+    }
+
+    @Override
+    public void close() throws InvalidOperationException
+    {
+        if ( closed.compareAndSet( false, true ) )
+        {
+            for ( BlockingPooledConnectionQueue pool : pools.values() )
+            {
+                pool.terminate();
+            }
+
+            pools.clear();
+        }
+    }
+
+    private void assertNotClosed() throws InvalidOperationException
+    {
+        if ( closed.get() )
+        {
+            throw poolClosedException();
+        }
+    }
+
+    private static InvalidOperationException poolClosedException()
+    {
+        return new InvalidOperationException( "Pool closed" );
     }
 
     private BlockingPooledConnectionQueue pool( BoltServerAddress address )
@@ -110,46 +152,11 @@ public class SocketConnectionPool implements ConnectionPool
         return pool;
     }
 
-    @Override
-    public void purge( BoltServerAddress address )
+    private class SocketConnectionPoolPooledConnectionReleaseManager extends PooledConnectionReleaseManager
     {
-        BlockingPooledConnectionQueue connections = pools.remove( address );
-        if ( connections != null )
+        SocketConnectionPoolPooledConnectionReleaseManager( BlockingPooledConnectionQueue connections )
         {
-            connections.terminate();
+            super( connections, new PooledConnectionValidator( SocketConnectionPool.this ) );
         }
-    }
-
-    @Override
-    public boolean hasAddress( BoltServerAddress address )
-    {
-        return pools.containsKey( address );
-    }
-
-    @Override
-    public void close()
-    {
-        if ( closed.compareAndSet( false, true ) )
-        {
-            for ( BlockingPooledConnectionQueue pool : pools.values() )
-            {
-                pool.terminate();
-            }
-
-            pools.clear();
-        }
-    }
-
-    private void assertNotClosed()
-    {
-        if ( closed.get() )
-        {
-            throw poolClosedException();
-        }
-    }
-
-    private static RuntimeException poolClosedException()
-    {
-        return new IllegalStateException( "Pool closed" );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.spi;
 
 import java.util.List;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.Notification;
 import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
@@ -36,9 +36,9 @@ public interface Collector
     Collector ACK_FAILURE = new NoOperationCollector()
     {
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( ServerNeo4jException error ) throws BoltProtocolException
         {
-            throw new ClientException(
+            throw new BoltProtocolException(
                     "Invalid server response message `FAILURE` received for client message `ACK_FAILURE`.", error );
         }
     };
@@ -47,9 +47,9 @@ public interface Collector
     {
         private String serverVersion;
         @Override
-        public void doneIgnored()
+        public void doneIgnored() throws BoltProtocolException
         {
-            throw new ClientException(
+            throw new BoltProtocolException(
                     "Invalid server response message `IGNORED` received for client message `INIT`." );
         }
 
@@ -82,16 +82,16 @@ public interface Collector
         }
 
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( ServerNeo4jException error ) throws BoltProtocolException
         {
-            throw new ClientException(
+            throw new BoltProtocolException(
                     "Invalid server response message `FAILURE` received for client message `RESET`.", error );
         }
 
         @Override
-        public void doneIgnored()
+        public void doneIgnored() throws BoltProtocolException
         {
-            throw new ClientException(
+            throw new BoltProtocolException(
                     "Invalid server response message `IGNORED` received for client message `RESET`." );
         }
 
@@ -142,13 +142,13 @@ public interface Collector
         }
 
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( ServerNeo4jException error ) throws BoltProtocolException
         {
             done();
         }
 
         @Override
-        public void doneIgnored()
+        public void doneIgnored() throws BoltProtocolException
         {
             done();
         }
@@ -185,9 +185,9 @@ public interface Collector
 
     void doneSuccess();
 
-    void doneFailure( Neo4jException error );
+    void doneFailure( ServerNeo4jException error ) throws BoltProtocolException;
 
-    void doneIgnored();
+    void doneIgnored() throws BoltProtocolException;
 
     void resultAvailableAfter( long l );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connector.java
@@ -18,9 +18,14 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 
 public interface Connector
 {
-    Connection connect( BoltServerAddress address );
+    Connection connect( BoltServerAddress address )
+            throws InvalidOperationException, ConnectionException, BoltProtocolException, ServerNeo4jException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
@@ -16,8 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.util;
+package org.neo4j.driver.internal.spi;
 
-public interface Supplier<T> {
-    T get();
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+
+public interface PooledConnection extends Connection
+{
+    /**
+     * If there are any errors that occur on this connection, invoke the given
+     * runnable. This is used in the driver to clean up resources associated with
+     * the connection, like an open transaction.
+     *
+     * @param runnable To be run on error.
+     */
+    void onError( Runnable runnable );
+
+    boolean hasUnrecoverableErrors();
+
+    void dispose() throws InvalidOperationException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.Notification;
 import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
@@ -149,7 +149,7 @@ public class SummaryBuilder implements Collector
     }
 
     @Override
-    public void doneFailure( Neo4jException erro )
+    public void doneFailure( ServerNeo4jException error )
     {
         // intentionally empty
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -22,7 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -40,7 +40,7 @@ public class NetworkSessionTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private final Connection mock = mock( Connection.class );
+    private final PooledConnection mock = mock( PooledConnection.class );
     private NetworkSession sess = new NetworkSession( mock );
 
     @Test
@@ -143,7 +143,7 @@ public class NetworkSessionTest
     public void shouldGetExceptionIfTryingToCloseSessionMoreThanOnce() throws Throwable
     {
         // Given
-        NetworkSession sess = new NetworkSession( mock(Connection.class) );
+        NetworkSession sess = new NetworkSession( mock(PooledConnection.class) );
         try
         {
             sess.close();

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -30,6 +30,10 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.driver.internal.cluster.RoutingSettings;
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.ConnectionException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
@@ -71,7 +75,7 @@ public class RoutingDriverTest
     private final Logging logging = EventLogger.provider( events, EventLogger.Level.TRACE );
 
     @Test
-    public void shouldDoRoutingOnInitialization()
+    public void shouldDoRoutingOnInitialization() throws Throwable
     {
         // Given
         ConnectionPool pool = poolWithServers(
@@ -88,7 +92,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldDoReRoutingOnSessionAcquisitionIfNecessary()
+    public void shouldDoReRoutingOnSessionAcquisitionIfNecessary() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithPool( pool(
@@ -107,7 +111,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldNotDoReRoutingOnSessionAcquisitionIfNotNecessary()
+    public void shouldNotDoReRoutingOnSessionAcquisitionIfNotNecessary() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithPool( pool(
@@ -128,7 +132,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldFailIfNoRouting()
+    public void shouldFailIfNoRouting() throws Throwable
     {
         // Given
         ConnectionPool pool = pool( new ThrowsException( new ClientException(
@@ -147,7 +151,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldFailIfNoRoutersProvided()
+    public void shouldFailIfNoRoutersProvided() throws Throwable
     {
         // Given
         ConnectionPool pool = poolWithServers(
@@ -169,7 +173,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldFailIfNoWritersProvided()
+    public void shouldFailIfNoWritersProvided() throws Throwable
     {
         // Given
         ConnectionPool pool = poolWithServers(
@@ -191,7 +195,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldForgetAboutServersOnRerouting()
+    public void shouldForgetAboutServersOnRerouting() throws Throwable
     {
         // Given
         ConnectionPool pool = pool(
@@ -214,7 +218,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldRediscoverOnTimeout()
+    public void shouldRediscoverOnTimeout() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithPool( pool(
@@ -237,7 +241,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldNotRediscoverWhenNoTimeout()
+    public void shouldNotRediscoverWhenNoTimeout() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithPool( pool(
@@ -259,7 +263,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldRoundRobinAmongReadServers()
+    public void shouldRoundRobinAmongReadServers() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithServers( 60, serverInfo( "ROUTE", "localhost:1111", "localhost:1112" ),
@@ -284,7 +288,7 @@ public class RoutingDriverTest
     }
 
     @Test
-    public void shouldRoundRobinAmongWriteServers()
+    public void shouldRoundRobinAmongWriteServers() throws Throwable
     {
         // Given
         RoutingDriver routingDriver = driverWithServers( 60, serverInfo( "ROUTE", "localhost:1111", "localhost:1112" ),
@@ -330,6 +334,7 @@ public class RoutingDriverTest
 
     @SafeVarargs
     private final RoutingDriver driverWithServers( long ttl, Map<String,Object>... serverInfo )
+            throws ConnectionException, BoltProtocolException, InvalidOperationException, ServerNeo4jException
     {
         return driverWithPool( poolWithServers( ttl, serverInfo ) );
     }
@@ -341,6 +346,7 @@ public class RoutingDriverTest
 
     @SafeVarargs
     private final ConnectionPool poolWithServers( long ttl, Map<String,Object>... serverInfo )
+            throws ConnectionException, BoltProtocolException, InvalidOperationException, ServerNeo4jException
     {
         return pool( withServers( ttl, serverInfo ) );
     }
@@ -357,6 +363,7 @@ public class RoutingDriverTest
     }
 
     private ConnectionPool pool( final Answer toGetServers, final Answer... furtherGetServers )
+            throws ConnectionException, BoltProtocolException, InvalidOperationException, ServerNeo4jException
     {
         ConnectionPool pool = mock( ConnectionPool.class );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
@@ -86,7 +86,7 @@ public class RoutingTransactionTest
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldHandleConnectionFailures()
+    public void shouldHandleConnectionFailures() throws Throwable
     {
         // Given
 
@@ -115,7 +115,7 @@ public class RoutingTransactionTest
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldHandleWriteFailuresInWriteAccessMode()
+    public void shouldHandleWriteFailuresInWriteAccessMode() throws Throwable
     {
         // Given
         doAnswer( throwingAnswer( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ) )
@@ -143,7 +143,7 @@ public class RoutingTransactionTest
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldHandleWriteFailuresInReadAccessMode()
+    public void shouldHandleWriteFailuresInReadAccessMode() throws Throwable
     {
         // Given
         doAnswer( throwingAnswer( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ) )
@@ -167,7 +167,7 @@ public class RoutingTransactionTest
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldRethrowNonWriteFailures()
+    public void shouldRethrowNonWriteFailures() throws Throwable
     {
         // Given
         ClientException toBeThrown = new ClientException( "code", "oh no!" );
@@ -193,7 +193,7 @@ public class RoutingTransactionTest
     }
 
     @Test
-    public void shouldHandleConnectionFailuresOnClose()
+    public void shouldHandleConnectionFailuresOnClose() throws Throwable
     {
         // Given
         doThrow( new ServiceUnavailableException( "oh no" ) ).
@@ -220,7 +220,7 @@ public class RoutingTransactionTest
     }
 
     @Test
-    public void shouldHandleWriteFailuresOnClose()
+    public void shouldHandleWriteFailuresOnClose() throws Throwable
     {
         // Given
         doThrow( new ClientException( "Neo.ClientError.Cluster.NotALeader", "oh no!" ) ).when( connection ).sync();

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.driver.internal.EventHandler;
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
@@ -153,17 +155,17 @@ public class ClusterCompositionProviderTest
                 .getClusterComposition( connection );
     }
 
-    private void keys( final String... keys )
+    private void keys( final String... keys ) throws InvalidOperationException, BoltProtocolException
     {
         onGetServers( doAnswer( withKeys( keys ) ) );
     }
 
-    private void values( final Value[]... records )
+    private void values( final Value[]... records ) throws InvalidOperationException, BoltProtocolException
     {
         onPullAll( doAnswer( withServerList( records ) ) );
     }
 
-    private void onGetServers( Stubber stubber )
+    private void onGetServers( Stubber stubber ) throws InvalidOperationException, BoltProtocolException
     {
         stubber.when( connection ).run(
                 eq( ClusterComposition.Provider.GET_SERVERS ),
@@ -171,7 +173,7 @@ public class ClusterCompositionProviderTest
                 any( Collector.class ) );
     }
 
-    private void onPullAll( Stubber stubber )
+    private void onPullAll( Stubber stubber ) throws InvalidOperationException, BoltProtocolException
     {
         stubber.when( connection ).pullAll( any( Collector.class ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/FragmentedMessageDeliveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/FragmentedMessageDeliveryTest.java
@@ -79,7 +79,7 @@ public class FragmentedMessageDeliveryTest
         }
     }
 
-    private void testPermutation( byte[] unfragmented, int... sizes ) throws IOException
+    private void testPermutation( byte[] unfragmented, int... sizes ) throws Throwable
     {
         int pos = 0;
         ByteBuffer[] fragments = new ByteBuffer[sizes.length];
@@ -91,7 +91,7 @@ public class FragmentedMessageDeliveryTest
         testPermutation( unfragmented, fragments );
     }
 
-    private void testPermutation( byte[] unfragmented, ByteBuffer[] fragments ) throws IOException
+    private void testPermutation( byte[] unfragmented, ByteBuffer[] fragments ) throws Throwable
     {
 
         // When data arrives split up according to the current permutation
@@ -145,7 +145,7 @@ public class FragmentedMessageDeliveryTest
         };
     }
 
-    private byte[] serialize( Message... msgs ) throws IOException
+    private byte[] serialize( Message... msgs ) throws Throwable
     {
 
             final ByteArrayOutputStream out = new ByteArrayOutputStream( 128 );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.InternalPath;
 import org.neo4j.driver.internal.InternalRelationship;
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.internal.net.ChunkedOutput;
 import org.neo4j.driver.internal.packstream.PackStream;
 import org.neo4j.driver.internal.util.BytePrinter;
@@ -126,12 +127,12 @@ public class MessageFormatTest
         unpack( format, out.toByteArray() );
     }
 
-    private void assertSerializesValue( Value value ) throws IOException
+    private void assertSerializesValue( Value value ) throws IOException, BoltProtocolException
     {
         assertSerializes( new RecordMessage( new Value[]{value} ) );
     }
 
-    private void assertSerializes( Message... messages ) throws IOException
+    private void assertSerializes( Message... messages ) throws IOException, BoltProtocolException
     {
         // Pack
         final ByteArrayOutputStream out = new ByteArrayOutputStream( 128 );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnectionTest.java
@@ -27,8 +27,8 @@ import org.mockito.stubbing.Answer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.spi.Connection;
-import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.Function;
 
 import static java.util.Arrays.asList;
@@ -66,7 +66,7 @@ public class ConcurrencyGuardingConnectionTest
     {
         // Given
         final AtomicReference<Connection> conn = new AtomicReference<>();
-        final AtomicReference<ClientException> exception = new AtomicReference<>();
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
 
         Connection delegate = mock( Connection.class, new Answer()
         {
@@ -78,7 +78,7 @@ public class ConcurrencyGuardingConnectionTest
                     operation.apply( conn.get() );
                     fail("Expected this call to fail, because it is calling a method on the connector while 'inside' " +
                          "a connector call already.");
-                } catch(ClientException e)
+                } catch( Throwable e )
                 {
                     exception.set( e );
                 }
@@ -100,7 +100,7 @@ public class ConcurrencyGuardingConnectionTest
     }
 
     @Test
-    public void shouldAllowConcurrentClose()
+    public void shouldAllowConcurrentClose() throws Throwable
     {
         // Given
         final AtomicReference<Connection> connection = new AtomicReference<>();
@@ -130,7 +130,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.init(null, null);
+            try
+            {
+                connection.init(null, null);
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -140,7 +147,15 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.run(null, null, null);
+
+            try
+            {
+                connection.run( null, null, null );
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -150,7 +165,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.discardAll(null);
+            try
+            {
+                connection.discardAll( null );
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -160,7 +182,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.pullAll(null);
+            try
+            {
+                connection.pullAll( null );
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -170,7 +199,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.reset();
+            try
+            {
+                connection.reset();
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -190,7 +226,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.receiveOne();
+            try
+            {
+                connection.receiveOne();
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -200,7 +243,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.sync();
+            try
+            {
+                connection.sync();
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };
@@ -210,7 +260,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.flush();
+            try
+            {
+                connection.flush();
+            }
+            catch ( InternalException e )
+            {
+                throw e.publicException();
+            }
             return null;
         }
     };

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
@@ -72,7 +72,7 @@ public class SocketClientTest
     }
 
     @Test
-    public void shouldReadAllBytes() throws IOException
+    public void shouldReadAllBytes() throws Throwable
     {
         // Given
         ByteBuffer buffer = ByteBuffer.allocate( 4 );
@@ -92,7 +92,7 @@ public class SocketClientTest
     }
 
     @Test
-    public void shouldFailIfConnectionFailsWhileReading() throws IOException
+    public void shouldFailIfConnectionFailsWhileReading() throws Throwable
     {
         // Given
         ByteBuffer buffer = ByteBuffer.allocate( 4 );
@@ -110,7 +110,7 @@ public class SocketClientTest
     }
 
     @Test
-    public void shouldWriteAllBytes() throws IOException
+    public void shouldWriteAllBytes() throws Throwable
     {
         // Given
         ByteBuffer buffer = ByteBuffer.wrap(  new byte[]{0, 1, 2, 3});
@@ -129,7 +129,7 @@ public class SocketClientTest
     }
 
     @Test
-    public void shouldFailIfConnectionFailsWhileWriting() throws IOException
+    public void shouldFailIfConnectionFailsWhileWriting() throws Throwable
     {
         // Given
         ByteBuffer buffer = ByteBuffer.allocate( 4 );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectorTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.AuthToken;
@@ -50,7 +51,7 @@ import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 public class SocketConnectorTest
 {
     @Test
-    public void connectCreatesConnection()
+    public void connectCreatesConnection() throws Throwable
     {
         ConnectionSettings settings = new ConnectionSettings( basicAuthToken() );
         SocketConnector connector = new RecordingSocketConnector( settings );
@@ -62,7 +63,7 @@ public class SocketConnectorTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void connectSendsInit()
+    public void connectSendsInit() throws Throwable
     {
         String userAgent = "agentSmith";
         ConnectionSettings settings = new ConnectionSettings( basicAuthToken(), userAgent );
@@ -94,10 +95,10 @@ public class SocketConnectorTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void connectClosesOpenedConnectionIfInitThrows()
+    public void connectClosesOpenedConnectionIfInitThrows() throws Throwable
     {
         Connection connection = mock( Connection.class );
-        RuntimeException initError = new RuntimeException( "Init error" );
+        ServerNeo4jException initError = new ServerNeo4jException( new ClientException( "Init error" ) );
         doThrow( initError ).when( connection ).init( anyString(), any( Map.class ) );
 
         StubSocketConnector connector = new StubSocketConnector( connection );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import org.neo4j.driver.internal.exceptions.InvalidOperationException;
 import org.neo4j.driver.internal.spi.PooledConnection;
-import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -21,18 +21,18 @@ package org.neo4j.driver.internal.net.pooling;
 
 import org.junit.Test;
 
-import org.neo4j.driver.internal.spi.Connection;
-import org.neo4j.driver.internal.util.Consumer;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_MOCKS;
@@ -42,54 +42,55 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
-import static org.neo4j.driver.internal.util.Clock.SYSTEM;
 
 public class BlockingPooledConnectionQueueTest
 {
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldCreateNewConnectionWhenEmpty()
+    public void shouldCreateNewConnectionWhenEmpty() throws Throwable
     {
         // Given
-        PooledConnection connection = mock( PooledConnection.class );
-        Supplier<PooledConnection> supplier = mock( Supplier.class );
-        when( supplier.get() ).thenReturn( connection );
+        PooledConnection connection = mock( PooledSocketConnection.class );
+        PooledConnectionFactory supplier = mock( PooledConnectionFactory.class );
+        when( supplier.newInstance() ).thenReturn( connection );
         BlockingPooledConnectionQueue queue = newConnectionQueue( 10 );
 
         // When
         queue.acquire( supplier );
 
         // Then
-        verify( supplier ).get();
+        verify( supplier ).newInstance();
     }
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldNotCreateNewConnectionWhenNotEmpty()
+    public void shouldNotCreateNewConnectionWhenNotEmpty() throws Throwable
     {
         // Given
-        PooledConnection connection = mock( PooledConnection.class );
-        Supplier<PooledConnection> supplier = mock( Supplier.class );
-        when( supplier.get() ).thenReturn( connection );
+        PooledConnection connection = mock( PooledSocketConnection.class );
+        PooledConnectionFactory supplier = mock( PooledConnectionFactory.class );
+        when( supplier.newInstance() ).thenReturn( connection );
         BlockingPooledConnectionQueue queue = newConnectionQueue( 1 );
+
         queue.offer( connection );
 
         // When
         queue.acquire( supplier );
 
         // Then
-        verify( supplier, never() ).get();
+        verify( supplier, never() ).newInstance();
     }
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldTerminateAllSeenConnections()
+    public void shouldTerminateAllSeenConnections() throws Throwable
     {
         // Given
-        PooledConnection connection1 = mock( PooledConnection.class );
-        PooledConnection connection2 = mock( PooledConnection.class );
-        Supplier<PooledConnection> supplier = mock( Supplier.class );
-        when( supplier.get() ).thenReturn( connection1 );
+
+        PooledSocketConnection connection1 = mock( PooledSocketConnection.class );
+        PooledSocketConnection connection2 = mock( PooledSocketConnection.class );
+        PooledConnectionFactory supplier = mock( PooledConnectionFactory.class );
+        when( supplier.newInstance() ).thenReturn( connection1 );
         BlockingPooledConnectionQueue queue = newConnectionQueue( 2 );
         queue.offer( connection1 );
         queue.offer( connection2 );
@@ -106,11 +107,12 @@ public class BlockingPooledConnectionQueueTest
     }
 
     @Test
-    public void shouldNotAcceptWhenFull()
+    public void shouldNotAcceptWhenFull() throws Throwable
     {
         // Given
-        PooledConnection connection1 = mock( PooledConnection.class );
-        PooledConnection connection2 = mock( PooledConnection.class );
+
+        PooledSocketConnection connection1 = mock( PooledSocketConnection.class );
+        PooledSocketConnection connection2 = mock( PooledSocketConnection.class );
         BlockingPooledConnectionQueue queue = newConnectionQueue( 1 );
 
         // Then
@@ -119,7 +121,7 @@ public class BlockingPooledConnectionQueueTest
     }
 
     @Test
-    public void shouldDisposeAllConnectionsWhenOneOfThemFailsToDispose()
+    public void shouldDisposeAllConnectionsWhenOneOfThemFailsToDispose() throws Throwable
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
 
@@ -127,7 +129,7 @@ public class BlockingPooledConnectionQueueTest
         PooledConnection connection2 = mock( PooledConnection.class );
         PooledConnection connection3 = mock( PooledConnection.class );
 
-        RuntimeException disposeError = new RuntimeException( "Failed to stop socket" );
+        InvalidOperationException disposeError = new InvalidOperationException( "Failed to stop socket" );
         doThrow( disposeError ).when( connection2 ).dispose();
 
         queue.offer( connection1 );
@@ -143,25 +145,25 @@ public class BlockingPooledConnectionQueueTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void shouldTryToCloseAllUnderlyingConnections()
+    public void shouldTryToCloseAllUnderlyingConnections() throws Throwable
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
 
-        Connection connection1 = mock( Connection.class );
-        Connection connection2 = mock( Connection.class );
-        Connection connection3 = mock( Connection.class );
+        PooledConnection connection1 = mock( PooledConnection.class );
+        PooledConnection connection2 = mock( PooledConnection.class );
+        PooledConnection connection3 = mock( PooledConnection.class );
 
-        RuntimeException closeError1 = new RuntimeException( "Failed to close 1" );
-        RuntimeException closeError2 = new RuntimeException( "Failed to close 2" );
-        RuntimeException closeError3 = new RuntimeException( "Failed to close 3" );
+        InvalidOperationException closeError1 = new InvalidOperationException( "Failed to close 1" );
+        InvalidOperationException closeError2 = new InvalidOperationException( "Failed to close 2" );
+        InvalidOperationException closeError3 = new InvalidOperationException( "Failed to close 3" );
 
         doThrow( closeError1 ).when( connection1 ).close();
         doThrow( closeError2 ).when( connection2 ).close();
         doThrow( closeError3 ).when( connection3 ).close();
 
-        PooledConnection pooledConnection1 = new PooledConnection( connection1, mock( Consumer.class ), SYSTEM );
-        PooledConnection pooledConnection2 = new PooledConnection( connection2, mock( Consumer.class ), SYSTEM );
-        PooledConnection pooledConnection3 = new PooledConnection( connection3, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection1 = new PooledSocketConnection( connection1, mock( PooledConnectionReleaseManager.class ) );
+        PooledConnection pooledConnection2 = new PooledSocketConnection( connection2, mock( PooledConnectionReleaseManager.class ) );
+        PooledConnection pooledConnection3 = new PooledSocketConnection( connection3, mock( PooledConnectionReleaseManager.class ) );
 
         queue.offer( pooledConnection1 );
         queue.offer( pooledConnection2 );
@@ -176,7 +178,7 @@ public class BlockingPooledConnectionQueueTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void shouldLogWhenConnectionDisposeFails()
+    public void shouldLogWhenConnectionDisposeFails() throws Throwable
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
@@ -184,10 +186,11 @@ public class BlockingPooledConnectionQueueTest
 
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5, logging );
 
-        Connection connection = mock( Connection.class );
-        RuntimeException closeError = new RuntimeException( "Fail" );
+        PooledConnection connection = mock( PooledConnection.class );
+        InvalidOperationException closeError = new InvalidOperationException( "Fail" );
         doThrow( closeError ).when( connection ).close();
-        PooledConnection pooledConnection = new PooledConnection( connection, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection = new PooledSocketConnection( connection, mock(
+                PooledConnectionReleaseManager.class ) );
         queue.offer( pooledConnection );
 
         queue.terminate();
@@ -196,7 +199,7 @@ public class BlockingPooledConnectionQueueTest
     }
 
     @Test
-    public void shouldHaveZeroSizeAfterTermination()
+    public void shouldHaveZeroSizeAfterTermination() throws Throwable
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
 
@@ -211,7 +214,7 @@ public class BlockingPooledConnectionQueueTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void shouldTerminateBothAcquiredAndIdleConnections()
+    public void shouldTerminateBothAcquiredAndIdleConnections() throws Throwable
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
 
@@ -225,8 +228,8 @@ public class BlockingPooledConnectionQueueTest
         queue.offer( connection3 );
         queue.offer( connection4 );
 
-        PooledConnection acquiredConnection1 = queue.acquire( mock( Supplier.class ) );
-        PooledConnection acquiredConnection2 = queue.acquire( mock( Supplier.class ) );
+        PooledConnection acquiredConnection1 = queue.acquire( mock( PooledConnectionFactory.class ) );
+        PooledConnection acquiredConnection2 = queue.acquire( mock( PooledConnectionFactory.class ) );
         assertSame( connection1, acquiredConnection1 );
         assertSame( connection2, acquiredConnection2 );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
-import java.io.IOException;
 import java.util.Queue;
 
 import org.neo4j.driver.internal.messaging.Message;
@@ -31,9 +30,8 @@ import org.neo4j.driver.internal.net.SocketClient;
 import org.neo4j.driver.internal.net.SocketConnection;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
-import org.neo4j.driver.internal.util.Clock;
-import org.neo4j.driver.internal.util.Consumers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -49,7 +47,7 @@ import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 public class PooledConnectionValidatorTest
 {
     @Test
-    public void resetAndSyncValidConnection()
+    public void resetAndSyncValidConnection() throws Throwable
     {
         Connection connection = mock( Connection.class );
         PooledConnection pooledConnection = newPooledConnection( connection );
@@ -65,7 +63,7 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void sendsSingleResetMessageForValidConnection() throws IOException
+    public void sendsSingleResetMessageForValidConnection() throws Throwable
     {
         SocketClient socket = mock( SocketClient.class );
         InternalServerInfo serverInfo = new InternalServerInfo( LOCAL_DEFAULT, "v1" );
@@ -87,7 +85,7 @@ public class PooledConnectionValidatorTest
 
     private static PooledConnection newPooledConnection( Connection connection )
     {
-        return new PooledConnection( connection, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
+        return new PooledSocketConnection( connection, null );
     }
 
     private static PooledConnectionValidator newValidatorWithMockedPool()

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.Connector;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logging;
 
 import static java.util.Collections.newSetFromMap;
@@ -53,7 +54,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.net.BoltServerAddress.DEFAULT_PORT;
 import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
-import static org.neo4j.driver.internal.util.Clock.SYSTEM;
 
 public class SocketConnectionPoolTest
 {
@@ -62,7 +62,7 @@ public class SocketConnectionPoolTest
     private static final BoltServerAddress ADDRESS_3 = new BoltServerAddress( "localhost", DEFAULT_PORT + 4242 );
 
     @Test
-    public void acquireCreatesNewConnectionWhenPoolIsEmpty()
+    public void acquireCreatesNewConnectionWhenPoolIsEmpty() throws Throwable
     {
         Connector connector = newMockConnector();
         SocketConnectionPool pool = newPool( connector );
@@ -74,7 +74,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void acquireUsesExistingConnectionIfPresent()
+    public void acquireUsesExistingConnectionIfPresent() throws Throwable
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         Connector connector = newMockConnector( connection );
@@ -92,7 +92,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void purgeDoesNothingForNonExistingAddress()
+    public void purgeDoesNothingForNonExistingAddress() throws Throwable
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         SocketConnectionPool pool = newPool( newMockConnector( connection ) );
@@ -105,7 +105,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void purgeRemovesAddress()
+    public void purgeRemovesAddress() throws Throwable
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         SocketConnectionPool pool = newPool( newMockConnector( connection ) );
@@ -118,7 +118,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void purgeTerminatesPoolCorrespondingToTheAddress()
+    public void purgeTerminatesPoolCorrespondingToTheAddress() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -141,7 +141,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void hasAddressReturnsFalseWhenPoolIsEmpty()
+    public void hasAddressReturnsFalseWhenPoolIsEmpty() throws Throwable
     {
         SocketConnectionPool pool = newPool( newMockConnector() );
 
@@ -150,7 +150,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void hasAddressReturnsFalseForUnknownAddress()
+    public void hasAddressReturnsFalseForUnknownAddress() throws Throwable
     {
         SocketConnectionPool pool = newPool( newMockConnector() );
 
@@ -160,7 +160,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void hasAddressReturnsTrueForKnownAddress()
+    public void hasAddressReturnsTrueForKnownAddress() throws Throwable
     {
         SocketConnectionPool pool = newPool( newMockConnector() );
 
@@ -170,7 +170,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void closeTerminatesAllPools()
+    public void closeTerminatesAllPools() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -198,7 +198,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void closeRemovesAllPools()
+    public void closeRemovesAllPools() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_2 );
@@ -224,7 +224,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void closeWithConcurrentAcquisitionsEmptiesThePool() throws InterruptedException
+    public void closeWithConcurrentAcquisitionsEmptiesThePool() throws Throwable
     {
         Connector connector = mock( Connector.class );
         Set<Connection> createdConnections = newSetFromMap( new ConcurrentHashMap<Connection,Boolean>() );
@@ -303,24 +303,24 @@ public class SocketConnectionPoolTest
         };
     }
 
-    private static Connector newMockConnector()
+    private static Connector newMockConnector() throws Throwable
     {
         Connection connection = mock( Connection.class );
         return newMockConnector( connection );
     }
 
-    private static Connector newMockConnector( Connection connection, Connection... otherConnections )
+    private static Connector newMockConnector( Connection connection, Connection... otherConnections ) throws Throwable
     {
         Connector connector = mock( Connector.class );
         when( connector.connect( any( BoltServerAddress.class ) ) ).thenReturn( connection, otherConnections );
         return connector;
     }
 
-    private static SocketConnectionPool newPool( Connector connector )
+    private static SocketConnectionPool newPool( Connector connector ) throws Throwable
     {
         PoolSettings poolSettings = new PoolSettings( 42 );
         Logging logging = mock( Logging.class, RETURNS_MOCKS );
-        return new SocketConnectionPool( poolSettings, connector, SYSTEM, logging );
+        return new SocketConnectionPool( poolSettings, connector, logging );
     }
 
     private static Connection newConnectionMock( BoltServerAddress address )

--- a/driver/src/test/java/org/neo4j/driver/internal/spi/StubConnectionPool.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/spi/StubConnectionPool.java
@@ -18,6 +18,10 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,15 +29,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-
 import org.neo4j.driver.internal.EventHandler;
+import org.neo4j.driver.internal.exceptions.InvalidOperationException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.net.pooling.PooledConnection;
+import org.neo4j.driver.internal.net.pooling.PooledConnectionReleaseManager;
+import org.neo4j.driver.internal.net.pooling.PooledSocketConnection;
 import org.neo4j.driver.internal.util.Clock;
-import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.util.Function;
 
@@ -164,14 +165,14 @@ public class StubConnectionPool implements ConnectionPool
     }
 
     @Override
-    public Connection acquire( BoltServerAddress address )
+    public PooledConnection acquire( BoltServerAddress address )
     {
         if ( hosts.replace( address, State.CONNECTED ) == null )
         {
             events.connectionFailure( address );
             throw new ServiceUnavailableException( "Host unavailable: " + address );
         }
-        Connection connection = new StubConnection( address, factory.apply( address ), events, clock );
+        PooledConnection connection = new StubConnection( address, factory.apply( address ), events, clock );
         events.acquire( address, connection );
         return connection;
     }
@@ -204,7 +205,7 @@ public class StubConnectionPool implements ConnectionPool
         hosts.clear();
     }
 
-    private static class StubConnection extends PooledConnection
+    private static class StubConnection extends PooledSocketConnection
     {
         private final BoltServerAddress address;
 
@@ -214,10 +215,10 @@ public class StubConnectionPool implements ConnectionPool
                 final EventSink events,
                 Clock clock )
         {
-            super( delegate, new Consumer<PooledConnection>()
+            super( delegate, new PooledConnectionReleaseManager( null, null )
             {
                 @Override
-                public void accept( PooledConnection self )
+                public void accept( PooledConnection self ) throws InvalidOperationException
                 {
                     events.release( address, self );
                     if ( delegate != null )
@@ -225,7 +226,7 @@ public class StubConnectionPool implements ConnectionPool
                         delegate.close();
                     }
                 }
-            }, clock );
+            } );
             this.address = address;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
@@ -28,6 +28,7 @@ import java.security.GeneralSecurityException;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import org.neo4j.driver.internal.exceptions.ServerNeo4jException;
 import org.neo4j.driver.internal.net.SocketClient;
 import org.neo4j.driver.internal.net.SocketResponseHandler;
 import org.neo4j.driver.internal.logging.DevNullLogger;
@@ -63,7 +64,7 @@ public class SocketClientIT
     }
 
     @After
-    public void tearDown()
+    public void tearDown() throws IOException
     {
         if( client != null )
         {
@@ -83,7 +84,7 @@ public class SocketClientIT
         when( handler.protocolViolationErrorOccurred() ).thenReturn( true );
         when( handler.collectorsWaiting() ).thenReturn( 2, 1, 0 );
         when( handler.serverFailure() ).thenReturn(
-                new ClientException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
+                new ServerNeo4jException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
 
         // When & Then
         client.start();

--- a/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/DumpMessage.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.BoltProtocolException;
 import org.neo4j.driver.internal.net.ChunkedInput;
 import org.neo4j.driver.internal.messaging.ResetMessage;
 import org.neo4j.driver.internal.messaging.AckFailureMessage;
@@ -171,7 +172,7 @@ public class DumpMessage
     }
 
     public static List<Message> unpack( List<Message> outcome, MessageFormat.Reader reader )
-            throws IOException
+            throws IOException, BoltProtocolException
     {
         do
         {


### PR DESCRIPTION
Introduced a few internal errors for tracking errors internally as checked errors.
Before the internal errors go outside (Driver, Session, Transaction, Result), the errors will be casted to a public error.

Each method is marked with the specific errors that it is going to throw for now. This could be put into one general error once we agree on the internal/external error mappings.

Just made it compile, still some work need to do to fix many tests