### PR TITLE
Improvements for StatementResultCursor API

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.util.concurrent.EventExecutorGroup;
 
 import java.io.IOException;
 import java.net.URI;
@@ -72,9 +73,12 @@ public class DriverFactory
         RoutingSettings newRoutingSettings = routingSettings.withRoutingContext( new RoutingContext( uri ) );
         SecurityPlan securityPlan = createSecurityPlan( address, config );
         ConnectionPool connectionPool = createConnectionPool( authToken, securityPlan, config );
-        RetryLogic retryLogic = createRetryLogic( retrySettings, config.logging() );
 
-        AsyncConnectionPool asyncConnectionPool = createAsyncConnectionPool( authToken, securityPlan, config );
+        Bootstrap bootstrap = BootstrapFactory.newBootstrap();
+        RetryLogic retryLogic = createRetryLogic( retrySettings, bootstrap.config().group(), config.logging() );
+
+        AsyncConnectionPool asyncConnectionPool = createAsyncConnectionPool( authToken, securityPlan, bootstrap,
+                config );
 
         try
         {
@@ -98,14 +102,13 @@ public class DriverFactory
     }
 
     private AsyncConnectionPool createAsyncConnectionPool( AuthToken authToken, SecurityPlan securityPlan,
-            Config config )
+            Bootstrap bootstrap, Config config )
     {
         Clock clock = createClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
         ActiveChannelTracker activeChannelTracker = new ActiveChannelTracker( config.logging() );
         AsyncConnectorImpl connector = new AsyncConnectorImpl( connectionSettings, securityPlan,
                 activeChannelTracker, config.logging(), clock );
-        Bootstrap bootstrap = BootstrapFactory.newBootstrap();
         PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize(),
                 config.idleTimeBeforeConnectionTest(), config.maxConnectionLifetimeMillis(),
                 config.maxConnectionPoolSize(),
@@ -250,9 +253,10 @@ public class DriverFactory
      * <p>
      * <b>This method is protected only for testing</b>
      */
-    protected RetryLogic createRetryLogic( RetrySettings settings, Logging logging )
+    protected RetryLogic createRetryLogic( RetrySettings settings, EventExecutorGroup eventExecutorGroup,
+            Logging logging )
     {
-        return new ExponentialBackoffRetryLogic( settings, createClock(), logging );
+        return new ExponentialBackoffRetryLogic( settings, eventExecutorGroup, createClock(), logging );
     }
 
     private static SecurityPlan createSecurityPlan( BoltServerAddress address, Config config )

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.internal.util.BiConsumer;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Response;
 import org.neo4j.driver.v1.Statement;
@@ -219,7 +220,7 @@ public class ExplicitTransaction implements Transaction, ResultResourcesHandler
         return internalCommitAsync();
     }
 
-    private InternalFuture<Void> internalCommitAsync()
+    InternalFuture<Void> internalCommitAsync()
     {
         if ( state == State.COMMITTED )
         {
@@ -259,12 +260,12 @@ public class ExplicitTransaction implements Transaction, ResultResourcesHandler
         }
     }
 
