### PR TITLE
fix memory leak with logger

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -64,7 +64,7 @@ public class NetworkSession implements Session, SessionResourcesHandler
         this.connectionProvider = connectionProvider;
         this.mode = mode;
         this.retryLogic = retryLogic;
-        this.logger = logging.getLog( "Session-" + hashCode() );
+        this.logger = logging.getLog(Session.class.getName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -57,7 +57,7 @@ public class SocketConnection implements Connection
 
     SocketConnection( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logging logging )
     {
-        Logger logger = logging.getLog( "Connection-" + hashCode() );
+        Logger logger = logging.getLog( Connection.class.getName() );
         this.socket = new SocketClient( address, securityPlan, timeoutMillis, logger );
         this.responseHandler = createResponseHandler( logger );
 


### PR DESCRIPTION
Someone at neo4j may have a better fix for this.

The logger was clearly constructed in this way with the intention of aiding diagnostics.  But looking through the usage of this logger, the instance id provided by the Session.hashCode() doesn't appear to be all that useful, so I just took it out.  But maybe someone at neo4j has a preferred method of fixing.

That said, it leaks memory, so it just needs to be fixed.

Just to give some context, rough estimates are that we are doing ~100 transactions/second.  This burned through a 6GB heap in a few days.