### PR TITLE
Make sure network channel is closed on handshake or INIT failure

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -28,7 +28,6 @@ import java.security.GeneralSecurityException;
 import org.neo4j.driver.internal.async.AsyncConnectorImpl;
 import org.neo4j.driver.internal.async.BootstrapFactory;
 import org.neo4j.driver.internal.async.Futures;
-import org.neo4j.driver.internal.async.pool.ActiveChannelTracker;
 import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.async.pool.AsyncConnectionPoolImpl;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -107,16 +106,13 @@ public class DriverFactory
             Bootstrap bootstrap, Config config )
     {
         Clock clock = createClock();
-        ConnectionSettings connectionSettings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
-        ActiveChannelTracker activeChannelTracker = new ActiveChannelTracker( config.logging() );
-        AsyncConnectorImpl connector = new AsyncConnectorImpl( connectionSettings, securityPlan,
-                activeChannelTracker, config.logging(), clock );
+        ConnectionSettings settings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
+        AsyncConnectorImpl connector = new AsyncConnectorImpl( settings, securityPlan, config.logging(), clock );
         PoolSettings poolSettings = new PoolSettings( config.maxIdleConnectionPoolSize(),
                 config.idleTimeBeforeConnectionTest(), config.maxConnectionLifetimeMillis(),
                 config.maxConnectionPoolSize(),
                 config.connectionAcquisitionTimeoutMillis() );
-        return new AsyncConnectionPoolImpl( connector, bootstrap, activeChannelTracker, poolSettings, config.logging(),
-                clock );
+        return new AsyncConnectionPoolImpl( connector, bootstrap, poolSettings, config.logging(), clock );
     }
 
     private Driver createDriver( URI uri, BoltServerAddress address, ConnectionPool connectionPool,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/AsyncConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/AsyncConnectorImpl.java
@@ -23,7 +23,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.pool.ChannelPoolHandler;
 
 import java.util.Map;
 
@@ -46,18 +45,16 @@ public class AsyncConnectorImpl implements AsyncConnector
     private final Map<String,Value> authToken;
     private final SecurityPlan securityPlan;
     private final int connectTimeoutMillis;
-    private final ChannelPoolHandler channelPoolHandler;
     private final Logging logging;
     private final Clock clock;
 
-    public AsyncConnectorImpl( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
-            ChannelPoolHandler channelPoolHandler, Logging logging, Clock clock )
+    public AsyncConnectorImpl( ConnectionSettings connectionSettings, SecurityPlan securityPlan, Logging logging,
+            Clock clock )
     {
         this.userAgent = connectionSettings.userAgent();
         this.authToken = tokenAsMap( connectionSettings.authToken() );
         this.connectTimeoutMillis = connectionSettings.connectTimeoutMillis();
         this.securityPlan = requireNonNull( securityPlan );
-        this.channelPoolHandler = requireNonNull( channelPoolHandler );
         this.logging = requireNonNull( logging );
         this.clock = requireNonNull( clock );
     }
@@ -66,7 +63,7 @@ public class AsyncConnectorImpl implements AsyncConnector
     public ChannelFuture connect( BoltServerAddress address, Bootstrap bootstrap )
     {
         bootstrap.option( ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis );
-        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, channelPoolHandler, clock ) );
+        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, clock ) );
 
         ChannelFuture channelConnected = bootstrap.connect( address.toSocketAddress() );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectedListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectedListener.java
@@ -55,15 +55,11 @@ public class ChannelConnectedListener implements ChannelFutureListener
             channel.pipeline().addLast( new HandshakeResponseHandler( handshakeCompletedPromise, logging ) );
             ChannelFuture handshakeFuture = channel.writeAndFlush( handshake() );
 
