### PR TITLE
More helper methods in StatementResultCursor

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -106,7 +106,7 @@ public class InternalStatementResult implements StatementResult
 
             if ( hasMoreThanOne )
             {
-                throw new NoSuchRecordException( "Expected result with a single record, but it contains " +
+                throw new NoSuchRecordException( "Expected a result with a single record, but this result contains " +
                                                  "at least one more. Ensure your query returns only one record." );
             }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -106,9 +106,8 @@ public class InternalStatementResult implements StatementResult
 
             if ( hasMoreThanOne )
             {
-                throw new NoSuchRecordException( "Expected a result with a single record, but this result contains at least one more. " +
-                        "Ensure your query returns only one record, or use `first` instead of `single` if " +
-                        "you do not care about the number of records in the result." );
+                throw new NoSuchRecordException( "Expected result with a single record, but it contains " +
+                                                 "at least one more. Ensure your query returns only one record." );
             }
 
             return single;

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
@@ -107,11 +107,11 @@ public class InternalStatementResultCursor implements StatementResultCursor
     }
 
     @Override
-    public CompletionStage<Void> forEachAsync( Consumer<Record> action )
+    public CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action )
     {
         CompletableFuture<Void> resultFuture = new CompletableFuture<>();
         internalForEachAsync( action, resultFuture );
-        return resultFuture;
+        return resultFuture.thenCompose( ignore -> summaryAsync() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
@@ -108,6 +108,14 @@ public class InternalStatementResultCursor implements StatementResultCursor
     }
 
     @Override
+    public CompletionStage<ResultSummary> consumeAsync()
+    {
+        return forEachAsync( record ->
+        {
+        } );
+    }
+
+    @Override
     public CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action )
     {
         CompletableFuture<Void> resultFuture = new CompletableFuture<>();

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalStatementResultCursor.java
@@ -99,8 +99,9 @@ public class InternalStatementResultCursor implements StatementResultCursor
             {
                 if ( secondRecord != null )
                 {
-                    throw new NoSuchRecordException( "Expected cursor with a single record, but it contains " +
-                                                     "at least one more. Ensure your query returns only one record." );
+                    throw new NoSuchRecordException( "Expected a cursor with a single record, but this cursor " +
+                                                     "contains at least one more. Ensure your query returns only " +
+                                                     "one record." );
                 }
                 return firstRecord;
             } );

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -41,7 +41,7 @@ public interface StatementResultCursor
 
     CompletionStage<Record> singleAsync();
 
-    CompletionStage<Void> forEachAsync( Consumer<Record> action );
+    CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action );
 
     CompletionStage<List<Record>> listAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -39,6 +39,8 @@ public interface StatementResultCursor
 
     CompletionStage<Record> peekAsync();
 
+    CompletionStage<Record> singleAsync();
+
     CompletionStage<Void> forEachAsync( Consumer<Record> action );
 
     CompletionStage<List<Record>> listAsync();

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.v1;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.neo4j.driver.v1.summary.ResultSummary;
 
@@ -44,4 +45,6 @@ public interface StatementResultCursor
     CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action );
 
     CompletionStage<List<Record>> listAsync();
+
+    <T> CompletionStage<List<T>> listAsync( Function<Record,T> mapFunction );
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResultCursor.java
@@ -42,6 +42,8 @@ public interface StatementResultCursor
 
     CompletionStage<Record> singleAsync();
 
+    CompletionStage<ResultSummary> consumeAsync();
+
     CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action );
 
     CompletionStage<List<Record>> listAsync();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
@@ -52,6 +52,7 @@ import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static java.util.Collections.emptyIterator;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -635,10 +636,13 @@ public class SessionAsyncIT
     {
         StatementResultCursor cursor = await( session.runAsync( query ) );
 
-        final AtomicInteger recordsSeen = new AtomicInteger();
-        CompletionStage<Void> forEachDone = cursor.forEachAsync( record -> recordsSeen.incrementAndGet() );
+        AtomicInteger recordsSeen = new AtomicInteger();
+        CompletionStage<ResultSummary> forEachDone = cursor.forEachAsync( record -> recordsSeen.incrementAndGet() );
+        ResultSummary summary = await( forEachDone );
 
-        assertNull( await( forEachDone ) );
+        assertNotNull( summary );
+        assertEquals( query, summary.statement().text() );
+        assertEquals( emptyMap(), summary.statement().parameters().asMap() );
         assertEquals( expectedSeenRecords, recordsSeen.get() );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
@@ -588,7 +588,7 @@ public class SessionAsyncIT
         }
         catch ( NoSuchRecordException e )
         {
-            assertThat( e.getMessage(), startsWith( "Expected cursor with a single record" ) );
+            assertThat( e.getMessage(), startsWith( "Expected a cursor with a single record" ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -694,7 +694,7 @@ public class TransactionAsyncIT
         }
         catch ( NoSuchRecordException e )
         {
-            assertThat( e.getMessage(), startsWith( "Expected cursor with a single record" ) );
+            assertThat( e.getMessage(), startsWith( "Expected a cursor with a single record" ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -45,6 +45,7 @@ import org.neo4j.driver.v1.summary.StatementType;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -686,10 +687,13 @@ public class TransactionAsyncIT
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( query ) );
 
-        final AtomicInteger recordsSeen = new AtomicInteger();
-        CompletionStage<Void> forEachDone = cursor.forEachAsync( record -> recordsSeen.incrementAndGet() );
+        AtomicInteger recordsSeen = new AtomicInteger();
+        CompletionStage<ResultSummary> forEachDone = cursor.forEachAsync( record -> recordsSeen.incrementAndGet() );
+        ResultSummary summary = await( forEachDone );
 
-        assertNull( await( forEachDone ) );
+        assertNotNull( summary );
+        assertEquals( query, summary.statement().text() );
+        assertEquals( emptyMap(), summary.statement().parameters().asMap() );
         assertEquals( expectedSeenRecords, recordsSeen.get() );
     }
 


### PR DESCRIPTION
This PR adds following methods to `StatementResultCursor`:

 * `CompletionStage<Record> singleAsync()` to safely retrieve single record from the cursor and assert that cursor contains exactly one record
 * `CompletionStage<List<T>> listAsync(Function<Record, T>)` to transform all incoming records and store them in list
 * `CompletionStage<ResultSummary> consumeAsync()` to drop/skip all incoming records and get result summary

They are added for convenience and to be consistent with existing blocking API in `StatementResult`.

Also `#forEachAsync(Consumer<Record>)` now returns future of `ResultSummary`.