### PR TITLE
Configurable test-on-borrow for pooled connections

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
@@ -51,6 +51,6 @@ public class PoolSettings
 
     public boolean idleTimeBeforeConnectionTestConfigured()
     {
-        return idleTimeBeforeConnectionTest > 0;
+        return idleTimeBeforeConnectionTest >= 0;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
@@ -20,20 +20,37 @@ package org.neo4j.driver.internal.net.pooling;
 
 public class PoolSettings
 {
+    public static final int NO_IDLE_CONNECTION_TEST = -1;
+
     public static final int DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE = 10;
+    public static final int DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST = NO_IDLE_CONNECTION_TEST;
 
-    /**
-     * Maximum number of idle connections per pool.
-     */
     private final int maxIdleConnectionPoolSize;
+    private final long idleTimeBeforeConnectionTest;
 
-    public PoolSettings( int maxIdleConnectionPoolSize )
+    public PoolSettings( int maxIdleConnectionPoolSize, long idleTimeBeforeConnectionTest )
     {
         this.maxIdleConnectionPoolSize = maxIdleConnectionPoolSize;
+        this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTest;
     }
 
     public int maxIdleConnectionPoolSize()
     {
         return maxIdleConnectionPoolSize;
+    }
+
+    public long idleTimeBeforeConnectionTest()
+    {
+        if ( !idleTimeBeforeConnectionTestConfigured() )
+        {
+            throw new IllegalStateException(
+                    "Idle time before connection test is not configured: " + idleTimeBeforeConnectionTest );
+        }
+        return idleTimeBeforeConnectionTest;
+    }
+
+    public boolean idleTimeBeforeConnectionTestConfigured()
+    {
+        return idleTimeBeforeConnectionTest > 0;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
@@ -18,10 +18,8 @@
  */
 package org.neo4j.driver.internal.net.pooling;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import org.neo4j.driver.internal.spi.ConnectionValidator;
 import org.neo4j.driver.internal.util.Consumer;
-import org.neo4j.driver.v1.util.Function;
 
 /**
  * The responsibility of the PooledConnectionReleaseConsumer is to release valid connections
@@ -30,19 +28,19 @@ import org.neo4j.driver.v1.util.Function;
 class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
 {
     private final BlockingPooledConnectionQueue connections;
-    private final Function<PooledConnection, Boolean> validConnection;
+    private final ConnectionValidator<PooledConnection> connectionValidator;
 
     PooledConnectionReleaseConsumer( BlockingPooledConnectionQueue connections,
-            Function<PooledConnection, Boolean> validConnection)
+            ConnectionValidator<PooledConnection> connectionValidator )
     {
         this.connections = connections;
-        this.validConnection = validConnection;
+        this.connectionValidator = connectionValidator;
     }
 
     @Override
     public void accept( PooledConnection pooledConnection )
     {
-        if ( validConnection.apply( pooledConnection ) )
+        if ( connectionValidator.isReusable( pooledConnection ) )
         {
             connections.offer( pooledConnection );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionValidator.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionValidator.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionValidator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.spi;
+
+public interface ConnectionValidator<T extends Connection>
+{
+    boolean isReusable( T connection );
+
+    boolean isConnected( T connection );
+}

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -123,7 +123,7 @@ public class Config
     }
 
     /**
-     * Pooled sessions that have been idle in the pool for longer than this timeout
+     * Pooled connections that have been idle in the pool for longer than this timeout
      * will be tested before they are used again, to ensure they are still live.
      *
      * @return idle time in milliseconds
@@ -277,16 +277,15 @@ public class Config
         }
 
         /**
-         * Pooled sessions that have been idle in the pool for longer than this timeout
+         * Pooled connections that have been idle in the pool for longer than this timeout
          * will be tested before they are used again, to ensure they are still live.
          * <p>
          * If this option is set too low, an additional network call will be
-         * incurred when acquiring a session, which causes a performance hit.
+         * incurred when acquiring a connection, which causes a performance hit.
          * <p>
-         * If this is set high, you may receive sessions that are no longer live,
+         * If this is set high, you may receive sessions that are backed by no longer live connections,
          * which will lead to exceptions in your application. Assuming the
-         * database is running, these exceptions will go away if you retry acquiring
-         * sessions.
+         * database is running, these exceptions will go away if you retry acquiring sessions.
          * <p>
          * Hence, this parameter tunes a balance between the likelihood of your
          * application seeing connection problems, and performance.

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -292,7 +292,8 @@ public class Config
          * application seeing connection problems, and performance.
          * <p>
          * You normally should not need to tune this parameter.
-         * This feature is turned off by default.
+         * This feature is turned off by default. Value {@code 0} means connections will always be tested for
+         * validity and negative values mean connections will never be tested.
          *
          * @param value the minimum idle time in milliseconds
          * @param unit the unit in which the duration is given
@@ -300,14 +301,7 @@ public class Config
          */
         public ConfigBuilder withConnectionLivenessCheckTimeout( long value, TimeUnit unit )
         {
-            long idleTimeBeforeConnectionTestMillis = unit.toMillis( value );
-            if ( idleTimeBeforeConnectionTestMillis <= 0 )
-            {
-                throw new IllegalArgumentException( String.format(
-                        "The timeout value must be positive when converted to ms, but was %d. Given %d %s",
-                        idleTimeBeforeConnectionTestMillis, value, unit ) );
-            }
-            this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTestMillis;
+            this.idleTimeBeforeConnectionTest = unit.toMillis( value );
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -261,18 +261,18 @@ public class Config
         }
 
         /**
-         * Please use {@link #withSessionLivenessCheckTimeout(long, TimeUnit)}.
+         * Please use {@link #withConnectionLivenessCheckTimeout(long, TimeUnit)}.
          *
          * @param timeout minimum idle time in milliseconds
          * @return this builder
-         * @see #withSessionLivenessCheckTimeout(long, TimeUnit)
-         * @deprecated please use overloaded method with {@link TimeUnit} parameter. This method will be removed in
-         * future release.
+         * @see #withConnectionLivenessCheckTimeout(long, TimeUnit)
+         * @deprecated please use {@link #withConnectionLivenessCheckTimeout(long, TimeUnit)} method. This method
+         * will be removed in future release.
          */
         @Deprecated
         public ConfigBuilder withSessionLivenessCheckTimeout( long timeout )
         {
-            withSessionLivenessCheckTimeout( timeout, TimeUnit.MILLISECONDS );
+            withConnectionLivenessCheckTimeout( timeout, TimeUnit.MILLISECONDS );
             return this;
         }
 
@@ -298,7 +298,7 @@ public class Config
          * @param unit the unit in which the duration is given
          * @return this builder
          */
-        public ConfigBuilder withSessionLivenessCheckTimeout( long value, TimeUnit unit )
+        public ConfigBuilder withConnectionLivenessCheckTimeout( long value, TimeUnit unit )
         {
             long idleTimeBeforeConnectionTestMillis = unit.toMillis( value );
             if ( idleTimeBeforeConnectionTestMillis <= 0 )

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -53,6 +53,12 @@ public class Config
 
     private final int maxIdleConnectionPoolSize;
 
+    /**
+     * Connections that have been idle in the pool longer than this threshold will
+     * be tested for validity before being returned to the user.
+     */
+    private final long idleTimeBeforeConnectionTest;
+
     /** Level of encryption we need to adhere to */
     private final EncryptionLevel encryptionLevel;
 
@@ -68,6 +74,7 @@ public class Config
         this.logging = builder.logging;
         this.logLeakedSessions = builder.logLeakedSessions;
 
+        this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
         this.maxIdleConnectionPoolSize = builder.maxIdleConnectionPoolSize;
 
         this.encryptionLevel = builder.encryptionLevel;
@@ -116,17 +123,14 @@ public class Config
     }
 
     /**
-     * Pooled connections that have been unused for longer than this timeout will be tested before they are
-     * used again, to ensure they are still live.
+     * Pooled sessions that have been idle in the pool for longer than this timeout
+     * will be tested before they are used again, to ensure they are still live.
      *
      * @return idle time in milliseconds
-     * @deprecated pooled sessions are automatically checked for validity before being returned to the pool. This
-     * method will always return <code>-1</code> and will be possibly removed in future.
      */
-    @Deprecated
     public long idleTimeBeforeConnectionTest()
     {
-        return -1;
+        return idleTimeBeforeConnectionTest;
     }
 
     /**
@@ -183,6 +187,7 @@ public class Config
         private Logging logging = new JULogging( Level.INFO );
         private boolean logLeakedSessions;
         private int maxIdleConnectionPoolSize = PoolSettings.DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
+        private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private EncryptionLevel encryptionLevel = EncryptionLevel.REQUIRED;
         private TrustStrategy trustStrategy = trustAllCertificates();
         private int routingFailureLimit = 1;
@@ -256,30 +261,53 @@ public class Config
         }
 
         /**
-         * Pooled sessions that have been unused for longer than this timeout
-         * will be tested before they are used again, to ensure they are still live.
-         *
-         * If this option is set too low, an additional network call will be
-         * incurred when acquiring a session, which causes a performance hit.
-         *
-         * If this is set high, you may receive sessions that are no longer live,
-         * which will lead to exceptions in your application. Assuming the
-         * database is running, these exceptions will go away if you retry acquiring
-         * sessions.
-         *
-         * Hence, this parameter tunes a balance between the likelihood of your
-         * application seeing connection problems, and performance.
-         *
-         * You normally should not need to tune this parameter.
+         * Please use {@link #withSessionLivenessCheckTimeout(long, TimeUnit)}.
          *
          * @param timeout minimum idle time in milliseconds
          * @return this builder
-         * @deprecated pooled sessions are automatically checked for validity before being returned to the pool.
-         * This setting will be ignored and possibly removed in future.
+         * @see #withSessionLivenessCheckTimeout(long, TimeUnit)
+         * @deprecated please use overloaded method with {@link TimeUnit} parameter. This method will be removed in
+         * future release.
          */
         @Deprecated
         public ConfigBuilder withSessionLivenessCheckTimeout( long timeout )
         {
+            withSessionLivenessCheckTimeout( timeout, TimeUnit.MILLISECONDS );
+            return this;
+        }
+
+        /**
+         * Pooled sessions that have been idle in the pool for longer than this timeout
+         * will be tested before they are used again, to ensure they are still live.
+         * <p>
+         * If this option is set too low, an additional network call will be
+         * incurred when acquiring a session, which causes a performance hit.
+         * <p>
+         * If this is set high, you may receive sessions that are no longer live,
+         * which will lead to exceptions in your application. Assuming the
+         * database is running, these exceptions will go away if you retry acquiring
+         * sessions.
+         * <p>
+         * Hence, this parameter tunes a balance between the likelihood of your
+         * application seeing connection problems, and performance.
+         * <p>
+         * You normally should not need to tune this parameter.
+         * This feature is turned off by default.
+         *
+         * @param value the minimum idle time in milliseconds
+         * @param unit the unit in which the duration is given
+         * @return this builder
+         */
+        public ConfigBuilder withSessionLivenessCheckTimeout( long value, TimeUnit unit )
+        {
+            long idleTimeBeforeConnectionTestMillis = unit.toMillis( value );
+            if ( idleTimeBeforeConnectionTestMillis <= 0 )
+            {
+                throw new IllegalArgumentException( String.format(
+                        "The timeout value must be positive when converted to ms, but was %d. Given %d %s",
+                        idleTimeBeforeConnectionTestMillis, value, unit ) );
+            }
+            this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTestMillis;
             return this;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -85,7 +85,7 @@ public class ConfigTest
     @Test
     public void shouldSupportLivenessCheckTimeoutSetting() throws Throwable
     {
-        Config config = Config.build().withSessionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.build().withConnectionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).toConfig();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.idleTimeBeforeConnectionTest() );
     }
@@ -97,7 +97,7 @@ public class ConfigTest
 
         try
         {
-            builder.withSessionLivenessCheckTimeout( 0, TimeUnit.SECONDS );
+            builder.withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -113,7 +113,7 @@ public class ConfigTest
 
         try
         {
-            builder.withSessionLivenessCheckTimeout( -42, TimeUnit.SECONDS );
+            builder.withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS );
             fail( "Exception expected" );
         }
         catch ( Exception e )

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -83,13 +83,43 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldIgnoreLivenessCheckTimeoutSetting() throws Throwable
+    public void shouldSupportLivenessCheckTimeoutSetting() throws Throwable
     {
-        // when
-        Config config = Config.build().withSessionLivenessCheckTimeout( 1337 ).toConfig();
+        Config config = Config.build().withSessionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).toConfig();
 
-        // then
-        assertEquals( -1, config.idleTimeBeforeConnectionTest() );
+        assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.idleTimeBeforeConnectionTest() );
+    }
+
+    @Test
+    public void shouldThrowForZeroTimeoutInLivenessCheckTimeoutSetting() throws Throwable
+    {
+        Config.ConfigBuilder builder = Config.build();
+
+        try
+        {
+            builder.withSessionLivenessCheckTimeout( 0, TimeUnit.SECONDS );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowForNegativeTimeoutInLivenessCheckTimeoutSetting() throws Throwable
+    {
+        Config.ConfigBuilder builder = Config.build();
+
+        try
+        {
+            builder.withSessionLivenessCheckTimeout( -42, TimeUnit.SECONDS );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ConfigTest.java
@@ -91,35 +91,19 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldThrowForZeroTimeoutInLivenessCheckTimeoutSetting() throws Throwable
+    public void shouldAllowZeroConnectionLivenessCheckTimeout() throws Throwable
     {
-        Config.ConfigBuilder builder = Config.build();
+        Config config = Config.build().withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS ).toConfig();
 
-        try
-        {
-            builder.withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertEquals( 0, config.idleTimeBeforeConnectionTest() );
     }
 
     @Test
-    public void shouldThrowForNegativeTimeoutInLivenessCheckTimeoutSetting() throws Throwable
+    public void shouldAllowNegativeConnectionLivenessCheckTimeout() throws Throwable
     {
-        Config.ConfigBuilder builder = Config.build();
+        Config config = Config.build().withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS ).toConfig();
 
-        try
-        {
-            builder.withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertEquals( TimeUnit.SECONDS.toMillis( -42 ), config.idleTimeBeforeConnectionTest() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -142,21 +142,22 @@ public class DriverFactoryTest
         }
 
         @Override
-        DirectDriver createDirectDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                SecurityPlan securityPlan, SessionFactory sessionFactory )
+        protected DirectDriver createDirectDriver( BoltServerAddress address, ConnectionPool connectionPool,
+                Config config, SecurityPlan securityPlan, SessionFactory sessionFactory )
         {
             throw new UnsupportedOperationException( "Can't create direct driver" );
         }
 
         @Override
-        RoutingDriver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                RoutingSettings routingSettings, SecurityPlan securityPlan, SessionFactory sessionFactory )
+        protected RoutingDriver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool,
+                Config config, RoutingSettings routingSettings, SecurityPlan securityPlan,
+                SessionFactory sessionFactory )
         {
             throw new UnsupportedOperationException( "Can't create routing driver" );
         }
 
         @Override
-        ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Config config )
+        protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Config config )
         {
             return connectionPool;
         }
