### PR TITLE
Byte array support

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingPooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingPooledConnection.java
@@ -221,6 +221,12 @@ class RoutingPooledConnection implements PooledConnection
     }
 
     @Override
+    public boolean supportsBytes()
+    {
+        return delegate.supportsBytes();
+    }
+
+    @Override
     public long lastUsedTimestamp()
     {
         return delegate.lastUsedTimestamp();

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.messaging;
 
+import org.neo4j.driver.internal.spi.Connection;
+
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -41,6 +43,8 @@ public interface MessageFormat
         void read( MessageHandler handler ) throws IOException;
 
     }
+
+    Writer newWriter( WritableByteChannel ch, Connection connection);
 
     Writer newWriter( WritableByteChannel ch );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ConcurrencyGuardingConnection.java
@@ -223,4 +223,10 @@ public class ConcurrencyGuardingConnection implements Connection
     {
         return delegate.boltServerAddress();
     }
+
+    @Override
+    public boolean supportsBytes()
+    {
+        return delegate.supportsBytes();
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -27,6 +27,7 @@ import java.util.Queue;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.BytePrinter;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -43,6 +44,7 @@ public class SocketClient
     private static final int NO_VERSION = 0;
     private static final int[] SUPPORTED_VERSIONS = new int[]{VERSION1, NO_VERSION, NO_VERSION, NO_VERSION};
 
+    private final Connection connection;
     private final BoltServerAddress address;
     private final SecurityPlan securityPlan;
     private final int timeoutMillis;
@@ -54,8 +56,9 @@ public class SocketClient
 
     private ByteChannel channel;
 
-    public SocketClient( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logger logger )
+    public SocketClient( Connection connection, BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logger logger )
     {
+        this.connection = connection;
         this.address = address;
         this.securityPlan = securityPlan;
         this.timeoutMillis = timeoutMillis;
@@ -255,7 +258,7 @@ public class SocketClient
         {
         case VERSION1:
             logger.debug( "S: [HANDSHAKE] -> 1" );
-            return new SocketProtocolV1( channel );
+            return new SocketProtocolV1( connection, channel );
         case NO_VERSION:
             throw new ClientException( "The server does not support any of the protocol versions supported by " +
                                        "this driver. Ensure that you are using driver and server versions that " +

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketConnection.java
@@ -61,7 +61,7 @@ public class SocketConnection implements Connection
     SocketConnection( BoltServerAddress address, SecurityPlan securityPlan, int timeoutMillis, Logging logging )
     {
         Logger logger = new DelegatingLogger( logging.getLog( LOG_NAME ), String.valueOf( hashCode() ) );
-        this.socket = new SocketClient( address, securityPlan, timeoutMillis, logger );
+        this.socket = new SocketClient( this, address, securityPlan, timeoutMillis, logger );
         this.responseHandler = createResponseHandler( logger );
 
         startSocketClient();
@@ -302,5 +302,11 @@ public class SocketConnection implements Connection
     public BoltServerAddress boltServerAddress()
     {
         return this.serverInfo.boltServerAddress();
+    }
+
+    @Override
+    public boolean supportsBytes()
+    {
+        return this.serverInfo.atLeast("Neo4j", 3, 2);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketProtocolV1.java
@@ -25,6 +25,7 @@ import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.MessageFormat.Reader;
 import org.neo4j.driver.internal.messaging.MessageFormat.Writer;
 import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
+import org.neo4j.driver.internal.spi.Connection;
 
 public class SocketProtocolV1 implements SocketProtocol
 {
@@ -32,11 +33,11 @@ public class SocketProtocolV1 implements SocketProtocol
     private final Reader reader;
     private final Writer writer;
 
-    public SocketProtocolV1( ByteChannel channel ) throws IOException
+    public SocketProtocolV1( Connection connection, ByteChannel channel ) throws IOException
     {
         messageFormat = new PackStreamMessageFormatV1();
 
-        ChunkedOutput output = new ChunkedOutput( channel );
+        ChunkedOutput output = new ChunkedOutput(channel, connection);
         BufferingChunkedInput input = new BufferingChunkedInput( channel );
 
         this.writer = new PackStreamMessageFormatV1.Writer( output, output.messageBoundaryHook() );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
@@ -22,12 +22,14 @@ import java.util.Map;
 
 import org.neo4j.driver.internal.SessionResourcesHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.packstream.PackStream;
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.PooledConnection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
 import org.neo4j.driver.v1.summary.ServerInfo;
 
@@ -169,6 +171,10 @@ public class PooledSocketConnection implements PooledConnection
         {
             delegate.flush();
         }
+        catch ( PackStream.BytesNotSupportedException e )
+        {
+            throw new ClientException("PackStream BYTES are not supported by this server");
+        }
         catch ( RuntimeException e )
         {
             onDelegateException( e );
@@ -243,6 +249,12 @@ public class PooledSocketConnection implements PooledConnection
     public BoltServerAddress boltServerAddress()
     {
         return delegate.boltServerAddress();
+    }
+
+    @Override
+    public boolean supportsBytes()
+    {
+        return delegate.supportsBytes();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackOutput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackOutput.java
@@ -45,4 +45,7 @@ public interface PackOutput
 
     /** Produce an 8-byte IEEE 754 "double format" floating-point number */
     PackOutput writeDouble( double value ) throws IOException;
+
+    /** Return a boolean indicating whether or not this output channel supports the PackStream BYTES type. */
+    boolean supportsBytes();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -118,4 +118,9 @@ public interface Connection extends AutoCloseable
      * Returns the BoltServerAddress connected to
      */
     BoltServerAddress boltServerAddress();
+
+    /**
+     * Returns true if this connection supports PackStream BYTES, false otherwise.
+     */
+    boolean supportsBytes();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
@@ -16,20 +16,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.neo4j.driver.internal.summary;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.packstream.PackStream;
 import org.neo4j.driver.v1.summary.ServerInfo;
 
 public class InternalServerInfo implements ServerInfo
 {
     private final BoltServerAddress address;
     private final String version;
+    private final String product;
+    private final int major;
+    private final int minor;
 
     public InternalServerInfo( BoltServerAddress address, String version )
     {
         this.address = address;
         this.version = version;
+        if (version != null)
+        {
+            int slash = version.indexOf("/");
+            if (slash >= 0)
+            {
+                product = version.substring(0, slash);
+                String[] numberStrings = version.substring(slash + 1).split("\\.");
+                int[] numbers = new int[2];
+                for (int i = 0; i < 2; i++)
+                {
+                    try
+                    {
+                        numbers[i] = Integer.parseInt(numberStrings[i]);
+                    }
+                    catch ( IndexOutOfBoundsException | NumberFormatException e )
+                    {
+                        numbers[i] = 0;
+                    }
+                }
+                major = numbers[0];
+                minor = numbers[1];
+            }
+            else
+            {
+                product = null;
+                major = 0;
+                minor = 0;
+            }
+        }
+        else
+        {
+            product = null;
+            major = 0;
+            minor = 0;
+        }
     }
 
     public BoltServerAddress boltServerAddress()
@@ -47,5 +87,29 @@ public class InternalServerInfo implements ServerInfo
     public String version()
     {
         return version;
+    }
+
+    @Override
+    public String product()
+    {
+        return product;
+    }
+
+    @Override
+    public int major()
+    {
+        return major;
+    }
+
+    @Override
+    public int minor()
+    {
+        return minor;
+    }
+
+    @Override
+    public boolean atLeast( String product, int major, int minor )
+    {
+        return this.product.equals(product) && (this.major > major || (this.major == major && this.minor >= minor));
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/types/InternalTypeSystem.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/types/InternalTypeSystem.java
@@ -33,6 +33,7 @@ import static org.neo4j.driver.internal.types.TypeConstructor.NULL_TyCon;
 import static org.neo4j.driver.internal.types.TypeConstructor.NUMBER_TyCon;
 import static org.neo4j.driver.internal.types.TypeConstructor.PATH_TyCon;
 import static org.neo4j.driver.internal.types.TypeConstructor.RELATIONSHIP_TyCon;
+import static org.neo4j.driver.internal.types.TypeConstructor.BYTES_TyCon;
 import static org.neo4j.driver.internal.types.TypeConstructor.STRING_TyCon;
 
 /**
@@ -47,6 +48,7 @@ public class InternalTypeSystem implements TypeSystem
 
     private final TypeRepresentation anyType = constructType( ANY_TyCon );
     private final TypeRepresentation booleanType = constructType( BOOLEAN_TyCon );
+    private final TypeRepresentation bytesType = constructType( BYTES_TyCon );
     private final TypeRepresentation stringType = constructType( STRING_TyCon );
     private final TypeRepresentation numberType = constructType( NUMBER_TyCon );
     private final TypeRepresentation integerType = constructType( INTEGER_TyCon );
@@ -74,6 +76,13 @@ public class InternalTypeSystem implements TypeSystem
     public Type BOOLEAN()
     {
         return booleanType;
+    }
+
+    /** the Cypher type BYTES */
+    @Override
+    public Type BYTES()
+    {
+        return bytesType;
     }
 
     /** the Cypher type STRING */

--- a/driver/src/main/java/org/neo4j/driver/internal/types/TypeConstructor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/types/TypeConstructor.java
@@ -44,6 +44,14 @@ public enum TypeConstructor
         }
     },
 
+    BYTES_TyCon {
+        @Override
+        public String typeName()
+        {
+            return "BYTES";
+        }
+    },
+
     STRING_TyCon {
         @Override
         public String typeName()

--- a/driver/src/main/java/org/neo4j/driver/internal/value/BytesValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/BytesValue.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value;
+
+import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.v1.types.Type;
+
+import java.util.Arrays;
+
+public class BytesValue extends ValueAdapter
+{
+    private final byte[] val;
+
+    public BytesValue( byte[] val )
+    {
+        if ( val == null )
+        {
+            throw new IllegalArgumentException( "Cannot construct BytesValue from null" );
+        }
+        this.val = val;
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return val.length == 0;
+    }
+
+    @Override
+    public int size()
+    {
+        return val.length;
+    }
+
+    @Override
+    public byte[] asObject()
+    {
+        return val;
+    }
+
+    @Override
+    public byte[] asByteArray()
+    {
+        return val;
+    }
+
+    @Override
+    public Type type()
+    {
+        return InternalTypeSystem.TYPE_SYSTEM.BYTES();
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        BytesValue values = (BytesValue) o;
+        return Arrays.equals(val, values.val);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode(val);
+    }
+
+    @Override
+    public String toString(Format valueFormat)
+    {
+        StringBuilder s = new StringBuilder("#");
+        for (byte b : val)
+        {
+            if (b < 0x10)
+            {
+                s.append('0');
+            }
+            s.append(Integer.toHexString(b));
+        }
+        return maybeWithType(
+                valueFormat.includeType(),
+                s.toString()
+        );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -151,6 +151,12 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     }
 
     @Override
+    public byte[] asByteArray()
+    {
+        throw new Uncoercible( type().name(), "Byte array" );
+    }
+
+    @Override
     public Number asNumber()
     {
         throw new Uncoercible( type().name(), "Java Number" );

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -194,6 +194,12 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     boolean asBoolean();
 
     /**
+     *  @return the value as a Java byte array, if possible.
+     *  @throws Uncoercible if value types are incompatible.
+     */
+    byte[] asByteArray();
+
+    /**
      *  @return the value as a Java String, if possible.
      *  @throws Uncoercible if value types are incompatible.
      */

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.neo4j.driver.internal.AsValue;
 import org.neo4j.driver.internal.value.BooleanValue;
+import org.neo4j.driver.internal.value.BytesValue;
 import org.neo4j.driver.internal.value.FloatValue;
 import org.neo4j.driver.internal.value.IntegerValue;
 import org.neo4j.driver.internal.value.ListValue;
@@ -84,6 +85,7 @@ public abstract class Values
         if ( value instanceof Iterable<?> ) { return value( (Iterable<Object>) value ); }
         if ( value instanceof Iterator<?> ) { return value( (Iterator<Object>) value ); }
 
+        if ( value instanceof byte[] ) { return new BytesValue( (byte[]) value ); }
         if ( value instanceof boolean[] ) { return value( (boolean[]) value ); }
         if ( value instanceof String[] ) { return value( (String[]) value ); }
         if ( value instanceof long[] ) { return value( (long[]) value ); }
@@ -112,6 +114,11 @@ public abstract class Values
         Value[] values = new Value[size];
         System.arraycopy( input, 0, values, 0, size );
         return new ListValue( values );
+    }
+
+    private static Value bytesValue( byte[] input )
+    {
+        return new BytesValue( input );
     }
 
     public static Value value( String... input )

--- a/driver/src/main/java/org/neo4j/driver/v1/summary/ServerInfo.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/summary/ServerInfo.java
@@ -36,4 +36,12 @@ public interface ServerInfo
      * @return The server version of <code>null</code> if not available.
      */
     String version();
+
+    String product();
+
+    int major();
+
+    int minor();
+
+    boolean atLeast(String product, int major, int minor);
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/types/TypeSystem.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/types/TypeSystem.java
@@ -33,6 +33,8 @@ public interface TypeSystem
 
     Type BOOLEAN();
 
+    Type BYTES();
+
     Type STRING();
 
     Type NUMBER();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/FragmentedMessageDeliveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/FragmentedMessageDeliveryTest.java
@@ -150,7 +150,7 @@ public class FragmentedMessageDeliveryTest
 
             final ByteArrayOutputStream out = new ByteArrayOutputStream( 128 );
 
-        ChunkedOutput output = new ChunkedOutput(  chunkSize + 2 /* for chunk header */, Channels.newChannel( out ) );
+        ChunkedOutput output = new ChunkedOutput(  chunkSize + 2 /* for chunk header */, Channels.newChannel( out ), null );
 
         PackStreamMessageFormatV1.Writer writer =
                 new PackStreamMessageFormatV1.Writer( output, output.messageBoundaryHook() );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -109,7 +109,7 @@ public class MessageFormatTest
         // Given
         ByteArrayOutputStream out = new ByteArrayOutputStream( 128 );
         WritableByteChannel writable = Channels.newChannel( out );
-        PackStream.Packer packer = new PackStream.Packer( new ChunkedOutput( writable ) );
+        PackStream.Packer packer = new PackStream.Packer( new ChunkedOutput(writable, null) );
 
         packer.packStructHeader( 1, PackStreamMessageFormatV1.MSG_RECORD );
         packer.packListHeader( 1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BufferingChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BufferingChunkedInputTest.java
@@ -259,7 +259,7 @@ public class BufferingChunkedInputTest
     {
         // Given
         RecordingByteChannel ch = new RecordingByteChannel();
-        ChunkedOutput out = new ChunkedOutput( ch );
+        ChunkedOutput out = new ChunkedOutput( ch, null );
 
         // these are written in one go on purpose, to check for buffer pointer errors where writes
         // would interfere with one another, writing at the wrong offsets

--- a/driver/src/test/java/org/neo4j/driver/internal/net/ChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/ChunkedInputTest.java
@@ -121,7 +121,7 @@ public class ChunkedInputTest
     {
         // Given
         RecordingByteChannel ch = new RecordingByteChannel();
-        ChunkedOutput out = new ChunkedOutput( ch );
+        ChunkedOutput out = new ChunkedOutput( ch, null );
 
         // these are written in one go on purpose, to check for buffer pointer errors where writes
         // would interfere with one another, writing at the wrong offsets

--- a/driver/src/test/java/org/neo4j/driver/internal/net/ChunkedOutputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/ChunkedOutputTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ChunkedOutputTest
 {
     private final RecordingByteChannel channel = new RecordingByteChannel();
-    private final ChunkedOutput out = new ChunkedOutput( 16, channel );
+    private final ChunkedOutput out = new ChunkedOutput( 16, channel, null );
 
     @Test
     public void shouldChunkSingleMessage() throws Throwable

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
@@ -106,7 +106,7 @@ public class SocketClientTest
 
     private SocketClient dummyClient( BoltServerAddress address )
     {
-        return new SocketClient( address, SecurityPlan.insecure(), CONNECTION_TIMEOUT, DEV_NULL_LOGGER );
+        return new SocketClient( null, address, SecurityPlan.insecure(), CONNECTION_TIMEOUT, DEV_NULL_LOGGER );
     }
 
     private SocketClient dummyClient()

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/BufferedChannelOutput.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/BufferedChannelOutput.java
@@ -107,7 +107,13 @@ public class BufferedChannelOutput implements PackOutput
         return this;
     }
 
-    private void ensure( int size ) throws IOException
+    @Override
+    public boolean supportsBytes()
+    {
+        return true;
+    }
+
+    private void ensure(int size ) throws IOException
     {
         if ( buffer.remaining() < size )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
@@ -344,7 +344,7 @@ public class PackStreamTest
 
             // Then
             assertThat( packType, equalTo( PackType.BYTES ) );
-            assertArrayEquals( array, unpacker.unpackBytes() );
+            assertArrayEquals( array, unpacker.unpackRawBytes() );
         }
     }
 
@@ -391,7 +391,7 @@ public class PackStreamTest
 
         // Then
         assertThat( packType, equalTo( PackType.BYTES ) );
-        assertArrayEquals( "ABCDEFGHIJ".getBytes(), unpacker.unpackBytes() );
+        assertArrayEquals( "ABCDEFGHIJ".getBytes(), unpacker.unpackRawBytes() );
 
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value;
+
+import org.junit.Test;
+import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.internal.types.TypeConstructor;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.types.TypeSystem;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class BytesValueTest
+{
+    public static final byte[] TEST_BYTES = "0123".getBytes();
+
+    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
+
+    @Test
+    public void testBytesValue() throws Exception
+    {
+        // Given
+        BytesValue value = new BytesValue( TEST_BYTES );
+
+        // Then
+        assertThat( value.asObject(), equalTo( TEST_BYTES ) );
+    }
+
+    @Test
+    public void testIsBytes() throws Exception
+    {
+        // Given
+        BytesValue value = new BytesValue( TEST_BYTES );
+
+        // Then
+        assertThat( typeSystem.BYTES().isTypeOf( value ), equalTo( true ) );
+    }
+
+    @Test
+    public void testEquals() throws Exception
+    {
+        // Given
+        BytesValue firstValue = new BytesValue( TEST_BYTES );
+        BytesValue secondValue = new BytesValue( TEST_BYTES );
+
+        // Then
+        assertThat( firstValue, equalTo( secondValue ) );
+    }
+
+    @Test
+    public void testHashCode() throws Exception
+    {
+        // Given
+        BytesValue value = new BytesValue( TEST_BYTES );
+
+        // Then
+        assertThat( value.hashCode(), notNullValue() );
+    }
+
+    @Test
+    public void shouldNotBeNull()
+    {
+        Value value = new BytesValue( TEST_BYTES );
+        assertFalse( value.isNull() );
+    }
+
+    @Test
+    public void shouldTypeAsString()
+    {
+        InternalValue value = new BytesValue( TEST_BYTES );
+        assertThat( value.typeConstructor(), equalTo( TypeConstructor.BYTES_TyCon ) );
+    }
+
+    @Test
+    public void shouldHaveBytesType()
+    {
+        InternalValue value = new BytesValue( TEST_BYTES );
+        assertThat( value.type(), equalTo( InternalTypeSystem.TYPE_SYSTEM.BYTES() ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SocketClientIT.java
@@ -59,7 +59,7 @@ public class SocketClientIT
     public void setup() throws GeneralSecurityException, IOException
     {
         SecurityPlan securityPlan = SecurityPlan.insecure();
-        client = new SocketClient( neo4j.address(), securityPlan, 42, DEV_NULL_LOGGER );
+        client = new SocketClient( null, neo4j.address(), securityPlan, 42, DEV_NULL_LOGGER );
     }
 
     @After

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -51,7 +51,7 @@ public class Neo4jRunner
 
     private static final boolean debug = true;
 
-    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.1.2";
+    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.2.0";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final URI DEFAULT_URI = URI.create( "bolt://localhost:7687" );
     public static final BoltServerAddress DEFAULT_ADDRESS = BoltServerAddress.from( DEFAULT_URI );


### PR DESCRIPTION
This PR adds client-side support for byte arrays using the PackStream BYTES type. Since this is only available in the 3.2 server and above, the code also detects when an attempt is made to write BYTES data to a connection to an earlier server version; in this case, a `ClientError` is raised with a useful error message.