-    private Runnable releaseConnectionAndNotifySession()
+    private BiConsumer<Void,Throwable> releaseConnectionAndNotifySession()
     {
-        return new Runnable()
+        return new BiConsumer<Void,Throwable>()
         {
             @Override
-            public void run()
+            public void accept( Void result, Throwable error )
             {
                 asyncConnection.release();
                 session.asyncTransactionClosed( ExplicitTransaction.this );

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -50,7 +50,7 @@ public class InternalStatementResult implements StatementResult
     {
         this.statement = statement;
         this.connection = connection;
-        this.runResponseHandler = new RunResponseHandler( null );
+        this.runResponseHandler = new RunResponseHandler( null, null );
         this.pullAllResponseHandler = new RecordsResponseHandler( runResponseHandler );
         this.resourcesHandler = resourcesHandler;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.EventExecutorGroup;
+
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.v1.AccessMode;
@@ -30,9 +32,9 @@ class LeakLoggingNetworkSession extends NetworkSession
     private final String stackTrace;
 
     LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic,
-            Logging logging )
+            EventExecutorGroup eventExecutorGroup, Logging logging )
     {
-        super( connectionProvider, mode, retryLogic, logging );
+        super( connectionProvider, mode, retryLogic, eventExecutorGroup, logging );
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalFuture.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalFuture.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.async;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 
+import org.neo4j.driver.internal.util.BiConsumer;
 import org.neo4j.driver.v1.Response;
 import org.neo4j.driver.v1.util.Function;
 
@@ -30,7 +31,7 @@ public interface InternalFuture<T> extends Future<T>, Response<T>
 
     <U> InternalFuture<U> thenApply( Function<T,U> fn );
 
-    <U> InternalFuture<U> thenCombine( Function<T,InternalFuture<U>> fn );
+    <U> InternalFuture<U> thenCompose( Function<T,InternalFuture<U>> fn );
 
-    InternalFuture<T> whenComplete( Runnable action );
+    InternalFuture<T> whenComplete( BiConsumer<T,Throwable> action );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalPromise.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalPromise.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.neo4j.driver.internal.util.BiConsumer;
 import org.neo4j.driver.v1.ResponseListener;
 import org.neo4j.driver.v1.util.Function;
 
@@ -61,13 +62,13 @@ public class InternalPromise<T> implements InternalFuture<T>, Promise<T>
     }
 
     @Override
-    public <U> InternalFuture<U> thenCombine( Function<T,InternalFuture<U>> fn )
+    public <U> InternalFuture<U> thenCompose( Function<T,InternalFuture<U>> fn )
     {
-        return Futures.thenCombine( this, fn );
+        return Futures.thenCompose( this, fn );
     }
 
     @Override
-    public InternalFuture<T> whenComplete( Runnable action )
+    public InternalFuture<T> whenComplete( BiConsumer<T,Throwable> action )
     {
         return Futures.whenComplete( this, action );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalPromise.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalPromise.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -40,7 +41,12 @@ public class InternalPromise<T> implements InternalFuture<T>, Promise<T>
 
     public InternalPromise( Bootstrap bootstrap )
     {
-        this( bootstrap.config().group().next() );
+        this( bootstrap.config().group() );
+    }
+
+    public InternalPromise( EventExecutorGroup eventExecutorGroup )
+    {
+        this( eventExecutorGroup.next() );
     }
 
     public InternalPromise( EventExecutor eventExecutor )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
@@ -18,27 +18,36 @@
  */
 package org.neo4j.driver.internal.async;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+
 import java.util.Collections;
 import java.util.List;
 
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
+import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Response;
 import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
+import static java.util.Objects.requireNonNull;
+
 public class InternalStatementResultCursor implements StatementResultCursor
 {
+    private final AsyncConnection connection;
     private final RunResponseHandler runResponseHandler;
     private final PullAllResponseHandler pullAllHandler;
 
-    private Response<Record> peekedRecordResponse;
+    private InternalFuture<Record> peekedRecordResponse;
 
-    public InternalStatementResultCursor( RunResponseHandler runResponseHandler, PullAllResponseHandler pullAllHandler )
+    public InternalStatementResultCursor( AsyncConnection connection, RunResponseHandler runResponseHandler,
+            PullAllResponseHandler pullAllHandler )
     {
-        this.runResponseHandler = runResponseHandler;
-        this.pullAllHandler = pullAllHandler;
+        this.connection = requireNonNull( connection );
+        this.runResponseHandler = requireNonNull( runResponseHandler );
+        this.pullAllHandler = requireNonNull( pullAllHandler );
     }
 
     @Override
@@ -57,16 +66,7 @@ public class InternalStatementResultCursor implements StatementResultCursor
     @Override
     public Response<Record> nextAsync()
     {
-        if ( peekedRecordResponse != null )
-        {
-            Response<Record> result = peekedRecordResponse;
-            peekedRecordResponse = null;
-            return result;
-        }
-        else
-        {
-            return pullAllHandler.nextAsync();
-        }
+        return internalNextAsync();
     }
 
     @Override
@@ -77,5 +77,61 @@ public class InternalStatementResultCursor implements StatementResultCursor
             peekedRecordResponse = pullAllHandler.nextAsync();
         }
         return peekedRecordResponse;
+    }
+
+    @Override
+    public Response<Void> forEachAsync( final Consumer<Record> action )
+    {
+        InternalPromise<Void> result = connection.newPromise();
+        internalForEachAsync( action, result );
+        return result;
+    }
+
+    private void internalForEachAsync( final Consumer<Record> action, final InternalPromise<Void> result )
+    {
+        final InternalFuture<Record> recordFuture = internalNextAsync();
+
+        recordFuture.addListener( new FutureListener<Record>()
+        {
+            @Override
+            public void operationComplete( Future<Record> future )
+            {
+                if ( future.isCancelled() )
+                {
+                    result.cancel( true );
+                }
+                else if ( future.isSuccess() )
+                {
+                    Record record = future.getNow();
+                    if ( record != null )
+                    {
+                        action.accept( record );
+                        internalForEachAsync( action, result );
+                    }
+                    else
+                    {
+                        result.setSuccess( null );
+                    }
+                }
+                else
+                {
+                    result.setFailure( future.cause() );
+                }
+            }
+        } );
+    }
+
+    private InternalFuture<Record> internalNextAsync()
+    {
+        if ( peekedRecordResponse != null )
+        {
+            InternalFuture<Record> result = peekedRecordResponse;
+            peekedRecordResponse = null;
+            return result;
+        }
+        else
+        {
+            return pullAllHandler.nextAsync();
+        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
@@ -33,6 +33,8 @@ public class InternalStatementResultCursor implements StatementResultCursor
     private final RunResponseHandler runResponseHandler;
     private final PullAllResponseHandler pullAllHandler;
 
+    private Response<Record> peekedRecordResponse;
+
     public InternalStatementResultCursor( RunResponseHandler runResponseHandler, PullAllResponseHandler pullAllHandler )
     {
         this.runResponseHandler = runResponseHandler;
@@ -53,14 +55,27 @@ public class InternalStatementResultCursor implements StatementResultCursor
     }
 
     @Override
-    public Response<Boolean> fetchAsync()
+    public Response<Record> nextAsync()
     {
-        return pullAllHandler.fetchRecordAsync();
+        if ( peekedRecordResponse != null )
+        {
+            Response<Record> result = peekedRecordResponse;
+            peekedRecordResponse = null;
+            return result;
+        }
+        else
+        {
+            return pullAllHandler.nextAsync();
+        }
     }
 
     @Override
-    public Record current()
+    public Response<Record> peekAsync()
     {
-        return pullAllHandler.currentRecord();
+        if ( peekedRecordResponse == null )
+        {
+            peekedRecordResponse = pullAllHandler.nextAsync();
+        }
+        return peekedRecordResponse;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/Main.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/Main.java
@@ -158,9 +158,9 @@ public class Main
                 Session session = driver.session();
                 Response<StatementResultCursor> cursorResponse = session.runAsync( QUERY, PARAMS_OBJ );
                 StatementResultCursor cursor = await( cursorResponse );
-                while ( await( cursor.fetchAsync() ) )
+                Record record;
+                while ( (record = await( cursor.nextAsync() )) != null )
                 {
-                    Record record = cursor.current();
                     useRecord( record );
                     recordsRead.increment();
                 }
@@ -202,9 +202,9 @@ public class Main
                 Session session = driver.session();
                 Transaction tx = await( session.beginTransactionAsync() );
                 StatementResultCursor cursor = await( tx.runAsync( QUERY, PARAMS_OBJ ) );
-                while ( await( cursor.fetchAsync() ) )
+                Record record;
+                while ( (record = await( cursor.nextAsync() )) != null )
                 {
-                    Record record = cursor.current();
                     useRecord( record );
                     recordsRead.increment();
                 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/QueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/QueryRunner.java
@@ -50,7 +50,7 @@ public final class QueryRunner
         Map<String,Value> params = statement.parameters().asMap( ofValue() );
 
         InternalPromise<Void> runCompletedPromise = connection.newPromise();
-        final RunResponseHandler runHandler = new RunResponseHandler( runCompletedPromise );
+        final RunResponseHandler runHandler = new RunResponseHandler( runCompletedPromise, tx );
         final PullAllResponseHandler pullAllHandler = newPullAllHandler( statement, runHandler, connection, tx );
 
         connection.run( query, params, runHandler );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/QueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/QueryRunner.java
@@ -43,7 +43,7 @@ public final class QueryRunner
         return runAsync( connection, statement, null );
     }
 
-    public static InternalFuture<StatementResultCursor> runAsync( AsyncConnection connection, Statement statement,
+    public static InternalFuture<StatementResultCursor> runAsync( final AsyncConnection connection, Statement statement,
             ExplicitTransaction tx )
     {
         String query = statement.text();
@@ -62,7 +62,7 @@ public final class QueryRunner
             @Override
             public StatementResultCursor apply( Void ignore )
             {
-                return new InternalStatementResultCursor( runHandler, pullAllHandler );
+                return new InternalStatementResultCursor( connection, runHandler, pullAllHandler );
             }
         } );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -53,15 +53,14 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     private final RunResponseHandler runResponseHandler;
     protected final AsyncConnection connection;
 
-    private final Queue<Record> records;
+    private final Queue<Record> records = new LinkedList<>();
+
     private boolean succeeded;
     private Throwable failure;
-
     private ResultSummary summary;
-    private volatile Record current;
 
-    private InternalPromise<Boolean> recordAvailablePromise;
-    private InternalPromise<ResultSummary> summaryAvailablePromise;
+    private InternalPromise<Record> recordPromise;
+    private InternalPromise<ResultSummary> summaryPromise;
 
     public PullAllResponseHandler( Statement statement, RunResponseHandler runResponseHandler,
             AsyncConnection connection )
@@ -69,26 +68,25 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         this.statement = requireNonNull( statement );
         this.runResponseHandler = requireNonNull( runResponseHandler );
         this.connection = requireNonNull( connection );
-        this.records = new LinkedList<>();
     }
 
     @Override
     public synchronized void onSuccess( Map<String,Value> metadata )
     {
         summary = extractResultSummary( metadata );
-        if ( summaryAvailablePromise != null )
+        if ( summaryPromise != null )
         {
-            summaryAvailablePromise.setSuccess( summary );
-            summaryAvailablePromise = null;
+            summaryPromise.setSuccess( summary );
+            summaryPromise = null;
         }
 
         succeeded = true;
         afterSuccess();
 
-        if ( recordAvailablePromise != null )
+        if ( recordPromise != null )
         {
-            recordAvailablePromise.setSuccess( false );
-            recordAvailablePromise = null;
+            recordPromise.setSuccess( null );
+            recordPromise = null;
         }
     }
 
@@ -100,10 +98,10 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         failure = error;
         afterFailure( error );
 
-        if ( recordAvailablePromise != null )
+        if ( recordPromise != null )
         {
-            recordAvailablePromise.setFailure( error );
-            recordAvailablePromise = null;
+            recordPromise.setFailure( error );
+            recordPromise = null;
         }
     }
 
@@ -114,11 +112,10 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     {
         Record record = new InternalRecord( runResponseHandler.statementKeys(), fields );
 
-        if ( recordAvailablePromise != null )
+        if ( recordPromise != null )
         {
-            current = record;
-            recordAvailablePromise.setSuccess( true );
-            recordAvailablePromise = null;
+            recordPromise.setSuccess( record );
+            recordPromise = null;
         }
         else
         {
@@ -126,40 +123,31 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         }
     }
 
-    public synchronized InternalFuture<Boolean> fetchRecordAsync()
+    public synchronized InternalFuture<Record> nextAsync()
     {
         Record record = dequeueRecord();
         if ( record == null )
         {
             if ( succeeded )
             {
-                return connection.<Boolean>newPromise().setSuccess( false );
+                return connection.<Record>newPromise().setSuccess( null );
             }
 
             if ( failure != null )
             {
-                return connection.<Boolean>newPromise().setFailure( failure );
+                return connection.<Record>newPromise().setFailure( failure );
             }
 
-            if ( recordAvailablePromise == null )
+            if ( recordPromise == null )
             {
-                recordAvailablePromise = connection.newPromise();
+                recordPromise = connection.newPromise();
             }
-
-            return recordAvailablePromise;
+            return recordPromise;
         }
         else
         {
-            current = record;
-            return connection.<Boolean>newPromise().setSuccess( true );
+            return connection.<Record>newPromise().setSuccess( record );
         }
-    }
-
-    public Record currentRecord()
-    {
-        Record result = current;
-        current = null;
-        return result;
     }
 
     public synchronized InternalFuture<ResultSummary> summaryAsync()
@@ -170,11 +158,11 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         }
         else
         {
-            if ( summaryAvailablePromise == null )
+            if ( summaryPromise == null )
             {
-                summaryAvailablePromise = connection.newPromise();
+                summaryPromise = connection.newPromise();
             }
-            return summaryAvailablePromise;
+            return summaryPromise;
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -82,12 +82,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
         succeeded = true;
         afterSuccess();
-
-        if ( recordPromise != null )
-        {
-            recordPromise.setSuccess( null );
-            recordPromise = null;
-        }
+        succeedRecordPromise( null );
     }
 
     protected abstract void afterSuccess();
@@ -97,12 +92,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     {
         failure = error;
         afterFailure( error );
-
-        if ( recordPromise != null )
-        {
-            recordPromise.setFailure( error );
-            recordPromise = null;
-        }
+        failRecordPromise( error );
     }
 
     protected abstract void afterFailure( Throwable error );
@@ -114,8 +104,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
         if ( recordPromise != null )
         {
-            recordPromise.setSuccess( record );
-            recordPromise = null;
+            succeedRecordPromise( record );
         }
         else
         {
@@ -141,6 +130,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
             if ( recordPromise == null )
             {
                 recordPromise = connection.newPromise();
+                System.out.println( "setting promise " + recordPromise.hashCode() );
             }
             return recordPromise;
         }
@@ -189,6 +179,26 @@ public abstract class PullAllResponseHandler implements ResponseHandler
             }
         }
         return record;