@@ -167,16 +168,17 @@ public class DriverFactoryTest
         SessionFactory capturedSessionFactory;
 
         @Override
-        DirectDriver createDirectDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                SecurityPlan securityPlan, SessionFactory sessionFactory )
+        protected DirectDriver createDirectDriver( BoltServerAddress address, ConnectionPool connectionPool,
+                Config config, SecurityPlan securityPlan, SessionFactory sessionFactory )
         {
             capturedSessionFactory = sessionFactory;
             return null;
         }
 
         @Override
-        RoutingDriver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                RoutingSettings routingSettings, SecurityPlan securityPlan, SessionFactory sessionFactory )
+        protected RoutingDriver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool,
+                Config config, RoutingSettings routingSettings, SecurityPlan securityPlan,
+                SessionFactory sessionFactory )
         {
             capturedSessionFactory = sessionFactory;
             return null;

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net.pooling;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PoolSettingsTest
+{
+    @Test
+    public void idleTimeBeforeConnectionTestWhenConfigured()
+    {
+        PoolSettings settings = new PoolSettings( 10, 42 );
+        assertTrue( settings.idleTimeBeforeConnectionTestConfigured() );
+        assertEquals( 42, settings.idleTimeBeforeConnectionTest() );
+    }
+
+    @Test
+    public void idleTimeBeforeConnectionTestWhenSetToZero()
+    {
+        testWithIllegalValue( 0 );
+    }
+
+    @Test
+    public void idleTimeBeforeConnectionTestWhenSetToNegativeValue()
+    {
+        testWithIllegalValue( -1 );
+        testWithIllegalValue( -42 );
+    }
+
+    private static void testWithIllegalValue( int value )
+    {
+        PoolSettings settings = new PoolSettings( 10, value );
+
+        assertFalse( settings.idleTimeBeforeConnectionTestConfigured() );
+
+        try
+        {
+            settings.idleTimeBeforeConnectionTest();
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
@@ -39,7 +39,9 @@ public class PoolSettingsTest
     @Test
     public void idleTimeBeforeConnectionTestWhenSetToZero()
     {
-        testWithIllegalValue( 0 );
+        PoolSettings settings = new PoolSettings( 10, 0 );
+        assertTrue( settings.idleTimeBeforeConnectionTestConfigured() );
+        assertEquals( 0, settings.idleTimeBeforeConnectionTest() );
     }
 
     @Test
@@ -47,6 +49,7 @@ public class PoolSettingsTest
     {
         testWithIllegalValue( -1 );
         testWithIllegalValue( -42 );
+        testWithIllegalValue( Integer.MIN_VALUE );
     }
 
     private static void testWithIllegalValue( int value )

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
@@ -23,23 +23,32 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Queue;
 
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.net.SocketClient;
 import org.neo4j.driver.internal.net.SocketConnection;
+import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumers;
+import org.neo4j.driver.v1.exceptions.DatabaseException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
@@ -49,13 +58,54 @@ import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 public class PooledConnectionValidatorTest
 {
     @Test
-    public void resetAndSyncValidConnection()
+    public void isNotReusableWhenPoolHasNoAddress()
     {
         Connection connection = mock( Connection.class );
         PooledConnection pooledConnection = newPooledConnection( connection );
 
-        PooledConnectionValidator validator = newValidatorWithMockedPool();
-        boolean connectionIsValid = validator.apply( pooledConnection );
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( false ) );
+
+        assertFalse( validator.isReusable( pooledConnection ) );
+        verify( connection, never() ).reset();
+        verify( connection, never() ).sync();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    public void isNotReusableWhenHasUnrecoverableErrors()
+    {
+        Connection connection = mock( Connection.class );
+        DatabaseException runError = new DatabaseException( "", "" );
+        doThrow( runError ).when( connection ).run( anyString(), any( Map.class ), any( Collector.class ) );
+
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        try
+        {
+            pooledConnection.run( "BEGIN", null, null );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertSame( runError, e );
+        }
+        assertTrue( pooledConnection.hasUnrecoverableErrors() );
+
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+
+        assertFalse( validator.isReusable( pooledConnection ) );
+        verify( connection, never() ).reset();
+        verify( connection, never() ).sync();
+    }
+
+    @Test
+    public void resetAndSyncValidConnectionWhenCheckingIfReusable()
+    {
+        Connection connection = mock( Connection.class );
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+        boolean connectionIsValid = validator.isReusable( pooledConnection );
 
         assertTrue( connectionIsValid );
 
@@ -65,15 +115,15 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void sendsSingleResetMessageForValidConnection() throws IOException
+    public void sendsSingleResetMessageForValidConnectionWhenCheckingIfReusable() throws IOException
     {
         SocketClient socket = mock( SocketClient.class );
         InternalServerInfo serverInfo = new InternalServerInfo( LOCAL_DEFAULT, "v1" );
         Connection connection = new SocketConnection( socket, serverInfo, DEV_NULL_LOGGER );
         PooledConnection pooledConnection = newPooledConnection( connection );
 
-        PooledConnectionValidator validator = newValidatorWithMockedPool();
-        boolean connectionIsValid = validator.apply( pooledConnection );
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+        boolean connectionIsValid = validator.isReusable( pooledConnection );
 
         assertTrue( connectionIsValid );
 
@@ -85,20 +135,56 @@ public class PooledConnectionValidatorTest
         assertEquals( RESET, messages.peek() );
     }
 
+    @Test
+    public void isConnectedReturnsFalseWhenResetFails()
+    {
+        Connection connection = mock( Connection.class );
+        doThrow( new RuntimeException() ).when( connection ).reset();
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+
+        assertFalse( validator.isConnected( pooledConnection ) );
+        verify( connection ).reset();
+        verify( connection, never() ).sync();
+    }
+
+    @Test
+    public void isConnectedReturnsFalseWhenSyncFails()
+    {
+        Connection connection = mock( Connection.class );
+        doThrow( new RuntimeException() ).when( connection ).sync();
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+
+        assertFalse( validator.isConnected( pooledConnection ) );
+        verify( connection ).reset();
+        verify( connection ).sync();
+    }
+
+    @Test
+    public void isConnectedReturnsTrueWhenUnderlyingConnectionWorks()
+    {
+        Connection connection = mock( Connection.class );
+        PooledConnection pooledConnection = newPooledConnection( connection );
+
+        PooledConnectionValidator validator = new PooledConnectionValidator( connectionPoolMock( true ) );
+
+        assertTrue( validator.isConnected( pooledConnection ) );
+        verify( connection ).reset();
+        verify( connection ).sync();
+    }
+
     private static PooledConnection newPooledConnection( Connection connection )
     {
         return new PooledConnection( connection, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
     }
 
-    private static PooledConnectionValidator newValidatorWithMockedPool()
-    {
-        return new PooledConnectionValidator( connectionPoolMock() );
-    }
-
-    private static ConnectionPool connectionPoolMock()
+    private static ConnectionPool connectionPoolMock( boolean knowsAddressed )
     {
         ConnectionPool pool = mock( ConnectionPool.class );
-        when( pool.hasAddress( any( BoltServerAddress.class ) ) ).thenReturn( true );
+        when( pool.hasAddress( any( BoltServerAddress.class ) ) ).thenReturn( knowsAddressed );
         return pool;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
@@ -448,7 +448,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void acquireRetriesAtMostMaxPoolSizeTimes()
+    public void acquireRetriesUntilAConnectionIsCreated()
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -459,12 +459,10 @@ public class SocketConnectionPoolTest
         doNothing().doThrow( new RuntimeException() ).when( connection2 ).reset();
         doNothing().doThrow( new RuntimeException() ).when( connection3 ).reset();
 
-        int maxIdleConnectionPoolSize = 3;
         int idleTimeBeforeConnectionTest = 10;
         FakeClock clock = new FakeClock();
         Connector connector = newMockConnector( connection1, connection2, connection3, connection4 );
-        SocketConnectionPool pool =
-                newPool( connector, clock, maxIdleConnectionPoolSize, idleTimeBeforeConnectionTest );
+        SocketConnectionPool pool = newPool( connector, clock, idleTimeBeforeConnectionTest );
 
         Connection acquiredConnection1 = pool.acquire( ADDRESS_1 );
         Connection acquiredConnection2 = pool.acquire( ADDRESS_1 );
@@ -540,13 +538,7 @@ public class SocketConnectionPoolTest
 
     private static SocketConnectionPool newPool( Connector connector, Clock clock, long idleTimeBeforeConnectionTest )
     {
-        return newPool( connector, clock, 42, idleTimeBeforeConnectionTest );
-    }
-
-    private static SocketConnectionPool newPool( Connector connector, Clock clock, int maxIdleConnectionPoolSize,
-            long idleTimeBeforeConnectionTest )
-    {
-        PoolSettings poolSettings = new PoolSettings( maxIdleConnectionPoolSize, idleTimeBeforeConnectionTest );
+        PoolSettings poolSettings = new PoolSettings( 42, idleTimeBeforeConnectionTest );
         Logging logging = mock( Logging.class, RETURNS_MOCKS );
         return new SocketConnectionPool( poolSettings, connector, clock, logging );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import java.util.Set;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.Connector;
+
+public class ConnectionTrackingConnector implements Connector
+{
+    private final Connector realConnector;
+    private final Set<Connection> connections;
+
+    public ConnectionTrackingConnector( Connector realConnector, Set<Connection> connections )
+    {
+        this.realConnector = realConnector;
+        this.connections = connections;
+    }
+
+    @Override
+    public Connection connect( BoltServerAddress address )
+    {
+        Connection connection = realConnector.connect( address );
+        connections.add( connection );
+        return connection;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.Connector;
+import org.neo4j.driver.v1.Logging;
+
+public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
+{
+    private final Set<Connection> connections =
+            Collections.newSetFromMap( new ConcurrentHashMap<Connection,Boolean>() );
+
+    public ConnectionTrackingDriverFactory( Clock clock )
+    {
+        super( clock );
+    }
+
+    @Override
+    protected Connector createConnector( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
+            Logging logging )
+    {
+        Connector connector = super.createConnector( connectionSettings, securityPlan, logging );
+        return new ConnectionTrackingConnector( connector, connections );
+    }
+
+    public void closeConnections()
+    {
+        for ( Connection connection : connections )
+        {
+            connection.close();
+        }
+        connections.clear();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithClock.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithClock.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithClock.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.neo4j.driver.internal.DriverFactory;
+
+public class DriverFactoryWithClock extends DriverFactory
+{
+    private final Clock clock;
+
+    public DriverFactoryWithClock( Clock clock )
+    {
+        this.clock = clock;
+    }
+
+    @Override
+    protected Clock createClock()
+    {
+        return clock;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FakeClock.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FakeClock.java
@@ -18,14 +18,14 @@
  */
 package org.neo4j.driver.internal.util;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
-
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 
 import org.neo4j.driver.internal.EventHandler;
 
@@ -62,6 +62,11 @@ public class FakeClock implements Clock
     private volatile long timestamp;
     private static final AtomicLongFieldUpdater<FakeClock> TIMESTAMP = newUpdater( FakeClock.class, "timestamp" );
     private PriorityBlockingQueue<WaitingThread> threads;
+
+    public FakeClock()
+    {
+        this( (EventHandler) null, false );
+    }
 
     public FakeClock( final EventHandler events, boolean progressOnSleep )
     {

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -22,10 +22,20 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.util.ConnectionTrackingDriverFactory;
+import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
@@ -44,6 +54,7 @@ import org.neo4j.driver.v1.util.cc.ClusterRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class CausalClusteringIT
@@ -181,6 +192,47 @@ public class CausalClusteringIT
         }
     }
 
+    @Test
+    public void shouldDropBrokenOldSessions() throws Exception
+    {
+        Cluster cluster = clusterRule.getCluster();
+
+        int concurrentSessionsCount = 9;
+        int livenessCheckTimeoutMinutes = 2;
+
+        Config config = Config.build()
+                .withSessionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
+                .withEncryptionLevel( Config.EncryptionLevel.NONE )
+                .toConfig();
+
+        FakeClock clock = new FakeClock();
+        ConnectionTrackingDriverFactory driverFactory = new ConnectionTrackingDriverFactory( clock );
+
+        URI routingUri = cluster.leader().getRoutingUri();
+        RoutingSettings routingSettings = new RoutingSettings( 1, TimeUnit.SECONDS.toMillis( 5 ) );
+        AuthToken authToken = clusterRule.getDefaultAuthToken();
+
+        try ( Driver driver = driverFactory.newInstance( routingUri, authToken, routingSettings, config ) )
+        {
+            // create nodes in different threads using different sessions
+            createNodesInDifferentThreads( concurrentSessionsCount, driver );
+
+            // now pool contains many sessions, make them all invalid
+            driverFactory.closeConnections();
+            // move clock forward more than configured liveness check timeout
+            clock.progress( TimeUnit.MINUTES.toMillis( livenessCheckTimeoutMinutes + 1 ) );
+
+            // now all idle connections should be considered too old and will be verified during acquisition
+            // they will appear broken because they were closed and new valid connection will be created
+            try ( Session session = driver.session( AccessMode.WRITE ) )
+            {
+                List<Record> records = session.run( "MATCH (n) RETURN count(n)" ).list();
+                assertEquals( 1, records.size() );
+                assertEquals( concurrentSessionsCount, records.get( 0 ).get( 0 ).asInt() );
+            }
+        }
+    }
+
     private int executeWriteAndReadThroughBolt( ClusterMember member ) throws TimeoutException, InterruptedException
     {
         try ( Driver driver = createDriver( member.getRoutingUri() ) )
@@ -264,5 +316,36 @@ public class CausalClusteringIT
                 .toConfig();
 
         return GraphDatabase.driver( boltUri, clusterRule.getDefaultAuthToken(), config );
+    }
+
+    private static void createNodesInDifferentThreads( int count, final Driver driver ) throws Exception
+    {
+        final CountDownLatch beforeRunLatch = new CountDownLatch( count );
+        final CountDownLatch runQueryLatch = new CountDownLatch( 1 );
+        final ExecutorService executor = Executors.newCachedThreadPool();
+
+        for ( int i = 0; i < count; i++ )
+        {
+            executor.submit( new Callable<Void>()
+            {
+                @Override
+                public Void call() throws Exception
+                {
+                    beforeRunLatch.countDown();
+                    try ( Session session = driver.session( AccessMode.WRITE ) )
+                    {
+                        runQueryLatch.await();
+                        session.run( "CREATE ()" );
+                    }
+                    return null;
+                }
+            } );
+        }
+
+        beforeRunLatch.await();
+        runQueryLatch.countDown();
+
+        executor.shutdown();
+        assertTrue( executor.awaitTermination( 1, TimeUnit.MINUTES ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -201,7 +201,7 @@ public class CausalClusteringIT
         int livenessCheckTimeoutMinutes = 2;
 
         Config config = Config.build()
-                .withSessionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
+                .withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
                 .withEncryptionLevel( Config.EncryptionLevel.NONE )
                 .toConfig();
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
@@ -96,7 +96,7 @@ public class ServerKilledIT
         // config with set liveness check timeout
         int livenessCheckTimeoutMinutes = 10;
         Config config = Config.build()
-                .withSessionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
+                .withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
                 .withEncryptionLevel( Config.EncryptionLevel.NONE )
                 .toConfig();
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -289,7 +289,7 @@ public class Cluster
                 .withTrustStrategy( trustAllCertificates() )
                 .withEncryptionLevel( Config.EncryptionLevel.NONE )
                 .withMaxIdleSessions( 1 )
-                .withSessionLivenessCheckTimeout( TimeUnit.HOURS.toMillis( 1 ) )
+                .withConnectionLivenessCheckTimeout( 1, TimeUnit.HOURS )
                 .toConfig();
     }
 


### PR DESCRIPTION
Connections are pooled for both direct and routing driver. Each acquired session contains a socket connection which was acquired from the pool. It is possible for an idle pooled connection to become invalid while just resting in the pool. This could happen when connection is terminated after some timeout by a load balancer or some other network facility.

This PR introduces a configurable connection liveness check timeout. So freshly acquired connection, that has been idle in the pool for more than configurable timeout, will be validated by sending a RESET message. If it appears to be broken acquisition will retry until a valid connection is found.