### PR TITLE
Fail early on auth errors in direct driver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
@@ -37,6 +37,8 @@ public class DirectConnectionProvider implements ConnectionProvider
     {
         this.address = address;
         this.pool = pool;
+
+        verifyConnectivity();
     }
 
     @Override
@@ -54,5 +56,14 @@ public class DirectConnectionProvider implements ConnectionProvider
     public BoltServerAddress getAddress()
     {
         return address;
+    }
+
+    /**
+     * Acquires and releases a connection to verify connectivity so this connection provider fails fast. This is
+     * especially valuable when driver was created with incorrect credentials.
+     */
+    private void verifyConnectivity()
+    {
+        acquireConnection( AccessMode.READ ).close();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal;
 
+import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.URI;
@@ -28,6 +30,7 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.util.StubServer;
+import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -40,6 +43,20 @@ import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
 
 public class DirectDriverTest
 {
+    @ClassRule
+    public static final TestNeo4j neo4j = new TestNeo4j();
+
+    private Driver driver;
+
+    @After
+    public void closeDriver() throws Exception
+    {
+        if ( driver != null )
+        {
+            driver.close();
+        }
+    }
+
     @Test
     public void shouldUseDefaultPortIfMissing()
     {
@@ -47,7 +64,7 @@ public class DirectDriverTest
         URI uri = URI.create( "bolt://localhost" );
 
         // When
-        Driver driver = GraphDatabase.driver( uri );
+        driver = GraphDatabase.driver( uri, neo4j.authToken() );
 
         // Then
         assertThat( driver, is( directDriverWithAddress( LOCAL_DEFAULT ) ) );
@@ -61,7 +78,7 @@ public class DirectDriverTest
         BoltServerAddress address = BoltServerAddress.from( uri );
 
         // When
-        Driver driver = GraphDatabase.driver( uri );
+        driver = GraphDatabase.driver( uri, neo4j.authToken() );
 
         // Then
         assertThat( driver, is( directDriverWithAddress( address ) ) );
@@ -76,7 +93,7 @@ public class DirectDriverTest
         // When & Then
         try
         {
-            Driver driver = GraphDatabase.driver( uri );
+            driver = GraphDatabase.driver( uri, neo4j.authToken() );
             fail("Expecting error for wrong uri");
         }
         catch( IllegalArgumentException e )
@@ -93,7 +110,7 @@ public class DirectDriverTest
         BoltServerAddress address = BoltServerAddress.from( uri );
 
         // When
-        Driver driver = GraphDatabase.driver( uri );
+        driver = GraphDatabase.driver( uri, neo4j.authToken() );
 
         // Then
         assertThat( driver, is( directDriverWithAddress( address ) ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
@@ -39,16 +39,18 @@ import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
 public class GraphDatabaseTest
 {
     @Test
-    public void boltSchemeShouldInstantiateDirectDriver()
+    public void boltSchemeShouldInstantiateDirectDriver() throws Exception
     {
         // Given
-        URI uri = URI.create( "bolt://localhost:7687" );
+        StubServer server = StubServer.start( "dummy_connection.script", 9001 );
+        URI uri = URI.create( "bolt://localhost:9001" );
 
         // When
-        Driver driver = GraphDatabase.driver( uri );
+        Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
 
         // Then
         assertThat( driver, is( directDriver() ) );
+        server.exit();
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ErrorIT.java
@@ -25,9 +25,7 @@ import org.junit.rules.ExpectedException;
 import java.util.UUID;
 
 import org.neo4j.driver.v1.Config;
-import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -114,18 +112,11 @@ public class ErrorIT
     @Test
     public void shouldExplainConnectionError() throws Throwable
     {
-        // Given
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:7777" );
-              Session session = driver.session() )
-        {
-            // Expect
-            exception.expect( ServiceUnavailableException.class );
-            exception.expectMessage( "Unable to connect to localhost:7777, ensure the database is running " +
-                                     "and that there is a working network connection to it." );
+        exception.expect( ServiceUnavailableException.class );
+        exception.expectMessage( "Unable to connect to localhost:7777, ensure the database is running " +
+                                 "and that there is a working network connection to it." );
 
-            // When
-            session.run( "RETURN 1" );
-        }
+        GraphDatabase.driver( "bolt://localhost:7777" );
     }
 
     @Test
@@ -157,22 +148,17 @@ public class ErrorIT
     @Test
     public void shouldGetHelpfulErrorWhenTryingToConnectToHttpPort() throws Throwable
     {
-        // Given
         //the http server needs some time to start up
         Thread.sleep( 2000 );
-        Config config = Config.build().withoutEncryption().toConfig();
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:7474", config );
-              Session session = driver.session() )
-        {
-            // Expect
-            exception.expect( ClientException.class );
-            exception.expectMessage(
-                    "Server responded HTTP. Make sure you are not trying to connect to the http endpoint " +
-                    "(HTTP defaults to port 7474 whereas BOLT defaults to port 7687)" );
 
-            // When
-            session.run( "RETURN 1" );
-        }
+        Config config = Config.build().withoutEncryption().toConfig();
+
+        exception.expect( ClientException.class );
+        exception.expectMessage(
+                "Server responded HTTP. Make sure you are not trying to connect to the http endpoint " +
+                "(HTTP defaults to port 7474 whereas BOLT defaults to port 7687)" );
+
+        GraphDatabase.driver( "bolt://localhost:7474", config );
     }
 
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
@@ -47,15 +47,15 @@ public class LoggingIT
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
 
-        try( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(),
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        when( logger.isDebugEnabled() ).thenReturn( true );
+        when( logger.isTraceEnabled() ).thenReturn( true );
+
+        try ( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(),
                 Config.build().withLogging( logging ).toConfig() ) )
         {
             // When
-            when( logging.getLog( anyString() ) ).thenReturn( logger );
-            when( logger.isDebugEnabled() ).thenReturn( true );
-            when( logger.isTraceEnabled() ).thenReturn( true );
-
-            try( Session session = driver.session() )
+            try ( Session session = driver.session() )
             {
                 session.run( "CREATE (a {name:'Cat'})" );
             }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
@@ -74,10 +74,15 @@ public class StubServer
         catch ( IllegalThreadStateException ex )
         {
             // not exited yet
-            process.destroy();
-            process.waitFor();
+            exit();
             throw new ForceKilled();
         }
+    }
+
+    public void exit() throws InterruptedException
+    {
+        process.destroy();
+        process.waitFor();
     }
 
     private static String resource( String fileName )

--- a/driver/src/test/resources/dummy_connection.script
+++ b/driver/src/test/resources/dummy_connection.script
@@ -1,0 +1,2 @@
+!: AUTO INIT
+!: AUTO RESET

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigTrustExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigTrustExample.java
@@ -34,7 +34,7 @@ public class ConfigTrustExample implements AutoCloseable
     public ConfigTrustExample( String uri, String user, String password )
     {
         driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ),
-                Config.build().withTrustStrategy( Config.TrustStrategy.trustSystemCertificates() ).toConfig() );
+                Config.build().withTrustStrategy( Config.TrustStrategy.trustAllCertificates() ).toConfig() );
     }
     // end::config-trust[]
 


### PR DESCRIPTION
This PR makes direct driver test connectivity on creation. It's done by opening and closing a connection. Previously driver did not try to connect during creation and auth errors (incorrect credentials, etc.) popped up only when first query was executed or first transaction was started. Such delayed errors were confusing. Also routing driver behaved differently because it fetches routing table at creation and auth errors come out of constructor.