### PR TITLE
Async routing improvements

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -76,7 +76,7 @@ public class DriverFactory
         SecurityPlan securityPlan = createSecurityPlan( address, config );
         ConnectionPool connectionPool = createConnectionPool( authToken, securityPlan, config );
 
-        Bootstrap bootstrap = BootstrapFactory.newBootstrap();
+        Bootstrap bootstrap = createBootstrap();
         EventLoopGroup eventLoopGroup = bootstrap.config().group();
         RetryLogic retryLogic = createRetryLogic( retrySettings, eventLoopGroup, config.logging() );
 
@@ -85,8 +85,8 @@ public class DriverFactory
 
         try
         {
-            return createDriver( uri, address, connectionPool, config, newRoutingSettings, securityPlan, retryLogic,
-                    asyncConnectionPool );
+            return createDriver( uri, address, connectionPool, asyncConnectionPool, config, newRoutingSettings,
+                    securityPlan, retryLogic );
         }
         catch ( Throwable driverError )
         {
@@ -121,8 +121,8 @@ public class DriverFactory
     }
 
     private Driver createDriver( URI uri, BoltServerAddress address, ConnectionPool connectionPool,
-            Config config, RoutingSettings routingSettings, SecurityPlan securityPlan, RetryLogic retryLogic,
-            AsyncConnectionPool asyncConnectionPool )
+            AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings,
+            SecurityPlan securityPlan, RetryLogic retryLogic )
     {
         String scheme = uri.getScheme().toLowerCase();
         switch ( scheme )
@@ -131,7 +131,8 @@ public class DriverFactory
             assertNoRoutingContext( uri, routingSettings );
             return createDirectDriver( address, connectionPool, config, securityPlan, retryLogic, asyncConnectionPool );
         case BOLT_ROUTING_URI_SCHEME:
-            return createRoutingDriver( address, connectionPool, config, routingSettings, securityPlan, retryLogic );
+            return createRoutingDriver( address, connectionPool, asyncConnectionPool, config, routingSettings,
+                    securityPlan, retryLogic );
         default:
             throw new ClientException( format( "Unsupported URI scheme: %s", scheme ) );
         }
@@ -158,13 +159,15 @@ public class DriverFactory
      * <b>This method is protected only for testing</b>
      */
     protected Driver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool,
-            Config config, RoutingSettings routingSettings, SecurityPlan securityPlan, RetryLogic retryLogic )
+            AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings,
+            SecurityPlan securityPlan, RetryLogic retryLogic )
     {
         if ( !securityPlan.isRoutingCompatible() )
         {
             throw new IllegalArgumentException( "The chosen security plan is not compatible with a routing driver" );
         }
-        ConnectionProvider connectionProvider = createLoadBalancer( address, connectionPool, config, routingSettings );
+        ConnectionProvider connectionProvider = createLoadBalancer( address, connectionPool, asyncConnectionPool,
+                config, routingSettings );
         SessionFactory sessionFactory = createSessionFactory( connectionProvider, retryLogic, config );
         return createDriver( config, securityPlan, sessionFactory );
     }
@@ -184,21 +187,22 @@ public class DriverFactory
      * <p>
      * <b>This method is protected only for testing</b>
      */
-    protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-            RoutingSettings routingSettings )
+    protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool,
+            AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings )
     {
-        return new LoadBalancer( address, routingSettings, connectionPool, createClock(), config.logging(),
-                createLoadBalancingStrategy( config, connectionPool ) );
+        return new LoadBalancer( address, routingSettings, connectionPool, asyncConnectionPool, createClock(),
+                config.logging(), createLoadBalancingStrategy( config, connectionPool, asyncConnectionPool ) );
     }
 
-    private static LoadBalancingStrategy createLoadBalancingStrategy( Config config, ConnectionPool connectionPool )
+    private static LoadBalancingStrategy createLoadBalancingStrategy( Config config, ConnectionPool connectionPool,
+            AsyncConnectionPool asyncConnectionPool )
     {
         switch ( config.loadBalancingStrategy() )
         {
         case ROUND_ROBIN:
             return new RoundRobinLoadBalancingStrategy( config.logging() );
         case LEAST_CONNECTED:
-            return new LeastConnectedLoadBalancingStrategy( connectionPool, config.logging() );
+            return new LeastConnectedLoadBalancingStrategy( connectionPool, asyncConnectionPool, config.logging() );
         default:
             throw new IllegalArgumentException( "Unknown load balancing strategy: " + config.loadBalancingStrategy() );
         }
@@ -253,7 +257,7 @@ public class DriverFactory
     }
 
     /**
-     * Creates new {@link RetryLogic >}.
+     * Creates new {@link RetryLogic}.
      * <p>
      * <b>This method is protected only for testing</b>
      */
@@ -261,6 +265,16 @@ public class DriverFactory
             Logging logging )
     {
         return new ExponentialBackoffRetryLogic( settings, eventExecutorGroup, createClock(), logging );
+    }
+
+    /**
+     * Creates new {@link Bootstrap}.
+     * <p>
+     * <b>This method is protected only for testing</b>
+     */
+    protected Bootstrap createBootstrap()
+    {
+        return BootstrapFactory.newBootstrap();
     }
 
     private static SecurityPlan createSecurityPlan( BoltServerAddress address, Config config )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/AsyncConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/AsyncConnection.java
