### PR TITLE
char values should be encoded as strings

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
@@ -177,6 +177,11 @@ public class PackStream
             out.writeByte( value ? TRUE : FALSE );
         }
 
+        public void pack( char value ) throws IOException
+        {
+            pack( String.valueOf(value) );
+        }
+
         public void pack( long value ) throws IOException
         {
             if ( value >= MINUS_2_TO_THE_4 && value < PLUS_2_TO_THE_7)

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -141,6 +141,17 @@ public abstract class Values
         }
         return new ListValue( values );
     }
+
+    public static Value value( char... input )
+    {
+        Value[] values = new Value[input.length];
+        for ( int i = 0; i < input.length; i++ )
+        {
+            values[i] = value( input[i] );
+        }
+        return new ListValue( values );
+    }
+
     public static Value value( long... input )
     {
         Value[] values = new Value[input.length];
@@ -207,7 +218,7 @@ public abstract class Values
         return new ListValue( values.toArray( new Value[values.size()] ) );
     }
 
-    public static Value value (final char val ) { return new StringValue( String.valueOf(val) ); }
+    public static Value value (final char val ) { return new StringValue( String.valueOf( val ) ); }
 
     public static Value value( final String val )
     {

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -207,6 +207,8 @@ public abstract class Values
         return new ListValue( values.toArray( new Value[values.size()] ) );
     }
 
+    public static Value value (final char val ) { return new StringValue( String.valueOf(val) ); }
+
     public static Value value( final String val )
     {
         return new StringValue( val );

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -80,6 +80,9 @@ public class ValuesTest
         assertThat( value( new boolean[]{true, false, true} ),
                 equalTo( (Value) new ListValue( values( true, false, true ) ) ) );
 
+        assertThat( value( new char[]{'a', 'b', 'c'} ),
+                equalTo( (Value) new ListValue( values( 'a', 'b', 'c' ) ) ) );
+
         assertThat( value( new String[]{"a", "b", "c"} ),
                 equalTo( (Value) new ListValue( values( "a", "b", "c" ) ) ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -118,6 +118,9 @@ public class ValuesTest
         assertNotEquals( value( "Hello" ), value( "hello" ) );
         assertNotEquals( value( "This åäö string ?? contains strange " ),
                 value( "This åäö string ?? contains strange Ü" ) );
+
+        assertEquals( value ( 'A' ), value( 'A' ));
+        assertEquals( value ( 'A' ), value( "A" ));
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
@@ -396,6 +396,26 @@ public class PackStreamTest
     }
 
     @Test
+    public void testCanPackAndUnpackChar() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+
+        // When
+        PackStream.Packer packer = machine.packer();
+        packer.pack( 'A' );
+        packer.flush();
+
+        // Then
+        PackStream.Unpacker unpacker = newUnpacker( machine.output() );
+        PackType packType = unpacker.peekNextType();
+
+        // Then
+        assertThat( packType, equalTo( PackType.STRING ) );
+        assertThat( unpacker.unpackString(), equalTo( "A" ));
+    }
+
+    @Test
     public void testCanPackAndUnpackString() throws Throwable
     {
         // Given


### PR DESCRIPTION
Added overloads of pack and value methods with a char parameter to stop calls of this to be invoked on int overloads. Added corresponding tests.