### PR TITLE
Support IPv6 in routing procedure responses

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -56,7 +56,7 @@ public class DriverFactory
     public final Driver newInstance( URI uri, AuthToken authToken, RoutingSettings routingSettings,
             RetrySettings retrySettings, Config config )
     {
-        BoltServerAddress address = BoltServerAddress.from( uri );
+        BoltServerAddress address = new BoltServerAddress( uri );
         RoutingSettings newRoutingSettings = routingSettings.withRoutingContext( new RoutingContext( uri ) );
         SecurityPlan securityPlan = createSecurityPlan( address, config );
         ConnectionPool connectionPool = createConnectionPool( authToken, securityPlan, config );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BoltServerAddress.java
@@ -34,46 +34,23 @@ public class BoltServerAddress
     public static final int DEFAULT_PORT = 7687;
     public static final BoltServerAddress LOCAL_DEFAULT = new BoltServerAddress( "localhost", DEFAULT_PORT );
 
-    public static BoltServerAddress from( URI uri )
-    {
-        int port = uri.getPort();
-        if ( port == -1 )
-        {
-            port = DEFAULT_PORT;
-        }
-
-        if( uri.getHost() == null )
-        {
-            throw new IllegalArgumentException( "Invalid URI format `" + uri.toString() + "`");
-        }
-
-        return new BoltServerAddress( uri.getHost(), port );
-    }
-
     private final String host;
     private final int port;
 
-    private SocketAddress socketAddress = null;  // created lazily if required
+    public BoltServerAddress( String address )
+    {
+        this( uriFrom( address ) );
+    }
+
+    public BoltServerAddress( URI uri )
+    {
+        this( hostFrom( uri ), portFrom( uri ) );
+    }
 
     public BoltServerAddress( String host, int port )
     {
         this.host = host;
         this.port = port;
-    }
-
-    public BoltServerAddress( String host )
-    {
-        int colon = host.indexOf( ':' );
-        if ( colon >= 0 )
-        {
-            this.port = Integer.parseInt( host.substring( colon + 1 ) );
-            this.host = host.substring( 0, colon );
-        }
-        else
-        {
-            this.host = host;
-            this.port = DEFAULT_PORT;
-        }
     }
 
     @Override
@@ -145,4 +122,27 @@ public class BoltServerAddress
         return port;
     }
 
