### PR TITLE
Improve logging around connection establishment

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -120,12 +120,17 @@ public class SocketClient
     {
         try
         {
-            logger.debug( "~~ [CONNECT] %s", address );
+            logger.debug( "Connecting to %s, secure: %s", address, securityPlan.requiresEncryption() );
             if( channel == null )
             {
                 setChannel( ChannelFactory.create( address, securityPlan, timeoutMillis, logger ) );
+                logger.debug( "Connected to %s, secure: %s", address, securityPlan.requiresEncryption() );
             }
-            setProtocol( negotiateProtocol() );
+
+            logger.debug( "Negotiating protocol with %s", address );
+            SocketProtocol protocol = negotiateProtocol();
+            setProtocol( protocol );
+            logger.debug( "Selected protocol %s with %s", protocol.getClass(), address );
         }
         catch ( ConnectException e )
         {
@@ -206,7 +211,7 @@ public class SocketClient
             {
                 channel.close();
                 setChannel( null );
-                logger.debug( "~~ [DISCONNECT]" );
+                logger.debug( "Disconnected from %s", address );
             }
         }
         catch ( IOException e )

--- a/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
@@ -121,7 +121,8 @@ public class TLSSocketChannel implements ByteChannel
      */
     private void runHandshake() throws IOException
     {
-        logger.debug( "~~ [OPENING SECURE CHANNEL]" );
+        logger.debug( "Running TLS handshake" );
+
         sslEngine.beginHandshake();
         HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
         while ( handshakeStatus != FINISHED && handshakeStatus != NOT_HANDSHAKING )
@@ -142,6 +143,8 @@ public class TLSSocketChannel implements ByteChannel
                 break;
             }
         }
+
+        logger.debug( "TLS handshake completed" );
     }
 
     private HandshakeStatus runDelegatedTasks()
@@ -479,7 +482,7 @@ public class TLSSocketChannel implements ByteChannel
             }
             // Close transport
             channel.close();
-            logger.debug( "~~ [CLOSED SECURE CHANNEL]" );
+            logger.debug( "Closed secure channel" );
         }
         catch ( IOException e )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -124,7 +124,7 @@ public class TLSSocketChannelIT
             sslChannel.close();
 
             // Then
-            verify( logger, atLeastOnce() ).debug( "~~ [OPENING SECURE CHANNEL]" );
+            verify( logger, atLeastOnce() ).debug( "Running TLS handshake" );
         }
         finally
         {
@@ -290,7 +290,7 @@ public class TLSSocketChannelIT
         sslChannel.close();
 
         // Then
-        verify( logger, atLeastOnce() ).debug( "~~ [OPENING SECURE CHANNEL]" );
+        verify( logger, atLeastOnce() ).debug( "Running TLS handshake" );
     }
 
     @Test
@@ -357,7 +357,7 @@ public class TLSSocketChannelIT
         sslChannel.close();
 
         // Then
-        verify( logger, atLeastOnce() ).debug( "~~ [CLOSED SECURE CHANNEL]" );
+        verify( logger, atLeastOnce() ).debug( "Closed secure channel" );
     }
 
     private File installRootCertificate() throws Exception


### PR DESCRIPTION
It will help diagnose long running TLS handshakes.

Example log:

```
2017-09-26 06:58:47,115 [Connection] [1206883981] Connecting to localhost:7687, secure: true
2017-09-26 06:58:47,117 [Connection] [1206883981] Running TLS handshake
2017-09-26 06:58:47,139 [Connection] [1206883981] TLS handshake completed
2017-09-26 06:58:47,139 [Connection] [1206883981] Connected to localhost:7687, secure: true
2017-09-26 06:58:47,139 [Connection] [1206883981] Negotiating protocol with localhost:7687
2017-09-26 06:58:47,139 [Connection] [1206883981] C: [HANDSHAKE] 0x6060B017
2017-09-26 06:58:47,140 [Connection] [1206883981] C: [HANDSHAKE] [1, 0, 0, 0]
2017-09-26 06:58:47,141 [Connection] [1206883981] S: [HANDSHAKE] -> 1
2017-09-26 06:58:47,142 [Connection] [1206883981] Selected protocol class org.neo4j.driver.internal.net.SocketProtocolV1 with localhost:7687
```

which gives us timestamps for various connection establishment stages.