### PR TITLE
Expose `Driver#closeAsync()`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.async.AsyncConnection;
-import org.neo4j.driver.internal.async.Futures;
 import org.neo4j.driver.internal.async.pool.AsyncConnectionPool;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -61,10 +60,18 @@ public class DirectConnectionProvider implements ConnectionProvider
     }
 
     @Override
-    public void close() throws Exception
+    public CompletionStage<Void> close()
     {
-        pool.close();
-        Futures.getBlocking( asyncPool.closeAsync() );
+        // todo: remove this try-catch when blocking API works on top of async
+        try
+        {
+            pool.close();
+        }
+        catch ( Exception e )
+        {
+            throw new RuntimeException( e );
+        }
+        return asyncPool.close();
     }
 
     public BoltServerAddress getAddress()

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -92,7 +92,7 @@ public class DriverFactory
             try
             {
                 connectionPool.close();
-                Futures.getBlocking( asyncConnectionPool.closeAsync() );
+                Futures.getBlocking( asyncConnectionPool.close() );
             }
             catch ( Throwable closeError )
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactory.java
@@ -18,10 +18,14 @@
  */
 package org.neo4j.driver.internal;
 
+import java.util.concurrent.CompletionStage;
+
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Session;
 
-public interface SessionFactory extends AutoCloseable
+public interface SessionFactory
 {
     Session newInstance( AccessMode mode, Bookmark bookmark );
+
+    CompletionStage<Void> close();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal;
 
+import java.util.concurrent.CompletionStage;
+
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.v1.AccessMode;
@@ -57,9 +59,9 @@ public class SessionFactoryImpl implements SessionFactory
     }
 
     @Override
-    public final void close() throws Exception
+    public final CompletionStage<Void> close()
     {
-        connectionProvider.close();
+        return connectionProvider.close();
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPool.java
@@ -33,5 +33,5 @@ public interface AsyncConnectionPool
 
     int activeConnections( BoltServerAddress address );
 
-    CompletionStage<?> closeAsync();
+    CompletionStage<Void> close();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImpl.java
@@ -109,7 +109,7 @@ public class AsyncConnectionPoolImpl implements AsyncConnectionPool
     }
 
     @Override
-    public CompletionStage<?> closeAsync()
+    public CompletionStage<Void> close()
     {
         if ( closed.compareAndSet( false, true ) )
         {
@@ -128,7 +128,8 @@ public class AsyncConnectionPoolImpl implements AsyncConnectionPool
                 eventLoopGroup().shutdownGracefully();
             }
         }
-        return Futures.asCompletionStage( eventLoopGroup().terminationFuture() );
+        return Futures.asCompletionStage( eventLoopGroup().terminationFuture() )
+                .thenApply( ignore -> null );
     }
 
     private ChannelPool getOrCreatePool( BoltServerAddress address )

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionProvider.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.v1.AccessMode;
  * Interface defines a layer used by the driver to obtain connections. It is meant to be the only component that
  * differs between "direct" and "routing" driver.
  */
-public interface ConnectionProvider extends AutoCloseable
+public interface ConnectionProvider
 {
     /**
      * Acquire new {@link PooledConnection pooled connection} for the given {@link AccessMode mode}.
@@ -38,4 +38,6 @@ public interface ConnectionProvider extends AutoCloseable
     PooledConnection acquireConnection( AccessMode mode );
 
     CompletionStage<AsyncConnection> acquireAsyncConnection( AccessMode mode );
+
+    CompletionStage<Void> close();
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Driver.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.v1;
 
+import java.util.concurrent.CompletionStage;
+
 /**
  * Accessor for a specific Neo4j graph database.
  * <p>
@@ -140,4 +142,6 @@ public interface Driver extends AutoCloseable
      * Close all the resources assigned to this driver, including any open connections.
      */
     void close();
+
+    CompletionStage<Void> closeAsync();
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.security.SecurityPlan;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.async.Futures.getBlocking;
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+
+public class InternalDriverTest
+{
+    @Test
+    public void shouldCloseSessionFactory()
+    {
+        SessionFactory sessionFactory = sessionFactoryMock();
+        InternalDriver driver = newDriver( sessionFactory );
+
+        assertNull( getBlocking( driver.closeAsync() ) );
+        verify( sessionFactory ).close();
+    }
+
+    @Test
+    public void shouldNotCloseSessionFactoryMultipleTimes()
+    {
+        SessionFactory sessionFactory = sessionFactoryMock();
+        InternalDriver driver = newDriver( sessionFactory );
+
+        assertNull( getBlocking( driver.closeAsync() ) );
+        assertNull( getBlocking( driver.closeAsync() ) );
+        assertNull( getBlocking( driver.closeAsync() ) );
+
+        verify( sessionFactory ).close();
+    }
+
+    private static InternalDriver newDriver( SessionFactory sessionFactory )
+    {
+        return new InternalDriver( SecurityPlan.insecure(), sessionFactory, DEV_NULL_LOGGING );
+    }
+
+    private static SessionFactory sessionFactoryMock()
+    {
+        SessionFactory sessionFactory = mock( SessionFactory.class );
+        when( sessionFactory.close() ).thenReturn( completedFuture( null ) );
+        return sessionFactory;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverTest.java
@@ -57,6 +57,7 @@ import org.neo4j.driver.v1.exceptions.ProtocolException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.util.Arrays.asList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -364,6 +365,7 @@ public class RoutingDriverTest
         Logging logging = DEV_NULL_LOGGING;
         RoutingSettings settings = new RoutingSettings( 10, 5_000, null );
         AsyncConnectionPool asyncConnectionPool = mock( AsyncConnectionPool.class );
+        when( asyncConnectionPool.close() ).thenReturn( completedFuture( null ) );
         LoadBalancingStrategy loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy( pool,
                 asyncConnectionPool, logging );
         ConnectionProvider connectionProvider = new LoadBalancer( SEED, settings, pool, asyncConnectionPool,

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/AsyncConnectionPoolImplTest.java
@@ -63,7 +63,7 @@ public class AsyncConnectionPoolImplTest
     @After
     public void tearDown() throws Exception
     {
-        pool.closeAsync();
+        pool.close();
     }
 
     @Test
@@ -104,7 +104,7 @@ public class AsyncConnectionPoolImplTest
     {
         AsyncConnection connection = await( pool.acquire( neo4j.address() ) );
         await( connection.forceRelease() );
-        await( pool.closeAsync() );
+        await( pool.close() );
 
         try
         {
@@ -159,8 +159,8 @@ public class AsyncConnectionPoolImplTest
     @Test
     public void shouldNotCloseWhenClosed()
     {
-        assertNull( await( pool.closeAsync() ) );
-        assertTrue( pool.closeAsync().toCompletableFuture().isDone() );
+        assertNull( await( pool.close() ) );
+        assertTrue( pool.close().toCompletableFuture().isDone() );
     }
 
     private AsyncConnectionPoolImpl newPool() throws Exception


### PR DESCRIPTION
To allow disposing of the driver and it's resources (including network connections, Netty event loop threads, etc.) in an async manner.