+    }
+
+    private void succeedRecordPromise( Record record )
+    {
+        if ( recordPromise != null )
+        {
+            InternalPromise<Record> promise = recordPromise;
+            recordPromise = null;
+            promise.setSuccess( record );
+        }
+    }
+
+    private void failRecordPromise( Throwable error )
+    {
+        if ( recordPromise != null )
+        {
+            InternalPromise<Record> promise = recordPromise;
+            recordPromise = null;
+            promise.setFailure( error );
+        }
     }
 
     private ResultSummary extractResultSummary( Map<String,Value> metadata )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -130,7 +130,6 @@ public abstract class PullAllResponseHandler implements ResponseHandler
             if ( recordPromise == null )
             {
                 recordPromise = connection.newPromise();
-                System.out.println( "setting promise " + recordPromise.hashCode() );
             }
             return recordPromise;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
@@ -25,19 +25,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.v1.Value;
 
 public class RunResponseHandler implements ResponseHandler
 {
     private final Promise<Void> runCompletedPromise;
+    private final ExplicitTransaction tx;
 
     private List<String> statementKeys;
     private long resultAvailableAfter;
 
-    public RunResponseHandler( Promise<Void> runCompletedPromise )
+    public RunResponseHandler( Promise<Void> runCompletedPromise, ExplicitTransaction tx )
     {
         this.runCompletedPromise = runCompletedPromise;
+        this.tx = tx;
     }
 
     @Override
@@ -55,6 +58,10 @@ public class RunResponseHandler implements ResponseHandler
     @Override
     public void onFailure( Throwable error )
     {
+        if ( tx != null )
+        {
+            tx.resultFailed( error );
+        }
         if ( runCompletedPromise != null )
         {
             runCompletedPromise.setFailure( error );

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -109,6 +109,13 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
         }
     }
 
+    protected boolean canRetryOn( Throwable error )
+    {
+        return error instanceof SessionExpiredException ||
+               error instanceof ServiceUnavailableException ||
+               isTransientError( error );
+    }
+
     private long computeDelayWithJitter( long delayMs )
     {
         long jitter = (long) (delayMs * jitterFactor);
@@ -152,13 +159,6 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
         {
             throw new IllegalArgumentException( "Clock should not be null" );
         }
-    }
-
-    private static boolean canRetryOn( Throwable error )
-    {
-        return error instanceof SessionExpiredException ||
-               error instanceof ServiceUnavailableException ||
-               isTransientError( error );
     }
 
     private static boolean isTransientError( Throwable error )

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -124,7 +124,7 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
     @Override
     public <T> InternalFuture<T> retryAsync( Supplier<InternalFuture<T>> work )
     {
-        InternalPromise<T> result = new InternalPromise<>( eventExecutorGroup.next() );
+        InternalPromise<T> result = new InternalPromise<>( eventExecutorGroup );
         executeWorkInEventLoop( result, work );
         return result;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/BiConsumer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/BiConsumer.java
@@ -16,14 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.retry;
+package org.neo4j.driver.internal.util;
 
-import org.neo4j.driver.internal.async.InternalFuture;
-import org.neo4j.driver.internal.util.Supplier;
-
-public interface RetryLogic
+public interface BiConsumer<T, U>
 {
-    <T> T retry( Supplier<T> work );
-
-    <T> InternalFuture<T> retryAsync( Supplier<InternalFuture<T>> work );
+    void accept( T t, U u );
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Session.java
@@ -96,6 +96,8 @@ public interface Session extends Resource, StatementRunner
      */
     <T> T readTransaction( TransactionWork<T> work );
 
+    <T> Response<T> readTransactionAsync( TransactionWork<Response<T>> work );
+
     /**
      * Execute given unit of work in a {@link AccessMode#WRITE write} transaction.
      * <p>
@@ -107,6 +109,8 @@ public interface Session extends Resource, StatementRunner
      * @return a result as returned by the given unit of work.
      */
     <T> T writeTransaction( TransactionWork<T> work );
+
+    <T> Response<T> writeTransactionAsync( TransactionWork<Response<T>> work );
 
     /**
      * Return the bookmark received following the last completed

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -39,4 +39,6 @@ public interface StatementResultCursor
     Response<Record> peekAsync();
 
     Response<Void> forEachAsync( Consumer<Record> action );
+
+    Response<List<Record>> listAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -33,7 +33,7 @@ public interface StatementResultCursor
 
     Response<ResultSummary> summaryAsync();
 
-    Response<Boolean> fetchAsync();
+    Response<Record> nextAsync();
 
-    Record current();
+    Response<Record> peekAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.v1;
 
 import java.util.List;
 
+import org.neo4j.driver.internal.util.Consumer;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
 public interface StatementResultCursor
@@ -36,4 +37,6 @@ public interface StatementResultCursor
     Response<Record> nextAsync();
 
     Response<Record> peekAsync();
+
+    Response<Void> forEachAsync( Consumer<Record> action );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -169,7 +170,8 @@ public class DriverFactoryTest
 
         @Override
         protected Driver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                RoutingSettings routingSettings, SecurityPlan securityPlan, RetryLogic retryLogic )
+                RoutingSettings routingSettings, SecurityPlan securityPlan, RetryLogic retryLogic,
+                EventExecutorGroup eventExecutorGroup )
         {
             throw new UnsupportedOperationException( "Can't create routing driver" );
         }
@@ -200,9 +202,10 @@ public class DriverFactoryTest
 
         @Override
         protected SessionFactory createSessionFactory( ConnectionProvider connectionProvider,
-                RetryLogic retryLogic, Config config )
+                RetryLogic retryLogic, EventExecutorGroup eventExecutorGroup, Config config )
         {
-            SessionFactory sessionFactory = super.createSessionFactory( connectionProvider, retryLogic, config );
+            SessionFactory sessionFactory =
+                    super.createSessionFactory( connectionProvider, retryLogic, eventExecutorGroup, config );
             capturedSessionFactory = sessionFactory;
             return sessionFactory;
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -99,7 +100,7 @@ public class LeakLoggingNetworkSessionTest
     private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
         return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ,
-                new FixedRetryLogic( 0 ), logging );
+                new FixedRetryLogic( 0 ), GlobalEventExecutor.INSTANCE, logging );
     }
 
     private static ConnectionProvider connectionProviderMock( final boolean openConnection )

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1010,7 +1011,8 @@ public class NetworkSessionTest
     private static NetworkSession newSession( ConnectionProvider connectionProvider, AccessMode mode,
             RetryLogic retryLogic, Bookmark bookmark )
     {
-        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic, DEV_NULL_LOGGING );
+        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic,
+                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
         session.setBookmark( bookmark );
         return session;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -439,7 +440,7 @@ public class RoutingDriverTest
     {
         NetworkSessionWithAddressFactory( ConnectionProvider connectionProvider, Config config )
         {
-            super( connectionProvider, new FixedRetryLogic( 0 ), config );
+            super( connectionProvider, new FixedRetryLogic( 0 ), GlobalEventExecutor.INSTANCE, config );
         }
 
         @Override
@@ -456,7 +457,7 @@ public class RoutingDriverTest
 
         NetworkSessionWithAddress( ConnectionProvider connectionProvider, AccessMode mode, Logging logging )
         {
-            super( connectionProvider, mode, new FixedRetryLogic( 0 ), logging );
+            super( connectionProvider, mode, new FixedRetryLogic( 0 ), GlobalEventExecutor.INSTANCE, logging );
             try ( PooledConnection connection = connectionProvider.acquireConnection( mode ) )
             {
                 this.address = connection.boltServerAddress();

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 
 import org.neo4j.driver.internal.retry.FixedRetryLogic;
@@ -61,6 +62,7 @@ public class SessionFactoryImplTest
 
     private static SessionFactory newSessionFactory( Config config )
     {
-        return new SessionFactoryImpl( mock( ConnectionProvider.class ), new FixedRetryLogic( 0 ), config );
+        return new SessionFactoryImpl( mock( ConnectionProvider.class ), new FixedRetryLogic( 0 ),
+                GlobalEventExecutor.INSTANCE, config );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
@@ -384,7 +385,8 @@ public class LoadBalancerTest
     private static Session newSession( LoadBalancer loadBalancer )
     {
         SleeplessClock clock = new SleeplessClock();
-        RetryLogic retryLogic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, clock, DEV_NULL_LOGGING );
+        RetryLogic retryLogic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, GlobalEventExecutor.INSTANCE,
+                clock, DEV_NULL_LOGGING );
         return new NetworkSession( loadBalancer, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -387,7 +387,8 @@ public class LoadBalancerTest
         SleeplessClock clock = new SleeplessClock();
         RetryLogic retryLogic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, GlobalEventExecutor.INSTANCE,
                 clock, DEV_NULL_LOGGING );
-        return new NetworkSession( loadBalancer, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING );
+        return new NetworkSession( loadBalancer, AccessMode.WRITE, retryLogic, GlobalEventExecutor.INSTANCE,
+                DEV_NULL_LOGGING );
     }
 
     private static PooledConnection newConnectionWithFailingSync( BoltServerAddress address )

--- a/driver/src/test/java/org/neo4j/driver/internal/retry/FixedRetryLogic.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/retry/FixedRetryLogic.java
@@ -18,6 +18,9 @@
  */
 package org.neo4j.driver.internal.retry;
 
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
+
 import org.neo4j.driver.internal.util.SleeplessClock;
 
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
@@ -29,7 +32,13 @@ public class FixedRetryLogic extends ExponentialBackoffRetryLogic
 
     public FixedRetryLogic( int retryCount )
     {
-        super( new RetrySettings( Long.MAX_VALUE ), new SleeplessClock(), DEV_NULL_LOGGING );
+        this( retryCount, GlobalEventExecutor.INSTANCE );
+    }
+
+    public FixedRetryLogic( int retryCount, EventExecutorGroup eventExecutorGroup )
+    {
+        super( new RetrySettings( Long.MAX_VALUE ), eventExecutorGroup, new SleeplessClock(),
+                DEV_NULL_LOGGING );
         this.retryCount = retryCount;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithFixedRetryLogic.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithFixedRetryLogic.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.util;
 
+import io.netty.util.concurrent.EventExecutorGroup;
+
 import org.neo4j.driver.internal.retry.FixedRetryLogic;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -34,8 +36,9 @@ public class DriverFactoryWithFixedRetryLogic extends DriverFactoryWithClock
     }
 
     @Override
-    protected RetryLogic createRetryLogic( RetrySettings settings, Logging logging )
+    protected RetryLogic createRetryLogic( RetrySettings settings, EventExecutorGroup eventExecutorGroup,
+            Logging logging )
     {
-        return new FixedRetryLogic( retryCount );
+        return new FixedRetryLogic( retryCount, eventExecutorGroup );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/TrackingEventExecutor.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/TrackingEventExecutor.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Collections.unmodifiableList;
+import static org.mockito.Mockito.mock;
+
+public class TrackingEventExecutor implements EventExecutor
+{
+    private final EventExecutor delegate;
+    private final List<Long> scheduleDelays;
+
+    public TrackingEventExecutor()
+    {
+        this( GlobalEventExecutor.INSTANCE );
+    }
+
+    public TrackingEventExecutor( EventExecutor delegate )
+    {
+        this.delegate = delegate;
+        this.scheduleDelays = new CopyOnWriteArrayList<>();
+    }
+
+    public List<Long> scheduleDelays()
+    {
+        return unmodifiableList( scheduleDelays );
+    }
+
+    @Override
+    public EventExecutor next()
+    {
+        return this;
+    }
+
+    @Override
+    public EventExecutorGroup parent()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean inEventLoop()
+    {
+        return delegate.inEventLoop();
+    }
+
+    @Override
+    public boolean inEventLoop( Thread thread )
+    {
+        return delegate.inEventLoop( thread );
+    }
+
+    @Override
+    public <V> Promise<V> newPromise()
+    {
+        return delegate.newPromise();
+    }
+
+    @Override
+    public <V> ProgressivePromise<V> newProgressivePromise()
+    {
+        return delegate.newProgressivePromise();
+    }
+
+    @Override
+    public <V> Future<V> newSucceededFuture( V result )
+    {
+        return delegate.newSucceededFuture( result );
+    }
+
+    @Override
+    public <V> Future<V> newFailedFuture( Throwable cause )
+    {
+        return delegate.newFailedFuture( cause );
+    }
+
+    @Override
+    public boolean isShuttingDown()
+    {
+        return delegate.isShuttingDown();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully()
+    {
+        return delegate.shutdownGracefully();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully( long quietPeriod, long timeout, TimeUnit unit )
+    {
+        return delegate.shutdownGracefully( quietPeriod, timeout, unit );
+    }
+
+    @Override
+    public Future<?> terminationFuture()
+    {
+        return delegate.terminationFuture();
+    }
+
+    @Override
+    @Deprecated
+    public void shutdown()
+    {
+        delegate.shutdown();
+    }
+
+    @Override
+    @Deprecated
+    public List<Runnable> shutdownNow()
+    {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public Iterator<EventExecutor> iterator()
+    {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Future<?> submit( Runnable task )
+    {
+        return delegate.submit( task );
+    }
+
+    @Override
+    public <T> Future<T> submit( Runnable task, T result )
+    {
+        return delegate.submit( task, result );
+    }
+
+    @Override
+    public <T> Future<T> submit( Callable<T> task )
+    {
+        return delegate.submit( task );
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule( Runnable command, long delay, TimeUnit unit )
+    {
+        scheduleDelays.add( unit.toMillis( delay ) );
+        delegate.execute( command );
+        return mock( ScheduledFuture.class );
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule( Callable<V> callable, long delay, TimeUnit unit )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate( Runnable command, long initialDelay, long period,
+            TimeUnit unit )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay( Runnable command, long initialDelay, long delay,
+            TimeUnit unit )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown()
+    {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated()
+    {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination( long timeout, TimeUnit unit ) throws InterruptedException
+    {
+        return delegate.awaitTermination( timeout, unit );
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll( Collection<? extends Callable<T>> tasks )
+            throws InterruptedException
+    {
+        return delegate.invokeAll( tasks );
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll( Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit ) throws InterruptedException
+    {
+        return delegate.invokeAll( tasks, timeout, unit );
+    }
+
+    @Override
+    public <T> T invokeAny( Collection<? extends Callable<T>> tasks ) throws InterruptedException, ExecutionException
+    {
+        return delegate.invokeAny( tasks );
+    }
+
+    @Override
+    public <T> T invokeAny( Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit )
+            throws InterruptedException, ExecutionException, TimeoutException
+    {
+        return delegate.invokeAny( tasks, timeout, unit );
+    }
+
+    @Override
+    public void execute( Runnable command )
+    {
+        delegate.execute( command );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestNeo4jSession.java
@@ -135,9 +135,21 @@ public class TestNeo4jSession extends TestNeo4j implements Session
     }
 
     @Override
+    public <T> Response<T> readTransactionAsync( TransactionWork<Response<T>> work )
+    {
+        return realSession.readTransactionAsync( work );
+    }
+
+    @Override
     public <T> T writeTransaction( TransactionWork<T> work )
     {
         return realSession.writeTransaction( work );
+    }
+
+    @Override
+    public <T> Response<T> writeTransactionAsync( TransactionWork<Response<T>> work )
+    {
+        return realSession.writeTransactionAsync( work );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -68,13 +68,7 @@ public final class TestUtil
         }
         catch ( ExecutionException e )
         {
-            Throwable cause = e.getCause();
-            StackTraceElement[] originalStackTrace = cause.getStackTrace();
-            RuntimeException exceptionWithOriginalStackTrace = new RuntimeException();
-            cause.setStackTrace( exceptionWithOriginalStackTrace.getStackTrace() );
-            exceptionWithOriginalStackTrace.setStackTrace( originalStackTrace );
-            cause.addSuppressed( exceptionWithOriginalStackTrace );
-            throwException( cause );
+            throwException( e.getCause() );
             return null;
         }
         catch ( TimeoutException e )


### PR DESCRIPTION
Based on https://github.com/neo4j/neo4j-java-driver/pull/404.

Main changes:
 * replaced `#fetchAsync()` + `#current()` with single `#nextAsync()` to simplify handling of futures
 * added `#forEachAsync()`
 * added `#listAsync()`