### PR TITLE
Added InDev neo4j server version as a legal version

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -28,6 +28,7 @@ import static java.lang.Integer.compare;
 
 public class ServerVersion
 {
+    private static final String NEO4J_IN_DEV_VERSION_STRING = "Neo4j/dev";
     private final int major;
     private final int minor;
     private final int patch;
@@ -44,6 +45,7 @@ public class ServerVersion
     public static final ServerVersion v3_2_0 = new ServerVersion(3, 2, 0);
     public static final ServerVersion v3_1_0 = new ServerVersion(3, 1, 0);
     public static final ServerVersion v3_0_0 = new ServerVersion(3, 0, 0);
+    public static final ServerVersion vInDev = new ServerVersion(0, 0, 0);
 
     public static ServerVersion version( Driver driver )
     {
@@ -74,6 +76,10 @@ public class ServerVersion
                     patch = Integer.valueOf( patchString );
                 }
                 return new ServerVersion( major, minor, patch );
+            }
+            else if ( server.equalsIgnoreCase( NEO4J_IN_DEV_VERSION_STRING ) )
+            {
+                return vInDev;
             }
             else
             {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -1,0 +1,44 @@
+package org.neo4j.driver.internal.util;
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+public class ServerVersionTest
+{
+    @Test
+    public void version() throws Exception
+    {
+        String nullVersion = null;
+        assertThat( ServerVersion.version( nullVersion ), is( ServerVersion.v3_0_0 ) );
+        assertThat( ServerVersion.version( "Neo4j/dev" ), is( ServerVersion.vInDev ) );
+        assertThat( ServerVersion.version( "Neo4j/3.2.0" ), is( ServerVersion.v3_2_0 ) );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void versionShouldThrowExceptionIfServerVersionCantBeParsed() throws Exception
+    {
+        ServerVersion.version( "" );
+        fail( "Should have failed to parse version" );
+    }
+
+}


### PR DESCRIPTION
When using driver for server tests, the server under development has a server version `Neo4j/InDev`, which will break driver's parsing of server version. This PR allow the inDev server version to be a legal server version 0.0.0. 
Related tests are added too