### PR TITLE
Fix possible logger leak

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -18,11 +18,10 @@
  */
 package org.neo4j.driver.internal;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.logging.DelegatingLogger;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -47,6 +46,8 @@ import static org.neo4j.driver.v1.Values.value;
 
 public class NetworkSession implements Session, SessionResourcesHandler
 {
+    private static final String LOG_NAME = "Session";
+
     private final ConnectionProvider connectionProvider;
     private final AccessMode mode;
     private final RetryLogic retryLogic;
@@ -64,7 +65,7 @@ public class NetworkSession implements Session, SessionResourcesHandler
         this.connectionProvider = connectionProvider;
         this.mode = mode;
         this.retryLogic = retryLogic;
-        this.logger = logging.getLog( "Session-" + hashCode() );
+        this.logger = new DelegatingLogger( logging.getLog( LOG_NAME ), String.valueOf( hashCode() ) );
     }
 
     @Override
@@ -376,30 +377,6 @@ public class NetworkSession implements Session, SessionResourcesHandler
         {
             connection.close();
             logger.debug( "Released connection " + connection.hashCode() );
-        }
-    }
-
-    private static List<Throwable> recordError( Throwable error, List<Throwable> errors )
-    {
-        if ( errors == null )
-        {
-            errors = new ArrayList<>();
-        }
-        errors.add( error );
-        return errors;
-    }
-
-    private static void addSuppressed( Throwable error, List<Throwable> suppressedErrors )
-    {
-        if ( suppressedErrors != null )
-        {
-            for ( Throwable suppressedError : suppressedErrors )
-            {
-                if ( error != suppressedError )
-                {
-                    error.addSuppressed( suppressedError );
-                }
-            }
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DelegatingLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DelegatingLogger.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.neo4j.driver.v1.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+public class DelegatingLogger implements Logger
+{
+    private final Logger delegate;
+    private final String messagePrefix;
+
+    public DelegatingLogger( Logger delegate )
+    {
+        this( delegate, null );
+    }
+
+    public DelegatingLogger( Logger delegate, String messagePrefix )
+    {
+        this.delegate = requireNonNull( delegate );
+        this.messagePrefix = messagePrefix;
+    }
+
+    @Override
+    public void error( String message, Throwable cause )
+    {
+        delegate.error( messageWithPrefix( message ), cause );
+    }
+
+    @Override
+    public void info( String message, Object... params )
+    {
+        delegate.info( messageWithPrefix( message ), params );
+    }
+
+    @Override
+    public void warn( String message, Object... params )
+    {
+        delegate.warn( messageWithPrefix( message ), params );
+    }
+
+    @Override
+    public void debug( String message, Object... params )
+    {
+        if ( isDebugEnabled() )
+        {
+            delegate.debug( messageWithPrefix( message ), params );
+        }
+    }
+
+    @Override
+    public void trace( String message, Object... params )
+    {
+        if ( isTraceEnabled() )
+        {
+            delegate.trace( messageWithPrefix( message ), params );
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return delegate.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return delegate.isDebugEnabled();
+    }
+
+    private String messageWithPrefix( String message )
+    {
+        if ( messagePrefix == null )
+        {
+            return message;
+        }
+        return String.format( "[%s] %s", messagePrefix, message );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.logging.DelegatingLogger;
 import org.neo4j.driver.internal.messaging.InitMessage;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.RunMessage;
@@ -47,6 +48,8 @@ import static org.neo4j.driver.internal.messaging.ResetMessage.RESET;
 
 public class SocketConnection implements Connection
 {
+    private static final String LOG_NAME = "Connection";
+
     private final Queue<Message> pendingMessages = new LinkedList<>();
     private final SocketResponseHandler responseHandler;
     private final AtomicBoolean isInterrupted = new AtomicBoolean( false );
@@ -57,7 +60,7 @@ public class SocketConnection implements Connection
 
     SocketConnection( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logging logging )
     {
-        Logger logger = logging.getLog( "Connection-" + hashCode() );
+        Logger logger = new DelegatingLogger( logging.getLog( LOG_NAME ), String.valueOf( hashCode() ) );
         this.socket = new SocketClient( address, securityPlan, timeoutMillis, logger );
         this.responseHandler = createResponseHandler( logger );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.driver.internal.logging.DelegatingLogger;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Supplier;
@@ -39,6 +40,8 @@ import org.neo4j.driver.v1.Logging;
  */
 public class BlockingPooledConnectionQueue
 {
+    public static final String LOG_NAME = "ConnectionQueue";
+
     /** The backing queue, keeps track of connections currently in queue */
     private final BlockingQueue<PooledConnection> queue;
     private final Logger logger;
@@ -162,6 +165,6 @@ public class BlockingPooledConnectionQueue
 
     private static Logger createLogger( BoltServerAddress address, Logging logging )
     {
-        return logging.getLog( "ConnectionQueue[" + address + "]" );
+        return new DelegatingLogger( logging.getLog( LOG_NAME ), address.toString() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -36,7 +36,6 @@ import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -83,7 +82,7 @@ public class LeakLoggingNetworkSessionTest
         assertEquals( 1, messageCaptor.getAllValues().size() );
 
         String loggedMessage = messageCaptor.getValue();
-        assertThat( loggedMessage, startsWith( "Neo4j Session object leaked" ) );
+        assertThat( loggedMessage, containsString( "Neo4j Session object leaked" ) );
         assertThat( loggedMessage, containsString( "Session was create at" ) );
         assertThat( loggedMessage, containsString(
                 getClass().getSimpleName() + "." + testName.getMethodName() )

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/DelegatingLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/DelegatingLoggerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.junit.Test;
+
+import org.neo4j.driver.v1.Logger;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DelegatingLoggerTest
+{
+    private static final String PREFIX = "Output";
+    private static final String MESSAGE = "Hello World!";
+    private static final Exception ERROR = new Exception();
+
+    @Test
+    public void shouldThrowWhenDelegateIsNull()
+    {
+        try
+        {
+            new DelegatingLogger( null );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( NullPointerException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldAllowNullPrefix()
+    {
+        assertNotNull( new DelegatingLogger( newLoggerMock(), null ) );
+    }
+
+    @Test
+    public void shouldDelegateIsDebugEnabled()
+    {
+        Logger delegate = newLoggerMock( true, false );
+
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        assertTrue( logger.isDebugEnabled() );
+        verify( delegate ).isDebugEnabled();
+    }
+
+    @Test
+    public void shouldDelegateIsTraceEnabled()
+    {
+        Logger delegate = newLoggerMock( false, true );
+
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        assertTrue( logger.isTraceEnabled() );
+        verify( delegate ).isTraceEnabled();
+    }
+
+    @Test
+    public void shouldNotDelegateDebugLogWhenDebugDisabled()
+    {
+        Logger delegate = newLoggerMock();
+
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+        logger.debug( MESSAGE );
+
+        verify( delegate, never() ).debug( anyString(), anyVararg() );
+    }
+
+    @Test
+    public void shouldNotDelegateTraceLogWhenTraceDisabled()
+    {
+        Logger delegate = newLoggerMock();
+
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+        logger.trace( MESSAGE );
+
+        verify( delegate, never() ).trace( anyString(), anyVararg() );
+    }
+
+    @Test
+    public void shouldDelegateErrorMessageWhenNoPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        logger.error( MESSAGE, ERROR );
+
+        verify( delegate ).error( MESSAGE, ERROR );
+    }
+
+    @Test
+    public void shouldDelegateInfoMessageWhenNoPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        logger.info( MESSAGE );
+
+        verify( delegate ).info( MESSAGE );
+    }
+
+    @Test
+    public void shouldDelegateWarnMessageWhenNoPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        logger.warn( MESSAGE );
+
+        verify( delegate ).warn( MESSAGE );
+    }
+
+    @Test
+    public void shouldDelegateDebugMessageWhenNoPrefix()
+    {
+        Logger delegate = newLoggerMock( true, false );
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        logger.debug( MESSAGE );
+
+        verify( delegate ).debug( MESSAGE );
+    }
+
+    @Test
+    public void shouldDelegateTraceMessageWhenNoPrefix()
+    {
+        Logger delegate = newLoggerMock( false, true );
+        DelegatingLogger logger = new DelegatingLogger( delegate );
+
+        logger.trace( MESSAGE );
+
+        verify( delegate ).trace( MESSAGE );
+    }
+
+    @Test
+    public void shouldDelegateErrorMessageWithPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate, PREFIX );
+
+        logger.error( MESSAGE, ERROR );
+
+        verify( delegate ).error( "[Output] Hello World!", ERROR );
+    }
+
+    @Test
+    public void shouldDelegateInfoMessageWithPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate, PREFIX );
+
+        logger.info( MESSAGE );
+
+        verify( delegate ).info( "[Output] Hello World!" );
+    }
+
+    @Test
+    public void shouldDelegateWarnMessageWithPrefix()
+    {
+        Logger delegate = newLoggerMock();
+        DelegatingLogger logger = new DelegatingLogger( delegate, PREFIX );
+
+        logger.warn( MESSAGE );
+
+        verify( delegate ).warn( "[Output] Hello World!" );
+    }
+
+    @Test
+    public void shouldDelegateDebugMessageWithPrefix()
+    {
+        Logger delegate = newLoggerMock( true, false );
+        DelegatingLogger logger = new DelegatingLogger( delegate, PREFIX );
+
+        logger.debug( MESSAGE );
+
+        verify( delegate ).debug( "[Output] Hello World!" );
+    }
+
+    @Test
+    public void shouldDelegateTraceMessageWithPrefix()
+    {
+        Logger delegate = newLoggerMock( false, true );
+        DelegatingLogger logger = new DelegatingLogger( delegate, PREFIX );
+
+        logger.trace( MESSAGE );
+
+        verify( delegate ).trace( "[Output] Hello World!" );
+    }
+
+    private static Logger newLoggerMock()
+    {
+        return newLoggerMock( false, false );
+    }
+
+    private static Logger newLoggerMock( boolean debugEnabled, boolean traceEnabled )
+    {
+        Logger logger = mock( Logger.class );
+        when( logger.isDebugEnabled() ).thenReturn( debugEnabled );
+        when( logger.isTraceEnabled() ).thenReturn( traceEnabled );
+        return logger;
+    }
+}


### PR DESCRIPTION
Various components like session and connection include their identifiers in logs for diagnostic purposes. Most did this by creating loggers with specialized names. This is a problematic approach because it forces logging framework to create many distinct logger objects. JUL keeps such loggers as weakly referenced values in a map. This caused excessive GC activity and application failures.

This PR introduces a logger able to prepend diagnostics to messages and delegate rest of the work. It makes identifiers part of messages. Session, connection and other objects that require identification in logs now use this logger.

Example log message:
 `2017-04-25 02:36:47,319 [ConnectionQueue] [127.0.0.1] Error disposing connection`

Related to https://github.com/neo4j/neo4j-java-driver/pull/360
Fixes https://github.com/neo4j/neo4j-java-driver/issues/359