### PR TITLE
Added --allow-script-in-comments to javadoc config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
             <script>hljs.initHighlightingOnLoad();</script>
           ]]></top>
           <!-- Required for Java 8u121 or later. See https://github.com/neo4j/neo4j-java-driver/pull/318  -->
-          <!--<additionalparam>--allow-script-in-comments</additionalparam>-->
+          <!--<additionalparam>&#45;&#45;allow-script-in-comments</additionalparam>-->
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,8 @@
             <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script>
             <script>hljs.initHighlightingOnLoad();</script>
           ]]></top>
-          <additionalparam>--allow-script-in-comments</additionalparam>
+          <!-- Required for Java 8u121 or later. See https://github.com/neo4j/neo4j-java-driver/pull/318  -->
+          <!--<additionalparam>--allow-script-in-comments</additionalparam>-->
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
             <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script>
             <script>hljs.initHighlightingOnLoad();</script>
           ]]></top>
+          <additionalparam>--allow-script-in-comments</additionalparam>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Since Java 8u121, JavaScript is disabled in JavaDoc's by default (http://www.oracle.com/technetwork/java/javase/8u121-relnotes-3315208.html), failing build. To fix this JavaScript should be enabled explicitly with a flag --allow-script-in-comments.