### PR TITLE
Don't leak open connections when the TLS handshake fails

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/ChannelFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/ChannelFactory.java
@@ -44,7 +44,22 @@ class ChannelFactory
 
         if ( securityPlan.requiresEncryption() )
         {
-            channel = TLSSocketChannel.create( address, securityPlan, soChannel, log );
+            try
+            {
+                channel = TLSSocketChannel.create( address, securityPlan, soChannel, log );
+            }
+            catch ( Exception e )
+            {
+                try
+                {
+                    channel.close();
+                }
+                catch( IOException e2 )
+                {
+                    // best effort
+                }
+                throw e;
+            }
         }
 
         if ( log.isTraceEnabled() )


### PR DESCRIPTION
Context: Our client is setup to keep retrying to connect to our neo4j server. When the client could not validate the certificate of the server, this leak caused it to take up all available tcp connections.

Example stacktrace of an exception where the connection was leaked:
```
Caused by: org.neo4j.driver.v1.exceptions.SecurityException: Failed to establish secured connection with the server: General SSLEngine problem
	at org.neo4j.driver.internal.security.TLSSocketChannel.create(TLSSocketChannel.java:85)
	at org.neo4j.driver.internal.security.TLSSocketChannel.create(TLSSocketChannel.java:73)
	at org.neo4j.driver.internal.net.ChannelFactory.create(ChannelFactory.java:47)
	at org.neo4j.driver.internal.net.SocketClient.start(SocketClient.java:124)
	at org.neo4j.driver.internal.net.SocketConnection.startSocketClient(SocketConnection.java:89)
	at org.neo4j.driver.internal.net.SocketConnection.<init>(SocketConnection.java:64)
	at org.neo4j.driver.internal.net.SocketConnector.createConnection(SocketConnector.java:77)
	at org.neo4j.driver.internal.net.SocketConnector.connect(SocketConnector.java:50)
       ...
Caused by: javax.net.ssl.SSLHandshakeException: General SSLEngine problem
	at sun.security.ssl.Handshaker.checkThrown(Handshaker.java:1478)
	at sun.security.ssl.SSLEngineImpl.checkTaskThrown(SSLEngineImpl.java:535)
	at sun.security.ssl.SSLEngineImpl.writeAppRecord(SSLEngineImpl.java:1214)
	at sun.security.ssl.SSLEngineImpl.wrap(SSLEngineImpl.java:1186)
	at javax.net.ssl.SSLEngine.wrap(SSLEngine.java:469)
	at org.neo4j.driver.internal.security.TLSSocketChannel.wrap(TLSSocketChannel.java:319)
	at org.neo4j.driver.internal.security.TLSSocketChannel.runHandshake(TLSSocketChannel.java:136)
	at org.neo4j.driver.internal.security.TLSSocketChannel.create(TLSSocketChannel.java:81)
        ...
```