### PR TITLE
Abstract PooledConnection interface to abstract pooling logic out of Connection

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -66,17 +66,17 @@ class ExplicitTransaction implements Transaction
     }
 
     private final Runnable cleanup;
-    private final Connection conn;
+    private final PooledConnection conn;
 
     private String bookmark = null;
     private State state = State.ACTIVE;
 
-    ExplicitTransaction( Connection conn, Runnable cleanup )
+    ExplicitTransaction( PooledConnection conn, Runnable cleanup )
     {
         this( conn, cleanup, null );
     }
 
-    ExplicitTransaction( Connection conn, Runnable cleanup, String bookmark )
+    ExplicitTransaction( PooledConnection conn, Runnable cleanup, String bookmark )
     {
         this.conn = conn;
         this.cleanup = cleanup;
@@ -241,7 +241,7 @@ class ExplicitTransaction implements Transaction
         this.bookmark = bookmark;
     }
 
-    private static void runBeginStatement( Connection connection, String bookmark )
+    private static void runBeginStatement( PooledConnection connection, String bookmark )
     {
         Map<String,Value> parameters;
         if ( bookmark != null )

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Queue;
 
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.summary.SummaryBuilder;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -47,7 +47,7 @@ import static java.util.Collections.emptyList;
 
 public class InternalStatementResult implements StatementResult
 {
-    private final Connection connection;
+    private final PooledConnection connection;
     private final Collector runResponseCollector;
     private final Collector pullAllResponseCollector;
     private final Queue<Record> recordBuffer = new LinkedList<>();
@@ -58,7 +58,7 @@ public class InternalStatementResult implements StatementResult
     private long position = -1;
     private boolean done = false;
 
-    InternalStatementResult( Connection connection, ExplicitTransaction transaction, Statement statement )
+    InternalStatementResult( PooledConnection connection, ExplicitTransaction transaction, Statement statement )
     {
         this.connection = connection;
         this.runResponseCollector = newRunResponseCollector();

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logger;
 
 import static java.lang.System.lineSeparator;
@@ -28,7 +28,7 @@ class LeakLoggingNetworkSession extends NetworkSession
     private final Logger log;
     private final String stackTrace;
 
-    LeakLoggingNetworkSession( Connection connection, Logger log )
+    LeakLoggingNetworkSession( PooledConnection connection, Logger log )
     {
         super( connection );
         this.log = log;

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactory.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
@@ -35,7 +35,7 @@ class LeakLoggingNetworkSessionFactory implements SessionFactory
     }
 
     @Override
-    public Session newInstance( Connection connection )
+    public Session newInstance( PooledConnection connection )
     {
         return new LeakLoggingNetworkSession( connection, logger );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.spi.PooledConnection;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Record;
@@ -117,7 +116,7 @@ public class NetworkSession implements Session
         return run( connection, statement );
     }
 
-    public static StatementResult run( Connection connection, Statement statement )
+    public static StatementResult run( PooledConnection connection, Statement statement )
     {
         InternalStatementResult cursor = new InternalStatementResult( connection, null, statement );
         connection.run( statement.text(), statement.parameters().asMap( Values.ofValue() ),

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.logging.DevNullLogger;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Logger;
@@ -41,7 +42,7 @@ import static org.neo4j.driver.v1.Values.value;
 
 public class NetworkSession implements Session
 {
-    protected Connection connection;
+    protected PooledConnection connection;
     private final String sessionId;
     private final Logger logger;
 
@@ -67,7 +68,7 @@ public class NetworkSession implements Session
     private ExplicitTransaction currentTransaction;
     private AtomicBoolean isOpen = new AtomicBoolean( true );
 
-    NetworkSession( Connection connection )
+    NetworkSession( PooledConnection connection )
     {
         this.connection = connection;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSessionFactory.java
@@ -18,13 +18,13 @@
  */
 package org.neo4j.driver.internal;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Session;
 
 class NetworkSessionFactory implements SessionFactory
 {
     @Override
-    public Session newInstance( Connection connection )
+    public Session newInstance( PooledConnection connection )
     {
         return new NetworkSession( connection );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RoutingDriver.java
@@ -21,8 +21,8 @@ package org.neo4j.driver.internal;
 import org.neo4j.driver.internal.cluster.LoadBalancer;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.security.SecurityPlan;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.AccessMode;
@@ -62,12 +62,12 @@ public class RoutingDriver extends BaseDriver
     @Override
     protected Session newSessionWithMode( AccessMode mode )
     {
-        Connection connection = acquireConnection( mode );
+        PooledConnection connection = acquireConnection( mode );
         Session networkSession = sessionFactory.newInstance( connection );
         return new RoutingNetworkSession( networkSession, mode, connection.boltServerAddress(), loadBalancer );
     }
 
-    private Connection acquireConnection( AccessMode role )
+    private PooledConnection acquireConnection( AccessMode role )
     {
         switch ( role )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
@@ -18,10 +18,10 @@
  */
 package org.neo4j.driver.internal;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Session;
 
 interface SessionFactory
 {
-    Session newInstance( Connection connection );
+    Session newInstance( PooledConnection connection );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Record;
@@ -41,7 +41,7 @@ final class ClusterComposition
     {
         String GET_SERVERS = "CALL dbms.cluster.routing.getServers";
 
-        ClusterComposition getClusterComposition( Connection connection ) throws ServiceUnavailableException;
+        ClusterComposition getClusterComposition( PooledConnection connection ) throws ServiceUnavailableException;
 
         final class Default implements Provider
         {
@@ -56,7 +56,7 @@ final class ClusterComposition
             }
 
             @Override
-            public ClusterComposition getClusterComposition( Connection connection ) throws ServiceUnavailableException
+            public ClusterComposition getClusterComposition( PooledConnection connection ) throws ServiceUnavailableException
             {
                 StatementResult cursor = getServers( connection );
                 List<Record> records = cursor.list();
@@ -77,7 +77,7 @@ final class ClusterComposition
                 }
             }
 
-            private StatementResult getServers( Connection connection )
+            private StatementResult getServers( PooledConnection connection )
             {
                 return NetworkSession.run( connection, GET_SERVER );
             }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 
 import org.neo4j.driver.internal.RoutingErrorHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
@@ -77,12 +78,12 @@ public final class LoadBalancer implements RoutingErrorHandler, AutoCloseable
         ensureRouting();
     }
 
-    public Connection acquireReadConnection() throws ServiceUnavailableException
+    public PooledConnection acquireReadConnection() throws ServiceUnavailableException
     {
         return acquireConnection( readers );
     }
 
-    public Connection acquireWriteConnection() throws ServiceUnavailableException
+    public PooledConnection acquireWriteConnection() throws ServiceUnavailableException
     {
         return acquireConnection( writers );
     }
@@ -105,7 +106,7 @@ public final class LoadBalancer implements RoutingErrorHandler, AutoCloseable
         connections.close();
     }
 
-    private Connection acquireConnection( RoundRobinAddressSet servers ) throws ServiceUnavailableException
+    private PooledConnection acquireConnection( RoundRobinAddressSet servers ) throws ServiceUnavailableException
     {
         for ( ; ; )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -22,9 +22,8 @@ import java.util.HashSet;
 
 import org.neo4j.driver.internal.RoutingErrorHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.spi.PooledConnection;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -184,7 +183,7 @@ public final class LoadBalancer implements RoutingErrorHandler, AutoCloseable
                     throw new ServiceUnavailableException( NO_ROUTERS_AVAILABLE );
                 }
                 ClusterComposition cluster;
-                try ( Connection connection = connections.acquire( address ) )
+                try ( PooledConnection connection = connections.acquire( address ) )
                 {
                     cluster = provider.getClusterComposition( connection );
                     log.info( "Got cluster composition %s", cluster );

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+
+/**
+ * Internal checked exceptions.
+ * This exception should never be visible to a driver user in anyway.
+ *
+ * The internal error should be casted to a public error in {@link org.neo4j.driver.v1.exceptions} with
+ * {@link #publicException()} method call before it reaches to a driver end user.
+ */
+public abstract class InternalException extends Exception
+{
+    public InternalException()
+    {}
+
+    public InternalException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    public InternalException( String message )
+    {
+        super( message );
+    }
+
+    public abstract Neo4jException publicException();
+
+    public boolean isUnrecoverableError()
+    {
+        return true;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalNeo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/exceptions/InternalNeo4jException.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.exceptions;
+
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.DatabaseException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.TransientException;
+
+/**
+ * This exception represents a {@link org.neo4j.driver.v1.exceptions.Neo4jException} that is passed from the server.
+ *
+ * It wraps around the {@link org.neo4j.driver.v1.exceptions.Neo4jException} to make it a checked exception for
+ * keeping track of it when it is passed internally.
+ * The exception should be mapped back to {@link org.neo4j.driver.v1.exceptions.Neo4jException} before reaching a user.
+ */
+public class InternalNeo4jException extends InternalException
+{
+    private final Neo4jException error;
+
+    public InternalNeo4jException( String code, String message )
+    {
+        String[] parts = code.split( "\\." );
+        String classification = parts[1];
+        switch ( classification )
+        {
+        case "ClientError":
+            error = new ClientException( code, message );
+            break;
+        case "TransientError":
+            error = new TransientException( code, message );
+            break;
+        default:
+            error = new DatabaseException( code, message );
+            break;
+        }
+    }
+
+    public InternalNeo4jException( Neo4jException error )
+    {
+        this.error = error;
+    }
+
+    @Override
+    public Neo4jException publicException()
+    {
+        return error;
+    }
+
+    public boolean isProtocolViolationError()
+    {
+        return error != null && error.code().startsWith( "Neo.ClientError.Request" );
+    }
+
+    private boolean isDatabaseError()
+    {
+        return error != null && error instanceof DatabaseException;
+    }
+
+    @Override
+    public boolean isUnrecoverableError()
+    {
+        return isDatabaseError() || isProtocolViolationError();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -186,27 +186,9 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void onError( Runnable runnable )
-    {
-        delegate.onError( runnable );
-    }
-
-    @Override
-    public boolean hasUnrecoverableErrors()
-    {
-        return delegate.hasUnrecoverableErrors();
-    }
-
-    @Override
     public void resetAsync()
     {
         delegate.resetAsync();
-    }
-
-    @Override
-    public boolean isAckFailureMuted()
-    {
-        return delegate.isAckFailureMuted();
     }
 
     private void markAsAvailable()

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.net;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Logger;
@@ -45,7 +46,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void init( String clientName, Map<String,Value> authToken )
+    public void init( String clientName, Map<String,Value> authToken ) throws InternalException
     {
         try
         {
@@ -60,7 +61,7 @@ public class ConcurrencyGuardingConnection implements Connection
 
     @Override
     public void run( String statement, Map<String,Value> parameters,
-            Collector collector )
+            Collector collector ) throws InternalException
     {
         try
         {
@@ -74,7 +75,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void discardAll( Collector collector )
+    public void discardAll( Collector collector ) throws InternalException
     {
         try
         {
@@ -88,7 +89,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void pullAll( Collector collector )
+    public void pullAll( Collector collector ) throws InternalException
     {
         try
         {
@@ -102,7 +103,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void reset()
+    public void reset() throws InternalException
     {
         try
         {
@@ -116,7 +117,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void ackFailure()
+    public void ackFailure() throws InternalException
     {
         try
         {
@@ -130,7 +131,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void sync()
+    public void sync() throws InternalException
     {
         try
         {
@@ -144,7 +145,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void flush()
+    public void flush() throws InternalException
     {
         try
         {
@@ -158,7 +159,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void receiveOne()
+    public void receiveOne() throws InternalException
     {
         try
         {
@@ -186,7 +187,7 @@ public class ConcurrencyGuardingConnection implements Connection
     }
 
     @Override
-    public void resetAsync()
+    public void resetAsync() throws InternalException
     {
         delegate.resetAsync();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -181,7 +181,7 @@ public class SocketClient
         if ( handler.protocolViolationErrorOccurred() )
         {
             stop();
-            throw handler.serverFailure();
+            throw handler.serverFailure().publicException();
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnector.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.net;
 import java.util.Map;
 
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
@@ -58,7 +59,13 @@ public class SocketConnector implements Connector
         {
             connection.init( connectionSettings.userAgent(), tokenAsMap( connectionSettings.authToken() ) );
         }
-        catch ( Throwable initError )
+        catch ( InternalException initError )
+        {
+            connection.close();
+            throw initError.publicException();
+        }
+        // TODO this runtime exception should go away once all internal exceptions are checked exceptions
+        catch ( RuntimeException initError )
         {
             connection.close();
             throw initError;

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.net.pooling;
 
 import org.neo4j.driver.internal.spi.ConnectionValidator;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Consumer;
 
 /**

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidator.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidator.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.net.pooling;
 
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ConnectionValidator;
+import org.neo4j.driver.internal.spi.PooledConnection;
 
 class PooledConnectionValidator implements ConnectionValidator<PooledConnection>
 {

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.Logger;
@@ -50,7 +51,7 @@ import org.neo4j.driver.v1.summary.ServerInfo;
  *                              |           pool.close          |
  *                              ---------------------------------
  */
-public class PooledConnection implements Connection
+public class PooledSocketConnection implements PooledConnection
 {
     /** The real connection who will do all the real jobs */
     private final Connection delegate;
@@ -61,7 +62,7 @@ public class PooledConnection implements Connection
     private final Clock clock;
     private long lastUsedTimestamp;
 
-    public PooledConnection( Connection delegate, Consumer<PooledConnection> release, Clock clock )
+    public PooledSocketConnection( Connection delegate, Consumer<PooledConnection> release, Clock clock )
     {
         this.delegate = delegate;
         this.release = release;
@@ -225,12 +226,6 @@ public class PooledConnection implements Connection
     }
 
     @Override
-    public boolean isAckFailureMuted()
-    {
-        return delegate.isAckFailureMuted();
-    }
-
-    @Override
     public ServerInfo server()
     {
         return delegate.server();
@@ -248,6 +243,7 @@ public class PooledConnection implements Connection
         return delegate.logger();
     }
 
+    @Override
     public void dispose()
     {
         delegate.close();
@@ -265,7 +261,7 @@ public class PooledConnection implements Connection
         {
             unrecoverableErrorsOccurred = true;
         }
-        else if( !isAckFailureMuted() )
+        else
         {
             ackFailure();
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -27,6 +27,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ConnectionValidator;
 import org.neo4j.driver.internal.spi.Connector;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logging;
@@ -68,7 +69,7 @@ public class SocketConnectionPool implements ConnectionPool
     }
 
     @Override
-    public Connection acquire( final BoltServerAddress address )
+    public PooledConnection acquire( final BoltServerAddress address )
     {
         assertNotClosed();
         BlockingPooledConnectionQueue connectionQueue = pool( address );
@@ -201,7 +202,7 @@ public class SocketConnectionPool implements ConnectionPool
             PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( connectionQueue,
                     connectionValidator );
             Connection connection = connector.connect( address );
-            PooledConnection pooledConnection = new PooledConnection( connection, releaseConsumer, clock );
+            PooledConnection pooledConnection = new PooledSocketConnection( connection, releaseConsumer, clock );
             connectionCreated = true;
             return pooledConnection;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Collector.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.spi;
 
 import java.util.List;
 
+import org.neo4j.driver.internal.exceptions.InternalNeo4jException;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.Notification;
 import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
@@ -36,7 +36,7 @@ public interface Collector
     Collector ACK_FAILURE = new NoOperationCollector()
     {
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( InternalNeo4jException error )
         {
             throw new ClientException(
                     "Invalid server response message `FAILURE` received for client message `ACK_FAILURE`.", error );
@@ -82,7 +82,7 @@ public interface Collector
         }
 
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( InternalNeo4jException error )
         {
             throw new ClientException(
                     "Invalid server response message `FAILURE` received for client message `RESET`.", error );
@@ -142,7 +142,7 @@ public interface Collector
         }
 
         @Override
-        public void doneFailure( Neo4jException error )
+        public void doneFailure( InternalNeo4jException error )
         {
             done();
         }
@@ -185,7 +185,7 @@ public interface Collector
 
     void doneSuccess();
 
-    void doneFailure( Neo4jException error );
+    void doneFailure( InternalNeo4jException error );
 
     void doneIgnored();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.spi;
 
 import java.util.Map;
 
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Value;
@@ -36,54 +37,54 @@ public interface Connection extends AutoCloseable
      * @param clientName should be the driver name and version: "java-driver/1.1.0"
      * @param authToken a map value
      */
-    void init( String clientName, Map<String,Value> authToken );
+    void init( String clientName, Map<String,Value> authToken ) throws InternalException;
 
     /**
      * Queue up a run action. The collector will value called with metadata about the stream that will become available
      * for retrieval.
      * @param parameters a map value of parameters
      */
-    void run( String statement, Map<String,Value> parameters, Collector collector );
+    void run( String statement, Map<String,Value> parameters, Collector collector ) throws InternalException;
 
     /**
      * Queue a discard all action, consuming any items left in the current stream.This will
      * close the stream once its completed, allowing another {@link #run(String, java.util.Map, Collector) run}
      */
-    void discardAll( Collector collector );
+    void discardAll( Collector collector ) throws InternalException;
 
     /**
      * Queue a pull-all action, output will be handed to the collector once the pull starts. This will
      * close the stream once its completed, allowing another {@link #run(String, java.util.Map, Collector) run}
      */
-    void pullAll( Collector collector );
+    void pullAll( Collector collector ) throws InternalException;
 
     /**
      * Queue a reset action, throw {@link org.neo4j.driver.v1.exceptions.ClientException} if an ignored message is received. This will
      * close the stream once its completed, allowing another {@link #run(String, java.util.Map, Collector) run}
      */
-    void reset();
+    void reset() throws InternalException;
 
     /**
      * Queue a ack_failure action, valid output could only be success. Throw {@link org.neo4j.driver.v1.exceptions.ClientException} if
      * a failure or ignored message is received. This will close the stream once it is completed, allowing another
      * {@link #run(String, java.util.Map, Collector) run}
      */
-    void ackFailure();
+    void ackFailure() throws InternalException;
 
     /**
      * Ensure all outstanding actions are carried out on the server.
      */
-    void sync();
+    void sync() throws InternalException;
 
     /**
      * Send all pending messages to the server and return the number of messages sent.
      */
-    void flush();
+    void flush() throws InternalException;
 
     /**
      * Receive the next message available.
      */
-    void receiveOne();
+    void receiveOne() throws InternalException;
 
     @Override
     void close();
@@ -101,7 +102,7 @@ public interface Connection extends AutoCloseable
     /**
      * Asynchronously sending reset to the socket output channel.
      */
-    void resetAsync();
+    void resetAsync() throws InternalException;
 
     /**
      * Returns the basic information of the server connected to.

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -99,27 +99,9 @@ public interface Connection extends AutoCloseable
     boolean isOpen();
 
     /**
-     * If there are any errors that occur on this connection, invoke the given
-     * runnable. This is used in the driver to clean up resources associated with
-     * the connection, like an open transaction.
-     *
-     * @param runnable To be run on error.
-     */
-    void onError( Runnable runnable );
-
-
-    boolean hasUnrecoverableErrors();
-
-    /**
      * Asynchronously sending reset to the socket output channel.
      */
     void resetAsync();
-
-    /**
-     * Return true if ack_failure message is temporarily muted as the failure message will be acked using reset instead
-     * @return true if no ack_failre message should be sent when ackable failures are received.
-     */
-    boolean isAckFailureMuted();
 
     /**
      * Returns the basic information of the server connected to.

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -28,7 +28,7 @@ public interface ConnectionPool extends AutoCloseable
      *
      * @param address The address to acquire
      */
-    Connection acquire( BoltServerAddress address );
+    PooledConnection acquire( BoltServerAddress address );
 
     /**
      * Removes all connections to a given address from the pool.

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.spi;
+
+public interface PooledConnection extends Connection
+{
+    /**
+     * If there are any errors that occur on this connection, invoke the given runnable.
+     * This is used in the driver to clean up resources associated with the connection, like an open transaction.
+     *
+     * @param runnable To be run on error.
+     */
+    void onError( Runnable runnable );
+
+    /**
+     * Return true if there is any unrecoverable error left in this connection in previous use.
+     * If the connection has any unrecoverable errors, then it cannot be pooled but disposed directly.
+     * @return true if there is any unrecoverable error left in this connection in previous use.
+     */
+    boolean hasUnrecoverableErrors();
+
+    /**
+     * Dispose all resources hold by the real connection.
+     */
+    void dispose();
+
+    /**
+     * Return the last used timestamp for pooling
+     * @return the last used timestamp
+     */
+    long lastUsedTimestamp();
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
@@ -18,6 +18,10 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import java.util.Map;
+
+import org.neo4j.driver.v1.Value;
+
 public interface PooledConnection extends Connection
 {
     /**
@@ -45,4 +49,35 @@ public interface PooledConnection extends Connection
      * @return the last used timestamp
      */
     long lastUsedTimestamp();
+
+    // Override the methods to not throw any exceptions
+    @Override
+    void init( String clientName, Map<String,Value> authToken );
+
+    @Override
+    void run( String statement, Map<String,Value> parameters, Collector collector );
+
+    @Override
+    void discardAll( Collector collector );
+
+    @Override
+    void pullAll( Collector collector );
+
+    @Override
+    void reset();
+
+    @Override
+    void ackFailure();
+
+    @Override
+    void sync();
+
+    @Override
+    void flush();
+
+    @Override
+    void receiveOne();
+
+    @Override
+    void resetAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/SummaryBuilder.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.driver.internal.exceptions.InternalNeo4jException;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.Notification;
 import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
@@ -149,7 +149,7 @@ public class SummaryBuilder implements Collector
     }
 
     @Override
-    public void doneFailure( Neo4jException erro )
+    public void doneFailure( InternalNeo4jException erro )
     {
         // intentionally empty
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -23,9 +23,8 @@ import org.mockito.InOrder;
 
 import java.util.Collections;
 import java.util.Map;
-
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Value;
 
 import static org.mockito.Matchers.any;
@@ -43,7 +42,7 @@ public class ExplicitTransactionTest
     public void shouldRollbackOnImplicitFailure() throws Throwable
     {
         // Given
-        Connection conn = mock( Connection.class );
+        PooledConnection conn = mock( PooledConnection.class );
         when( conn.isOpen() ).thenReturn( true );
         Runnable cleanup = mock( Runnable.class );
         ExplicitTransaction tx = new ExplicitTransaction( conn, cleanup );
@@ -67,7 +66,7 @@ public class ExplicitTransactionTest
     public void shouldRollbackOnExplicitFailure() throws Throwable
     {
         // Given
-        Connection conn = mock( Connection.class );
+        PooledConnection conn = mock( PooledConnection.class );
         when( conn.isOpen() ).thenReturn( true );
         Runnable cleanup = mock( Runnable.class );
         ExplicitTransaction tx = new ExplicitTransaction( conn, cleanup );
@@ -93,7 +92,7 @@ public class ExplicitTransactionTest
     public void shouldCommitOnSuccess() throws Throwable
     {
         // Given
-        Connection conn = mock( Connection.class );
+        PooledConnection conn = mock( PooledConnection.class );
         when( conn.isOpen() ).thenReturn( true );
         Runnable cleanup = mock( Runnable.class );
         ExplicitTransaction tx = new ExplicitTransaction( conn, cleanup );
@@ -118,7 +117,7 @@ public class ExplicitTransactionTest
     @Test
     public void shouldOnlyQueueMessagesWhenNoBookmarkGiven()
     {
-        Connection connection = mock( Connection.class );
+        PooledConnection connection = mock( PooledConnection.class );
 
         new ExplicitTransaction( connection, mock( Runnable.class ), null );
 
@@ -132,7 +131,7 @@ public class ExplicitTransactionTest
     public void shouldSyncWhenBookmarkGiven()
     {
         String bookmark = "hi, I'm bookmark";
-        Connection connection = mock( Connection.class );
+        PooledConnection connection = mock( PooledConnection.class );
 
         new ExplicitTransaction( connection, mock( Runnable.class ), bookmark );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
@@ -31,7 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
@@ -167,7 +167,7 @@ public class ExtractTest
     public void testFields() throws Exception
     {
         // GIVEN
-        Connection connection = mock( Connection.class );
+        PooledConnection connection = mock( PooledConnection.class );
         String statement = "<unknown>";
 
         InternalStatementResult cursor = new InternalStatementResult( connection, null, new Statement( statement ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
@@ -19,17 +19,17 @@
 package org.neo4j.driver.internal;
 
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import org.neo4j.driver.internal.spi.Connection;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -39,7 +39,6 @@ import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.util.Pair;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertFalse;
@@ -50,7 +49,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.driver.v1.Records.column;
 import static org.neo4j.driver.v1.Values.ofString;
 import static org.neo4j.driver.v1.Values.value;
@@ -388,7 +386,7 @@ public class InternalStatementResultTest
 
     private StatementResult createResult( int numberOfRecords )
     {
-        Connection connection = mock( Connection.class );
+        PooledConnection connection = mock( PooledConnection.class );
         String statement = "<unknown>";
 
         final InternalStatementResult cursor = new InternalStatementResult( connection, null, new Statement( statement ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionFactoryTest.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal;
 
 import org.junit.Test;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
@@ -35,7 +35,7 @@ public class LeakLoggingNetworkSessionFactoryTest
     {
         SessionFactory factory = new LeakLoggingNetworkSessionFactory( mock( Logging.class ) );
 
-        Session session = factory.newInstance( mock( Connection.class ) );
+        Session session = factory.newInstance( mock( PooledConnection.class ) );
 
         assertThat( session, instanceOf( LeakLoggingNetworkSession.class ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -25,7 +25,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Session;
 
@@ -83,9 +83,9 @@ public class LeakLoggingNetworkSessionTest
         finalizeMethod.invoke( session );
     }
 
-    private static Connection connectionMock( boolean open )
+    private static PooledConnection connectionMock( boolean open )
     {
-        Connection connection = mock( Connection.class );
+        PooledConnection connection = mock( PooledConnection.class );
         when( connection.isOpen() ).thenReturn( open );
         return connection;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionFactoryTest.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal;
 
 import org.junit.Test;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Session;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -34,7 +34,7 @@ public class NetworkSessionFactoryTest
     {
         SessionFactory factory = new NetworkSessionFactory();
 
-        Session session = factory.newInstance( mock( Connection.class ) );
+        Session session = factory.newInstance( mock( PooledConnection.class ) );
 
         assertThat( session, instanceOf( NetworkSession.class ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -22,7 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -40,7 +40,7 @@ public class NetworkSessionTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private final Connection mock = mock( Connection.class );
+    private final PooledConnection mock = mock( PooledConnection.class );
     private NetworkSession sess = new NetworkSession( mock );
 
     @Test
@@ -143,7 +143,7 @@ public class NetworkSessionTest
     public void shouldGetExceptionIfTryingToCloseSessionMoreThanOnce() throws Throwable
     {
         // Given
-        NetworkSession sess = new NetworkSession( mock(Connection.class) );
+        NetworkSession sess = new NetworkSession( mock(PooledConnection.class) );
         try
         {
             sess.close();

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Config;
@@ -361,15 +361,15 @@ public class RoutingDriverTest
     {
         ConnectionPool pool = mock( ConnectionPool.class );
 
-        when( pool.acquire( any( BoltServerAddress.class ) ) ).thenAnswer( new Answer<Connection>()
+        when( pool.acquire( any( BoltServerAddress.class ) ) ).thenAnswer( new Answer<PooledConnection>()
         {
             int answer;
 
             @Override
-            public Connection answer( InvocationOnMock invocationOnMock ) throws Throwable
+            public PooledConnection answer( InvocationOnMock invocationOnMock ) throws Throwable
             {
                 BoltServerAddress address = invocationOnMock.getArgumentAt( 0, BoltServerAddress.class );
-                Connection connection = mock( Connection.class );
+                PooledConnection connection = mock( PooledConnection.class );
                 when( connection.isOpen() ).thenReturn( true );
                 when( connection.boltServerAddress() ).thenReturn( address );
                 doAnswer( withKeys( "ttl", "servers" ) ).when( connection ).run(

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingNetworkSessionTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import java.util.Map;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -46,14 +46,14 @@ import static org.mockito.Mockito.when;
 
 public class RoutingNetworkSessionTest
 {
-    private Connection connection;
+    private PooledConnection connection;
     private RoutingErrorHandler onError;
     private static final BoltServerAddress LOCALHOST = new BoltServerAddress( "localhost", 7687 );
 
     @Before
     public void setUp()
     {
-        connection = mock( Connection.class );
+        connection = mock( PooledConnection.class );
         when( connection.boltServerAddress() ).thenReturn( LOCALHOST );
         when( connection.isOpen() ).thenReturn( true );
         onError = mock( RoutingErrorHandler.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingTransactionTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 public class RoutingTransactionTest
 {
     private static final BoltServerAddress LOCALHOST = new BoltServerAddress( "localhost", 7687 );
-    private Connection connection;
+    private PooledConnection connection;
     private RoutingErrorHandler onError;
     private Runnable cleanup;
 
@@ -77,7 +77,7 @@ public class RoutingTransactionTest
     @Before
     public void setUp()
     {
-        connection = mock( Connection.class );
+        connection = mock( PooledConnection.class );
         when( connection.boltServerAddress() ).thenReturn( LOCALHOST );
         when( connection.isOpen() ).thenReturn( true );
         onError = mock( RoutingErrorHandler.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import org.neo4j.driver.internal.EventHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Value;
@@ -55,7 +55,7 @@ import static org.neo4j.driver.v1.Values.value;
 public class ClusterCompositionProviderTest
 {
     private final FakeClock clock = new FakeClock( (EventHandler) null, true );
-    private final Connection connection = mock( Connection.class );
+    private final PooledConnection connection = mock( PooledConnection.class );
 
     @Test
     public void shouldParseClusterComposition() throws Exception

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterTopology.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterTopology.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import org.neo4j.driver.internal.Event;
 import org.neo4j.driver.internal.EventHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 
 import static java.util.Arrays.asList;
@@ -138,7 +138,7 @@ class ClusterTopology implements ClusterComposition.Provider
     }
 
     @Override
-    public ClusterComposition getClusterComposition( Connection connection )
+    public ClusterComposition getClusterComposition( PooledConnection connection )
     {
         BoltServerAddress router = connection.boltServerAddress();
         View view = views.get( router );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnectionTest.java
@@ -27,6 +27,7 @@ import org.mockito.stubbing.Answer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.driver.internal.exceptions.InternalException;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.Function;
@@ -78,7 +79,8 @@ public class ConcurrencyGuardingConnectionTest
                     operation.apply( conn.get() );
                     fail("Expected this call to fail, because it is calling a method on the connector while 'inside' " +
                          "a connector call already.");
-                } catch(ClientException e)
+                }
+                catch( ClientException e )
                 {
                     exception.set( e );
                 }
@@ -86,7 +88,7 @@ public class ConcurrencyGuardingConnectionTest
             }
         });
 
-        conn.set(new ConcurrencyGuardingConnection( delegate ));
+        conn.set( new ConcurrencyGuardingConnection( delegate ) );
 
         // When
         operation.apply( conn.get() );
@@ -130,7 +132,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.init(null, null);
+            try
+            {
+                connection.init(null, null);
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -140,7 +149,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.run(null, null, null);
+            try
+            {
+                connection.run(null, null, null);
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -150,7 +166,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.discardAll(null);
+            try
+            {
+                connection.discardAll(null);
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -160,7 +183,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.pullAll(null);
+            try
+            {
+                connection.pullAll(null);
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -170,7 +200,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.reset();
+            try
+            {
+                connection.reset();
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -180,7 +217,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.ackFailure();
+            try
+            {
+                connection.ackFailure();
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -190,7 +234,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.receiveOne();
+            try
+            {
+                connection.receiveOne();
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -200,7 +251,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.sync();
+            try
+            {
+                connection.sync();
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };
@@ -210,7 +268,14 @@ public class ConcurrencyGuardingConnectionTest
         @Override
         public Void apply( Connection connection )
         {
-            connection.flush();
+            try
+            {
+                connection.flush();
+            }
+            catch ( InternalException e )
+            {
+                // left empty on purpose
+            }
             return null;
         }
     };

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectorTest.java
@@ -70,7 +70,7 @@ public class SocketConnectorTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void connectSendsInit()
+    public void connectSendsInit() throws Throwable
     {
         String userAgent = "agentSmith";
         ConnectionSettings settings = new ConnectionSettings( basicAuthToken(), userAgent, CONNECTION_TIMEOUT );
@@ -102,7 +102,7 @@ public class SocketConnectorTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void connectClosesOpenedConnectionIfInitThrows()
+    public void connectClosesOpenedConnectionIfInitThrows() throws Throwable
     {
         Connection connection = mock( Connection.class );
         RuntimeException initError = new RuntimeException( "Init error" );
@@ -124,7 +124,7 @@ public class SocketConnectorTest
     }
 
     @Test
-    public void createsConnectionWithUsingConnectionSettings()
+    public void createsConnectionWithUsingConnectionSettings() throws Throwable
     {
         AuthToken authToken = AuthTokens.basic( "neo4j", "test" );
         String userAgent = "tester";

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -22,6 +22,7 @@ package org.neo4j.driver.internal.net.pooling;
 import org.junit.Test;
 
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logger;
@@ -159,9 +160,9 @@ public class BlockingPooledConnectionQueueTest
         doThrow( closeError2 ).when( connection2 ).close();
         doThrow( closeError3 ).when( connection3 ).close();
 
-        PooledConnection pooledConnection1 = new PooledConnection( connection1, mock( Consumer.class ), SYSTEM );
-        PooledConnection pooledConnection2 = new PooledConnection( connection2, mock( Consumer.class ), SYSTEM );
-        PooledConnection pooledConnection3 = new PooledConnection( connection3, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection1 = new PooledSocketConnection( connection1, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection2 = new PooledSocketConnection( connection2, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection3 = new PooledSocketConnection( connection3, mock( Consumer.class ), SYSTEM );
 
         queue.offer( pooledConnection1 );
         queue.offer( pooledConnection2 );
@@ -187,7 +188,7 @@ public class BlockingPooledConnectionQueueTest
         Connection connection = mock( Connection.class );
         RuntimeException closeError = new RuntimeException( "Fail" );
         doThrow( closeError ).when( connection ).close();
-        PooledConnection pooledConnection = new PooledConnection( connection, mock( Consumer.class ), SYSTEM );
+        PooledConnection pooledConnection = new PooledSocketConnection( connection, mock( Consumer.class ), SYSTEM );
         queue.offer( pooledConnection );
 
         queue.terminate();

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/ConnectionInvalidationTest.java
@@ -28,6 +28,7 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumers;
 import org.neo4j.driver.v1.Value;
@@ -57,7 +58,7 @@ public class ConnectionInvalidationTest
     private final Clock clock = mock( Clock.class );
 
     private final PooledConnection conn =
-            new PooledConnection( delegate, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
+            new PooledSocketConnection( delegate, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
 
     @SuppressWarnings( "unchecked" )
     @Test
@@ -66,7 +67,7 @@ public class ConnectionInvalidationTest
         // Given a connection that's broken
         Mockito.doThrow( new ClientException( "That didn't work" ) )
                 .when( delegate ).run( anyString(), anyMap(), any( Collector.class ) );
-        PooledConnection conn = new PooledConnection( delegate, Consumers.<PooledConnection>noOp(), clock );
+        PooledConnection conn = new PooledSocketConnection( delegate, Consumers.<PooledConnection>noOp(), clock );
         PooledConnectionValidator validator = new PooledConnectionValidator( pool( true ) );
 
         // When/Then
@@ -98,7 +99,7 @@ public class ConnectionInvalidationTest
     {
         // Given a connection that's broken
         Mockito.doThrow( new ClientException( "That didn't work" ) ).when( delegate ).reset();
-        PooledConnection conn = new PooledConnection( delegate, Consumers.<PooledConnection>noOp(), clock );
+        PooledConnection conn = new PooledSocketConnection( delegate, Consumers.<PooledConnection>noOp(), clock );
         PooledConnectionValidator validator = new PooledConnectionValidator( pool( true ) );
         // When/Then
         BlockingPooledConnectionQueue

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionValidator;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.Logging;
@@ -59,7 +60,7 @@ public class PooledConnectionTest
         PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, INVALID_CONNECTION );
 
 
-        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+        PooledConnection pooledConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
             @Override
             public void dispose()
@@ -87,7 +88,7 @@ public class PooledConnectionTest
         Connection conn = mock( Connection.class );
         PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION );
 
-                PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+                PooledConnection pooledConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
             @Override
             public void dispose()
@@ -117,8 +118,8 @@ public class PooledConnectionTest
         Connection conn = mock( Connection.class );
         PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
-        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM );
-        PooledConnection shouldBeClosedConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+        PooledConnection pooledConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM );
+        PooledConnection shouldBeClosedConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
             @Override
             public void dispose()
@@ -204,7 +205,7 @@ public class PooledConnectionTest
         Connection conn = mock( Connection.class );
         PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
-        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+        PooledConnection pooledConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
             @Override
             public void dispose()
@@ -233,7 +234,7 @@ public class PooledConnectionTest
 
         PooledConnectionReleaseConsumer releaseConsumer = new PooledConnectionReleaseConsumer( pool, VALID_CONNECTION);
 
-        PooledConnection pooledConnection = new PooledConnection( conn, releaseConsumer, Clock.SYSTEM )
+        PooledConnection pooledConnection = new PooledSocketConnection( conn, releaseConsumer, Clock.SYSTEM )
         {
             @Override
             public void dispose()
@@ -257,7 +258,7 @@ public class PooledConnectionTest
         Connection conn = mock( Connection.class );
         ClientException error = new ClientException( "Neo.ClientError", "a recoverable error" );
         doThrow( error ).when( conn ).sync();
-        PooledConnection pooledConnection = new PooledConnection(
+        PooledConnection pooledConnection = new PooledSocketConnection(
                 conn,
                 mock( PooledConnectionReleaseConsumer.class ),
                 mock( Clock.class ) );
@@ -284,7 +285,7 @@ public class PooledConnectionTest
         Connection conn = mock( Connection.class );
         ClientException error = new ClientException( "an unrecoverable error" );
         doThrow( error ).when( conn ).sync();
-        PooledConnection pooledConnection = new PooledConnection(
+        PooledConnection pooledConnection = new PooledSocketConnection(
                 conn,
                 mock( PooledConnectionReleaseConsumer.class ),
                 mock( Clock.class ) );
@@ -315,7 +316,7 @@ public class PooledConnectionTest
                 "Invalid server response message `FAILURE` received for client message `ACK_FAILURE`." );
         doThrow( error ).doThrow( failedToAckFailError ).when( conn ).sync();
 
-        PooledConnection pooledConnection = new PooledConnection(
+        PooledConnection pooledConnection = new PooledSocketConnection(
                 conn,
                 mock( PooledConnectionReleaseConsumer.class ),
                 mock( Clock.class ) );
@@ -353,7 +354,7 @@ public class PooledConnectionTest
         PooledConnectionReleaseConsumer releaseConsumer = mock( PooledConnectionReleaseConsumer.class );
         Clock clock = when( mock( Clock.class ).millis() ).thenReturn( 42L ).getMock();
 
-        PooledConnection connection = new PooledConnection( mock( Connection.class ), releaseConsumer, clock );
+        PooledConnection connection = new PooledSocketConnection( mock( Connection.class ), releaseConsumer, clock );
 
         assertEquals( 42L, connection.lastUsedTimestamp() );
     }
@@ -365,7 +366,7 @@ public class PooledConnectionTest
         Clock clock = when( mock( Clock.class ).millis() )
                 .thenReturn( 42L ).thenReturn( 4242L ).thenReturn( 424242L ).getMock();
 
-        PooledConnection connection = new PooledConnection( mock( Connection.class ), releaseConsumer, clock );
+        PooledConnection connection = new PooledSocketConnection( mock( Connection.class ), releaseConsumer, clock );
 
         assertEquals( 42, connection.lastUsedTimestamp() );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.net.SocketConnection;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumers;
@@ -178,7 +179,7 @@ public class PooledConnectionValidatorTest
 
     private static PooledConnection newPooledConnection( Connection connection )
     {
-        return new PooledConnection( connection, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
+        return new PooledSocketConnection( connection, Consumers.<PooledConnection>noOp(), Clock.SYSTEM );
     }
 
     private static ConnectionPool connectionPoolMock( boolean knowsAddressed )

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionValidatorTest.java
@@ -59,7 +59,7 @@ import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 public class PooledConnectionValidatorTest
 {
     @Test
-    public void isNotReusableWhenPoolHasNoAddress()
+    public void isNotReusableWhenPoolHasNoAddress() throws Throwable
     {
         Connection connection = mock( Connection.class );
         PooledConnection pooledConnection = newPooledConnection( connection );
@@ -73,7 +73,7 @@ public class PooledConnectionValidatorTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void isNotReusableWhenHasUnrecoverableErrors()
+    public void isNotReusableWhenHasUnrecoverableErrors() throws Throwable
     {
         Connection connection = mock( Connection.class );
         DatabaseException runError = new DatabaseException( "", "" );
@@ -100,7 +100,7 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void resetAndSyncValidConnectionWhenCheckingIfReusable()
+    public void resetAndSyncValidConnectionWhenCheckingIfReusable() throws Throwable
     {
         Connection connection = mock( Connection.class );
         PooledConnection pooledConnection = newPooledConnection( connection );
@@ -137,7 +137,7 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void isConnectedReturnsFalseWhenResetFails()
+    public void isConnectedReturnsFalseWhenResetFails() throws Throwable
     {
         Connection connection = mock( Connection.class );
         doThrow( new RuntimeException() ).when( connection ).reset();
@@ -151,7 +151,7 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void isConnectedReturnsFalseWhenSyncFails()
+    public void isConnectedReturnsFalseWhenSyncFails() throws Throwable
     {
         Connection connection = mock( Connection.class );
         doThrow( new RuntimeException() ).when( connection ).sync();
@@ -165,7 +165,7 @@ public class PooledConnectionValidatorTest
     }
 
     @Test
-    public void isConnectedReturnsTrueWhenUnderlyingConnectionWorks()
+    public void isConnectedReturnsTrueWhenUnderlyingConnectionWorks() throws Throwable
     {
         Connection connection = mock( Connection.class );
         PooledConnection pooledConnection = newPooledConnection( connection );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
@@ -40,6 +40,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.Connector;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.FakeClock;
+import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.v1.Logging;
 
 import static java.util.Collections.newSetFromMap;

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
@@ -285,7 +285,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void recentlyUsedConnectionNotValidatedDuringAcquisition()
+    public void recentlyUsedConnectionNotValidatedDuringAcquisition() throws Throwable
     {
         long idleTimeBeforeConnectionTest = 100;
         long creationTimestamp = 42;
@@ -318,7 +318,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void connectionThatWasIdleForALongTimeIsValidatedDuringAcquisition()
+    public void connectionThatWasIdleForALongTimeIsValidatedDuringAcquisition() throws Throwable
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         long idleTimeBeforeConnectionTest = 100;
@@ -346,7 +346,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void connectionThatWasIdleForALongTimeIsNotValidatedDuringAcquisitionWhenTimeoutNotConfigured()
+    public void connectionThatWasIdleForALongTimeIsNotValidatedDuringAcquisitionWhenTimeoutNotConfigured() throws Throwable
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         long idleTimeBeforeConnectionTest = PoolSettings.NO_IDLE_CONNECTION_TEST;
@@ -372,7 +372,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void brokenConnectionsSkippedDuringAcquisition()
+    public void brokenConnectionsSkippedDuringAcquisition() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -405,7 +405,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void limitedNumberOfBrokenConnectionsIsSkippedDuringAcquisition()
+    public void limitedNumberOfBrokenConnectionsIsSkippedDuringAcquisition() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -449,7 +449,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void acquireRetriesUntilAConnectionIsCreated()
+    public void acquireRetriesUntilAConnectionIsCreated() throws Throwable
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/spi/StubConnectionPool.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/spi/StubConnectionPool.java
@@ -18,6 +18,10 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,13 +29,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-
 import org.neo4j.driver.internal.EventHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.internal.net.pooling.PooledConnection;
+import org.neo4j.driver.internal.net.pooling.PooledSocketConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -164,14 +164,14 @@ public class StubConnectionPool implements ConnectionPool
     }
 
     @Override
-    public Connection acquire( BoltServerAddress address )
+    public PooledConnection acquire( BoltServerAddress address )
     {
         if ( hosts.replace( address, State.CONNECTED ) == null )
         {
             events.connectionFailure( address );
             throw new ServiceUnavailableException( "Host unavailable: " + address );
         }
-        Connection connection = new StubConnection( address, factory.apply( address ), events, clock );
+        PooledConnection connection = new StubConnection( address, factory.apply( address ), events, clock );
         events.acquire( address, connection );
         return connection;
     }
@@ -204,7 +204,7 @@ public class StubConnectionPool implements ConnectionPool
         hosts.clear();
     }
 
-    private static class StubConnection extends PooledConnection
+    private static class StubConnection extends PooledSocketConnection
     {
         private final BoltServerAddress address;
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
@@ -28,6 +28,7 @@ import java.security.GeneralSecurityException;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import org.neo4j.driver.internal.exceptions.InternalNeo4jException;
 import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.messaging.InitMessage;
 import org.neo4j.driver.internal.messaging.Message;
@@ -83,7 +84,7 @@ public class SocketClientIT
         when( handler.protocolViolationErrorOccurred() ).thenReturn( true );
         when( handler.collectorsWaiting() ).thenReturn( 2, 1, 0 );
         when( handler.serverFailure() ).thenReturn(
-                new ClientException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
+                new InternalNeo4jException( "Neo.ClientError.Request.InvalidFormat", "Hello, world!" ) );
 
         // When & Then
         client.start();


### PR DESCRIPTION
Session will hold a PooledConnection rather than Connect after this change.
This PR is a start step to introduce internal checked errors.