-            handshakeFuture.addListener( new ChannelFutureListener()
+            handshakeFuture.addListener( channelFuture ->
             {
-                @Override
-                public void operationComplete( ChannelFuture future ) throws Exception
+                if ( !channelFuture.isSuccess() )
                 {
-                    if ( !future.isSuccess() )
-                    {
-                        handshakeCompletedPromise.setFailure( future.cause() );
-                    }
+                    handshakeCompletedPromise.setFailure( channelFuture.cause() );
                 }
             } );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
@@ -99,8 +99,7 @@ public class HandshakeResponseHandler extends ReplayingDecoder<Void>
 
     private void fail( ChannelHandlerContext ctx, Throwable error )
     {
-        ctx.close();
-        handshakeCompletedPromise.setFailure( error );
+        ctx.close().addListener( future -> handshakeCompletedPromise.setFailure( error ) );
     }
 
     private static Throwable protocolNoSupportedByServerError()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
@@ -54,13 +54,13 @@ public class HandshakeResponseHandler extends ReplayingDecoder<Void>
     }
 
     @Override
-    public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause ) throws Exception
+    public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause )
     {
         fail( ctx, cause );
     }
 
     @Override
-    protected void decode( ChannelHandlerContext ctx, ByteBuf in, List<Object> out ) throws Exception
+    protected void decode( ChannelHandlerContext ctx, ByteBuf in, List<Object> out )
     {
         int serverSuggestedVersion = in.readInt();
         log.debug( "Server suggested protocol version: %s", serverSuggestedVersion );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -20,7 +20,6 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.handler.ssl.SslHandler;
 
 import javax.net.ssl.SSLContext;
@@ -40,20 +39,17 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
 {
     private final BoltServerAddress address;
     private final SecurityPlan securityPlan;
-    private final ChannelPoolHandler channelPoolHandler;
     private final Clock clock;
 
-    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan,
-            ChannelPoolHandler channelPoolHandler, Clock clock )
+    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan, Clock clock )
     {
         this.address = address;
         this.securityPlan = securityPlan;
-        this.channelPoolHandler = channelPoolHandler;
         this.clock = clock;
     }
 
     @Override
-    protected void initChannel( Channel channel ) throws Exception
+    protected void initChannel( Channel channel )
     {
         if ( securityPlan.requiresEncryption() )
         {
@@ -62,8 +58,6 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
         }
 
         updateChannelAttributes( channel );
-
-        channelPoolHandler.channelCreated( channel );
     }
 
     private SslHandler createSslHandler()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImpl.java
@@ -52,12 +52,12 @@ public class AsyncConnectionPoolImpl implements AsyncConnectionPool
     private final ConcurrentMap<BoltServerAddress,ChannelPool> pools = new ConcurrentHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
 
