### PR TITLE
Ensure content also contains the last element

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceSteps.java
@@ -141,7 +141,9 @@ public class DriverComplianceSteps
     @Given( "^a list containing$" )
     public static void a_list_containing( List<String> table ) throws Throwable
     {
-        List<String> content = table.subList( 1, table.size() - 1 );
+        List<String> content = table.subList( 1, table.size() );
+        assertThat( content.size(), equalTo( table.size() - 1 ) );
+
         for ( String value : content )
         {
             listOfObjects.add( getJavaValueIntAsLong( value ) );


### PR DESCRIPTION
Ensure content also contains the last element

The second parameter of subList is last index exclusive, so adding the "- 1" accidentally removed the last item from the list