### PR TITLE
Guard couple tests with assumption about bookmark support

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.TransientException;
+import org.neo4j.driver.v1.util.ServerVersion;
 import org.neo4j.driver.v1.util.TestNeo4jSession;
 
 import static java.util.Arrays.asList;
@@ -43,7 +44,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.driver.v1.util.ServerVersion.v3_1_0;
-import static org.neo4j.driver.v1.util.ServerVersion.version;
 
 public class BookmarkIT
 {
@@ -61,8 +61,8 @@ public class BookmarkIT
         driver = sessionRule.driver();
         session = sessionRule;
 
-        String version = session.run( "RETURN 1" ).consume().server().version();
-        assumeTrue( version( version ).greaterThanOrEqual( v3_1_0 ) );
+        ServerVersion serverVersion = ServerVersion.version( driver );
+        assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -44,6 +44,7 @@ import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.util.ServerVersion;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -60,12 +61,14 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.v1.Config.defaultConfig;
 import static org.neo4j.driver.v1.Values.parameters;
+import static org.neo4j.driver.v1.util.ServerVersion.v3_1_0;
 
 public class SessionIT
 {
@@ -551,6 +554,7 @@ public class SessionIT
         try ( Driver driver = newDriverWithoutRetries();
               Session session = driver.session() )
         {
+            assumeBookmarkSupport( driver );
             assertNull( session.lastBookmark() );
 
             long answer = session.readTransaction( new TransactionWork<Long>()
@@ -600,6 +604,7 @@ public class SessionIT
         try ( Driver driver = newDriverWithoutRetries();
               Session session = driver.session() )
         {
+            assumeBookmarkSupport( driver );
             assertNull( session.lastBookmark() );
 
             long answer = session.readTransaction( new TransactionWork<Long>()
@@ -654,6 +659,7 @@ public class SessionIT
         try ( Driver driver = newDriverWithoutRetries();
               Session session = driver.session() )
         {
+            assumeBookmarkSupport( driver );
             assertNull( session.lastBookmark() );
 
             try
@@ -723,6 +729,7 @@ public class SessionIT
         try ( Driver driver = newDriverWithoutRetries();
               Session session = driver.session() )
         {
+            assumeBookmarkSupport( driver );
             assertNull( session.lastBookmark() );
 
             long answer = session.readTransaction( new TransactionWork<Long>()
@@ -779,6 +786,7 @@ public class SessionIT
         try ( Driver driver = newDriverWithoutRetries();
               Session session = driver.session() )
         {
+            assumeBookmarkSupport( driver );
             assertNull( session.lastBookmark() );
 
             try
@@ -955,6 +963,12 @@ public class SessionIT
     private static ThrowingWork newThrowingWorkSpy( String query, int failures )
     {
         return spy( new ThrowingWork( query, failures ) );
+    }
+
+    private static void assumeBookmarkSupport( Driver driver )
+    {
+        ServerVersion serverVersion = ServerVersion.version( driver );
+        assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ) );
     }
 
     private static class ThrowingWork implements TransactionWork<Record>

--- a/driver/src/test/java/org/neo4j/driver/v1/util/ServerVersion.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/ServerVersion.java
@@ -21,6 +21,9 @@ package org.neo4j.driver.v1.util;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+
 import static java.lang.Integer.compare;
 
 public class ServerVersion
@@ -40,6 +43,15 @@ public class ServerVersion
     }
     public static final ServerVersion v3_1_0 = new ServerVersion(3, 1, 0);
     public static final ServerVersion v3_0_0 = new ServerVersion(3, 0, 0);
+
+    public static ServerVersion version( Driver driver )
+    {
+        try ( Session session = driver.session() )
+        {
+            String versionString = session.run( "RETURN 1" ).consume().server().version();
+            return version( versionString );
+        }
+    }
 
     public static ServerVersion version( String server )
     {


### PR DESCRIPTION
Some newly added tests check bookmark to assert that read transaction was committed. They failed when using Neo4j version earlier than 3.1.0 because those are not bookmark-aware. This commit guards such tests with JUnit assumption about bookmark support based on server version.