+    private static String hostFrom( URI uri )
+    {
+        String host = uri.getHost();
+        if ( host == null )
+        {
+            throw new IllegalArgumentException( "Invalid URI format `" + uri.toString() + "`" );
+        }
+        return host;
+    }
+
+    private static int portFrom( URI uri )
+    {
+        int port = uri.getPort();
+        return port == -1 ? DEFAULT_PORT : port;
+    }
+
+    private static URI uriFrom( String address )
+    {
+        // URI can't parse addresses without scheme, prepend fake "bolt://" to reuse the parsing facility
+        boolean hasScheme = address.contains( "://" );
+        String addressWithScheme = hasScheme ? address : "bolt://" + address;
+        return URI.create( addressWithScheme );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
@@ -106,7 +106,7 @@ public class DirectDriverTest
         }
         catch ( IllegalArgumentException e )
         {
-            assertThat( e.getMessage(), equalTo( "Invalid URI format `*`" ) );
+            assertThat( e.getMessage(), equalTo( "Invalid address format `*`" ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverTest.java
@@ -83,7 +83,7 @@ public class DirectDriverTest
 
         // Given
         URI uri = URI.create( "bolt://[::1]" );
-        BoltServerAddress address = BoltServerAddress.from( uri );
+        BoltServerAddress address = new BoltServerAddress( uri );
 
         // When
         driver = GraphDatabase.driver( uri, neo4j.authToken() );
@@ -115,7 +115,7 @@ public class DirectDriverTest
     {
         // Given
         URI uri = URI.create( "bolt://localhost:7687" );
-        BoltServerAddress address = BoltServerAddress.from( uri );
+        BoltServerAddress address = new BoltServerAddress( uri );
 
         // When
         driver = GraphDatabase.driver( uri, neo4j.authToken() );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalBuilderTest.java
@@ -26,8 +26,8 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.summary.InternalSummaryCounters;
 import org.neo4j.driver.internal.summary.SummaryBuilder;
-import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.ServerInfo;
 import org.neo4j.driver.v1.summary.SummaryCounters;
 
@@ -90,7 +90,7 @@ public class InternalBuilderTest
     {
         // Given
         SummaryBuilder builder = new SummaryBuilder( new Statement( "This is a test statement"), new
-                InternalServerInfo( BoltServerAddress.from( URI.create( "http://neo4j.com" ) ),
+                InternalServerInfo( new BoltServerAddress( URI.create( "http://neo4j.com" ) ),
                 "super-awesome" ) );
 
         // When

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalBuilderTest.java
@@ -20,8 +20,6 @@ package org.neo4j.driver.internal;
 
 import org.junit.Test;
 
-import java.net.URI;
-
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.summary.InternalSummaryCounters;
@@ -89,9 +87,8 @@ public class InternalBuilderTest
     public void shouldObtainStatementAndServerInfoFromSummaryBuilder() throws Throwable
     {
         // Given
-        SummaryBuilder builder = new SummaryBuilder( new Statement( "This is a test statement"), new
-                InternalServerInfo( new BoltServerAddress( URI.create( "http://neo4j.com" ) ),
-                "super-awesome" ) );
+        SummaryBuilder builder = new SummaryBuilder( new Statement( "This is a test statement" ),
+                new InternalServerInfo( new BoltServerAddress( "neo4j.com" ), "super-awesome" ) );
 
         // When
         ResultSummary summary = builder.build();

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressParsingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressParsingTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.driver.internal.net.BoltServerAddress.DEFAULT_PORT;
+
+@RunWith( Parameterized.class )
+public class BoltServerAddressParsingTest
+{
+    @Parameter
+    public String address;
+    @Parameter( 1 )
+    public String expectedHost;
+    @Parameter( 2 )
+    public int expectedPort;
+
+    @Parameters( name = "{0}" )
+    public static Object[][] addressesToParse()
+    {
+        return new Object[][]{
+                // Hostname
+                {"localhost", "localhost", DEFAULT_PORT},
+                {"localhost:9193", "localhost", 9193},
+                {"neo4j.com", "neo4j.com", DEFAULT_PORT},
+                {"royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
+                {"royal-server.com.uk:4546", "royal-server.com.uk", 4546},
+
+                // Hostname with scheme
+                {"bolt://localhost", "localhost", DEFAULT_PORT},
+                {"bolt+routing://localhost", "localhost", DEFAULT_PORT},
+                {"bolt://localhost:9193", "localhost", 9193},
+                {"bolt+routing://localhost:9193", "localhost", 9193},
+                {"bolt://neo4j.com", "neo4j.com", DEFAULT_PORT},
+                {"bolt+routing://neo4j.com", "neo4j.com", DEFAULT_PORT},
+                {"bolt://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
+                {"bolt+routing://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
+                {"bolt://royal-server.com.uk:4546", "royal-server.com.uk", 4546},
+                {"bolt+routing://royal-server.com.uk:4546", "royal-server.com.uk", 4546},
+
+                // IPv4
+                {"127.0.0.1", "127.0.0.1", DEFAULT_PORT},
+                {"8.8.8.8:8080", "8.8.8.8", 8080},
+                {"0.0.0.0", "0.0.0.0", DEFAULT_PORT},
+                {"192.0.2.235:4329", "192.0.2.235", 4329},
+                {"172.31.255.255:255", "172.31.255.255", 255},
+
+                // IPv4 with scheme
+                {"bolt://198.51.100.0", "198.51.100.0", DEFAULT_PORT},
+                {"bolt://65.21.10.12:5656", "65.21.10.12", 5656},
+                {"bolt+routing://12.0.0.5", "12.0.0.5", DEFAULT_PORT},
+                {"bolt+routing://155.55.20.6:9191", "155.55.20.6", 9191},
+
+                // IPv6
+                {"::1", "[::1]", DEFAULT_PORT},
+                {"ff02::2:ff00:0", "[ff02::2:ff00:0]", DEFAULT_PORT},
+                {"[1afc:0:a33:85a3::ff2f]", "[1afc:0:a33:85a3::ff2f]", DEFAULT_PORT},
+                {"[::1]:1515", "[::1]", 1515},
+                {"[ff0a::101]:8989", "[ff0a::101]", 8989},
+
+                // IPv6 with scheme
+                {"bolt://[::1]", "[::1]", DEFAULT_PORT},
+                {"bolt+routing://[::1]", "[::1]", DEFAULT_PORT},
+                {"bolt://[ff02::d]", "[ff02::d]", DEFAULT_PORT},
+                {"bolt+routing://[fe80::b279:2f]", "[fe80::b279:2f]", DEFAULT_PORT},
+                {"bolt://[::1]:8687", "[::1]", 8687},
+                {"bolt+routing://[::1]:1212", "[::1]", 1212},
+                {"bolt://[ff02::d]:9090", "[ff02::d]", 9090},
+                {"bolt+routing://[fe80::b279:2f]:7878", "[fe80::b279:2f]", 7878},
+
+                // IPv6 with zone id
+                {"::1%eth0", "[::1%eth0]", DEFAULT_PORT},
+                {"ff02::2:ff00:0%12", "[ff02::2:ff00:0%12]", DEFAULT_PORT},
+                {"[1afc:0:a33:85a3::ff2f%eth1]", "[1afc:0:a33:85a3::ff2f%eth1]", DEFAULT_PORT},
+                {"[::1%eth0]:3030", "[::1%eth0]", 3030},
+                {"[ff0a::101%8]:4040", "[ff0a::101%8]", 4040},
+
+                // IPv6 with scheme and zone id
+                {"bolt://[::1%eth5]", "[::1%eth5]", DEFAULT_PORT},
+                {"bolt+routing://[::1%12]", "[::1%12]", DEFAULT_PORT},
+                {"bolt://[ff02::d%3]", "[ff02::d%3]", DEFAULT_PORT},
+                {"bolt+routing://[fe80::b279:2f%eth0]", "[fe80::b279:2f%eth0]", DEFAULT_PORT},
+                {"bolt://[::1%eth3]:8687", "[::1%eth3]", 8687},
+                {"bolt+routing://[::1%2]:1212", "[::1%2]", 1212},
+                {"bolt://[ff02::d%3]:9090", "[ff02::d%3]", 9090},
+                {"bolt+routing://[fe80::b279:2f%eth1]:7878", "[fe80::b279:2f%eth1]", 7878},
+        };
+    }
+
+    @Test
+    public void shouldParseAddress()
+    {
+        BoltServerAddress parsed = new BoltServerAddress( address );
+        assertEquals( expectedHost, parsed.host() );
+        assertEquals( expectedPort, parsed.port() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.net.SocketAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 
@@ -49,5 +50,38 @@ public class BoltServerAddressTest
         SocketAddress socketAddress2 = boltAddress.toSocketAddress();
 
         assertNotSame( socketAddress1, socketAddress2 );
+    }
+
+    @Test
+    public void shouldParseIPv4Addresses()
+    {
+        BoltServerAddress address1 = new BoltServerAddress( "127.0.0.1:1234" );
+        assertEquals( "127.0.0.1", address1.host() );
+        assertEquals( 1234, address1.port() );
+
+        BoltServerAddress address2 = new BoltServerAddress( "8.8.8.8:8080" );
+        assertEquals( "8.8.8.8", address2.host() );
+        assertEquals( 8080, address2.port() );
+    }
+
+    @Test
+    public void shouldParseIPv6Addresses()
+    {
+        BoltServerAddress address1 = new BoltServerAddress( "[::1]:7688" );
+        assertEquals( "[::1]", address1.host() );
+        assertEquals( 7688, address1.port() );
+
+        BoltServerAddress address2 = new BoltServerAddress( "[1afc:0:a33:85a3::ff2f]:9001" );
+        assertEquals( "[1afc:0:a33:85a3::ff2f]", address2.host() );
+        assertEquals( 9001, address2.port() );
+    }
+
+    @Test
+    public void shouldParseBoltAddresses()
+    {
+        BoltServerAddress address = new BoltServerAddress( "bolt://host:6565" );
+
+        assertEquals( "host", address.host() );
+        assertEquals( 6565, address.port() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -23,16 +23,16 @@ import org.junit.Test;
 import java.net.SocketAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.driver.internal.net.BoltServerAddress.DEFAULT_PORT;
 
 public class BoltServerAddressTest
 {
     @Test
     public void defaultPortShouldBe7687()
     {
-        assertThat( BoltServerAddress.DEFAULT_PORT, equalTo( 7687 ) );
+        assertThat( DEFAULT_PORT, equalTo( 7687 ) );
     }
 
     @Test
@@ -50,38 +50,5 @@ public class BoltServerAddressTest
         SocketAddress socketAddress2 = boltAddress.toSocketAddress();
 
         assertNotSame( socketAddress1, socketAddress2 );
-    }
-
-    @Test
-    public void shouldParseIPv4Addresses()
-    {
-        BoltServerAddress address1 = new BoltServerAddress( "127.0.0.1:1234" );
-        assertEquals( "127.0.0.1", address1.host() );
-        assertEquals( 1234, address1.port() );
-
-        BoltServerAddress address2 = new BoltServerAddress( "8.8.8.8:8080" );
-        assertEquals( "8.8.8.8", address2.host() );
-        assertEquals( 8080, address2.port() );
-    }
-
-    @Test
-    public void shouldParseIPv6Addresses()
-    {
-        BoltServerAddress address1 = new BoltServerAddress( "[::1]:7688" );
-        assertEquals( "[::1]", address1.host() );
-        assertEquals( 7688, address1.port() );
-
-        BoltServerAddress address2 = new BoltServerAddress( "[1afc:0:a33:85a3::ff2f]:9001" );
-        assertEquals( "[1afc:0:a33:85a3::ff2f]", address2.host() );
-        assertEquals( 9001, address2.port() );
-    }
-
-    @Test
-    public void shouldParseBoltAddresses()
-    {
-        BoltServerAddress address = new BoltServerAddress( "bolt://host:6565" );
-
-        assertEquals( "host", address.host() );
-        assertEquals( 6565, address.port() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
@@ -23,7 +23,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Queue;
@@ -63,7 +62,7 @@ public class SocketConnectionTest
         SocketClient socket = mock( SocketClient.class );
         SocketConnection conn = new SocketConnection( socket, SERVER_INFO, DEV_NULL_LOGGER );
 
-        when( socket.address() ).thenReturn( new BoltServerAddress( URI.create( "http://neo4j.com:9000" ) ) );
+        when( socket.address() ).thenReturn( new BoltServerAddress( "neo4j.com:9000" ) );
 
         // set up response messages
         ArrayList<Message> serverResponses = new ArrayList<>();

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketConnectionTest.java
@@ -63,7 +63,7 @@ public class SocketConnectionTest
         SocketClient socket = mock( SocketClient.class );
         SocketConnection conn = new SocketConnection( socket, SERVER_INFO, DEV_NULL_LOGGER );
 
-        when( socket.address() ).thenReturn( BoltServerAddress.from( URI.create( "http://neo4j.com:9000" ) ) );
+        when( socket.address() ).thenReturn( new BoltServerAddress( URI.create( "http://neo4j.com:9000" ) ) );
 
         // set up response messages
         ArrayList<Message> serverResponses = new ArrayList<>();

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -54,7 +54,7 @@ public class Neo4jRunner
     private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.2.0";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final URI DEFAULT_URI = URI.create( "bolt://localhost:7687" );
-    public static final BoltServerAddress DEFAULT_ADDRESS = BoltServerAddress.from( DEFAULT_URI );
+    public static final BoltServerAddress DEFAULT_ADDRESS = new BoltServerAddress( DEFAULT_URI );
 
     public static final String USER = "neo4j";
     public static final String PASSWORD = "password";

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -380,7 +380,7 @@ public class Cluster
     {
         try
         {
-            return BoltServerAddress.from( uri ).resolve();
+            return new BoltServerAddress( uri ).resolve();
         }
         catch ( UnknownHostException e )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterMember.java
@@ -75,7 +75,7 @@ public class ClusterMember
     {
         try
         {
-            return BoltServerAddress.from( uri ).resolve();
+            return new BoltServerAddress( uri ).resolve();
         }
         catch ( UnknownHostException e )
         {


### PR DESCRIPTION
This PR improves parsing in `BoltServerAddress` to support IPv6 in `getServers()` and `getRoutingTable()` procedure responses.