### PR TITLE
Routing context in URI

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -157,7 +157,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
             Clock clock, Logger log )
     {
         ClusterCompositionProvider clusterComposition =
-                new GetServersProcedureClusterCompositionProvider( clock, log, settings );
+                new RoutingProcedureClusterCompositionProvider( clock, log, settings );
         return new Rediscovery( initialRouter, settings, clock, log, clusterComposition, new DnsResolver( log ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -59,7 +59,7 @@ public class Rediscovery
     {
         int failures = 0;
 
-        for ( long start = clock.millis(), delay = 0; ; delay = Math.max( settings.retryTimeoutDelay, delay * 2 ) )
+        for ( long start = clock.millis(), delay = 0; ; delay = Math.max( settings.retryTimeoutDelay(), delay * 2 ) )
         {
             long waitTime = start + delay - clock.millis();
             sleep( waitTime );
@@ -71,7 +71,7 @@ public class Rediscovery
                 return composition;
             }
 
-            if ( ++failures >= settings.maxRoutingFailures )
+            if ( ++failures >= settings.maxRoutingFailures() )
             {
                 throw new ServiceUnavailableException( NO_ROUTERS_AVAILABLE );
             }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
+public class RoutingContext
+{
+    public static final RoutingContext EMPTY = new RoutingContext();
+
+    private final Map<String,String> context;
+
+    private RoutingContext()
+    {
+        this.context = emptyMap();
+    }
+
+    public RoutingContext( URI uri )
+    {
+        this.context = unmodifiableMap( parseParameters( uri ) );
+    }
+
+    public boolean isDefined()
+    {
+        return !context.isEmpty();
+    }
+
+    public Map<String,String> asMap()
+    {
+        return context;
+    }
+
+    private static Map<String,String> parseParameters( URI uri )
+    {
+        String query = uri.getQuery();
+
+        if ( query == null || query.isEmpty() )
+        {
+            return emptyMap();
+        }
+
+        Map<String,String> parameters = new HashMap<>();
+        String[] pairs = query.split( "&" );
+        for ( String pair : pairs )
+        {
+            String[] keyValue = pair.split( "=" );
+            if ( keyValue.length != 2 )
+            {
+                throw new IllegalArgumentException(
+                        "Invalid parameters: '" + pair + "' in URI '" + uri + "'" );
+            }
+
+            String key = keyValue[0];
+            String value = keyValue[1];
+            String previousValue = parameters.put( key, value );
+
+            if ( previousValue != null )
+            {
+                throw new IllegalArgumentException(
+                        "Duplicated query parameters with key '" + key + "' in URI '" + uri + "'" );
+            }
+        }
+        return parameters;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingSettings.java
@@ -18,18 +18,41 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import java.util.Map;
-
 public class RoutingSettings
 {
-    final int maxRoutingFailures;
-    final long retryTimeoutDelay;
-    final Map<String, String> routingParameters;
+    private final int maxRoutingFailures;
+    private final long retryTimeoutDelay;
+    private final RoutingContext routingContext;
 
-    public RoutingSettings( int maxRoutingFailures, long retryTimeoutDelay, Map<String, String> routingParameters )
+    public RoutingSettings( int maxRoutingFailures, long retryTimeoutDelay )
+    {
+        this( maxRoutingFailures, retryTimeoutDelay, RoutingContext.EMPTY );
+    }
+
+    public RoutingSettings( int maxRoutingFailures, long retryTimeoutDelay, RoutingContext routingContext )
     {
         this.maxRoutingFailures = maxRoutingFailures;
         this.retryTimeoutDelay = retryTimeoutDelay;
-        this.routingParameters = routingParameters;
+        this.routingContext = routingContext;
+    }
+
+    public RoutingSettings withRoutingContext( RoutingContext newRoutingContext )
+    {
+        return new RoutingSettings( maxRoutingFailures, retryTimeoutDelay, newRoutingContext );
+    }
+
+    public int maxRoutingFailures()
+    {
+        return maxRoutingFailures;
+    }
+
+    public long retryTimeoutDelay()
+    {
+        return retryTimeoutDelay;
+    }
+
+    public RoutingContext routingContext()
+    {
+        return routingContext;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -19,7 +19,6 @@
 package org.neo4j.driver.v1;
 
 import java.io.File;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -33,7 +32,6 @@ import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.util.Immutable;
 import org.neo4j.driver.v1.util.Resource;
 
-import static java.util.Collections.EMPTY_MAP;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
 
 /**
@@ -76,8 +74,6 @@ public class Config
     private final int connectionTimeoutMillis;
     private final RetrySettings retrySettings;
 
-    private final Map<String, String> routingContext;
-
     private Config( ConfigBuilder builder)
     {
         this.logging = builder.logging;
@@ -92,8 +88,6 @@ public class Config
         this.routingRetryDelayMillis = builder.routingRetryDelayMillis;
         this.connectionTimeoutMillis = builder.connectionTimeoutMillis;
         this.retrySettings = builder.retrySettings;
-
-        this.routingContext = builder.routingContext;
     }
 
     /**
@@ -188,7 +182,7 @@ public class Config
 
     RoutingSettings routingSettings()
     {
-        return new RoutingSettings( routingFailureLimit, routingRetryDelayMillis, routingContext );
+        return new RoutingSettings( routingFailureLimit, routingRetryDelayMillis );
     }
 
     RetrySettings retrySettings()
@@ -211,7 +205,6 @@ public class Config
         private long routingRetryDelayMillis = TimeUnit.SECONDS.toMillis( 5 );
         private int connectionTimeoutMillis = (int) TimeUnit.SECONDS.toMillis( 5 );
         private RetrySettings retrySettings = RetrySettings.DEFAULT;
-        private Map<String,String> routingContext = EMPTY_MAP;
 
         private ConfigBuilder() {}
 
@@ -477,21 +470,6 @@ public class Config
                         "The max retry time may not be smaller than 0, but was %d %s.", value, unit ) );
             }
             this.retrySettings = new RetrySettings( maxRetryTimeMs );
-            return this;
-        }
-
-        /**
-         * Specify routing context that would be passed to server in getRoutingTable Procedure call for customized
-         * routing table reply.
-         * This parameter is only valid for the routing driver, a.k.a. the driver created use bolt+routing in URI
-         * scheme with 3.2+ Neo4j Casual Cluster servers.
-         * @param context The routing context to pass to getRoutingTable Procedure
-         * @since 1.3
-         * @return this builder
-         */
-        public ConfigBuilder withRoutingContext( Map<String, String> context )
-        {
-            this.routingContext = context;
             return this;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -149,8 +149,8 @@ public class RoutingDriverTest
         // Then
         catch ( ServiceUnavailableException e )
         {
-            assertThat( e.getMessage(), containsString( "Failed to run " +
-                    "'Statement{text='CALL dbms.cluster.routing.getServers', parameters={}}' on server." ) );
+            assertThat( e.getMessage(),
+                    containsString( "Failed to run 'CALL dbms.cluster.routing.getServers {}' on server." ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ProtocolException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -53,8 +54,8 @@ public class ClusterCompositionProviderTest
     public void shouldProtocolErrorWhenNoRecord() throws Throwable
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mock( Clock.class ),
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mock( Clock.class ),
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -82,8 +83,8 @@ public class ClusterCompositionProviderTest
     public void shouldProtocolErrorWhenMoreThanOneRecord() throws Throwable
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mock( Clock.class ),
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mock( Clock.class ),
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -111,8 +112,8 @@ public class ClusterCompositionProviderTest
     public void shouldProtocolErrorWhenUnparsableRecord() throws Throwable
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mock( Clock.class ),
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mock( Clock.class ),
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -140,9 +141,9 @@ public class ClusterCompositionProviderTest
     public void shouldProtocolErrorWhenNoRouters() throws Throwable
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
         Clock mockedClock = mock( Clock.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mockedClock,
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mockedClock,
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -175,9 +176,9 @@ public class ClusterCompositionProviderTest
     public void shouldProtocolErrorWhenNoReaders() throws Throwable
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
         Clock mockedClock = mock( Clock.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mockedClock,
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mockedClock,
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -211,8 +212,8 @@ public class ClusterCompositionProviderTest
     public void shouldPropagateConnectionFailureExceptions() throws Exception
     {
         // Given
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mock( Clock.class ),
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mock( Clock.class ),
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -242,8 +243,8 @@ public class ClusterCompositionProviderTest
     {
         // Given
         Clock mockedClock = mock( Clock.class );
-        GetServersProcedureRunner mockedRunner = mock( GetServersProcedureRunner.class );
-        ClusterCompositionProvider provider = new GetServersProcedureClusterCompositionProvider( mockedClock,
+        RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
+        ClusterCompositionProvider provider = new RoutingProcedureClusterCompositionProvider( mockedClock,
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
@@ -286,4 +287,10 @@ public class ClusterCompositionProviderTest
         return result;
     }
 
+    private static RoutingProcedureRunner newProcedureRunnerMock()
+    {
+        RoutingProcedureRunner mock = mock( RoutingProcedureRunner.class );
+        when( mock.invokedProcedure() ).thenReturn( new Statement( "procedure" ) );
+        return mock;
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RoutingContextTest
+{
+    @Test
+    public void emptyContextIsNotDefined()
+    {
+        assertFalse( RoutingContext.EMPTY.isDefined() );
+    }
+
+    @Test
+    public void emptyContextInEmptyMap()
+    {
+        assertTrue( RoutingContext.EMPTY.asMap().isEmpty() );
+    }
+
+    @Test
+    public void uriWithoutQueryIsParsedToEmptyContext()
+    {
+        URI uri = URI.create( "bolt+routing://localhost:7687/" );
+        RoutingContext context = new RoutingContext( uri );
+
+        assertFalse( context.isDefined() );
+        assertTrue( context.asMap().isEmpty() );
+    }
+
+    @Test
+    public void uriWithQueryIsParsed()
+    {
+        URI uri = URI.create( "bolt+routing://localhost:7687/?key1=value1&key2=value2&key3=value3" );
+        RoutingContext context = new RoutingContext( uri );
+
+        assertTrue( context.isDefined() );
+        Map<String,String> expectedMap = new HashMap<>();
+        expectedMap.put( "key1", "value1" );
+        expectedMap.put( "key2", "value2" );
+        expectedMap.put( "key3", "value3" );
+        assertEquals( expectedMap, context.asMap() );
+    }
+
+    @Test
+    public void throwsForInvalidUriQuery()
+    {
+        URI uri = URI.create( "bolt+routing://localhost:7687/?justKey" );
+
+        try
+        {
+            new RoutingContext( uri );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void throwsForDuplicatedUriQueryParameters()
+    {
+        URI uri = URI.create( "bolt+routing://localhost:7687/?key1=value1&key2=value2&key1=value2" );
+
+        try
+        {
+            new RoutingContext( uri );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void mapRepresentationIsUnmodifiable()
+    {
+        URI uri = URI.create( "bolt+routing://localhost:7687/?key1=value1" );
+        RoutingContext context = new RoutingContext( uri );
+
+        assertEquals( singletonMap( "key1", "value1" ), context.asMap() );
+
+        try
+        {
+            context.asMap().put( "key2", "value2" );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( UnsupportedOperationException.class ) );
+        }
+
+        assertEquals( singletonMap( "key1", "value1" ), context.asMap() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -20,33 +20,33 @@ package org.neo4j.driver.internal.cluster;
 
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
 
 import static java.util.Collections.EMPTY_MAP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.driver.internal.cluster.GetServersProcedureRunner.GET_ROUTING_TABLE;
-import static org.neo4j.driver.internal.cluster.GetServersProcedureRunner.GET_ROUTING_TABLE_PARAM;
-import static org.neo4j.driver.internal.cluster.GetServersProcedureRunner.GET_SERVERS;
+import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE;
+import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE_PARAM;
+import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_SERVERS;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class GetServersProcedureRunnerTest
+public class RoutingProcedureRunnerTest
 {
     @Test
     public void shouldCallGetRoutingTableWithEmptyMap() throws Throwable
     {
         // Given
-        GetServersProcedureRunner runner = new TestGetServersProcedureRunner( EMPTY_MAP );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY );
         Connection mock = mock( Connection.class );
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.2.1" ) );
@@ -54,7 +54,7 @@ public class GetServersProcedureRunnerTest
         runner.run( mock );
 
         // Then
-        assertThat( runner.procedureCalled(), equalTo(
+        assertThat( runner.invokedProcedure(), equalTo(
                 new Statement( "CALL " + GET_ROUTING_TABLE, parameters( GET_ROUTING_TABLE_PARAM, EMPTY_MAP ) ) ) );
     }
 
@@ -62,10 +62,9 @@ public class GetServersProcedureRunnerTest
     public void shouldCallGetRoutingTableWithParam() throws Throwable
     {
         // Given
-        HashMap<String,String> param = new HashMap<>();
-        param.put( "key1", "value1" );
-        param.put( "key2", "value2" );
-        GetServersProcedureRunner runner = new TestGetServersProcedureRunner( param );
+        URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
+        RoutingContext context = new RoutingContext( uri );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( context );
         Connection mock = mock( Connection.class );
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.2.1" ) );
@@ -73,18 +72,18 @@ public class GetServersProcedureRunnerTest
         runner.run( mock );
 
         // Then
-        assertThat( runner.procedureCalled(), equalTo(
-                new Statement( "CALL " + GET_ROUTING_TABLE, parameters( GET_ROUTING_TABLE_PARAM, param ) ) ) );
+        Value expectedParams = parameters( GET_ROUTING_TABLE_PARAM, context.asMap() );
+        assertThat( runner.invokedProcedure(), equalTo(
+                new Statement( "CALL " + GET_ROUTING_TABLE, expectedParams ) ) );
     }
 
     @Test
     public void shouldCallGetServers() throws Throwable
     {
         // Given
-        HashMap<String,String> param = new HashMap<>();
-        param.put( "key1", "value1" );
-        param.put( "key2", "value2" );
-        GetServersProcedureRunner runner = new TestGetServersProcedureRunner( param );
+        URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
+        RoutingContext context = new RoutingContext( uri );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( context );
         Connection mock = mock( Connection.class );
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.1.8" ) );
@@ -92,16 +91,15 @@ public class GetServersProcedureRunnerTest
         runner.run( mock );
 
         // Then
-        assertThat( runner.procedureCalled(), equalTo(
+        assertThat( runner.invokedProcedure(), equalTo(
                 new Statement( "CALL " + GET_SERVERS ) ) );
     }
 
-    private static class TestGetServersProcedureRunner extends GetServersProcedureRunner
+    private static class TestRoutingProcedureRunner extends RoutingProcedureRunner
     {
-
-        TestGetServersProcedureRunner( Map<String, String> parameters )
+        TestRoutingProcedureRunner( RoutingContext context )
         {
-            super( parameters );
+            super( context );
         }
 
         @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
@@ -90,4 +90,18 @@ public class GraphDatabaseTest
             assertThat( e, instanceOf( IllegalArgumentException.class ) );
         }
     }
+
+    @Test
+    public void throwsWhenBoltSchemeUsedWithRoutingParams()
+    {
+        try
+        {
+            GraphDatabase.driver( "bolt://localhost:7687/?policy=my_policy" );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -105,8 +105,7 @@ public class CausalClusteringIT
         }
         catch ( ServiceUnavailableException ex )
         {
-            assertThat( ex.getMessage(), containsString(
-                    "Failed to run 'Statement{text='CALL dbms.cluster.routing." ) );
+            assertThat( ex.getMessage(), containsString( "Failed to run 'CALL dbms.cluster.routing" ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.logging.DevNullLogging;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -1341,7 +1341,7 @@ public class SessionIT
     private Driver newDriverWithFixedRetries( int maxRetriesCount )
     {
         DriverFactory driverFactory = new DriverFactoryWithFixedRetryLogic( maxRetriesCount );
-        RoutingSettings routingConf = new RoutingSettings( 1, 1, Collections.<String,String>emptyMap() );
+        RoutingSettings routingConf = new RoutingSettings( 1, 1, RoutingContext.EMPTY );
         AuthToken auth = AuthTokens.none();
         return driverFactory.newInstance( neo4j.uri(), auth, routingConf, RetrySettings.DEFAULT, noLoggingConfig() );
     }

--- a/driver/src/test/resources/get_routing_table.script
+++ b/driver/src/test/resources/get_routing_table.script
@@ -1,0 +1,17 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-java/dev"
+S: SUCCESS {"server": "Neo4j/3.2.2"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Alice"]
+   RECORD ["Bob"]
+   RECORD ["Eve"]
+   SUCCESS {}

--- a/driver/src/test/resources/get_routing_table_with_context.script
+++ b/driver/src/test/resources/get_routing_table_with_context.script
@@ -1,0 +1,16 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-java/dev"
+S: SUCCESS {"server": "Neo4j/3.2.3"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {"policy": "my_policy", "region": "china"}}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Alice"]
+   RECORD ["Bob"]
+   SUCCESS {}

--- a/driver/src/test/resources/rediscover_and_read_with_init.script
+++ b/driver/src/test/resources/rediscover_and_read_with_init.script
@@ -1,0 +1,16 @@
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: INIT "neo4j-java/dev"
+S: SUCCESS {"server": "Neo4j/3.1.0"}
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Tina"]
+   SUCCESS {}


### PR DESCRIPTION
Routing context is a map of string key-value pairs. It is send to the database when calling `dbms.cluster.routing.getRoutingTable` procedure as it's single argument. This is only supported by 3.2+ servers.

Previously routing context was defined on the config. It is problematic because routing context in `bolt+routing` specific and thus makes no sense for single instance database.

This PR makes routing context part of the `bolt+routing` URI. It lives in the query part of the URI as regular query parameters like:
`bolt+routing://localhost:7687/?policy=my_policy&region=china`.

Clustering-specific configuration method is removed.