### PR TITLE
Reparent AuthEx

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.driver.v1.exceptions.SecurityException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
@@ -124,9 +125,9 @@ public class Rediscovery
         {
             response = provider.getClusterComposition( connection );
         }
-        catch ( SecurityException e )
+        catch ( AuthenticationException | SecurityException e )
         {
-            // auth error happened, terminate the discovery procedure immediately
+            // auth error or TLS error happened, terminate the discovery procedure immediately
             throw e;
         }
         catch ( Throwable t )

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/AuthenticationException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/AuthenticationException.java
@@ -25,7 +25,7 @@ package org.neo4j.driver.v1.exceptions;
  *
  * @since 1.1
  */
-public class AuthenticationException extends SecurityException
+public class AuthenticationException extends ClientException
 {
     public AuthenticationException( String code, String message )
     {

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/SecurityException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/SecurityException.java
@@ -27,12 +27,7 @@ package org.neo4j.driver.v1.exceptions;
  */
 public class SecurityException extends Neo4jException
 {
-    public SecurityException( String code, String message )
-    {
-        super( code, message );
-    }
-
-    public SecurityException( String message, Throwable t )
+    public SecurityException(String message, Throwable t )
     {
         super( message, t );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/security/TLSSocketChannelTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/TLSSocketChannelTest.java
@@ -107,7 +107,7 @@ public class TLSSocketChannelTest
     }
 
     @Test
-    public void shouldThrowUnauthorizedIfFailedToHandshake() throws Throwable
+    public void shouldThrowTLSExceptionIfFailedToHandshake() throws Throwable
     {
         // Given
         ByteChannel mockedChannel = mock( ByteChannel.class );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -30,7 +30,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.exceptions.SecurityException;
+import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.driver.v1.util.Neo4jSettings;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
@@ -79,7 +79,7 @@ public class CredentialsIT
         }
         catch ( Throwable e )
         {
-            assertThat( e, instanceOf( SecurityException.class ) );
+            assertThat( e, instanceOf( AuthenticationException.class ) );
             assertThat( e.getMessage(), containsString( "The client is unauthorized due to authentication failure." ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
@@ -50,8 +50,8 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.SecurityException;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.util.DaemonThreadFactory;
 import org.neo4j.driver.v1.util.cc.LocalOrRemoteClusterRule;
@@ -489,7 +489,7 @@ public class CausalClusteringStressIT
             }
             catch ( Exception e )
             {
-                assertThat( e, instanceOf( SecurityException.class ) );
+                assertThat( e, instanceOf( AuthenticationException.class ) );
                 assertThat( e.getMessage(), containsString( "authentication failure" ) );
 
                 ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass( Throwable.class );


### PR DESCRIPTION
Reparent `AuthenticationException` under `ClientException` since this originates on the server, not locally. `SecurityException` remains in use for local TLS failures.