### PR TITLE
Restore backwards compatibility in Logger

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -160,7 +160,7 @@ public class NetworkSession implements Session, SessionResourcesHandler
                 }
                 catch ( Throwable e )
                 {
-                    logger.warn( "Failed to close transaction", e );
+                    logger.error( "Failed to close transaction", e );
                 }
             }
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogger.java
@@ -44,11 +44,6 @@ public class DevNullLogger implements Logger
     }
 
     @Override
-    public void warn( String message, Throwable cause )
-    {
-    }
-
-    @Override
     public void debug( String message, Object... params )
     {
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
@@ -55,12 +55,6 @@ public class JULogger implements Logger
     }
 
     @Override
-    public void warn( String message, Throwable cause )
-    {
-        delegate.log( Level.WARNING, message, cause );
-    }
-
-    @Override
     public void debug( String format, Object... params )
     {
         if( debugEnabled )

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -203,7 +203,7 @@ public class SocketClient
             }
             else
             {
-                logger.warn( "Unable to close socket connection properly: '" + e.getMessage() + "'", e );
+                logger.error( "Unable to close socket connection properly", e );
             }
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -95,7 +95,7 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
                     if ( elapsedTime < maxRetryTimeMs )
                     {
                         long delayWithJitterMs = computeDelayWithJitter( nextDelayMs );
-                        log.warn( "Transaction failed and will be retried in " + delayWithJitterMs + "ms", error );
+                        log.error( "Transaction failed and will be retried in " + delayWithJitterMs + "ms", error );
 
                         sleep( delayWithJitterMs );
                         nextDelayMs = (long) (nextDelayMs * multiplier);

--- a/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
@@ -28,11 +28,11 @@ import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLHandshakeException;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
-import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.internal.util.BytePrinter;
+import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SecurityException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.lang.String.format;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
@@ -474,7 +474,7 @@ public class TLSSocketChannel implements ByteChannel
         catch ( IOException e )
         {
             // Treat this as ok - the connection is closed, even if the TLS session did not exit cleanly.
-            logger.warn( "TLS socket could not be closed cleanly: '" + e.getMessage() + "'", e );
+            logger.error( "TLS socket could not be closed cleanly", e );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/Logger.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Logger.java
@@ -29,8 +29,6 @@ public interface Logger
 
     void warn( String message, Object... params );
 
-    void warn( String message, Throwable cause );
-
     void debug( String message, Object... params );
 
     void trace( String message, Object... params );

--- a/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
@@ -446,7 +446,7 @@ public class ExponentialBackoffRetryLogicTest
 
         retry( logic, retries );
 
-        verify( logger, times( retries ) ).warn(
+        verify( logger, times( retries ) ).error(
                 startsWith( "Transaction failed and will be retried" ),
                 any( ServiceUnavailableException.class )
         );

--- a/driver/src/test/java/org/neo4j/driver/v1/EventLogger.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/EventLogger.java
@@ -111,12 +111,6 @@ public class EventLogger implements Logger
     }
 
     @Override
-    public void warn( String message, Throwable cause )
-    {
-        events.log( name, Level.WARN, cause, message );
-    }
-
-    @Override
     public void debug( String message, Object... params )
     {
         events.log( name, Level.DEBUG, null, message, params );


### PR DESCRIPTION
Method `Logger#warn(String, Throwable)` was added recently and it breaks backwards compatibility of the `Logger` interface. This commit removes it and replaces all usages with `Logger#error(String, Throwable)`.