### PR TITLE
Remember initial routing address

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -143,7 +143,7 @@ public class DriverFactory
     protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool, Config config,
             RoutingSettings routingSettings )
     {
-        return new LoadBalancer( routingSettings, connectionPool, createClock(), config.logging(), address );
+        return new LoadBalancer( address, routingSettings, connectionPool, createClock(), config.logging() );
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -127,23 +127,17 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
         if ( routingTable.isStale() )
         {
             log.info( "Routing information is stale. %s", routingTable );
-            try
-            {
-                // get a new routing table
-                ClusterComposition cluster = rediscovery.lookupRoutingTable( connections, routingTable );
-                Set<BoltServerAddress> removed = routingTable.update( cluster );
-                // purge connections to removed addresses
-                for ( BoltServerAddress address : removed )
-                {
-                    connections.purge( address );
-                }
 
-                log.info( "Refreshed routing information. %s", routingTable );
-            }
-            catch ( InterruptedException e )
+            // get a new routing table
+            ClusterComposition cluster = rediscovery.lookupClusterComposition( connections, routingTable );
+            Set<BoltServerAddress> removed = routingTable.update( cluster );
+            // purge connections to removed addresses
+            for ( BoltServerAddress address : removed )
             {
-                throw new ServiceUnavailableException( "Thread was interrupted while establishing connection.", e );
+                connections.purge( address );
             }
+
+            log.info( "Refreshed routing information. %s", routingTable );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -345,7 +345,7 @@ public class RoutingDriverTest
     private Driver driverWithPool( ConnectionPool pool )
     {
         RoutingSettings settings = new RoutingSettings( 10, 5_000 );
-        ConnectionProvider connectionProvider = new LoadBalancer( settings, pool, clock, logging, SEED );
+        ConnectionProvider connectionProvider = new LoadBalancer( SEED, settings, pool, clock, logging );
         Config config = Config.build().withLogging( logging ).toConfig();
         SessionFactory sessionFactory = new NetworkSessionWithAddressFactory( connectionProvider, config );
         return new InternalDriver( insecure(), sessionFactory, logging );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
@@ -78,7 +78,7 @@ public class LoadBalancerTest
         // then
         assertNotNull( balancer );
         InOrder inOrder = inOrder( rediscovery, routingTable, conns );
-        inOrder.verify( rediscovery ).lookupRoutingTable( conns, routingTable );
+        inOrder.verify( rediscovery ).lookupClusterComposition( conns, routingTable );
         inOrder.verify( routingTable ).update( any( ClusterComposition.class ) );
         inOrder.verify( conns ).purge( new BoltServerAddress( "abc", 12 ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
@@ -73,7 +73,7 @@ public class LoadBalancerTest
         when( routingTable.update( any( ClusterComposition.class ) ) ).thenReturn( set );
 
         // when
-        LoadBalancer balancer = new LoadBalancer( routingTable, conns, rediscovery, DEV_NULL_LOGGER );
+        LoadBalancer balancer = new LoadBalancer( conns, routingTable, rediscovery, DEV_NULL_LOGGER );
 
         // then
         assertNotNull( balancer );
@@ -88,7 +88,7 @@ public class LoadBalancerTest
     {
         // given & when
         final AtomicInteger ensureRoutingCounter = new AtomicInteger( 0 );
-        LoadBalancer balancer = new LoadBalancer( mock( RoutingTable.class ), mock( ConnectionPool.class ),
+        LoadBalancer balancer = new LoadBalancer( mock( ConnectionPool.class ), mock( RoutingTable.class ),
                 mock( Rediscovery.class ), DEV_NULL_LOGGER )
         {
             @Override
@@ -143,7 +143,7 @@ public class LoadBalancerTest
         RoutingTable routingTable = mock( RoutingTable.class );
         ConnectionPool connectionPool = mock( ConnectionPool.class );
         Rediscovery rediscovery = mock( Rediscovery.class );
-        LoadBalancer loadBalancer = new LoadBalancer( routingTable, connectionPool, rediscovery, DEV_NULL_LOGGER );
+        LoadBalancer loadBalancer = new LoadBalancer( connectionPool, routingTable, rediscovery, DEV_NULL_LOGGER );
         BoltServerAddress address = new BoltServerAddress( "host", 42 );
 
         PooledConnection connection = newConnectionWithFailingSync( address );
@@ -174,7 +174,7 @@ public class LoadBalancerTest
         PooledConnection connectionWithFailingSync = newConnectionWithFailingSync( address );
         when( connectionPool.acquire( any( BoltServerAddress.class ) ) ).thenReturn( connectionWithFailingSync );
         Rediscovery rediscovery = mock( Rediscovery.class );
-        LoadBalancer loadBalancer = new LoadBalancer( routingTable, connectionPool, rediscovery, DEV_NULL_LOGGER );
+        LoadBalancer loadBalancer = new LoadBalancer( connectionPool, routingTable, rediscovery, DEV_NULL_LOGGER );
 
         Session session = newSession( loadBalancer );
         // begin transaction to make session obtain a connection
@@ -205,7 +205,7 @@ public class LoadBalancerTest
         when( routingTable.readers() ).thenReturn( readerAddrs );
         when( routingTable.writers() ).thenReturn( writerAddrs );
 
-        return new LoadBalancer( routingTable, connPool, mock( Rediscovery.class ), DEV_NULL_LOGGER );
+        return new LoadBalancer( connPool, routingTable, mock( Rediscovery.class ), DEV_NULL_LOGGER );
     }
 
     private static Session newSession( LoadBalancer loadBalancer )

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -38,14 +38,16 @@ import org.neo4j.driver.v1.exceptions.ProtocolException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.fail;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,8 +58,10 @@ import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.D;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.E;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.F;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.INVALID_CLUSTER_COMPOSITION;
+import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.VALID_CLUSTER_COMPOSITION;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.createClusterComposition;
 import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
+import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
 
 @RunWith( Enclosed.class )
 public class RediscoveryTest
@@ -81,14 +85,14 @@ public class RediscoveryTest
             // given
             int maxRoutingFailures = 7;
             RoutingSettings settings = new RoutingSettings( maxRoutingFailures, 10 );
-
+            Clock clock = mock( Clock.class );
             RoutingTable routingTable = new TestRoutingTable( A );
 
             ClusterCompositionProvider mockedProvider = mock( ClusterCompositionProvider.class );
             when( mockedProvider.getClusterComposition( any( Connection.class ) ) )
                     .thenReturn( success( INVALID_CLUSTER_COMPOSITION ) );
 
-            Rediscovery rediscovery = new Rediscovery( settings, mock( Clock.class ), DEV_NULL_LOGGER, mockedProvider );
+            Rediscovery rediscovery = new Rediscovery( A, settings, clock, DEV_NULL_LOGGER, mockedProvider );
 
             // when
             try
@@ -123,7 +127,7 @@ public class RediscoveryTest
             ClusterCompositionProvider
                     mockedProvider = mock( ClusterCompositionProvider.class );
             when( mockedProvider.getClusterComposition( healthyConn ) )
-                    .thenReturn( success( ClusterCompositionUtil.VALID_CLUSTER_COMPOSITION ) );
+                    .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
 
             // When
             ClusterComposition clusterComposition = rediscover( mockedConnections, routingTable, mockedProvider );
@@ -131,7 +135,7 @@ public class RediscoveryTest
             // Then
             assertThat( routingTable.removedRouters.size(), equalTo( 1 ) );
             assertThat( routingTable.removedRouters.get( 0 ), equalTo( A ) );
-            assertThat( clusterComposition, equalTo( ClusterCompositionUtil.VALID_CLUSTER_COMPOSITION ) );
+            assertThat( clusterComposition, equalTo( VALID_CLUSTER_COMPOSITION ) );
         }
     }
 
@@ -204,13 +208,13 @@ public class RediscoveryTest
                     mockedProvider = mock( ClusterCompositionProvider.class );
             when( mockedProvider.getClusterComposition( noWriterConn ) ).thenReturn( success( noWriters ) );
             when( mockedProvider.getClusterComposition( healthyConn ) )
-                    .thenReturn( success( ClusterCompositionUtil.VALID_CLUSTER_COMPOSITION ) );
+                    .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
 
             // When
             ClusterComposition clusterComposition = rediscover( mockedConnections, routingTable, mockedProvider );
 
             // Then
-            assertThat( clusterComposition, equalTo( ClusterCompositionUtil.VALID_CLUSTER_COMPOSITION ) );
+            assertThat( clusterComposition, equalTo( VALID_CLUSTER_COMPOSITION ) );
         }
 
         @Test
@@ -230,7 +234,7 @@ public class RediscoveryTest
             // When & THen
             try
             {
-                rediscover( mockedConnections, routingTable, mockedProvider );
+                rediscover( A, mockedConnections, routingTable, mockedProvider );
                 fail( "Expecting a failure but not triggered." );
             }
             catch( Exception e )
@@ -318,15 +322,139 @@ public class RediscoveryTest
         }
     }
 
-    private static ClusterComposition rediscover( ConnectionPool connections, RoutingTable routingTable,
-            ClusterCompositionProvider provider ) throws InterruptedException
+    public static class InitialRouterTest
     {
+        @Test
+        public void shouldNotTouchInitialRouterWhenSomePresentRouterResponds()
+        {
+            PooledConnection brokenConnection = mock( PooledConnection.class );
+            PooledConnection healthyConnection = mock( PooledConnection.class );
+            ConnectionPool connections = mock( ConnectionPool.class );
+            when( connections.acquire( B ) ).thenReturn( brokenConnection );
+            when( connections.acquire( C ) ).thenReturn( healthyConnection );
 
-        RoutingSettings defaultRoutingSettings = new RoutingSettings( 1, 0 );
+            ClusterCompositionProvider clusterComposition = mock( ClusterCompositionProvider.class );
+            when( clusterComposition.getClusterComposition( brokenConnection ) )
+                    .thenThrow( new ServiceUnavailableException( "Can't connect" ) );
+            when( clusterComposition.getClusterComposition( healthyConnection ) )
+                    .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
+
+            RoutingTable routingTable = new TestRoutingTable( B, C );
+
+            ClusterComposition composition = rediscover( A, connections, routingTable, clusterComposition );
+
+            assertEquals( VALID_CLUSTER_COMPOSITION, composition );
+
+            verify( clusterComposition ).getClusterComposition( brokenConnection );
+            verify( clusterComposition ).getClusterComposition( healthyConnection );
+            verify( connections, never() ).acquire( A );
+            verify( connections ).acquire( B );
+            verify( connections ).acquire( C );
+        }
+
+        @Test
+        public void shouldUseInitialRouterWhenNoneOfExistingRoutersRespond()
+        {
+            PooledConnection healthyConnection = mock( PooledConnection.class );
+            PooledConnection brokenConnection1 = mock( PooledConnection.class );
+            PooledConnection brokenConnection2 = mock( PooledConnection.class );
+            ConnectionPool connections = mock( ConnectionPool.class );
+            when( connections.acquire( A ) ).thenReturn( healthyConnection );
+            when( connections.acquire( B ) ).thenReturn( brokenConnection1 );
+            when( connections.acquire( C ) ).thenReturn( brokenConnection2 );
+
+            ClusterCompositionProvider clusterComposition = mock( ClusterCompositionProvider.class );
+            when( clusterComposition.getClusterComposition( healthyConnection ) )
+                    .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
+            when( clusterComposition.getClusterComposition( brokenConnection1 ) )
+                    .thenThrow( new ServiceUnavailableException( "Can't connect" ) );
+            when( clusterComposition.getClusterComposition( brokenConnection2 ) )
+                    .thenThrow( new ServiceUnavailableException( "Can't connect" ) );
+
+            RoutingTable routingTable = new TestRoutingTable( B, C );
+
+            ClusterComposition composition = rediscover( A, connections, routingTable, clusterComposition );
+
+            assertEquals( VALID_CLUSTER_COMPOSITION, composition );
+
+            verify( clusterComposition ).getClusterComposition( brokenConnection1 );
+            verify( clusterComposition ).getClusterComposition( brokenConnection2 );
+            verify( clusterComposition ).getClusterComposition( healthyConnection );
+            verify( connections ).acquire( A );
+            verify( connections ).acquire( B );
+            verify( connections ).acquire( C );
+        }
+
+        @Test
+        public void shouldUseInitialRouterWhenNoExistingRouters()
+        {
+            PooledConnection connection = mock( PooledConnection.class );
+            ConnectionPool connections = mock( ConnectionPool.class );
+            when( connections.acquire( A ) ).thenReturn( connection );
+
+            ClusterCompositionProvider clusterComposition = mock( ClusterCompositionProvider.class );
+            when( clusterComposition.getClusterComposition( connection ) )
+                    .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
+
+            // empty routing table
+            RoutingTable routingTable = new TestRoutingTable();
+
+            ClusterComposition composition = rediscover( A, connections, routingTable, clusterComposition );
+
+            assertEquals( VALID_CLUSTER_COMPOSITION, composition );
+
+            verify( clusterComposition ).getClusterComposition( connection );
+            verify( connections ).acquire( A );
+        }
+
+        @Test
+        public void shouldNotUseInitialRouterTwiceIfRoutingTableContainsIt()
+        {
+            PooledConnection brokenConnection1 = mock( PooledConnection.class );
+            PooledConnection brokenConnection2 = mock( PooledConnection.class );
+            ConnectionPool connections = mock( ConnectionPool.class );
+            when( connections.acquire( A ) ).thenReturn( brokenConnection1 );
+            when( connections.acquire( B ) ).thenReturn( brokenConnection2 );
+
+            ClusterCompositionProvider clusterComposition = mock( ClusterCompositionProvider.class );
+            when( clusterComposition.getClusterComposition( brokenConnection1 ) )
+                    .thenThrow( new ServiceUnavailableException( "Can't connect" ) );
+            when( clusterComposition.getClusterComposition( brokenConnection2 ) )
+                    .thenThrow( new ServiceUnavailableException( "Can't connect" ) );
+
+            RoutingTable routingTable = new TestRoutingTable( A, B );
+
+            try
+            {
+                rediscover( B, connections, routingTable, clusterComposition );
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( ServiceUnavailableException.class ) );
+            }
+
+            verify( clusterComposition ).getClusterComposition( brokenConnection1 );
+            verify( clusterComposition ).getClusterComposition( brokenConnection2 );
+            verify( connections ).acquire( A );
+            verify( connections ).acquire( B );
+        }
+    }
+
+    private static ClusterComposition rediscover( ConnectionPool connections, RoutingTable routingTable,
+            ClusterCompositionProvider provider )
+    {
+        return rediscover( LOCAL_DEFAULT, connections, routingTable, provider );
+    }
+
+    private static ClusterComposition rediscover( BoltServerAddress initialRouter, ConnectionPool connections,
+            RoutingTable routingTable, ClusterCompositionProvider provider )
+    {
+        RoutingSettings settings = new RoutingSettings( 1, 0 );
         Clock mockedClock = mock( Clock.class );
         Logger mockedLogger = mock( Logger.class );
 
-        Rediscovery rediscovery = new Rediscovery( defaultRoutingSettings, mockedClock, mockedLogger, provider );
+        Rediscovery rediscovery = new Rediscovery( initialRouter, settings, mockedClock, mockedLogger, provider );
         return rediscovery.lookupClusterComposition( connections, routingTable );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -93,7 +93,7 @@ public class RediscoveryTest
             // when
             try
             {
-                rediscovery.lookupRoutingTable( mock( ConnectionPool.class ), routingTable );
+                rediscovery.lookupClusterComposition( mock( ConnectionPool.class ), routingTable );
                 fail("Should fail as failed to discovery");
             }
             catch( ServiceUnavailableException e )
@@ -327,7 +327,7 @@ public class RediscoveryTest
         Logger mockedLogger = mock( Logger.class );
 
         Rediscovery rediscovery = new Rediscovery( defaultRoutingSettings, mockedClock, mockedLogger, provider );
-        return rediscovery.lookupRoutingTable( connections, routingTable );
+        return rediscovery.lookupClusterComposition( connections, routingTable );
     }
 
     private static class TestRoutingTable extends ClusterRoutingTable

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
@@ -315,7 +315,7 @@ public class RoutingPooledConnectionErrorHandlingTest
 
     private static LoadBalancer newLoadBalancer( RoutingTable routingTable, ConnectionPool connectionPool )
     {
-        return new LoadBalancer( routingTable, connectionPool, mock( Rediscovery.class ), DEV_NULL_LOGGER );
+        return new LoadBalancer( connectionPool, routingTable, mock( Rediscovery.class ), DEV_NULL_LOGGER );
     }
 
     private interface ConnectionMethod

--- a/driver/src/test/resources/rediscover_using_initial_router.script
+++ b/driver/src/test/resources/rediscover_using_initial_router.script
@@ -1,0 +1,15 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {}


### PR DESCRIPTION
Rediscovery procedure will try to contact initial router when all other routers have failed or current routing table does not have any routers.