@@ -21,9 +21,10 @@ package org.neo4j.driver.internal.async;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.summary.ServerInfo;
 
 public interface AsyncConnection
 {
@@ -43,5 +44,7 @@ public interface AsyncConnection
 
     CompletionStage<Void> forceRelease();
 
-    ServerInfo serverInfo();
+    BoltServerAddress serverAddress();
+
+    ServerVersion serverVersion();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelAttributes.java
@@ -23,29 +23,40 @@ import io.netty.util.AttributeKey;
 
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.util.ServerVersion;
 
 import static io.netty.util.AttributeKey.newInstance;
 
 public final class ChannelAttributes
 {
-    private static final AttributeKey<BoltServerAddress> ADDRESS = newInstance( "address" );
+    private static final AttributeKey<BoltServerAddress> ADDRESS = newInstance( "serverAddress" );
+    private static final AttributeKey<ServerVersion> SERVER_VERSION = newInstance( "serverVersion" );
     private static final AttributeKey<Long> CREATION_TIMESTAMP = newInstance( "creationTimestamp" );
     private static final AttributeKey<Long> LAST_USED_TIMESTAMP = newInstance( "lastUsedTimestamp" );
     private static final AttributeKey<InboundMessageDispatcher> MESSAGE_DISPATCHER = newInstance( "messageDispatcher" );
-    private static final AttributeKey<String> SERVER_VERSION = newInstance( "serverVersion" );
 
     private ChannelAttributes()
     {
     }
 
-    public static BoltServerAddress address( Channel channel )
+    public static BoltServerAddress serverAddress( Channel channel )
     {
         return get( channel, ADDRESS );
     }
 
-    public static void setAddress( Channel channel, BoltServerAddress address )
+    public static void setServerAddress( Channel channel, BoltServerAddress address )
     {
         setOnce( channel, ADDRESS, address );
+    }
+
+    public static ServerVersion serverVersion( Channel channel )
+    {
+        return get( channel, SERVER_VERSION );
+    }
+
+    public static void setServerVersion( Channel channel, ServerVersion version )
+    {
+        setOnce( channel, SERVER_VERSION, version );
     }
 
     public static long creationTimestamp( Channel channel )
@@ -76,16 +87,6 @@ public final class ChannelAttributes
     public static void setMessageDispatcher( Channel channel, InboundMessageDispatcher messageDispatcher )
     {
         setOnce( channel, MESSAGE_DISPATCHER, messageDispatcher );
-    }
-
-    public static String serverVersion( Channel channel )
-    {
-        return get( channel, SERVER_VERSION );
-    }
-
-    public static void setServerVersion( Channel channel, String serverVersion )
-    {
-        setOnce( channel, SERVER_VERSION, serverVersion );
     }
 
     private static <T> T get( Channel channel, AttributeKey<T> key )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -31,9 +31,9 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
 
-import static org.neo4j.driver.internal.async.ChannelAttributes.setAddress;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
+import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 public class NettyChannelInitializer extends ChannelInitializer<Channel>
@@ -82,7 +82,7 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
 
     private void updateChannelAttributes( Channel channel )
     {
-        setAddress( channel, address );
+        setServerAddress( channel, address );
         setCreationTimestamp( channel, clock.millis() );
         setMessageDispatcher( channel, new InboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
@@ -32,16 +32,14 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.PullAllMessage;
 import org.neo4j.driver.internal.messaging.ResetMessage;
 import org.neo4j.driver.internal.messaging.RunMessage;
+import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ResponseHandler;
-import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.summary.ServerInfo;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.neo4j.driver.internal.async.ChannelAttributes.address;
 import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
-import static org.neo4j.driver.internal.async.ChannelAttributes.serverVersion;
 import static org.neo4j.driver.internal.async.Futures.asCompletionStage;
 
 // todo: keep state flags to prohibit interaction with released connections
@@ -127,9 +125,15 @@ public class NettyConnection implements AsyncConnection
     }
 
     @Override
-    public ServerInfo serverInfo()
+    public BoltServerAddress serverAddress()
     {
-        return new InternalServerInfo( address( channel ), serverVersion( channel ) );
+        return ChannelAttributes.serverAddress( channel );
+    }
+
+    @Override
+    public ServerVersion serverVersion()
+    {
+        return ChannelAttributes.serverVersion( channel );
     }
 
     private void run( String statement, Map<String,Value> parameters, ResponseHandler runHandler,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/RoutingAsyncConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/RoutingAsyncConnection.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Value;
+
+public class RoutingAsyncConnection implements AsyncConnection
+{
+    private final AsyncConnection delegate;
+    private final AccessMode accessMode;
+    private final RoutingErrorHandler errorHandler;
+
+    public RoutingAsyncConnection( AsyncConnection delegate, AccessMode accessMode, RoutingErrorHandler errorHandler )
+    {
+        this.delegate = delegate;
+        this.accessMode = accessMode;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public boolean tryMarkInUse()
+    {
+        return delegate.tryMarkInUse();
+    }
+
+    @Override
+    public void enableAutoRead()
+    {
+        delegate.enableAutoRead();
+    }
+
+    @Override
+    public void disableAutoRead()
+    {
+        delegate.disableAutoRead();
+    }
+
+    @Override
+    public void run( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
+            ResponseHandler pullAllHandler )
+    {
+        delegate.run( statement, parameters, newRoutingResponseHandler( runHandler ),
+                newRoutingResponseHandler( pullAllHandler ) );
+    }
+
+    @Override
+    public void runAndFlush( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
+            ResponseHandler pullAllHandler )
+    {
+        delegate.runAndFlush( statement, parameters, newRoutingResponseHandler( runHandler ),
+                newRoutingResponseHandler( pullAllHandler ) );
+    }
+
+    @Override
+    public void release()
+    {
+        delegate.release();
+    }
+
+    @Override
+    public CompletionStage<Void> forceRelease()
+    {
+        return delegate.forceRelease();
+    }
+
+    @Override
+    public BoltServerAddress serverAddress()
+    {
+        return delegate.serverAddress();
+    }
+
+    @Override
+    public ServerVersion serverVersion()
+    {
+        return delegate.serverVersion();
+    }
+
+    private RoutingResponseHandler newRoutingResponseHandler( ResponseHandler handler )
+    {
+        return new RoutingResponseHandler( handler, serverAddress(), accessMode, errorHandler );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/RoutingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/RoutingResponseHandler.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+
+import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.exceptions.TransientException;
+
+import static java.lang.String.format;
+
+public class RoutingResponseHandler implements ResponseHandler
+{
+    private final ResponseHandler delegate;
+    private final BoltServerAddress address;
+    private final AccessMode accessMode;
+    private final RoutingErrorHandler errorHandler;
+
+    public RoutingResponseHandler( ResponseHandler delegate, BoltServerAddress address, AccessMode accessMode,
+            RoutingErrorHandler errorHandler )
+    {
+        this.delegate = delegate;
+        this.address = address;
+        this.accessMode = accessMode;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public void onSuccess( Map<String,Value> metadata )
+    {
+        delegate.onSuccess( metadata );
+    }
+
+    @Override
+    public void onFailure( Throwable error )
+    {
+        Throwable newError = handledError( error );
+        delegate.onFailure( newError );
+    }
+
+    @Override
+    public void onRecord( Value[] fields )
+    {
+        delegate.onRecord( fields );
+    }
+
+    private Throwable handledError( Throwable error )
+    {
+        if ( error instanceof CompletionException )
+        {
+            error = error.getCause();
+        }
+
+        if ( error instanceof ServiceUnavailableException )
+        {
+            return handledServiceUnavailableException( ((ServiceUnavailableException) error) );
+        }
+        else if ( error instanceof ClientException )
+        {
+            return handledClientException( ((ClientException) error) );
+        }
+        else if ( error instanceof TransientException )
+        {
+            return handledTransientException( ((TransientException) error) );
+        }
+        else
+        {
+            return error;
+        }
+    }
+
+    private Throwable handledServiceUnavailableException( ServiceUnavailableException e )
+    {
+        errorHandler.onConnectionFailure( address );
+        return new SessionExpiredException( format( "Server at %s is no longer available", address ), e );
+    }
+
+    private Throwable handledTransientException( TransientException e )
+    {
+        String errorCode = e.code();
+        if ( Objects.equals( errorCode, "Neo.TransientError.General.DatabaseUnavailable" ) )
+        {
+            errorHandler.onConnectionFailure( address );
+        }
+        return e;
+    }
+
+    private Throwable handledClientException( ClientException e )
+    {
+        if ( isFailureToWrite( e ) )
+        {
+            // The server is unaware of the session mode, so we have to implement this logic in the driver.
+            // In the future, we might be able to move this logic to the server.
+            switch ( accessMode )
+            {
+            case READ:
+                return new ClientException( "Write queries cannot be performed in READ access mode." );
+            case WRITE:
+                errorHandler.onWriteFailure( address );
+                return new SessionExpiredException( format( "Server at %s no longer accepts writes", address ) );
+            default:
+                throw new IllegalArgumentException( accessMode + " not supported." );
+            }
+        }
+        return e;
+    }
+
+    private static boolean isFailureToWrite( ClientException e )
+    {
+        String errorCode = e.code();
+        return Objects.equals( errorCode, "Neo.ClientError.Cluster.NotALeader" ) ||
+               Objects.equals( errorCode, "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase" );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ActiveChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ActiveChannelTracker.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
-import static org.neo4j.driver.internal.async.ChannelAttributes.address;
+import static org.neo4j.driver.internal.async.ChannelAttributes.serverAddress;
 
 public class ActiveChannelTracker implements ChannelPoolHandler
 {
@@ -83,7 +83,7 @@ public class ActiveChannelTracker implements ChannelPoolHandler
 
     private void channelActive( Channel channel )
     {
-        BoltServerAddress address = address( channel );
+        BoltServerAddress address = serverAddress( channel );
         ConcurrentSet<Channel> activeChannels = addressToActiveChannelCount.get( address );
         if ( activeChannels == null )
         {
@@ -105,7 +105,7 @@ public class ActiveChannelTracker implements ChannelPoolHandler
 
     private void channelInactive( Channel channel )
     {
-        BoltServerAddress address = address( channel );
+        BoltServerAddress address = serverAddress( channel );
         ConcurrentSet<Channel> activeChannels = addressToActiveChannelCount.get( address );
         if ( activeChannels == null )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.cluster;
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
@@ -95,14 +96,38 @@ public final class ClusterComposition
     }
 
     @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ClusterComposition that = (ClusterComposition) o;
+        return expirationTimestamp == that.expirationTimestamp &&
+               Objects.equals( readers, that.readers ) &&
+               Objects.equals( writers, that.writers ) &&
+               Objects.equals( routers, that.routers );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( readers, writers, routers, expirationTimestamp );
+    }
+
+    @Override
     public String toString()
     {
         return "ClusterComposition{" +
-                "expirationTimestamp=" + expirationTimestamp +
-                ", readers=" + readers +
-                ", writers=" + writers +
-                ", routers=" + routers +
-                '}';
+               "readers=" + readers +
+               ", writers=" + writers +
+               ", routers=" + routers +
+               ", expirationTimestamp=" + expirationTimestamp +
+               '}';
     }
 
     public static ClusterComposition parse( Record record, long now )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
@@ -18,9 +18,15 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.internal.async.AsyncConnection;
 import org.neo4j.driver.internal.spi.Connection;
 
 public interface ClusterCompositionProvider
 {
     ClusterCompositionResponse getClusterComposition( Connection connection );
+
+    CompletionStage<ClusterCompositionResponse> getClusterComposition(
+            CompletionStage<AsyncConnection> connectionStage );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -384,7 +384,6 @@ public class Rediscovery
         }
         else
         {
-            System.err.println( error );
             // connection turned out to be broken
             logger.error( format( "Failed to connect to routing server '%s'.", routerAddress ), error );
             routingTable.forget( routerAddress );

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -25,7 +25,6 @@ import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
-import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ProtocolException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.value.ValueException;
@@ -38,38 +37,35 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
 
     private final Clock clock;
     private final Logger log;
-    private final RoutingProcedureRunner getServersRunner;
+    private final RoutingProcedureRunner routingProcedureRunner;
 
     public RoutingProcedureClusterCompositionProvider( Clock clock, Logger log, RoutingSettings settings )
     {
         this( clock, log, new RoutingProcedureRunner( settings.routingContext() ) );
     }
 
-    RoutingProcedureClusterCompositionProvider( Clock clock, Logger log, RoutingProcedureRunner getServersRunner )
+    RoutingProcedureClusterCompositionProvider( Clock clock, Logger log, RoutingProcedureRunner routingProcedureRunner )
     {
         this.clock = clock;
         this.log = log;
-        this.getServersRunner = getServersRunner;
+        this.routingProcedureRunner = routingProcedureRunner;
     }
 
     @Override
     public ClusterCompositionResponse getClusterComposition( Connection connection )
     {
-        List<Record> records;
+        RoutingProcedureResponse response = routingProcedureRunner.run( connection );
 
-        // failed to invoke procedure
-        try
-        {
-            records = getServersRunner.run( connection );
-        }
-        catch ( ClientException e )
+        if ( !response.isSuccess() )
         {
             return new ClusterCompositionResponse.Failure( new ServiceUnavailableException( format(
                     "Failed to run '%s' on server. " +
                     "Please make sure that there is a Neo4j 3.1+ causal cluster up running.",
-                    invokedProcedureString() ), e
+                    invokedProcedureString( response ) ), response.error()
             ) );
         }
+
+        List<Record> records = response.records();
 
         log.info( "Got getServers response: %s", records );
         long now = clock.millis();
@@ -79,7 +75,7 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
         {
             return new ClusterCompositionResponse.Failure( new ProtocolException( format(
                     PROTOCOL_ERROR_MESSAGE + "records received '%s' is too few or too many.",
-                    invokedProcedureString(), records.size() ) ) );
+                    invokedProcedureString( response ), records.size() ) ) );
         }
 
         // failed to parse the record
@@ -92,7 +88,7 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
         {
             return new ClusterCompositionResponse.Failure( new ProtocolException( format(
                     PROTOCOL_ERROR_MESSAGE + "unparsable record received.",
-                    invokedProcedureString() ), e ) );
+                    invokedProcedureString( response ) ), e ) );
         }
 
         // the cluster result is not a legal reply
@@ -100,16 +96,16 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
         {
             return new ClusterCompositionResponse.Failure( new ProtocolException( format(
                     PROTOCOL_ERROR_MESSAGE + "no router or reader found in response.",
-                    invokedProcedureString() ) ) );
+                    invokedProcedureString( response ) ) ) );
         }
 
         // all good
         return new ClusterCompositionResponse.Success( cluster );
     }
 
-    private String invokedProcedureString()
+    private static String invokedProcedureString( RoutingProcedureResponse response )
     {
-        Statement statement = getServersRunner.invokedProcedure();
+        Statement statement = response.procedure();
         return statement.text() + " " + statement.parameters();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponse.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import java.util.List;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Statement;
+
+public class RoutingProcedureResponse
+{
+    private final Statement procedure;
+    private final List<Record> records;
+    private final Throwable error;
+
+    public RoutingProcedureResponse( Statement procedure, List<Record> records )
+    {
+        this( procedure, records, null );
+    }
+
+    public RoutingProcedureResponse( Statement procedure, Throwable error )
+    {
+        this( procedure, null, error );
+    }
+
+    private RoutingProcedureResponse( Statement procedure, List<Record> records, Throwable error )
+    {
+        this.procedure = procedure;
+        this.records = records;
+        this.error = error;
+    }
+
+    public boolean isSuccess()
+    {
+        return records != null;
+    }
+
+    public Statement procedure()
+    {
+        return procedure;
+    }
+
+    public List<Record> records()
+    {
+        if ( !isSuccess() )
+        {
+            throw new IllegalStateException( "Can't access records of a failed result", error );
+        }
+        return records;
+    }
+
+    public Throwable error()
+    {
+        if ( isSuccess() )
+        {
+            throw new IllegalStateException( "Can't access error of a succeeded result " + records );
+        }
+        return error;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -28,13 +28,13 @@ import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.async.AsyncConnection;
 import org.neo4j.driver.internal.async.QueryRunner;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static org.neo4j.driver.internal.util.ServerVersion.v3_2_0;
-import static org.neo4j.driver.internal.util.ServerVersion.version;
 import static org.neo4j.driver.v1.Values.parameters;
 
 public class RoutingProcedureRunner
@@ -52,7 +52,7 @@ public class RoutingProcedureRunner
 
     public RoutingProcedureResponse run( Connection connection )
     {
-        Statement procedure = procedureStatement( connection.server().version() );
+        Statement procedure = procedureStatement( ServerVersion.version( connection.server().version() ) );
 
         try
         {
@@ -68,7 +68,7 @@ public class RoutingProcedureRunner
     {
         return connectionStage.thenCompose( connection ->
         {
-            Statement procedure = procedureStatement( connection.serverInfo().version() );
+            Statement procedure = procedureStatement( connection.serverVersion() );
             return runProcedure( connection, procedure ).handle( ( records, error ) ->
             {
                 if ( error != null )
@@ -94,9 +94,9 @@ public class RoutingProcedureRunner
                 .thenCompose( StatementResultCursor::listAsync );
     }
 
-    private Statement procedureStatement( String serverVersionString )
+    private Statement procedureStatement( ServerVersion serverVersion )
     {
-        if ( version( serverVersionString ).greaterThanOrEqual( v3_2_0 ) )
+        if ( serverVersion.greaterThanOrEqual( v3_2_0 ) )
         {
             return new Statement( "CALL " + GET_ROUTING_TABLE,
                     parameters( GET_ROUTING_TABLE_PARAM, context.asMap() ) );

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategy.java
@@ -18,6 +18,9 @@
  */
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
+import java.util.function.Function;
+
+import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.v1.Logger;
@@ -36,28 +39,44 @@ public class LeastConnectedLoadBalancingStrategy implements LoadBalancingStrateg
     private final RoundRobinArrayIndex writersIndex = new RoundRobinArrayIndex();
 
     private final ConnectionPool connectionPool;
+    private final AsyncConnectionPool asyncConnectionPool;
     private final Logger log;
 
-    public LeastConnectedLoadBalancingStrategy( ConnectionPool connectionPool, Logging logging )
+    public LeastConnectedLoadBalancingStrategy( ConnectionPool connectionPool, AsyncConnectionPool asyncConnectionPool,
+            Logging logging )
     {
         this.connectionPool = connectionPool;
+        this.asyncConnectionPool = asyncConnectionPool;
         this.log = logging.getLog( LOGGER_NAME );
     }
 
     @Override
     public BoltServerAddress selectReader( BoltServerAddress[] knownReaders )
     {
-        return select( knownReaders, readersIndex, "reader" );
+        return select( knownReaders, readersIndex, "reader", connectionPool::activeConnections );
+    }
+
+    @Override
+    public BoltServerAddress selectReaderAsync( BoltServerAddress[] knownReaders )
+    {
+        return select( knownReaders, readersIndex, "reader", asyncConnectionPool::activeConnections );
     }
 
     @Override
     public BoltServerAddress selectWriter( BoltServerAddress[] knownWriters )
     {
-        return select( knownWriters, writersIndex, "writer" );
+        return select( knownWriters, writersIndex, "writer", connectionPool::activeConnections );
     }
 
+    @Override
+    public BoltServerAddress selectWriterAsync( BoltServerAddress[] knownWriters )
+    {
+        return select( knownWriters, writersIndex, "writer", asyncConnectionPool::activeConnections );
+    }
+
+    // todo: remove Function from params when only async is supported
     private BoltServerAddress select( BoltServerAddress[] addresses, RoundRobinArrayIndex addressesIndex,
-            String addressType )
+            String addressType, Function<BoltServerAddress,Integer> activeConnectionFunction )
     {
         int size = addresses.length;
         if ( size == 0 )
@@ -77,7 +96,7 @@ public class LeastConnectedLoadBalancingStrategy implements LoadBalancingStrateg
         do
         {
             BoltServerAddress address = addresses[index];
-            int activeConnections = connectionPool.activeConnections( address );
+            int activeConnections = activeConnectionFunction.apply( address );
 
             if ( activeConnections < leastActiveConnections )
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancingStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancingStrategy.java
@@ -33,6 +33,8 @@ public interface LoadBalancingStrategy
      */
     BoltServerAddress selectReader( BoltServerAddress[] knownReaders );
 
+    BoltServerAddress selectReaderAsync( BoltServerAddress[] knownReaders );
+
     /**
      * Select most appropriate write address from the given array of addresses.
      *
@@ -40,4 +42,6 @@ public interface LoadBalancingStrategy
      * @return most appropriate writer or {@code null} if it can't be selected.
      */
     BoltServerAddress selectWriter( BoltServerAddress[] knownWriters );
+
+    BoltServerAddress selectWriterAsync( BoltServerAddress[] knownWriters );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinLoadBalancingStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinLoadBalancingStrategy.java
@@ -47,9 +47,21 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy
     }
 
     @Override
+    public BoltServerAddress selectReaderAsync( BoltServerAddress[] knownReaders )
+    {
+        return selectReader( knownReaders );
+    }
+
+    @Override
     public BoltServerAddress selectWriter( BoltServerAddress[] knownWriters )
     {
         return select( knownWriters, writersIndex, "writer" );
+    }
+
+    @Override
+    public BoltServerAddress selectWriterAsync( BoltServerAddress[] knownWriters )
+    {
+        return selectWriter( knownWriters );
     }
 
     private BoltServerAddress select( BoltServerAddress[] addresses, RoundRobinArrayIndex roundRobinIndex,

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.summary.InternalNotification;
 import org.neo4j.driver.internal.summary.InternalPlan;
 import org.neo4j.driver.internal.summary.InternalProfiledPlan;
 import org.neo4j.driver.internal.summary.InternalResultSummary;
+import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.summary.InternalSummaryCounters;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -204,7 +205,9 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
     private ResultSummary extractResultSummary( Map<String,Value> metadata )
     {
-        return new InternalResultSummary( statement, connection.serverInfo(), extractStatementType( metadata ),
+        InternalServerInfo serverInfo = new InternalServerInfo( connection.serverAddress(),
+                connection.serverVersion() );
+        return new InternalResultSummary( statement, serverInfo, extractStatementType( metadata ),
                 extractCounters( metadata ), extractPlan( metadata ), extractProfiledPlan( metadata ),
                 extractNotifications( metadata ), runResponseHandler.resultAvailableAfter(),
                 extractResultConsumedAfter( metadata ) );

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
@@ -20,12 +20,18 @@
 package org.neo4j.driver.internal.summary;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.summary.ServerInfo;
 
 public class InternalServerInfo implements ServerInfo
 {
     private final BoltServerAddress address;
     private final String version;
+
+    public InternalServerInfo( BoltServerAddress address, ServerVersion version )
+    {
+        this( address, version.toString() );
+    }
 
     public InternalServerInfo( BoltServerAddress address, String version )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -152,6 +152,8 @@ public class ServerVersion
     @Override
     public String toString()
     {
-        return String.format( "%s.%s.%s", major, minor, patch );
+        return this == vInDev
+               ? NEO4J_IN_DEV_VERSION_STRING
+               : String.format( "Neo4j/%s.%s.%s", major, minor, patch );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
+import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.net.BoltServerAddress;
@@ -168,8 +169,9 @@ public class DriverFactoryTest
         }
 
         @Override
-        protected Driver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool, Config config,
-                RoutingSettings routingSettings, SecurityPlan securityPlan, RetryLogic retryLogic )
+        protected Driver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool,
+                AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings,
+                SecurityPlan securityPlan, RetryLogic retryLogic )
         {
             throw new UnsupportedOperationException( "Can't create routing driver" );
         }
@@ -193,7 +195,7 @@ public class DriverFactoryTest
 
         @Override
         protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool,
-                Config config, RoutingSettings routingSettings )
+                AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings )
         {
             return null;
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -171,7 +172,7 @@ public class DriverFactoryTest
         @Override
         protected Driver createRoutingDriver( BoltServerAddress address, ConnectionPool connectionPool,
                 AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings,
-                SecurityPlan securityPlan, RetryLogic retryLogic )
+                SecurityPlan securityPlan, RetryLogic retryLogic, EventExecutorGroup eventExecutorGroup )
         {
             throw new UnsupportedOperationException( "Can't create routing driver" );
         }
@@ -195,7 +196,8 @@ public class DriverFactoryTest
 
         @Override
         protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool,
-                AsyncConnectionPool asyncConnectionPool, Config config, RoutingSettings routingSettings )
+                AsyncConnectionPool asyncConnectionPool, EventExecutorGroup eventExecutorGroup,
+                Config config, RoutingSettings routingSettings )
         {
             return null;
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -365,8 +366,8 @@ public class RoutingDriverTest
         AsyncConnectionPool asyncConnectionPool = mock( AsyncConnectionPool.class );
         LoadBalancingStrategy loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy( pool,
                 asyncConnectionPool, logging );
-        ConnectionProvider connectionProvider = new LoadBalancer( SEED, settings, pool, asyncConnectionPool, clock,
-                logging, loadBalancingStrategy );
+        ConnectionProvider connectionProvider = new LoadBalancer( SEED, settings, pool, asyncConnectionPool,
+                GlobalEventExecutor.INSTANCE, clock, logging, loadBalancingStrategy );
         Config config = Config.build().withLogging( logging ).toConfig();
         SessionFactory sessionFactory = new NetworkSessionWithAddressFactory( connectionProvider, config );
         return new InternalDriver( insecure(), sessionFactory, logging );

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.driver.internal.cluster.ClusterCompositionProviderTest.serverInfo;
+import static org.neo4j.driver.internal.cluster.RoutingProcedureClusterCompositionProviderTest.serverInfo;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.security.SecurityPlan.insecure;
 import static org.neo4j.driver.v1.Values.value;

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.util.ServerVersion;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -31,16 +32,17 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.driver.internal.async.ChannelAttributes.address;
 import static org.neo4j.driver.internal.async.ChannelAttributes.creationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.lastUsedTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
+import static org.neo4j.driver.internal.async.ChannelAttributes.serverAddress;
 import static org.neo4j.driver.internal.async.ChannelAttributes.serverVersion;
-import static org.neo4j.driver.internal.async.ChannelAttributes.setAddress;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setLastUsedTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
+import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerVersion;
+import static org.neo4j.driver.internal.util.ServerVersion.version;
 
 public class ChannelAttributesTest
 {
@@ -56,18 +58,18 @@ public class ChannelAttributesTest
     public void shouldSetAndGetAddress()
     {
         BoltServerAddress address = new BoltServerAddress( "local:42" );
-        setAddress( channel, address );
-        assertEquals( address, address( channel ) );
+        setServerAddress( channel, address );
+        assertEquals( address, serverAddress( channel ) );
     }
 
     @Test
     public void shouldFailToSetAddressTwice()
     {
-        setAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
+        setServerAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
 
         try
         {
-            setAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
+            setServerAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -144,18 +146,19 @@ public class ChannelAttributesTest
     @Test
     public void shouldSetAndGetServerVersion()
     {
-        setServerVersion( channel, "3.2.1" );
-        assertEquals( "3.2.1", serverVersion( channel ) );
+        ServerVersion version = version( "3.2.1" );
+        setServerVersion( channel, version );
+        assertEquals( version, serverVersion( channel ) );
     }
 
     @Test
     public void shouldFailToSetServerVersionTwice()
     {
-        setServerVersion( channel, "3.2.2" );
+        setServerVersion( channel, version( "3.2.2" ) );
 
         try
         {
-            setServerVersion( channel, "3.2.3" );
+            setServerVersion( channel, version( "3.2.3" ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/RoutingAsyncConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/RoutingAsyncConnectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.driver.v1.AccessMode.READ;
+
+public class RoutingAsyncConnectionTest
+{
+    @Test
+    public void shouldWrapGivenHandlersInRun()
+    {
+        testHandlersWrapping( false );
+    }
+
+    @Test
+    public void shouldWrapGivenHandlersInRunAndFlush()
+    {
+        testHandlersWrapping( true );
+    }
+
+    private static void testHandlersWrapping( boolean flush )
+    {
+        AsyncConnection connection = mock( AsyncConnection.class );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+        RoutingAsyncConnection routingConnection = new RoutingAsyncConnection( connection, READ, errorHandler );
+
+        if ( flush )
+        {
+            routingConnection.runAndFlush( "RETURN 1", emptyMap(), mock( ResponseHandler.class ),
+                    mock( ResponseHandler.class ) );
+        }
+        else
+        {
+            routingConnection.run( "RETURN 1", emptyMap(), mock( ResponseHandler.class ),
+                    mock( ResponseHandler.class ) );
+        }
+
+        ArgumentCaptor<ResponseHandler> runHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
+        ArgumentCaptor<ResponseHandler> pullAllHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
+
+        if ( flush )
+        {
+            verify( connection ).runAndFlush( eq( "RETURN 1" ), eq( emptyMap() ), runHandlerCaptor.capture(),
+                    pullAllHandlerCaptor.capture() );
+        }
+        else
+        {
+            verify( connection ).run( eq( "RETURN 1" ), eq( emptyMap() ), runHandlerCaptor.capture(),
+                    pullAllHandlerCaptor.capture() );
+        }
+
+        assertThat( runHandlerCaptor.getValue(), instanceOf( RoutingResponseHandler.class ) );
+        assertThat( pullAllHandlerCaptor.getValue(), instanceOf( RoutingResponseHandler.class ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/RoutingResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/RoutingResponseHandlerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.CompletionException;
+
+import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
+import org.neo4j.driver.v1.exceptions.TransientException;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
+
+public class RoutingResponseHandlerTest
+{
+    @Test
+    public void shouldUnwrapCompletionException()
+    {
+        RuntimeException error = new RuntimeException( "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( new CompletionException( error ), errorHandler );
+
+        assertEquals( error, handledError );
+        verifyZeroInteractions( errorHandler );
+    }
+
+    @Test
+    public void shouldHandleServiceUnavailableException()
+    {
+        ServiceUnavailableException error = new ServiceUnavailableException( "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler );
+
+        assertThat( handledError, instanceOf( SessionExpiredException.class ) );
+        verify( errorHandler ).onConnectionFailure( LOCAL_DEFAULT );
+    }
+
+    @Test
+    public void shouldHandleDatabaseUnavailableError()
+    {
+        TransientException error = new TransientException( "Neo.TransientError.General.DatabaseUnavailable", "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler );
+
+        assertEquals( error, handledError );
+        verify( errorHandler ).onConnectionFailure( LOCAL_DEFAULT );
+    }
+
+    @Test
+    public void shouldHandleTransientException()
+    {
+        TransientException error = new TransientException( "Neo.TransientError.Transaction.DeadlockDetected", "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler );
+
+        assertEquals( error, handledError );
+        verifyZeroInteractions( errorHandler );
+    }
+
+    @Test
+    public void shouldHandleNotALeaderErrorWithReadAccessMode()
+    {
+        testWriteFailureWithReadAccessMode( "Neo.ClientError.Cluster.NotALeader" );
+    }
+
+    @Test
+    public void shouldHandleNotALeaderErrorWithWriteAccessMode()
+    {
+        testWriteFailureWithWriteAccessMode( "Neo.ClientError.Cluster.NotALeader" );
+    }
+
+    @Test
+    public void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithReadAccessMode()
+    {
+        testWriteFailureWithReadAccessMode( "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase" );
+    }
+
+    @Test
+    public void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithWriteAccessMode()
+    {
+        testWriteFailureWithWriteAccessMode( "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase" );
+    }
+
+    @Test
+    public void shouldHandleClientException()
+    {
+        ClientException error = new ClientException( "Neo.ClientError.Request.Invalid", "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler, AccessMode.READ );
+
+        assertEquals( error, handledError );
+        verifyZeroInteractions( errorHandler );
+    }
+
+    private void testWriteFailureWithReadAccessMode( String code )
+    {
+        ClientException error = new ClientException( code, "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler, AccessMode.READ );
+
+        assertThat( handledError, instanceOf( ClientException.class ) );
+        assertEquals( "Write queries cannot be performed in READ access mode.", handledError.getMessage() );
+        verifyZeroInteractions( errorHandler );
+    }
+
+    private void testWriteFailureWithWriteAccessMode( String code )
+    {
+        ClientException error = new ClientException( code, "Hi" );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+
+        Throwable handledError = handle( error, errorHandler, AccessMode.WRITE );
+
+        assertThat( handledError, instanceOf( SessionExpiredException.class ) );
+        assertEquals( "Server at " + LOCAL_DEFAULT + " no longer accepts writes", handledError.getMessage() );
+        verify( errorHandler ).onWriteFailure( LOCAL_DEFAULT );
+    }
+
+    private static Throwable handle( Throwable error, RoutingErrorHandler errorHandler )
+    {
+        return handle( error, errorHandler, AccessMode.READ );
+    }
+
+    private static Throwable handle( Throwable error, RoutingErrorHandler errorHandler, AccessMode accessMode )
+    {
+        ResponseHandler responseHandler = mock( ResponseHandler.class );
+        RoutingResponseHandler routingResponseHandler =
+                new RoutingResponseHandler( responseHandler, LOCAL_DEFAULT, accessMode, errorHandler );
+
+        routingResponseHandler.onFailure( error );
+
+        ArgumentCaptor<Throwable> handledErrorCaptor = ArgumentCaptor.forClass( Throwable.class );
+        verify( responseHandler ).onFailure( handledErrorCaptor.capture() );
+        return handledErrorCaptor.getValue();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ActiveChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ActiveChannelTrackerTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.driver.internal.async.ChannelAttributes.setAddress;
+import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
@@ -138,7 +138,7 @@ public class ActiveChannelTrackerTest
     private Channel newChannel()
     {
         EmbeddedChannel channel = new EmbeddedChannel();
-        setAddress( channel, address );
+        setServerAddress( channel, address );
         return channel;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionProviderTest.java
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 package org.neo4j.driver.internal.cluster;
+
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -59,8 +59,8 @@ public class ClusterCompositionProviderTest
                 DEV_NULL_LOGGER, mockedRunner );
 
         PooledConnection mockedConn = mock( PooledConnection.class );
-        ArrayList<Record> emptyRecord = new ArrayList<>();
-        when( mockedRunner.run( mockedConn ) ).thenReturn( emptyRecord );
+        RoutingProcedureResponse noRecordsResponse = newRoutingResponse();
+        when( mockedRunner.run( mockedConn ) ).thenReturn( noRecordsResponse );
 
         // When
         ClusterCompositionResponse response = provider.getClusterComposition( mockedConn );
@@ -89,7 +89,8 @@ public class ClusterCompositionProviderTest
 
         PooledConnection mockedConn = mock( PooledConnection.class );
         Record aRecord = new InternalRecord( asList( "key1", "key2" ), new Value[]{ new StringValue( "a value" ) } );
-        when( mockedRunner.run( mockedConn ) ).thenReturn( asList( aRecord, aRecord ) );
+        RoutingProcedureResponse routingResponse = newRoutingResponse( aRecord, aRecord );
+        when( mockedRunner.run( mockedConn ) ).thenReturn( routingResponse );
 
         // When
         ClusterCompositionResponse response = provider.getClusterComposition( mockedConn );
@@ -118,7 +119,8 @@ public class ClusterCompositionProviderTest
 
         PooledConnection mockedConn = mock( PooledConnection.class );
         Record aRecord = new InternalRecord( asList( "key1", "key2" ), new Value[]{ new StringValue( "a value" ) } );
-        when( mockedRunner.run( mockedConn ) ).thenReturn( asList( aRecord ) );
+        RoutingProcedureResponse routingResponse = newRoutingResponse( aRecord );
+        when( mockedRunner.run( mockedConn ) ).thenReturn( routingResponse );
 
         // When
         ClusterCompositionResponse response = provider.getClusterComposition( mockedConn );
@@ -152,7 +154,8 @@ public class ClusterCompositionProviderTest
                 serverInfo( "READ", "one:1337", "two:1337" ),
                 serverInfo( "WRITE", "one:1337" ) ) )
         } );
-        when( mockedRunner.run( mockedConn ) ).thenReturn( asList( record ) );
+        RoutingProcedureResponse routingResponse = newRoutingResponse( record );
+        when( mockedRunner.run( mockedConn ) ).thenReturn( routingResponse );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
@@ -187,7 +190,8 @@ public class ClusterCompositionProviderTest
                 serverInfo( "WRITE", "one:1337" ),
                 serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
         } );
-        when( mockedRunner.run( mockedConn ) ).thenReturn( asList( record ) );
+        RoutingProcedureResponse routingResponse = newRoutingResponse( record );
+        when( mockedRunner.run( mockedConn ) ).thenReturn( routingResponse );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
@@ -254,7 +258,8 @@ public class ClusterCompositionProviderTest
                 serverInfo( "WRITE", "one:1337" ),
                 serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
         } );
-        when( mockedRunner.run( mockedConn ) ).thenReturn( asList( record ) );
+        RoutingProcedureResponse routingResponse = newRoutingResponse( record );
+        when( mockedRunner.run( mockedConn ) ).thenReturn( routingResponse );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
@@ -289,8 +294,11 @@ public class ClusterCompositionProviderTest
 
     private static RoutingProcedureRunner newProcedureRunnerMock()
     {
-        RoutingProcedureRunner mock = mock( RoutingProcedureRunner.class );
-        when( mock.invokedProcedure() ).thenReturn( new Statement( "procedure" ) );
-        return mock;
+        return mock( RoutingProcedureRunner.class );
+    }
+
+    private static RoutingProcedureResponse newRoutingResponse( Record... records )
+    {
+        return new RoutingProcedureResponse( new Statement( "procedure" ), asList( records ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryAsyncTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryAsyncTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.driver.internal.cluster;
 
 import io.netty.util.concurrent.GlobalEventExecutor;

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -106,7 +107,8 @@ public class RediscoveryTest
             ClusterCompositionProvider mockedProvider = mock( ClusterCompositionProvider.class );
             when( mockedProvider.getClusterComposition( any( Connection.class ) ) ).thenThrow( new RuntimeException() );
 
-            Rediscovery rediscovery = new Rediscovery( A, settings, clock, DEV_NULL_LOGGER, mockedProvider, directMapProvider );
+            Rediscovery rediscovery = new Rediscovery( A, settings, mockedProvider, GlobalEventExecutor.INSTANCE,
+                    directMapProvider, clock, DEV_NULL_LOGGER );
 
             // when
             try
@@ -245,8 +247,9 @@ public class RediscoveryTest
             when( mockedProvider.getClusterComposition( initialRouterConn ) )
                     .thenReturn( success( VALID_CLUSTER_COMPOSITION ) );
 
-            Rediscovery rediscovery = new Rediscovery( F, new RoutingSettings( 1, 0 ), new FakeClock(),
-                    DEV_NULL_LOGGER, mockedProvider, directMapProvider );
+            Rediscovery rediscovery = new Rediscovery( F, new RoutingSettings( 1, 0 ), mockedProvider,
+                    GlobalEventExecutor.INSTANCE, directMapProvider, new FakeClock(),
+                    DEV_NULL_LOGGER );
 
             // first rediscovery should accept table with no writers
             ClusterComposition composition1 = rediscovery.lookupClusterComposition( routingTable, mockedConnections );
@@ -481,8 +484,9 @@ public class RediscoveryTest
             Clock mockedClock = mock( Clock.class );
             Logger mockedLogger = mock( Logger.class );
 
-            Rediscovery rediscovery = new Rediscovery( A, settings, mockedClock, mockedLogger, clusterComposition,
-                    directMapProvider );
+            Rediscovery rediscovery = new Rediscovery( A, settings, clusterComposition, GlobalEventExecutor.INSTANCE,
+                    directMapProvider, mockedClock, mockedLogger
+            );
 
             ClusterComposition composition1 = rediscovery.lookupClusterComposition( routingTable, connections );
             assertEquals( VALID_CLUSTER_COMPOSITION, composition1 );
@@ -512,8 +516,9 @@ public class RediscoveryTest
         Clock mockedClock = mock( Clock.class );
         Logger mockedLogger = mock( Logger.class );
 
-        Rediscovery rediscovery = new Rediscovery( initialRouter, settings, mockedClock, mockedLogger, provider,
-                directMapProvider );
+        Rediscovery rediscovery = new Rediscovery( initialRouter, settings, provider, GlobalEventExecutor.INSTANCE,
+                directMapProvider, mockedClock, mockedLogger
+        );
         return rediscovery.lookupClusterComposition( routingTable, connections );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -381,7 +382,8 @@ public class RoutingPooledConnectionErrorHandlingTest
         Rediscovery rediscovery = mock( Rediscovery.class );
         when( rediscovery.lookupClusterComposition( routingTable, connectionPool ) ).thenReturn( clusterComposition );
         AsyncConnectionPool asyncConnectionPool = mock( AsyncConnectionPool.class );
-        return new LoadBalancer( connectionPool, asyncConnectionPool, routingTable, rediscovery, DEV_NULL_LOGGING );
+        return new LoadBalancer( connectionPool, asyncConnectionPool, routingTable, rediscovery,
+                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
     }
 
     private interface ConnectionMethod

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
@@ -379,7 +380,8 @@ public class RoutingPooledConnectionErrorHandlingTest
     {
         Rediscovery rediscovery = mock( Rediscovery.class );
         when( rediscovery.lookupClusterComposition( routingTable, connectionPool ) ).thenReturn( clusterComposition );
-        return new LoadBalancer( connectionPool, routingTable, rediscovery, DEV_NULL_LOGGING );
+        AsyncConnectionPool asyncConnectionPool = mock( AsyncConnectionPool.class );
+        return new LoadBalancer( connectionPool, asyncConnectionPool, routingTable, rediscovery, DEV_NULL_LOGGING );
     }
 
     private interface ConnectionMethod

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RoutingProcedureResponseTest
+{
+    private static final Statement PROCEDURE = new Statement( "procedure" );
+
+    private static final Record RECORD_1 = new InternalRecord( asList( "a", "b" ),
+            new Value[]{new StringValue( "a" ), new StringValue( "b" )} );
+    private static final Record RECORD_2 = new InternalRecord( asList( "a", "b" ),
+            new Value[]{new StringValue( "aa" ), new StringValue( "bb" )} );
+
+    @Test
+    public void shouldBeSuccessfulWithRecords()
+    {
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
+        assertTrue( response.isSuccess() );
+    }
+
+    @Test
+    public void shouldNotBeSuccessfulWithError()
+    {
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, new RuntimeException() );
+        assertFalse( response.isSuccess() );
+    }
+
+    @Test
+    public void shouldThrowWhenFailedAndAskedForRecords()
+    {
+        RuntimeException error = new RuntimeException();
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, error );
+
+        try
+        {
+            response.records();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+            assertEquals( e.getCause(), error );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenSuccessfulAndAskedForError()
+    {
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
+
+        try
+        {
+            response.error();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldHaveErrorWhenFailed()
+    {
+        RuntimeException error = new RuntimeException( "Hi!" );
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, error );
+        assertEquals( error, response.error() );
+    }
+
+    @Test
+    public void shouldHaveRecordsWhenSuccessful()
+    {
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
+        assertEquals( asList( RECORD_1, RECORD_2 ), response.records() );
+    }
+
+    @Test
+    public void shouldHaveProcedure()
+    {
+        RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
+        assertEquals( PROCEDURE, response.procedure() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -50,6 +50,7 @@ import static org.neo4j.driver.internal.async.Futures.getBlocking;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE_PARAM;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_SERVERS;
+import static org.neo4j.driver.internal.util.ServerVersion.version;
 import static org.neo4j.driver.v1.Values.parameters;
 
 public class RoutingProcedureRunnerTest
@@ -186,8 +187,8 @@ public class RoutingProcedureRunnerTest
     private static CompletionStage<AsyncConnection> connectionStage( String serverVersion )
     {
         AsyncConnection connection = mock( AsyncConnection.class );
-        InternalServerInfo serverInfo = new InternalServerInfo( new BoltServerAddress( "123:45" ), serverVersion );
-        when( connection.serverInfo() ).thenReturn( serverInfo );
+        when( connection.serverAddress() ).thenReturn( new BoltServerAddress( "123:45" ) );
+        when( connection.serverVersion() ).thenReturn( version( serverVersion ) );
         return completedFuture( connection );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -51,10 +51,10 @@ public class RoutingProcedureRunnerTest
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.2.1" ) );
         // When
-        runner.run( mock );
+        RoutingProcedureResponse response = runner.run( mock );
 
         // Then
-        assertThat( runner.invokedProcedure(), equalTo(
+        assertThat( response.procedure(), equalTo(
                 new Statement( "CALL " + GET_ROUTING_TABLE, parameters( GET_ROUTING_TABLE_PARAM, EMPTY_MAP ) ) ) );
     }
 
@@ -69,11 +69,11 @@ public class RoutingProcedureRunnerTest
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.2.1" ) );
         // When
-        runner.run( mock );
+        RoutingProcedureResponse response = runner.run( mock );
 
         // Then
         Value expectedParams = parameters( GET_ROUTING_TABLE_PARAM, context.asMap() );
-        assertThat( runner.invokedProcedure(), equalTo(
+        assertThat( response.procedure(), equalTo(
                 new Statement( "CALL " + GET_ROUTING_TABLE, expectedParams ) ) );
     }
 
@@ -88,10 +88,10 @@ public class RoutingProcedureRunnerTest
         when( mock.server() ).thenReturn(
                 new InternalServerInfo( new BoltServerAddress( "123:45" ), "Neo4j/3.1.8" ) );
         // When
-        runner.run( mock );
+        RoutingProcedureResponse response = runner.run( mock );
 
         // Then
-        assertThat( runner.invokedProcedure(), equalTo(
+        assertThat( response.procedure(), equalTo(
                 new Statement( "CALL " + GET_SERVERS ) ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -22,19 +22,31 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.internal.async.AsyncConnection;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.ClientException;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_MAP;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.async.Futures.failedFuture;
+import static org.neo4j.driver.internal.async.Futures.getBlocking;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE_PARAM;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_SERVERS;
@@ -59,6 +71,20 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
+    public void shouldCallGetRoutingTableWithEmptyMapAsync()
+    {
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY,
+                completedFuture( asList( mock( Record.class ), mock( Record.class ) ) ) );
+
+        RoutingProcedureResponse response = getBlocking( runner.run( connectionStage( "Neo4j/3.2.1" ) ) );
+
+        assertTrue( response.isSuccess() );
+        assertEquals( 2, response.records().size() );
+        assertEquals( new Statement( "CALL " + GET_ROUTING_TABLE, parameters( GET_ROUTING_TABLE_PARAM, EMPTY_MAP ) ),
+                response.procedure() );
+    }
+
+    @Test
     public void shouldCallGetRoutingTableWithParam() throws Throwable
     {
         // Given
@@ -75,6 +101,23 @@ public class RoutingProcedureRunnerTest
         Value expectedParams = parameters( GET_ROUTING_TABLE_PARAM, context.asMap() );
         assertThat( response.procedure(), equalTo(
                 new Statement( "CALL " + GET_ROUTING_TABLE, expectedParams ) ) );
+    }
+
+    @Test
+    public void shouldCallGetRoutingTableWithParamAsync()
+    {
+        URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
+        RoutingContext context = new RoutingContext( uri );
+
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( context,
+                completedFuture( singletonList( mock( Record.class ) ) ) );
+
+        RoutingProcedureResponse response = getBlocking( runner.run( connectionStage( "Neo4j/3.2.1" ) ) );
+
+        assertTrue( response.isSuccess() );
+        assertEquals( 1, response.records().size() );
+        Value expectedParams = parameters( GET_ROUTING_TABLE_PARAM, context.asMap() );
+        assertEquals( new Statement( "CALL " + GET_ROUTING_TABLE, expectedParams ), response.procedure() );
     }
 
     @Test
@@ -95,11 +138,72 @@ public class RoutingProcedureRunnerTest
                 new Statement( "CALL " + GET_SERVERS ) ) );
     }
 
+    @Test
+    public void shouldCallGetServersAsync()
+    {
+        URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
+        RoutingContext context = new RoutingContext( uri );
+
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( context,
+                completedFuture( asList( mock( Record.class ), mock( Record.class ) ) ) );
+
+        RoutingProcedureResponse response = getBlocking( runner.run( connectionStage( "Neo4j/3.1.8" ) ) );
+
+        assertTrue( response.isSuccess() );
+        assertEquals( 2, response.records().size() );
+        assertEquals( new Statement( "CALL " + GET_SERVERS ), response.procedure() );
+    }
+
+    @Test
+    public void shouldReturnFailedResponseOnClientException()
+    {
+        ClientException error = new ClientException( "Hi" );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
+
+        RoutingProcedureResponse response = getBlocking( runner.run( connectionStage( "Neo4j/3.2.2" ) ) );
+
+        assertFalse( response.isSuccess() );
+        assertEquals( error, response.error() );
+    }
+
+    @Test
+    public void shouldReturnFailedStageOnError()
+    {
+        Exception error = new Exception( "Hi" );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
+
+        try
+        {
+            getBlocking( runner.run( connectionStage( "Neo4j/3.2.2" ) ) );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+    }
+
+    private static CompletionStage<AsyncConnection> connectionStage( String serverVersion )
+    {
+        AsyncConnection connection = mock( AsyncConnection.class );
+        InternalServerInfo serverInfo = new InternalServerInfo( new BoltServerAddress( "123:45" ), serverVersion );
+        when( connection.serverInfo() ).thenReturn( serverInfo );
+        return completedFuture( connection );
+    }
+
     private static class TestRoutingProcedureRunner extends RoutingProcedureRunner
     {
+        final CompletionStage<List<Record>> runProcedureResult;
+
         TestRoutingProcedureRunner( RoutingContext context )
         {
+            this( context, null );
+        }
+
+        TestRoutingProcedureRunner( RoutingContext context, CompletionStage<List<Record>> runProcedureResult )
+        {
             super( context );
+            this.runProcedureResult = runProcedureResult;
         }
 
         @Override
@@ -107,6 +211,12 @@ public class RoutingProcedureRunnerTest
         {
             // I do not want any network traffic
             return null;
+        }
+
+        @Override
+        CompletionStage<List<Record>> runProcedure( AsyncConnection connection, Statement procedure )
+        {
+            return runProcedureResult;
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -184,6 +184,23 @@ public class RoutingProcedureRunnerTest
         }
     }
 
+    @Test
+    public void shouldPropagateErrorFromConnectionStage()
+    {
+        RuntimeException error = new RuntimeException( "Hi" );
+        RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY );
+
+        try
+        {
+            getBlocking( runner.run( failedFuture( error ) ) );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( error, e );
+        }
+    }
+
     private static CompletionStage<AsyncConnection> connectionStage( String serverVersion )
     {
         AsyncConnection connection = mock( AsyncConnection.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategyTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategyTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.v1.Logger;
@@ -44,13 +45,15 @@ public class LeastConnectedLoadBalancingStrategyTest
 {
     @Mock
     private ConnectionPool connectionPool;
+    @Mock
+    private AsyncConnectionPool asyncConnectionPool;
     private LeastConnectedLoadBalancingStrategy strategy;
 
     @Before
     public void setUp() throws Exception
     {
         initMocks( this );
-        strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, DEV_NULL_LOGGING );
+        strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, asyncConnectionPool, DEV_NULL_LOGGING );
     }
 
     @Test
@@ -166,7 +169,8 @@ public class LeastConnectedLoadBalancingStrategyTest
         Logger logger = mock( Logger.class );
         when( logging.getLog( anyString() ) ).thenReturn( logger );
 
-        LoadBalancingStrategy strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, logging );
+        LoadBalancingStrategy strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, asyncConnectionPool,
+                logging );
 
         strategy.selectReader( new BoltServerAddress[0] );
         strategy.selectWriter( new BoltServerAddress[0] );
@@ -184,7 +188,8 @@ public class LeastConnectedLoadBalancingStrategyTest
 
         when( connectionPool.activeConnections( any( BoltServerAddress.class ) ) ).thenReturn( 42 );
 
-        LoadBalancingStrategy strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, logging );
+        LoadBalancingStrategy strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, asyncConnectionPool,
+                logging );
 
         strategy.selectReader( new BoltServerAddress[]{A} );
         strategy.selectWriter( new BoltServerAddress[]{A} );

--- a/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
@@ -54,7 +54,7 @@ public class TrustOnFirstUseTrustManagerTest
     private String knownServer;
 
     @Rule
-    public TemporaryFolder testDir = new TemporaryFolder();
+    public TemporaryFolder testDir = new TemporaryFolder( new File( "target" ) );
     private X509Certificate knownCertificate;
 
     @Before

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithOneEventLoopThread.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithOneEventLoopThread.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import io.netty.bootstrap.Bootstrap;
+
+import java.net.URI;
+
+import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.async.BootstrapFactory;
+import org.neo4j.driver.internal.cluster.RoutingSettings;
+import org.neo4j.driver.internal.retry.RetrySettings;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+
+public class DriverFactoryWithOneEventLoopThread extends DriverFactory
+{
+    public Driver newInstance( URI uri, AuthToken authToken, Config config )
+    {
+        return newInstance( uri, authToken, new RoutingSettings( 1, 0 ), RetrySettings.DEFAULT, config );
+    }
+
+    @Override
+    protected Bootstrap createBootstrap()
+    {
+        return BootstrapFactory.newBootstrap( 1 );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -23,6 +23,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.neo4j.driver.internal.security.InternalAuthToken;
@@ -52,7 +53,7 @@ import static org.neo4j.driver.v1.Values.parameters;
 public class CredentialsIT
 {
     @ClassRule
-    public static TemporaryFolder tempDir = new TemporaryFolder();
+    public static TemporaryFolder tempDir = new TemporaryFolder( new File( "target" ) );
 
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -66,7 +66,7 @@ public class TLSSocketChannelIT
     public TestNeo4j neo4j = new TestNeo4j();
 
     @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder( new File( "target" ) );
 
     @BeforeClass
     public static void setup() throws IOException, InterruptedException

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -60,7 +60,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 public abstract class AbstractStressTestBase<C extends AbstractContext>
 {
@@ -110,9 +109,6 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
     @Test
     public void asyncApiStressTest() throws Throwable
     {
-        // todo: re-enable when async is supported in routing driver
-        assumeTrue( "bolt".equalsIgnoreCase( databaseUri().getScheme() ) );
-
         runStressTest( this::launchAsyncWorkerThreads );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.driver.v1.util.TestNeo4j;
@@ -37,7 +38,7 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 public class DriverComplianceIT
 {
     @Rule
-    TemporaryFolder folder = new TemporaryFolder();
+    TemporaryFolder folder = new TemporaryFolder( new File( "target" ) );
 
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -51,7 +51,7 @@ public class Neo4jRunner
 
     private static final boolean debug = true;
 
-    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.2.0";
+    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.2.5";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final URI DEFAULT_URI = URI.create( "bolt://localhost:7687" );
     public static final BoltServerAddress DEFAULT_ADDRESS = new BoltServerAddress( DEFAULT_URI );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -19,9 +19,13 @@
 package org.neo4j.driver.v1.util;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.PlatformDependent;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -66,7 +70,7 @@ public final class TestUtil
         }
         catch ( ExecutionException e )
         {
-            throwException( e.getCause() );
+            PlatformDependent.throwException( e.getCause() );
             return null;
         }
         catch ( TimeoutException e )
@@ -112,15 +116,10 @@ public final class TestUtil
         }
     }
 
-    private static void throwException( Throwable t )
+    @SafeVarargs
+    public static <T> Set<T> asOrderedSet( T... elements )
     {
-        TestUtil.<RuntimeException>doThrowException( t );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private static <E extends Throwable> void doThrowException( Throwable t ) throws E
-    {
-        throw (E) t;
+        return new LinkedHashSet<>( Arrays.asList( elements ) );
     }
 
     private static Number read( ByteBuf buf, Class<? extends Number> type )

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterRule.java
@@ -92,7 +92,7 @@ public class LocalOrRemoteClusterRule extends ExternalResource
         }
         if ( uri != null && !BOLT_ROUTING_URI_SCHEME.equals( uri.getScheme() ) )
         {
-            throw new IllegalStateException( "CLuster uri should have bolt+routing scheme: '" + uri + "'" );
+            throw new IllegalStateException( "Cluster uri should have bolt+routing scheme: '" + uri + "'" );
         }
     }
 


### PR DESCRIPTION
PR makes async routing respect `Config#withRoutingRetryDelay()` setting and retry rediscovery configured amount of times with this delay. Retries are scheduled in Netty even loop. Also it makes load balancer "loop" until a working connection is acquired instead of failing on first failed acquisition attempt.

Based on https://github.com/neo4j/neo4j-java-driver/pull/409