### PR TITLE
Do not cache resolved inet address

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
@@ -103,20 +103,24 @@ public class BoltServerAddress
         return format( "%s:%d", host, port );
     }
 
+    /**
+     * Create a {@link SocketAddress} from this bolt address. This method always attempts to resolve the hostname into
+     * an {@link InetAddress}.
+     *
+     * @return new socket address.
+     * @see InetSocketAddress
+     */
     public SocketAddress toSocketAddress()
     {
-        if (socketAddress == null)
-        {
-            socketAddress = new InetSocketAddress( host, port );
-        }
-        return socketAddress;
+        return new InetSocketAddress( host, port );
     }
 
     /**
      * Resolve the host name down to an IP address, if not already resolved.
      *
      * @return this instance if already resolved, otherwise a new address instance
-     * @throws UnknownHostException
+     * @throws UnknownHostException if no IP address for the host could be found
+     * @see InetAddress#getByName(String)
      */
     public BoltServerAddress resolve() throws UnknownHostException
     {

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -19,10 +19,12 @@
 package org.neo4j.driver.internal.net;
 
 import org.junit.Test;
-import org.neo4j.driver.internal.net.BoltServerAddress;
+
+import java.net.SocketAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 
 public class BoltServerAddressTest
 {
@@ -38,4 +40,14 @@ public class BoltServerAddressTest
         assertThat( new BoltServerAddress( "localhost" ).port(), equalTo( BoltServerAddress.DEFAULT_PORT ) );
     }
 
+    @Test
+    public void shouldAlwaysResolveAddress()
+    {
+        BoltServerAddress boltAddress = new BoltServerAddress( "localhost" );
+
+        SocketAddress socketAddress1 = boltAddress.toSocketAddress();
+        SocketAddress socketAddress2 = boltAddress.toSocketAddress();
+
+        assertNotSame( socketAddress1, socketAddress2 );
+    }
 }


### PR DESCRIPTION
Internally driver always uses `BoltServerAddress` to represent host and port. These addresses are constructed from the initial driver URI and from routing procedure output in routing driver. Bolt address is only resolved to an `InetAddress` when new connection is established.

Resolved `InetSocketAddress` was cached in `BoltServerAddress` which caused problems when corresponding DNS record changed. Driver would then still try to connect to a cached stale `InetSocketAddress`.

This PR makes resolution happen on every connection.