### PR TITLE
Tls connections throw ServiceUnavaliable after restart of server

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.internal.util.BytePrinter;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
@@ -163,7 +164,8 @@ public class TLSSocketChannel implements ByteChannel
          */
         if ( channel.read( cipherIn ) < 0 )
         {
-            throw new ClientException( "SSL Connection terminated while receiving data. " +
+            throw new ServiceUnavailableException(
+                    "SSL Connection terminated while receiving data. " +
                     "This can happen due to network instabilities, or due to restarts of the database." );
         }
         cipherIn.flip();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
@@ -57,16 +57,16 @@ public class ServerKilledIT
     @Parameters(name = "{0} connections")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "plaintext", Config.build().withEncryptionLevel( Config.EncryptionLevel.NONE ) },
-                { "tls encrypted", Config.build().withEncryptionLevel( Config.EncryptionLevel.REQUIRED ) }
+                { "plaintext", Config.EncryptionLevel.NONE },
+                { "tls encrypted", Config.EncryptionLevel.REQUIRED }
         });
     }
 
-    private Config.ConfigBuilder configBuilder;
+    private Config.EncryptionLevel encryptionLevel;
 
-    public ServerKilledIT( String testName, Config.ConfigBuilder configBuilder )
+    public ServerKilledIT( String testName, Config.EncryptionLevel encryptionLevel )
     {
-        this.configBuilder = configBuilder;
+        this.encryptionLevel = encryptionLevel;
     }
 
     @Test
@@ -74,7 +74,7 @@ public class ServerKilledIT
     {
         // Given
         // config with sessionLivenessCheckTimeout not set, i.e. turned off
-        Config config = configBuilder.toConfig();
+        Config config = Config.build().withEncryptionLevel( encryptionLevel ).toConfig();
 
         try ( Driver driver = GraphDatabase.driver( Neo4jRunner.DEFAULT_URI, config ) )
         {
@@ -113,7 +113,7 @@ public class ServerKilledIT
     {
         // config with set liveness check timeout
         int livenessCheckTimeoutMinutes = 10;
-        Config config = configBuilder
+        Config config = Config.build().withEncryptionLevel( encryptionLevel )
                 .withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES )
                 .toConfig();
 


### PR DESCRIPTION
Fixed the bug where tls connections are failed with ClientException, while  plaintext connections are failed with ServiceUnav when server restart.
#302 