### PR TITLE
Fix `Transaction#isOpen()` after errors

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -135,6 +135,12 @@ class ExplicitTransaction implements Transaction
                 {
                     rollbackTx();
                 }
+                else if ( state == State.FAILED )
+                {
+                    // unrecoverable error happened, transaction should've been rolled back on the server
+                    // update state so that this transaction does not remain open
+                    state = State.ROLLED_BACK;
+                }
             }
         }
         finally

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -207,6 +207,17 @@ public class ExplicitTransactionTest
         assertFalse( tx.isOpen() );
     }
 
+    @Test
+    public void shouldBeClosedWhenMarkedToCloseAndClosed()
+    {
+        ExplicitTransaction tx = new ExplicitTransaction( openConnectionMock(), mock( Runnable.class ) );
+
+        tx.markToClose();
+        tx.close();
+
+        assertFalse( tx.isOpen() );
+    }
+
     private static Connection openConnectionMock()
     {
         Connection connection = mock( Connection.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -30,7 +30,9 @@ import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertNotNull;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -163,5 +165,39 @@ public class NetworkSessionTest
         {
            assertThat( e.getMessage(), equalTo("This session has already been closed." ));
         }
+    }
+
+    @Test
+    public void transactionShouldBeOpenAfterSessionReset()
+    {
+        NetworkSession session = new NetworkSession( openConnectionMock() );
+        Transaction tx = session.beginTransaction();
+
+        assertTrue( tx.isOpen() );
+
+        session.reset();
+        assertTrue( tx.isOpen() );
+    }
+
+    @Test
+    public void transactionShouldBeClosedAfterSessionResetAndClose()
+    {
+        NetworkSession session = new NetworkSession( openConnectionMock() );
+        Transaction tx = session.beginTransaction();
+
+        assertTrue( tx.isOpen() );
+
+        session.reset();
+        assertTrue( tx.isOpen() );
+
+        tx.close();
+        assertFalse( tx.isOpen() );
+    }
+
+    private static Connection openConnectionMock()
+    {
+        Connection connection = mock( Connection.class );
+        when( connection.isOpen() ).thenReturn( true );
+        return connection;
     }
 }


### PR DESCRIPTION
`ExplicitTransaction` has a FAILED state which is reached when fatal connection error happens or `Session#reset()` is called. In both cases corresponding transaction on server will be rolled back by the database. This PR makes sure FAILED state is changed to ROLLED_BACK when transaction is closed. It's needed to make sure `Transaction#isOpen()` does not report status incorrectly after closing of a FAILED transaction.