### PR TITLE
Added Clirr Maven Plugin to verify backwards compatibility

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -1,0 +1,38 @@
+<differences>
+
+    <difference>
+        <!-- Method Added to Interface -->
+        <differenceType>7012</differenceType>
+        <className>org/neo4j/driver/v1/**</className>
+        <method>*</method>
+        <justification>
+            Allow addition of methods to interfaces.
+            Most interfaces are not expected to be implemented by users and expose driver APIs.
+        </justification>
+    </difference>
+
+    <difference>
+        <!-- Method Argument Type changed -->
+        <differenceType>7005</differenceType>
+        <className>org/neo4j/driver/v1/Config$ConfigBuilder</className>
+        <method>org.neo4j.driver.v1.Config$ConfigBuilder withLogging(org.neo4j.driver.internal.spi.Logging)</method>
+        <to>org.neo4j.driver.v1.Config$ConfigBuilder withLogging(org.neo4j.driver.v1.Logging)</to>
+        <justification>
+            Logging interface initially lived in a private package but was exposed as part of public API.
+            It was later moved to the correct public package.
+        </justification>
+    </difference>
+
+    <difference>
+        <!-- Method Return Type changed -->
+        <differenceType>7006</differenceType>
+        <className>org/neo4j/driver/v1/Config</className>
+        <method>org.neo4j.driver.internal.spi.Logging logging()</method>
+        <to>org.neo4j.driver.v1.Logging</to>
+        <justification>
+            Logging interface initially lived in a private package but was exposed as part of public API.
+            It was later moved to the correct public package.
+        </justification>
+    </difference>
+
+</differences>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -102,6 +102,15 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <comparisonVersion>1.2.0</comparisonVersion>
+          <includes>org/neo4j/driver/v1/**</includes>
+          <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
@@ -112,12 +121,12 @@
             </goals>
             <configuration>
               <archive>
-                  <manifestEntries>
-                      <Bundle-Name>${project.name} (Source)</Bundle-Name>
-                      <Bundle-SymbolicName>${bundle.name}.source</Bundle-SymbolicName>
-                      <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}</Bundle-Version>
-                      <Eclipse-SourceBundle>${bundle.name};version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}";roots:="."</Eclipse-SourceBundle>
-                  </manifestEntries>
+                <manifestEntries>
+                  <Bundle-Name>${project.name} (Source)</Bundle-Name>
+                  <Bundle-SymbolicName>${bundle.name}.source</Bundle-SymbolicName>
+                  <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}</Bundle-Version>
+                  <Eclipse-SourceBundle>${bundle.name};version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${build.timestamp}";roots:="."</Eclipse-SourceBundle>
+                </manifestEntries>
               </archive>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,23 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>2.8</version>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.mycila</groupId>


### PR DESCRIPTION
This plugin compares sources in `org.neo4j.driver.v1` package for backwards compatibility against previous (currently 1.2.0) driver version. Configuration currently permits adding new interface methods. Plugin reads exclusions from `clirr-ignored-differences.xml` file. It binds to `compile` Maven phase to perform verification.