### PR TITLE
Rename hashcode method to hashCode to override Object.hashCode()

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
@@ -41,7 +41,7 @@ public class InternalRecord extends InternalMapAccessorWithDefaultValue implemen
 {
     private final List<String> keys;
     private final Value[] values;
-    private int hashcode = 0;
+    private int hashCode = 0;
 
     public InternalRecord( List<String> keys, Value[] values )
     {
@@ -132,6 +132,7 @@ public class InternalRecord extends InternalMapAccessorWithDefaultValue implemen
         return format( "Record<%s>", formatPairs( InternalValue.Format.VALUE_ONLY, asMap( ofValue() ) ) );
     }
 
+    @Override
     public boolean equals( Object other )
     {
         if ( this == other )
@@ -167,12 +168,13 @@ public class InternalRecord extends InternalMapAccessorWithDefaultValue implemen
         }
     }
 
-    public int hashcode()
+    @Override
+    public int hashCode()
     {
-        if ( hashcode == 0 )
+        if ( hashCode == 0 )
         {
-            hashcode = 31 * keys.hashCode() + Arrays.hashCode( values );
+            hashCode = 31 * keys.hashCode() + Arrays.hashCode( values );
         }
-        return hashcode;
+        return hashCode;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Record.java
@@ -129,11 +129,4 @@ public interface Record extends MapAccessorWithDefaultValue
      */
     List<Pair<String, Value>> fields();
 
-    // Force implementation
-    @Override
-    boolean equals( Object other );
-
-    // Force implementation
-    @Override
-    int hashCode();
 }


### PR DESCRIPTION
The `hashCode()` method in the [`InternalRecord`](https://github.com/neo4j/neo4j-java-driver/blob/262224400350e0f9db41be7db5d75be8ed880f7a/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java#L170) class is spelt with a lowercase `c`, hence it is not executed when running `hashCode()`. Instead, the `Object.hashCode()` method is executed, which does not work well for `InternalRecord` instances and gives different hash values for tuples with the same key-value pairs.

This pull request fixes that by renaming the method appropriately.

Additionally, the [`Record`](https://github.com/neo4j/neo4j-java-driver/blob/262224400350e0f9db41be7db5d75be8ed880f7a/driver/src/main/java/org/neo4j/driver/v1/Record.java#L134) interface tries to enforce the implementation of `equals()` and `hashCode()`. However, it seems it is not possible to enforce the implementation of the these methods by using an interface - if they are not overridden in the class, the implementation of the `Object` method will be used.

As a minimal example, this interface and its implementation compile without errors.

```java
public interface MyInterface {

    @Override
    int hashCode();

}

public class MyImplementation implements MyInterface {

}
```

One could enforce their implementation is to use an abstract class. The following code does not compile.

```java
public abstract class MyAbstractClass {

    @Override
    public abstract int hashCode();

}


public class MyConcreteClass extends MyAbstractClass {

}
```

However, this solution cannot be applied to `Record` as the `InternalRecord` class already implements another class (`InternalMapAccessorWithDefaultValue`).

In this pull request, I also deleted the `@Override` definitions for `equals` and `hashCode` in the `Record` interface as they basically have no effect.