### PR TITLE
Added ability to enforce max connection lifetime

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -177,7 +177,7 @@ public class DriverFactory
 
         ConnectionSettings connectionSettings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
         PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize(),
-                config.idleTimeBeforeConnectionTest() );
+                config.idleTimeBeforeConnectionTest(), config.maxConnectionLifetime() );
         Connector connector = createConnector( connectionSettings, securityPlan, config.logging() );
 
         return new SocketConnectionPool( poolSettings, connector, createClock(), config.logging() );

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingPooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingPooledConnection.java
@@ -222,6 +222,12 @@ public class RoutingPooledConnection implements PooledConnection
     }
 
     @Override
+    public long creationTimestamp()
+    {
+        return delegate.creationTimestamp();
+    }
+
+    @Override
     public long lastUsedTimestamp()
     {
         return delegate.lastUsedTimestamp();

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueue.java
@@ -107,7 +107,7 @@ public class BlockingPooledConnectionQueue
         return connection;
     }
 
-    void disposeBroken( PooledConnection connection )
+    void dispose( PooledConnection connection )
     {
         acquiredConnections.remove( connection );
         disposeSafely( connection );

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PoolSettings.java
@@ -21,17 +21,21 @@ package org.neo4j.driver.internal.net.pooling;
 public class PoolSettings
 {
     public static final int NO_IDLE_CONNECTION_TEST = -1;
+    public static final int INFINITE_CONNECTION_LIFETIME = -1;
 
     public static final int DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE = 10;
     public static final int DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST = NO_IDLE_CONNECTION_TEST;
+    public static final int DEFAULT_MAX_CONNECTION_LIFETIME = INFINITE_CONNECTION_LIFETIME;
 
     private final int maxIdleConnectionPoolSize;
     private final long idleTimeBeforeConnectionTest;
+    private final long maxConnectionLifetime;
 
-    public PoolSettings( int maxIdleConnectionPoolSize, long idleTimeBeforeConnectionTest )
+    public PoolSettings( int maxIdleConnectionPoolSize, long idleTimeBeforeConnectionTest, long maxConnectionLifetime )
     {
         this.maxIdleConnectionPoolSize = maxIdleConnectionPoolSize;
         this.idleTimeBeforeConnectionTest = idleTimeBeforeConnectionTest;
+        this.maxConnectionLifetime = maxConnectionLifetime;
     }
 
     public int maxIdleConnectionPoolSize()
@@ -52,5 +56,20 @@ public class PoolSettings
     public boolean idleTimeBeforeConnectionTestConfigured()
     {
         return idleTimeBeforeConnectionTest >= 0;
+    }
+
+    public long maxConnectionLifetime()
+    {
+        if ( !maxConnectionLifetimeConfigured() )
+        {
+            throw new IllegalStateException(
+                    "Max connection lifetime is not configured: " + maxConnectionLifetime );
+        }
+        return maxConnectionLifetime;
+    }
+
+    public boolean maxConnectionLifetimeConfigured()
+    {
+        return maxConnectionLifetime > 0;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumer.java
@@ -47,7 +47,7 @@ class PooledConnectionReleaseConsumer implements Consumer<PooledConnection>
         }
         else
         {
-            connections.disposeBroken( pooledConnection );
+            connections.dispose( pooledConnection );
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnection.java
@@ -60,6 +60,8 @@ public class PooledSocketConnection implements PooledConnection
     private boolean unrecoverableErrorsOccurred = false;
     private SessionResourcesHandler resourcesHandler;
     private final Clock clock;
+
+    private final long creationTimestamp;
     private long lastUsedTimestamp;
 
     public PooledSocketConnection( Connection delegate, Consumer<PooledConnection> release, Clock clock )
@@ -67,6 +69,7 @@ public class PooledSocketConnection implements PooledConnection
         this.delegate = delegate;
         this.release = release;
         this.clock = clock;
+        this.creationTimestamp = clock.millis();
         updateLastUsedTimestamp();
     }
 
@@ -281,6 +284,12 @@ public class PooledSocketConnection implements PooledConnection
     }
 
     @Override
+    public long creationTimestamp()
+    {
+        return creationTimestamp;
+    }
+
+    @Override
     public long lastUsedTimestamp()
     {
         return lastUsedTimestamp;
@@ -315,6 +324,6 @@ public class PooledSocketConnection implements PooledConnection
 
     private void updateLastUsedTimestamp()
     {
-        this.lastUsedTimestamp = clock.millis();
+        lastUsedTimestamp = clock.millis();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/PooledConnection.java
@@ -41,6 +41,13 @@ public interface PooledConnection extends Connection
     boolean hasUnrecoverableErrors();
 
     /**
+     * Timestamp of when this connection was created. This timestamp should never change.
+     *
+     * @return timestamp as returned by {@link Clock#millis()}.
+     */
+    long creationTimestamp();
+
+    /**
      * Timestamp of when this connection was used. This timestamp is updated when connection is returned to the pool.
      *
      * @return timestamp as returned by {@link Clock#millis()}.

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.net.pooling.PoolSettings.DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
+import static org.neo4j.driver.internal.net.pooling.PoolSettings.INFINITE_CONNECTION_LIFETIME;
 import static org.neo4j.driver.internal.net.pooling.PoolSettings.NO_IDLE_CONNECTION_TEST;
 import static org.neo4j.driver.internal.spi.Collector.NO_OP;
 import static org.neo4j.driver.internal.util.Matchers.containsReader;
@@ -351,7 +352,8 @@ public class RoutingPooledConnectionErrorHandlingTest
     private static ConnectionPool newConnectionPool( Connector connector, BoltServerAddress... addresses )
     {
         int maxIdleConnections = DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE;
-        PoolSettings settings = new PoolSettings( maxIdleConnections, NO_IDLE_CONNECTION_TEST );
+        PoolSettings settings = new PoolSettings( maxIdleConnections, NO_IDLE_CONNECTION_TEST,
+                INFINITE_CONNECTION_LIFETIME );
         SocketConnectionPool pool = new SocketConnectionPool( settings, connector, Clock.SYSTEM, DEV_NULL_LOGGING );
 
         // force pool to create and memorize some connections

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.driver.internal.spi.PooledConnection;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class RoutingPooledConnectionTest
+{
+    @Mock
+    private PooledConnection pooledConnection;
+    @InjectMocks
+    private RoutingPooledConnection routingPooledConnection;
+
+    @Test
+    public void shouldExposeCreationTimestamp()
+    {
+        when( pooledConnection.creationTimestamp() ).thenReturn( 42L );
+
+        long timestamp = routingPooledConnection.creationTimestamp();
+
+        assertEquals( 42L, timestamp );
+    }
+
+    @Test
+    public void shouldExposeLastUsedTimestamp()
+    {
+        when( pooledConnection.lastUsedTimestamp() ).thenReturn( 42L );
+
+        long timestamp = routingPooledConnection.lastUsedTimestamp();
+
+        assertEquals( 42L, timestamp );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -287,7 +287,7 @@ public class BlockingPooledConnectionQueueTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void shouldDisposeBrokenConnections()
+    public void shouldDisposeConnections()
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
 
@@ -295,7 +295,25 @@ public class BlockingPooledConnectionQueueTest
         PooledConnection connection = queue.acquire( mock( Supplier.class ) );
         assertEquals( 1, queue.activeConnections() );
 
-        queue.disposeBroken( connection );
+        queue.dispose( connection );
+        assertEquals( 0, queue.activeConnections() );
+        verify( connection ).dispose();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    public void shouldDisposeConnectionsThatThrowOnDisposal()
+    {
+        BlockingPooledConnectionQueue queue = newConnectionQueue( 5 );
+
+        PooledConnection pooledConnection = mock( PooledConnection.class );
+        doThrow( new RuntimeException() ).when( pooledConnection ).dispose();
+
+        queue.offer( pooledConnection );
+        PooledConnection connection = queue.acquire( mock( Supplier.class ) );
+        assertEquals( 1, queue.activeConnections() );
+
+        queue.dispose( connection );
         assertEquals( 0, queue.activeConnections() );
         verify( connection ).dispose();
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PoolSettingsTest.java
@@ -31,7 +31,7 @@ public class PoolSettingsTest
     @Test
     public void idleTimeBeforeConnectionTestWhenConfigured()
     {
-        PoolSettings settings = new PoolSettings( 10, 42 );
+        PoolSettings settings = new PoolSettings( 10, 42, 10 );
         assertTrue( settings.idleTimeBeforeConnectionTestConfigured() );
         assertEquals( 42, settings.idleTimeBeforeConnectionTest() );
     }
@@ -39,7 +39,7 @@ public class PoolSettingsTest
     @Test
     public void idleTimeBeforeConnectionTestWhenSetToZero()
     {
-        PoolSettings settings = new PoolSettings( 10, 0 );
+        PoolSettings settings = new PoolSettings( 10, 0, 10 );
         assertTrue( settings.idleTimeBeforeConnectionTestConfigured() );
         assertEquals( 0, settings.idleTimeBeforeConnectionTest() );
     }
@@ -47,20 +47,53 @@ public class PoolSettingsTest
     @Test
     public void idleTimeBeforeConnectionTestWhenSetToNegativeValue()
     {
-        testWithIllegalValue( -1 );
-        testWithIllegalValue( -42 );
-        testWithIllegalValue( Integer.MIN_VALUE );
+        testIdleTimeBeforeConnectionTestWithIllegalValue( -1 );
+        testIdleTimeBeforeConnectionTestWithIllegalValue( -42 );
+        testIdleTimeBeforeConnectionTestWithIllegalValue( Integer.MIN_VALUE );
     }
 
-    private static void testWithIllegalValue( int value )
+    @Test
+    public void maxConnectionLifetimeWhenConfigured()
     {
-        PoolSettings settings = new PoolSettings( 10, value );
+        PoolSettings settings = new PoolSettings( 10, 10, 42 );
+        assertTrue( settings.maxConnectionLifetimeConfigured() );
+        assertEquals( 42, settings.maxConnectionLifetime() );
+    }
+
+    @Test
+    public void maxConnectionLifetimeWhenSetToZeroOrNegativeValue()
+    {
+        testMaxConnectionLifetimeWithIllegalValue( 0 );
+        testMaxConnectionLifetimeWithIllegalValue( -1 );
+        testMaxConnectionLifetimeWithIllegalValue( -42 );
+        testMaxConnectionLifetimeWithIllegalValue( Integer.MIN_VALUE );
+    }
+
+    private static void testIdleTimeBeforeConnectionTestWithIllegalValue( int value )
+    {
+        PoolSettings settings = new PoolSettings( 10, value, 10 );
 
         assertFalse( settings.idleTimeBeforeConnectionTestConfigured() );
 
         try
         {
             settings.idleTimeBeforeConnectionTest();
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    private static void testMaxConnectionLifetimeWithIllegalValue( int value )
+    {
+        PoolSettings settings = new PoolSettings( 10, 10, value );
+
+        assertFalse( settings.maxConnectionLifetimeConfigured() );
+
+        try
+        {
+            settings.maxConnectionLifetime();
         }
         catch ( Exception e )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnectionTest.java
@@ -364,7 +364,7 @@ public class PooledSocketConnectionTest
     {
         PooledConnectionReleaseConsumer releaseConsumer = mock( PooledConnectionReleaseConsumer.class );
         Clock clock = when( mock( Clock.class ).millis() )
-                .thenReturn( 42L ).thenReturn( 4242L ).thenReturn( 424242L ).getMock();
+                .thenReturn( 42L ).thenReturn( 42L ).thenReturn( 4242L ).thenReturn( 424242L ).getMock();
 
         PooledConnection connection = new PooledSocketConnection( mock( Connection.class ), releaseConsumer, clock );
 
@@ -375,6 +375,42 @@ public class PooledSocketConnectionTest
 
         connection.close();
         assertEquals( 424242, connection.lastUsedTimestamp() );
+    }
+
+    @Test
+    public void shouldHaveCreationTimestampAfterConstruction()
+    {
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( 424242L ).thenReturn( -1L );
+
+        PooledSocketConnection connection = new PooledSocketConnection( mock( Connection.class ),
+                mock( PooledConnectionReleaseConsumer.class ), clock );
+
+        long timestamp = connection.creationTimestamp();
+
+        assertEquals( 424242L, timestamp );
+    }
+
+    @Test
+    public void shouldNotChangeCreationTimestampAfterClose()
+    {
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( 424242L ).thenReturn( -1L );
+
+        PooledSocketConnection connection = new PooledSocketConnection( mock( Connection.class ),
+                mock( PooledConnectionReleaseConsumer.class ), clock );
+
+        long timestamp1 = connection.creationTimestamp();
+
+        connection.close();
+        long timestamp2 = connection.creationTimestamp();
+
+        connection.close();
+        long timestamp3 = connection.creationTimestamp();
+
+        assertEquals( 424242L, timestamp1 );
+        assertEquals( timestamp1, timestamp2 );
+        assertEquals( timestamp1, timestamp3 );
     }
 
     private static BlockingPooledConnectionQueue newConnectionQueue( int capacity )

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingConnector.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.util;
 
-import java.util.Set;
+import java.util.List;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Connection;
@@ -27,9 +27,9 @@ import org.neo4j.driver.internal.spi.Connector;
 public class ConnectionTrackingConnector implements Connector
 {
     private final Connector realConnector;
-    private final Set<Connection> connections;
+    private final List<Connection> connections;
 
-    public ConnectionTrackingConnector( Connector realConnector, Set<Connection> connections )
+    public ConnectionTrackingConnector( Connector realConnector, List<Connection> connections )
     {
         this.realConnector = realConnector;
         this.connections = connections;

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.driver.internal.util;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.security.SecurityPlan;
@@ -30,8 +30,7 @@ import org.neo4j.driver.v1.Logging;
 
 public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
 {
-    private final Set<Connection> connections =
-            Collections.newSetFromMap( new ConcurrentHashMap<Connection,Boolean>() );
+    private final List<Connection> connections = new CopyOnWriteArrayList<>();
 
     public ConnectionTrackingDriverFactory( Clock clock )
     {
@@ -44,6 +43,11 @@ public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
     {
         Connector connector = super.createConnector( connectionSettings, securityPlan, logging );
         return new ConnectionTrackingConnector( connector, connections );
+    }
+
+    public List<Connection> connections()
+    {
+        return new ArrayList<>( connections );
     }
 
     public void closeConnections()

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -107,6 +107,30 @@ public class ConfigTest
     }
 
     @Test
+    public void shouldSupportMaxConnectionLifetimeSetting() throws Throwable
+    {
+        Config config = Config.build().withMaxConnectionLifetime( 42, TimeUnit.SECONDS ).toConfig();
+
+        assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.maxConnectionLifetime() );
+    }
+
+    @Test
+    public void shouldAllowZeroConnectionMaxConnectionLifetime() throws Throwable
+    {
+        Config config = Config.build().withMaxConnectionLifetime( 0, TimeUnit.SECONDS ).toConfig();
+
+        assertEquals( 0, config.maxConnectionLifetime() );
+    }
+
+    @Test
+    public void shouldAllowNegativeConnectionMaxConnectionLifetime() throws Throwable
+    {
+        Config config = Config.build().withMaxConnectionLifetime( -42, TimeUnit.SECONDS ).toConfig();
+
+        assertEquals( TimeUnit.SECONDS.toMillis( -42 ), config.maxConnectionLifetime() );
+    }
+
+    @Test
     public void shouldTurnOnLeakedSessionsLogging()
     {
         // leaked sessions logging is turned off by default

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
@@ -360,7 +360,7 @@ public class ConnectionHandlingIT
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Config config )
         {
             ConnectionSettings connectionSettings = new ConnectionSettings( authToken, 1000 );
-            PoolSettings poolSettings = new PoolSettings( 10, 0 );
+            PoolSettings poolSettings = new PoolSettings( 10, 0, 0 );
             Connector connector = createConnector( connectionSettings, securityPlan, config.logging() );
             connectionPool = new MemorizingConnectionPool( poolSettings, connector, createClock(), config.logging() );
             return connectionPool;


### PR DESCRIPTION
Driver keeps idle socket connections in a connection pool. These connections can get invalidated while resting idle in the pool. They can be killed by network equipment like load balancer, proxy or firewall. It is also safer to refresh connections once in a while so that database can renew corresponding resources.

This PR adds `maxConnectionLifetime` setting and makes driver close too old connections. Checking and closing happens in an application thread that tries to acquire a connection. Feature can be used on it's own or in combination with `connectionLivenessCheckTimeout` to guarantee validity of acquired connections.