### PR TITLE
Fix `Transaction#isOpen()`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -205,7 +205,7 @@ class ExplicitTransaction implements Transaction
     @Override
     public boolean isOpen()
     {
-        return state == State.ACTIVE;
+        return state != State.SUCCEEDED && state != State.ROLLED_BACK;
     }
 
     private void ensureNotFailed()

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -26,8 +26,11 @@ import java.util.Map;
 
 import org.neo4j.driver.internal.spi.Collector;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.Value;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -142,5 +145,72 @@ public class ExplicitTransactionTest
         inOrder.verify( connection ).run( "BEGIN", expectedParams, Collector.NO_OP );
         inOrder.verify( connection ).pullAll( Collector.NO_OP );
         inOrder.verify( connection ).sync();
+    }
+
+    @Test
+    public void shouldBeOpenAfterConstruction()
+    {
+        Transaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        assertTrue( tx.isOpen() );
+    }
+
+    @Test
+    public void shouldBeOpenWhenMarkedForSuccess()
+    {
+        Transaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.success();
+
+        assertTrue( tx.isOpen() );
+    }
+
+    @Test
+    public void shouldBeOpenWhenMarkedForFailure()
+    {
+        Transaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.failure();
+
+        assertTrue( tx.isOpen() );
+    }
+
+    @Test
+    public void shouldBeOpenWhenMarkedToClose()
+    {
+        ExplicitTransaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.markToClose();
+
+        assertTrue( tx.isOpen() );
+    }
+
+    @Test
+    public void shouldBeClosedAfterCommit()
+    {
+        Transaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.success();
+        tx.close();
+
+        assertFalse( tx.isOpen() );
+    }
+
+    @Test
+    public void shouldBeClosedAfterRollback()
+    {
+        Transaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.failure();
+        tx.close();
+
+        assertFalse( tx.isOpen() );
+    }
+
+    private static Connection openConnectionMock()
+    {
+        Connection connection = mock( Connection.class );
+        when( connection.isOpen() ).thenReturn( true );
+        return connection;
     }
 }


### PR DESCRIPTION
It was previously reporting transactions marked for success/failure as closed which is not correct. Transaction will now be considered closed only after `Transaction#close()` call which executes commit/rollback.