### PR TITLE
Read in absence of viable writer

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.driver.internal;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -376,30 +374,6 @@ public class NetworkSession implements Session, SessionResourcesHandler
         {
             connection.close();
             logger.debug( "Released connection " + connection.hashCode() );
-        }
-    }
-
-    private static List<Throwable> recordError( Throwable error, List<Throwable> errors )
-    {
-        if ( errors == null )
-        {
-            errors = new ArrayList<>();
-        }
-        errors.add( error );
-        return errors;
-    }
-
-    private static void addSuppressed( Throwable error, List<Throwable> suppressedErrors )
-    {
-        if ( suppressedErrors != null )
-        {
-            for ( Throwable suppressedError : suppressedErrors )
-            {
-                if ( error != suppressedError )
-                {
-                    error.addSuppressed( suppressedError );
-                }
-            }
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -21,10 +21,11 @@ package org.neo4j.driver.internal.cluster;
 import java.util.Set;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.v1.AccessMode;
 
 public interface RoutingTable
 {
-    boolean isStale();
+    boolean isStaleFor( AccessMode mode );
 
     Set<BoltServerAddress> update( ClusterComposition cluster );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -69,7 +69,7 @@ public class SocketConnectionPool implements ConnectionPool
     }
 
     @Override
-    public PooledConnection acquire( final BoltServerAddress address )
+    public PooledConnection acquire( BoltServerAddress address )
     {
         assertNotClosed();
         BlockingPooledConnectionQueue connectionQueue = pool( address );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionUtil.java
@@ -20,7 +20,7 @@
 package org.neo4j.driver.internal.cluster;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -60,9 +60,9 @@ public final class ClusterCompositionUtil
     public static ClusterComposition createClusterComposition( long expirationTimestamp, List<BoltServerAddress>...
             servers )
     {
-        Set<BoltServerAddress> routers = new HashSet<>();
-        Set<BoltServerAddress> writers = new HashSet<>();
-        Set<BoltServerAddress> readers = new HashSet<>();
+        Set<BoltServerAddress> routers = new LinkedHashSet<>();
+        Set<BoltServerAddress> writers = new LinkedHashSet<>();
+        Set<BoltServerAddress> readers = new LinkedHashSet<>();
 
         switch( servers.length )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 
+import static java.util.Collections.unmodifiableSet;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
 
@@ -101,6 +102,11 @@ public class Cluster
         return leader;
     }
 
+    public Set<ClusterMember> members()
+    {
+        return unmodifiableSet( members );
+    }
+
     public ClusterMember leader()
     {
         Set<ClusterMember> leaders = membersWithRole( ClusterMemberRole.LEADER );
@@ -139,7 +145,9 @@ public class Cluster
 
     public void startOfflineMembers()
     {
-        for ( ClusterMember member : offlineMembers )
+        // copy offline members to avoid ConcurrentModificationException
+        Set<ClusterMember> currentlyOfflineMembers = new HashSet<>( offlineMembers );
+        for ( ClusterMember member : currentlyOfflineMembers )
         {
             startNoWait( member );
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterRule.java
@@ -87,6 +87,8 @@ public class ClusterRule extends ExternalResource
                 addShutdownHookToStopCluster();
             }
         }
+
+        getCluster().deleteData();
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/SharedCluster.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.v1.util.cc;
 
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -55,7 +56,7 @@ final class SharedCluster
     static void install( String neo4jVersion, int cores, int readReplicas, String password, int port, Path path )
     {
         assertClusterDoesNotExist();
-        if( path.toFile().exists() )
+        if ( Files.isDirectory( path ) )
         {
             debug( "Found and using cluster installed at `%s`.", path );
         }

--- a/driver/src/test/resources/discover_no_writers.script
+++ b/driver/src/test/resources/discover_no_writers.script
@@ -1,0 +1,9 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9005"], "role": "ROUTE"}]]
+   SUCCESS {}

--- a/driver/src/test/resources/rediscover_using_initial_router.script
+++ b/driver/src/test/resources/rediscover_using_initial_router.script
@@ -1,6 +1,9 @@
 !: AUTO INIT
 !: AUTO RESET
 !: AUTO PULL_ALL
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+!: AUTO RUN "ROLLBACK" {}
 
 C: RUN "CALL dbms.cluster.routing.getServers" {}
    PULL_ALL


### PR DESCRIPTION
Previously driver did not allow reads and writes when received routing table did not contains both routers, readers and writers. This was inconsistent with Causal Cluster which allows reads when leader is absent. Leader might be unavailable for a long time (when there is a DC failure, etc.) so it makes sense to allow clients to perform read activity.

This commit makes driver accept routing table with no writers and allow clients to perform read operations when writers are not available. It might be problematic when there is a cluster partition and one partition contains majority. For this case special care must be taken so driver does not get stuck talking only to the smaller partition which only knows about itself. This is done on best effort basis - driver tries to contact seed router if previously accepted routing table did not contain writes.