### PR TITLE
Make socket connection timeout configurable

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ConnectionSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ConnectionSettings.java
@@ -29,7 +29,7 @@ import static java.lang.String.format;
  */
 public class ConnectionSettings
 {
-    public static final String DEFAULT_USER_AGENT = format( "neo4j-java/%s", driverVersion() );
+    private static final String DEFAULT_USER_AGENT = format( "neo4j-java/%s", driverVersion() );
 
     /**
      * Extracts the driver version from the driver jar MANIFEST.MF file.
@@ -52,16 +52,18 @@ public class ConnectionSettings
 
     private final AuthToken authToken;
     private final String userAgent;
+    private final int timeoutMillis;
 
-    public ConnectionSettings( AuthToken authToken, String userAgent )
+    public ConnectionSettings( AuthToken authToken, String userAgent, int timeoutMillis )
     {
         this.authToken = authToken;
         this.userAgent = userAgent;
+        this.timeoutMillis = timeoutMillis;
     }
 
-    public ConnectionSettings( AuthToken authToken )
+    public ConnectionSettings( AuthToken authToken, int timeoutMillis )
     {
-        this( authToken, DEFAULT_USER_AGENT );
+        this( authToken, DEFAULT_USER_AGENT, timeoutMillis );
     }
 
     public AuthToken authToken()
@@ -74,4 +76,8 @@ public class ConnectionSettings
         return userAgent;
     }
 
+    public int timeoutMillis()
+    {
+        return timeoutMillis;
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -120,7 +120,7 @@ public class DriverFactory
     {
         authToken = authToken == null ? AuthTokens.none() : authToken;
 
-        ConnectionSettings connectionSettings = new ConnectionSettings( authToken );
+        ConnectionSettings connectionSettings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
         PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize() );
         Connector connector = new SocketConnector( connectionSettings, securityPlan, config.logging() );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ChannelFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ChannelFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.StandardSocketOptions;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SocketChannel;
+import java.security.GeneralSecurityException;
+
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.security.TLSSocketChannel;
+import org.neo4j.driver.v1.Logger;
+
+class ChannelFactory
+{
+    static ByteChannel create( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logger log )
+            throws IOException, GeneralSecurityException
+    {
+        SocketChannel soChannel = SocketChannel.open();
+        soChannel.setOption( StandardSocketOptions.SO_REUSEADDR, true );
+        soChannel.setOption( StandardSocketOptions.SO_KEEPALIVE, true );
+        connect( soChannel, address, timeoutMillis );
+
+        ByteChannel channel;
+
+        if ( securityPlan.requiresEncryption() )
+        {
+            channel = TLSSocketChannel.create( address, securityPlan, soChannel, log );
+        }
+        else
+        {
+            channel = soChannel;
+        }
+
+        if ( log.isTraceEnabled() )
+        {
+            channel = new LoggingByteChannel( channel, log );
+        }
+
+        return channel;
+    }
+
+    private static void connect( SocketChannel soChannel, BoltServerAddress address, int timeoutMillis )
+            throws IOException
+    {
+        Socket socket = soChannel.socket();
+        try
+        {
+            socket.connect( address.toSocketAddress(), timeoutMillis );
+        }
+        catch ( SocketTimeoutException e )
+        {
+            throw new IOException( "Timeout " + timeoutMillis + "ms expired", e );
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -58,10 +58,10 @@ public class SocketConnection implements Connection
 
     private final Logger logger;
 
-    public SocketConnection( BoltServerAddress address, SecurityPlan securityPlan, Logging logging )
+    public SocketConnection( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logging logging )
     {
         this.logger = logging.getLog( format( "conn-%s", UUID.randomUUID().toString() ) );
-        this.socket = new SocketClient( address, securityPlan, logger );
+        this.socket = new SocketClient( address, securityPlan, timeoutMillis, logger );
         this.responseHandler = createResponseHandler( logger );
         this.socket.start();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
@@ -47,7 +47,8 @@ public class SocketConnector implements Connector
     @Override
     public final Connection connect( BoltServerAddress address )
     {
-        Connection connection = createConnection( address, securityPlan, logging );
+        Connection connection = createConnection( address, securityPlan, connectionSettings.timeoutMillis(),
+                logging );
 
         // Because SocketConnection is not thread safe, wrap it in this guard
         // to ensure concurrent access leads causes application errors
@@ -71,9 +72,10 @@ public class SocketConnector implements Connector
      * <p>
      * <b>This method is package-private only for testing</b>
      */
-    Connection createConnection( BoltServerAddress address, SecurityPlan securityPlan, Logging logging )
+    Connection createConnection( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis,
+            Logging logging )
     {
-        return new SocketConnection( address, securityPlan, logging );
+        return new SocketConnection( address, securityPlan, timeoutMillis, logging );
     }
 
     private static Map<String,Value> tokenAsMap( AuthToken token )

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -187,7 +187,7 @@ public class Config
         private TrustStrategy trustStrategy = trustAllCertificates();
         private int routingFailureLimit = 1;
         private long routingRetryDelayMillis = TimeUnit.SECONDS.toMillis( 5 );
-        private int connectionTimeoutMillis = (int) TimeUnit.SECONDS.toMillis( 30 );
+        private int connectionTimeoutMillis = (int) TimeUnit.SECONDS.toMillis( 5 );
 
         private ConfigBuilder() {}
 
@@ -386,6 +386,8 @@ public class Config
          * <p>
          * Timeout value should be greater or equal to zero and represent a valid {@code int} value when converted to
          * {@link TimeUnit#MILLISECONDS milliseconds}.
+         * <p>
+         * The default value of this parameter is {@code 5 SECONDS}.
          *
          * @param value the timeout duration
          * @param unit the unit in which duration is given

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -106,7 +106,7 @@ public class ConfigTest
     public void shouldHaveDefaultConnectionTimeout()
     {
         Config defaultConfig = Config.defaultConfig();
-        assertEquals( TimeUnit.SECONDS.toMillis( 30 ), defaultConfig.connectionTimeoutMillis() );
+        assertEquals( TimeUnit.SECONDS.toMillis( 5 ), defaultConfig.connectionTimeoutMillis() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
@@ -39,9 +39,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 
 public class SocketClientTest
 {
+    private static final int CONNECTION_TIMEOUT = 42;
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -56,7 +59,7 @@ public class SocketClientTest
         BoltServerAddress address = new BoltServerAddress( "localhost", server.getLocalPort() );
 
         SecurityPlan securityPlan = SecurityPlan.insecure();
-        SocketClient client = new SocketClient( address, securityPlan, new DevNullLogger() );
+        SocketClient client = new SocketClient( address, securityPlan, CONNECTION_TIMEOUT, new DevNullLogger() );
 
         // Expect
         exception.expect( ClientException.class );
@@ -68,7 +71,7 @@ public class SocketClientTest
 
     private SocketClient dummyClient()
     {
-        return new SocketClient( BoltServerAddress.LOCAL_DEFAULT, SecurityPlan.insecure(), new DevNullLogger() );
+        return new SocketClient( LOCAL_DEFAULT, SecurityPlan.insecure(), CONNECTION_TIMEOUT, new DevNullLogger() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
@@ -28,11 +28,11 @@ import java.security.GeneralSecurityException;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import org.neo4j.driver.internal.net.SocketClient;
-import org.neo4j.driver.internal.net.SocketResponseHandler;
 import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.messaging.InitMessage;
 import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.net.SocketClient;
+import org.neo4j.driver.internal.net.SocketResponseHandler;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.TestNeo4j;
@@ -45,8 +45,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.Values.ofValue;
+import static org.neo4j.driver.v1.Values.parameters;
 
 public class SocketClientIT
 {
@@ -59,7 +59,7 @@ public class SocketClientIT
     public void setup() throws GeneralSecurityException, IOException
     {
         SecurityPlan securityPlan = SecurityPlan.insecure();
-        client = new SocketClient( neo4j.address(), securityPlan, new DevNullLogger() );
+        client = new SocketClient( neo4j.address(), securityPlan, 42, new DevNullLogger() );
     }
 
     @After


### PR DESCRIPTION
Previously socket connect did not have a timeout and was bounded only by the timeout configured on the OS level. Such timeout could be rather long and result in repeated stalls trying to refresh routing table against a failed router.