-    public AsyncConnectionPoolImpl( AsyncConnector connector, Bootstrap bootstrap,
-            ActiveChannelTracker activeChannelTracker, PoolSettings settings, Logging logging, Clock clock )
+    public AsyncConnectionPoolImpl( AsyncConnector connector, Bootstrap bootstrap, PoolSettings settings,
+            Logging logging, Clock clock )
     {
         this.connector = connector;
         this.bootstrap = bootstrap;
-        this.activeChannelTracker = activeChannelTracker;
+        this.activeChannelTracker = new ActiveChannelTracker( logging );
         this.channelHealthChecker = new NettyChannelHealthChecker( settings, clock );
         this.settings = settings;
         this.clock = clock;

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
@@ -57,6 +57,15 @@ public class NettyChannelPool extends FixedChannelPool
     @Override
     protected ChannelFuture connectChannel( Bootstrap bootstrap )
     {
-        return connector.connect( address, bootstrap );
+        ChannelFuture channelFuture = connector.connect( address, bootstrap );
+        channelFuture.addListener( future ->
+        {
+            if ( future.isSuccess() )
+            {
+                // notify pool handler about a successful connection
+                handler().channelCreated( channelFuture.channel() );
+            }
+        } );
+        return channelFuture;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncConnectorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncConnectorImplTest.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal.async;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.pool.ChannelPoolHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,7 +47,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
@@ -70,7 +68,7 @@ public class AsyncConnectorImplTest
     {
         if ( bootstrap != null )
         {
-            bootstrap.config().group().shutdownGracefully();
+            bootstrap.config().group().shutdownGracefully().syncUninterruptibly();
         }
     }
 
@@ -161,7 +159,6 @@ public class AsyncConnectorImplTest
     private AsyncConnectorImpl newConnector( AuthToken authToken, int connectTimeoutMillis ) throws Exception
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, 1000 );
-        return new AsyncConnectorImpl( settings, SecurityPlan.forAllCertificates(),
-                mock( ChannelPoolHandler.class ), DEV_NULL_LOGGING, new FakeClock() );
+        return new AsyncConnectorImpl( settings, SecurityPlan.forAllCertificates(), DEV_NULL_LOGGING, new FakeClock() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeResponseHandlerTest.java
@@ -51,13 +51,13 @@ public class HandshakeResponseHandlerTest
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
     @Before
-    public void setUp() throws Exception
+    public void setUp()
     {
         setMessageDispatcher( channel, new InboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown()
     {
         channel.close();
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.pool.ChannelPoolHandler;
+import io.netty.handler.ssl.SslHandler;
+import org.junit.Test;
+
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.internal.util.FakeClock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.async.ChannelAttributes.address;
+import static org.neo4j.driver.internal.async.ChannelAttributes.creationTimestamp;
+import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
+import static org.neo4j.driver.internal.net.BoltServerAddress.LOCAL_DEFAULT;
+
+public class NettyChannelInitializerTest
+{
+    @Test
+    public void shouldAddSslHandlerWhenRequiresEncryption() throws Exception
+    {
+        SecurityPlan securityPlan = SecurityPlan.forAllCertificates();
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, securityPlan,
+                mock( ChannelPoolHandler.class ), new FakeClock() );
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+        initializer.initChannel( channel );
+
+        assertNotNull( channel.pipeline().get( SslHandler.class ) );
+    }
+
+    @Test
+    public void shouldNotAddSslHandlerWhenDoesNotRequireEncryption() throws Exception
+    {
+        SecurityPlan securityPlan = SecurityPlan.insecure();
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, securityPlan,
+                mock( ChannelPoolHandler.class ), new FakeClock() );
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+        initializer.initChannel( channel );
+
+        assertNull( channel.pipeline().get( SslHandler.class ) );
+    }
+
+    @Test
+    public void shouldUpdateChannelAttributes() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( 42L );
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, SecurityPlan.insecure(),
+                mock( ChannelPoolHandler.class ), clock );
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+        initializer.initChannel( channel );
+
+        assertEquals( LOCAL_DEFAULT, address( channel ) );
+        assertEquals( 42L, creationTimestamp( channel ) );
+        assertNotNull( messageDispatcher( channel ) );
+    }
+
+    @Test
+    public void shouldNotifyPoolHandlerAboutCreatedConnection() throws Exception
+    {
+        ChannelPoolHandler poolHandler = mock( ChannelPoolHandler.class );
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, SecurityPlan.insecure(),
+                poolHandler, new FakeClock() );
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+        initializer.initChannel( channel );
+
+        verify( poolHandler ).channelCreated( channel );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImplTest.java
@@ -167,11 +167,10 @@ public class AsyncConnectionPoolImplTest
     {
         FakeClock clock = new FakeClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( neo4j.authToken(), 5000 );
-        ActiveChannelTracker poolHandler = new ActiveChannelTracker( DEV_NULL_LOGGING );
         AsyncConnectorImpl connector = new AsyncConnectorImpl( connectionSettings, SecurityPlan.forAllCertificates(),
-                poolHandler, DEV_NULL_LOGGING, clock );
+                DEV_NULL_LOGGING, clock );
         PoolSettings poolSettings = new PoolSettings( 5, -1, -1, 10, 5000 );
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
-        return new AsyncConnectionPoolImpl( connector, bootstrap, poolHandler, poolSettings, DEV_NULL_LOGGING, clock );
+        return new AsyncConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_LOGGING, clock );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelHealthChecker;
+import io.netty.channel.pool.ChannelPoolHandler;
+import io.netty.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.async.AsyncConnectorImpl;
+import org.neo4j.driver.internal.async.BootstrapFactory;
+import org.neo4j.driver.internal.security.InternalAuthToken;
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.util.FakeClock;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.AuthenticationException;
+import org.neo4j.driver.v1.util.Neo4jRunner;
+import org.neo4j.driver.v1.util.TestNeo4j;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+import static org.neo4j.driver.v1.Values.value;
+
+public class NettyChannelPoolTest
+{
+    @Rule
+    public final TestNeo4j neo4j = new TestNeo4j();
+
+    private Bootstrap bootstrap;
+    private ChannelPoolHandler poolHandler;
+    private NettyChannelPool pool;
+
+    @Before
+    public void setUp()
+    {
+        bootstrap = BootstrapFactory.newBootstrap( 1 );
+        poolHandler = mock( ChannelPoolHandler.class );
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( pool != null )
+        {
+            pool.close();
+        }
+        if ( bootstrap != null )
+        {
+            bootstrap.config().group().shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    public void shouldAcquireAndReleaseWithCorrectCredentials() throws Exception
+    {
+        pool = newPool( neo4j.authToken() );
+
+        Future<Channel> acquireFuture = pool.acquire();
+        acquireFuture.await( 5, TimeUnit.SECONDS );
+
+        assertTrue( acquireFuture.isSuccess() );
+        Channel channel = acquireFuture.getNow();
+        assertNotNull( channel );
+        verify( poolHandler ).channelCreated( channel );
+        verify( poolHandler, never() ).channelReleased( channel );
+
+        Future<Void> releaseFuture = pool.release( channel );
+        releaseFuture.await( 5, TimeUnit.SECONDS );
+
+        assertTrue( releaseFuture.isSuccess() );
+        verify( poolHandler ).channelReleased( channel );
+    }
+
+    @Test
+    public void shouldFailToAcquireWithWrongCredentials() throws Exception
+    {
+        pool = newPool( AuthTokens.basic( "wrong", "wrong" ) );
+
+        Future<Channel> future = pool.acquire();
+        future.await( 5, TimeUnit.DAYS );
+
+        assertTrue( future.isDone() );
+        assertNotNull( future.cause() );
+        assertThat( future.cause(), instanceOf( AuthenticationException.class ) );
+
+        verify( poolHandler, never() ).channelCreated( any() );
+        verify( poolHandler, never() ).channelReleased( any() );
+    }
+
+    @Test
+    public void shouldAllowAcquireAfterFailures() throws Exception
+    {
+        int maxConnections = 2;
+
+        Map<String,Value> authTokenMap = new HashMap<>();
+        authTokenMap.put( "scheme", value( "basic" ) );
+        authTokenMap.put( "principal", value( "neo4j" ) );
+        authTokenMap.put( "credentials", value( "wrong" ) );
+        InternalAuthToken authToken = new InternalAuthToken( authTokenMap );
+
+        pool = newPool( authToken, maxConnections );
+
+        for ( int i = 0; i < maxConnections; i++ )
+        {
+            try
+            {
+                pool.acquire().get( 5, TimeUnit.SECONDS );
+                fail( "Exception expected" );
+            }
+            catch ( ExecutionException e )
+            {
+                assertThat( e.getCause(), instanceOf( AuthenticationException.class ) );
+            }
+        }
+
+        authTokenMap.put( "credentials", value( Neo4jRunner.PASSWORD ) );
+
+        Channel channel = pool.acquire().get( 5, TimeUnit.SECONDS );
+        assertNotNull( channel );
+    }
+
+    @Test
+    public void shouldLimitNumberOfConcurrentConnections() throws Exception
+    {
+        int maxConnections = 5;
+        pool = newPool( neo4j.authToken(), maxConnections );
+
+        for ( int i = 0; i < maxConnections; i++ )
+        {
+            Channel channel = pool.acquire().get( 5, TimeUnit.SECONDS );
+            assertNotNull( channel );
+        }
+
+        try
+        {
+            pool.acquire().get( 5, TimeUnit.SECONDS );
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertThat( e.getCause(), instanceOf( TimeoutException.class ) );
+            assertEquals( e.getCause().getMessage(), "Acquire operation took longer then configured maximum time" );
+        }
+    }
+
+    private NettyChannelPool newPool( AuthToken authToken )
+    {
+        return newPool( authToken, 100 );
+    }
+
+    private NettyChannelPool newPool( AuthToken authToken, int maxConnections )
+    {
+        ConnectionSettings settings = new ConnectionSettings( authToken, 5_000 );
+        AsyncConnectorImpl connector = new AsyncConnectorImpl( settings, SecurityPlan.insecure(), DEV_NULL_LOGGING,
+                new FakeClock() );
+        return new NettyChannelPool( neo4j.address(), connector, bootstrap, poolHandler, ChannelHealthChecker.ACTIVE,
+                1_000, maxConnections );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/AsyncInitResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/AsyncInitResponseHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.handlers;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.internal.async.outbound.OutboundMessageHandler;
+import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
+import org.neo4j.driver.internal.messaging.RunMessage;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.driver.internal.async.ChannelAttributes.serverVersion;
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+import static org.neo4j.driver.v1.Values.value;
+
+public class AsyncInitResponseHandlerTest
+{
+    private final EmbeddedChannel channel = new EmbeddedChannel();
+
+    @Before
+    public void setUp()
+    {
+        channel.pipeline().addLast( OutboundMessageHandler.NAME,
+                new OutboundMessageHandler( new PackStreamMessageFormatV1(), DEV_NULL_LOGGING ) );
+    }
+
+    @Test
+    public void shouldSetServerVersionOnChannel()
+    {
+        ChannelPromise channelPromise = channel.newPromise();
+        AsyncInitResponseHandler handler = new AsyncInitResponseHandler( channelPromise );
+
+        Map<String,Value> metadata = singletonMap( "server", value( ServerVersion.v3_2_0.toString() ) );
+        handler.onSuccess( metadata );
+
+        assertTrue( channelPromise.isSuccess() );
+        assertEquals( ServerVersion.v3_2_0, serverVersion( channel ) );
+    }
+
+    @Test
+    public void shouldSetServerVersionToDefaultValueWhenUnknown()
+    {
+        ChannelPromise channelPromise = channel.newPromise();
+        AsyncInitResponseHandler handler = new AsyncInitResponseHandler( channelPromise );
+
+        Map<String,Value> metadata = singletonMap( "server", Values.NULL );
+        handler.onSuccess( metadata );
+
+        assertTrue( channelPromise.isSuccess() );
+        assertEquals( ServerVersion.v3_0_0, serverVersion( channel ) );
+    }
+
+    @Test
+    public void shouldAllowByteArraysForNewerVersions()
+    {
+        AsyncInitResponseHandler handler = new AsyncInitResponseHandler( channel.newPromise() );
+
+        Map<String,Value> metadata = singletonMap( "server", value( ServerVersion.v3_2_0.toString() ) );
+        handler.onSuccess( metadata );
+
+        Map<String,Value> params = singletonMap( "array", value( new byte[]{1, 2, 3} ) );
+        assertTrue( channel.writeOutbound( new RunMessage( "RETURN 1", params ) ) );
+        assertTrue( channel.finish() );
+    }
+
+    @Test
+    public void shouldAllowByteArraysForOldVersions()
+    {
+        AsyncInitResponseHandler handler = new AsyncInitResponseHandler( channel.newPromise() );
+
+        Map<String,Value> metadata = singletonMap( "server", value( ServerVersion.v3_0_0.toString() ) );
+        handler.onSuccess( metadata );
+
+        Map<String,Value> params = singletonMap( "array", value( new byte[]{1, 2, 3} ) );
+        try
+        {
+            channel.writeOutbound( new RunMessage( "RETURN 1", params ) );
+            fail( "Exception expected" );
+        }
+        catch ( EncoderException e )
+        {
+            assertThat( e.getCause().getMessage(), startsWith( "Packing bytes is not supported" ) );
+        }
+    }
+
+    @Test
+    public void shouldCloseChannelOnFailure() throws Exception
+    {
+        ChannelPromise channelPromise = channel.newPromise();
+        AsyncInitResponseHandler handler = new AsyncInitResponseHandler( channelPromise );
+
+        RuntimeException error = new RuntimeException( "Hi!" );
+        handler.onFailure( error );
+
+        ChannelFuture channelCloseFuture = channel.closeFuture();
+        channelCloseFuture.await( 5, TimeUnit.SECONDS );
+
+        assertTrue( channelCloseFuture.isSuccess() );
+        assertTrue( channelPromise.isDone() );
+        assertEquals( error, channelPromise.cause() );
+    }
+}


### PR DESCRIPTION
Channel connection executed by `AsyncConnectorImpl` is a three step process:
 1) connect netty channel
 2) perform bolt handshake
 3) send INIT message

When either of these steps fail we should close (possibly open) network channel from step (1) and not track this channel in the pool or in the set of active channels.

This PR makes sure channels are closed and pool does not account for connections that failed during step (2) or (3).