### PR TITLE
Treat one router as valid in routing table

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -60,7 +60,7 @@ public class ClusterRoutingTable implements RoutingTable
     public boolean isStaleFor( AccessMode mode )
     {
         return expirationTimeout < clock.millis() ||
-               routers.size() <= MIN_ROUTERS ||
+               routers.size() < MIN_ROUTERS ||
                mode == AccessMode.READ && readers.size() == 0 ||
                mode == AccessMode.WRITE && writers.size() == 0;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.util.FakeClock;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -180,5 +181,20 @@ public class ClusterRoutingTableTest
         assertEquals( C, routingTable.readers().next() );
         assertEquals( D, routingTable.readers().next() );
         assertEquals( B, routingTable.readers().next() );
+    }
+
+    @Test
+    public void shouldTreatOneRouterAsValid()
+    {
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+
+        List<BoltServerAddress> routers = singletonList( A );
+        List<BoltServerAddress> writers = asList( B, C );
+        List<BoltServerAddress> readers = asList( D, E );
+
+        routingTable.update( createClusterComposition( routers, writers, readers ) );
+
+        assertFalse( routingTable.isStaleFor( READ ) );
+        assertFalse( routingTable.isStaleFor( WRITE ) );
     }
 }

--- a/driver/src/test/resources/discover_one_router.script
+++ b/driver/src/test/resources/discover_one_router.script
@@ -1,0 +1,9 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9005"], "role": "ROUTE"}]]
+   SUCCESS {}


### PR DESCRIPTION
Previously driver considered routing table with single router to be stale and had to perform rediscovery before read/write transaction. Requirement to have more than 1 router is quite strict and can easily be violated by partially unavailable clusters. Additional rediscoveries in such cases add more load on the available core server.

This PR makes driver tread routing table with single router as not stale, given that other non-staleness requirements are satisfied as well.