### PR TITLE
 Treat request errors as fatal

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelErrorHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelErrorHandler.java
@@ -93,7 +93,7 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
     {
         Throwable cause = transformError( error );
         messageDispatcher.handleFatalError( cause );
-        log.debug( "Closing channel: %s", ctx.channel() );
+        log.debug( "Closing channel because of an error: %s", ctx.channel() );
         ctx.close();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import io.netty.channel.ChannelPipeline;
+
+import org.neo4j.driver.internal.async.inbound.ChunkDecoder;
+import org.neo4j.driver.internal.async.inbound.InboundMessageHandler;
+import org.neo4j.driver.internal.async.inbound.MessageDecoder;
+import org.neo4j.driver.internal.async.outbound.OutboundMessageHandler;
+import org.neo4j.driver.internal.messaging.MessageFormat;
+import org.neo4j.driver.v1.Logging;
+
+public class ChannelPipelineBuilderImpl implements ChannelPipelineBuilder
+{
+    @Override
+    public void build( MessageFormat messageFormat, ChannelPipeline pipeline, Logging logging )
+    {
+        // inbound handlers
+        pipeline.addLast( new ChunkDecoder() );
+        pipeline.addLast( new MessageDecoder() );
+        pipeline.addLast( new InboundMessageHandler( messageFormat, logging ) );
+
+        // outbound handlers
+        pipeline.addLast( OutboundMessageHandler.NAME, new OutboundMessageHandler( messageFormat, logging ) );
+
+        // last one - error handler
+        pipeline.addLast( new ChannelErrorHandler( logging ) );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeResponseHandler.java
@@ -41,12 +41,15 @@ import static org.neo4j.driver.internal.async.ProtocolUtil.PROTOCOL_VERSION_1;
 
 public class HandshakeResponseHandler extends ReplayingDecoder<Void>
 {
+    private final ChannelPipelineBuilder pipelineBuilder;
     private final ChannelPromise handshakeCompletedPromise;
     private final Logging logging;
     private final Logger log;
 
-    public HandshakeResponseHandler( ChannelPromise handshakeCompletedPromise, Logging logging )
+    public HandshakeResponseHandler( ChannelPipelineBuilder pipelineBuilder, ChannelPromise handshakeCompletedPromise,
+            Logging logging )
     {
+        this.pipelineBuilder = pipelineBuilder;
         this.handshakeCompletedPromise = handshakeCompletedPromise;
         this.logging = logging;
         this.log = logging.getLog( getClass().getSimpleName() );
@@ -80,10 +83,9 @@ public class HandshakeResponseHandler extends ReplayingDecoder<Void>
         switch ( serverSuggestedVersion )
         {
         case PROTOCOL_VERSION_1:
-            MessageFormat format = new PackStreamMessageFormatV1();
-            ChannelPipelineBuilder.buildPipeline( ctx.channel(), format, logging );
+            MessageFormat messageFormat = new PackStreamMessageFormatV1();
+            pipelineBuilder.build( messageFormat, pipeline, logging );
             handshakeCompletedPromise.setSuccess();
-
             break;
         case NO_PROTOCOL_VERSION:
             fail( ctx, protocolNoSupportedByServerError() );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageHandler.java
@@ -61,9 +61,16 @@ public class InboundMessageHandler extends SimpleChannelInboundHandler<ByteBuf>
     @Override
     protected void channelRead0( ChannelHandlerContext ctx, ByteBuf msg )
     {
+        if ( messageDispatcher.fatalErrorOccurred() )
+        {
+            log.warn( "Message ignored because of the previous fatal error. Channel will be closed. Message:\n%s\n",
+                    prettyHexDump( msg ) );
+            return;
+        }
+
         if ( log.isTraceEnabled() )
         {
-            log.trace( "Inbound message received: \n%s\n", prettyHexDump( msg ) );
+            log.trace( "Inbound message received:\n%s\n", prettyHexDump( msg ) );
         }
 
         input.start( msg );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandler.java
@@ -68,11 +68,7 @@ public class OutboundMessageHandler extends MessageToMessageEncoder<Message>
         }
         catch ( Throwable error )
         {
-            EncoderException exception = new EncoderException( "Failed to write outbound message: " + msg, error );
-            // tell ChannelErrorHandler which is the last handler in the pipeline about this error
-            ctx.fireExceptionCaught( exception );
-            // rethrow, encoder contract requires handler to either fail or populate out list
-            throw exception;
+            throw new EncoderException( "Failed to write outbound message: " + msg, error );
         }
         finally
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -51,22 +51,21 @@ public final class ErrorUtil
         }
     }
 
-    // todo: use this method and close channel after unrecoverable error
-    public static boolean isRecoverable( Throwable error )
+    public static boolean isFatal( Throwable error )
     {
         if ( error instanceof Neo4jException )
         {
             if ( isProtocolViolationError( ((Neo4jException) error) ) )
             {
-                return false;
+                return true;
             }
 
             if ( isClientOrTransientError( ((Neo4jException) error) ) )
             {
-                return true;
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     private static boolean isProtocolViolationError( Neo4jException error )
@@ -84,6 +83,10 @@ public final class ErrorUtil
     private static String extractClassification( String code )
     {
         String[] parts = code.split( "\\." );
+        if ( parts.length < 2 )
+        {
+            return "";
+        }
         return parts[1];
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.driver.internal.async.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.async.ProtocolUtil.handshake;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
-import static org.neo4j.driver.internal.async.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
 public class ChannelConnectedListenerTest
@@ -43,7 +43,7 @@ public class ChannelConnectedListenerTest
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown()
     {
         channel.close();
     }
@@ -90,6 +90,7 @@ public class ChannelConnectedListenerTest
 
     private static ChannelConnectedListener newListener( ChannelPromise handshakeCompletedPromise )
     {
-        return new ChannelConnectedListener( LOCAL_DEFAULT, handshakeCompletedPromise, DEV_NULL_LOGGING );
+        return new ChannelConnectedListener( LOCAL_DEFAULT, new ChannelPipelineBuilderImpl(),
+                handshakeCompletedPromise, DEV_NULL_LOGGING );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImplTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class ChannelPipelineBuilderTest
+public class ChannelPipelineBuilderImplTest
 {
     @Test
     public void shouldBuildPipeline()
@@ -45,7 +45,7 @@ public class ChannelPipelineBuilderTest
         EmbeddedChannel channel = new EmbeddedChannel();
         ChannelAttributes.setMessageDispatcher( channel, new InboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );
 
-        ChannelPipelineBuilder.buildPipeline( channel, new PackStreamMessageFormatV1(), DEV_NULL_LOGGING );
+        new ChannelPipelineBuilderImpl().build( new PackStreamMessageFormatV1(), channel.pipeline(), DEV_NULL_LOGGING );
 
         Iterator<Map.Entry<String,ChannelHandler>> iterator = channel.pipeline().iterator();
         assertThat( iterator.next().getValue(), instanceOf( ChunkDecoder.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeResponseHandlerTest.java
@@ -158,6 +158,7 @@ public class HandshakeResponseHandlerTest
 
     private static HandshakeResponseHandler newHandler( ChannelPromise handshakeCompletedPromise )
     {
-        return new HandshakeResponseHandler( handshakeCompletedPromise, DEV_NULL_LOGGING );
+        return new HandshakeResponseHandler( new ChannelPipelineBuilderImpl(), handshakeCompletedPromise,
+                DEV_NULL_LOGGING );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.InternalPath;
 import org.neo4j.driver.internal.InternalRelationship;
-import org.neo4j.driver.internal.async.ChannelPipelineBuilder;
+import org.neo4j.driver.internal.async.ChannelPipelineBuilderImpl;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.async.outbound.ChunkAwareByteBufOutput;
 import org.neo4j.driver.internal.packstream.PackStream;
@@ -151,7 +151,7 @@ public class MessageFormatTest
     {
         EmbeddedChannel channel = new EmbeddedChannel();
         setMessageDispatcher( channel, new MemorizingInboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );
-        ChannelPipelineBuilder.buildPipeline( channel, format, DEV_NULL_LOGGING );
+        new ChannelPipelineBuilderImpl().build( format, channel.pipeline(), DEV_NULL_LOGGING );
         return channel;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ChannelPipelineBuilderWithMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ChannelPipelineBuilderWithMessageFormat.java
@@ -16,14 +16,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.async;
+package org.neo4j.driver.internal.util;
 
 import io.netty.channel.ChannelPipeline;
 
+import org.neo4j.driver.internal.async.ChannelPipelineBuilder;
+import org.neo4j.driver.internal.async.ChannelPipelineBuilderImpl;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.v1.Logging;
 
-public interface ChannelPipelineBuilder
+public class ChannelPipelineBuilderWithMessageFormat implements ChannelPipelineBuilder
 {
-    void build( MessageFormat messageFormat, ChannelPipeline pipeline, Logging logging );
+    private final MessageFormat messageFormat;
+
+    public ChannelPipelineBuilderWithMessageFormat( MessageFormat messageFormat )
+    {
+        this.messageFormat = messageFormat;
+    }
+
+    @Override
+    public void build( MessageFormat ignored, ChannelPipeline pipeline, Logging logging )
+    {
+        new ChannelPipelineBuilderImpl().build( messageFormat, pipeline, logging );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactory.java
@@ -44,19 +44,29 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock
     }
 
     @Override
-    protected ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan, Config config,
-            Clock clock )
+    protected final ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan,
+            Config config, Clock clock )
     {
-        ChannelConnector connector = super.createConnector( settings, securityPlan, config, clock );
-        return new ChannelTrackingConnector( connector, channels );
+        return createChannelTrackingConnector( createRealConnector( settings, securityPlan, config, clock ) );
     }
 
     @Override
-    protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan,
+    protected final ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan,
             Bootstrap bootstrap, Config config )
     {
         pool = super.createConnectionPool( authToken, securityPlan, bootstrap, config );
         return pool;
+    }
+
+    protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan,
+            Config config, Clock clock )
+    {
+        return super.createConnector( settings, securityPlan, config, clock );
+    }
+
+    private ChannelTrackingConnector createChannelTrackingConnector( ChannelConnector connector )
+    {
+        return new ChannelTrackingConnector( connector, channels );
     }
 
     public List<Channel> channels()

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactoryWithMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactoryWithMessageFormat.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.async.ChannelConnector;
+import org.neo4j.driver.internal.async.ChannelConnectorImpl;
+import org.neo4j.driver.internal.async.ChannelPipelineBuilder;
+import org.neo4j.driver.internal.messaging.MessageFormat;
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.v1.Config;
+
+public class ChannelTrackingDriverFactoryWithMessageFormat extends ChannelTrackingDriverFactory
+{
+    private final MessageFormat messageFormat;
+
+    public ChannelTrackingDriverFactoryWithMessageFormat( MessageFormat messageFormat, Clock clock )
+    {
+        super( clock );
+        this.messageFormat = messageFormat;
+    }
+
+    @Override
+    protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan,
+            Config config, Clock clock )
+    {
+        ChannelPipelineBuilder pipelineBuilder = new ChannelPipelineBuilderWithMessageFormat( messageFormat );
+        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock );
+    }
+}
+

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.driver.v1.exceptions.AuthenticationException;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.DatabaseException;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.TransientException;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.driver.internal.util.ErrorUtil.isFatal;
+import static org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError;
+
+public class ErrorUtilTest
+{
+    @Test
+    public void shouldCreateAuthenticationException()
+    {
+        String code = "Neo.ClientError.Security.Unauthorized";
+        String message = "Wrong credentials";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( AuthenticationException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
+    }
+
+    @Test
+    public void shouldCreateClientException()
+    {
+        String code = "Neo.ClientError.Transaction.InvalidBookmark";
+        String message = "Wrong bookmark";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( ClientException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
+    }
+
+    @Test
+    public void shouldCreateTransientException()
+    {
+        String code = "Neo.TransientError.Transaction.DeadlockDetected";
+        String message = "Deadlock occurred";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( TransientException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
+    }
+
+    @Test
+    public void shouldCreateDatabaseException()
+    {
+        String code = "Neo.DatabaseError.Transaction.TransactionLogError";
+        String message = "Failed to write the transaction log";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( DatabaseException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
+    }
+
+    @Test
+    public void shouldCreateDatabaseExceptionWhenErrorCodeIsWrong()
+    {
+        String code = "WrongErrorCode";
+        String message = "Some really strange error";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( DatabaseException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
+    }
+
+    @Test
+    public void shouldTreatNotNeo4jExceptionAsFatal()
+    {
+        assertTrue( isFatal( new IOException( "IO failed!" ) ) );
+    }
+
+    @Test
+    public void shouldTreatProtocolErrorAsFatal()
+    {
+        assertTrue( isFatal( new ClientException( "Neo.ClientError.Request.Invalid", "Illegal request" ) ) );
+        assertTrue( isFatal( new ClientException( "Neo.ClientError.Request.InvalidFormat", "Wrong format" ) ) );
+        assertTrue( isFatal( new ClientException( "Neo.ClientError.Request.TransactionRequired", "No tx!" ) ) );
+    }
+
+    @Test
+    public void shouldTreatAuthenticationExceptionAsNonFatal()
+    {
+        assertFalse( isFatal( new AuthenticationException( "Neo.ClientError.Security.Unauthorized", "" ) ) );
+    }
+
+    @Test
+    public void shouldTreatClientExceptionAsNonFatal()
+    {
+        assertFalse( isFatal( new ClientException( "Neo.ClientError.Transaction.ConstraintsChanged", "" ) ) );
+    }
+
+    @Test
+    public void shouldTreatDatabaseExceptionAsFatal()
+    {
+        assertTrue( isFatal( new ClientException( "Neo.DatabaseError.Schema.ConstraintCreationFailed", "" ) ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingMessageFormat.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.driver.internal.messaging.FailureMessage;
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.messaging.MessageFormat;
+import org.neo4j.driver.internal.messaging.MessageHandler;
+import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
+import org.neo4j.driver.internal.packstream.PackInput;
+import org.neo4j.driver.internal.packstream.PackOutput;
+
+public class FailingMessageFormat implements MessageFormat
+{
+    private final MessageFormat delegate;
+    private final AtomicReference<Throwable> writerThrowableRef = new AtomicReference<>();
+    private final AtomicReference<Throwable> readerThrowableRef = new AtomicReference<>();
+    private final AtomicReference<FailureMessage> readerFailureRef = new AtomicReference<>();
+
+    public FailingMessageFormat()
+    {
+        this( new PackStreamMessageFormatV1() );
+    }
+
+    public FailingMessageFormat( MessageFormat delegate )
+    {
+        this.delegate = delegate;
+    }
+
+    public void makeWriterThrow( Throwable error )
+    {
+        writerThrowableRef.set( error );
+    }
+
+    public void makeReaderThrow( Throwable error )
+    {
+        readerThrowableRef.set( error );
+    }
+
+    public void makeReaderFail( FailureMessage failureMsg )
+    {
+        readerFailureRef.set( failureMsg );
+    }
+
+    @Override
+    public Writer newWriter( PackOutput output, boolean byteArraySupportEnabled )
+    {
+        return new ThrowingWriter( delegate.newWriter( output, byteArraySupportEnabled ), writerThrowableRef );
+    }
+
+    @Override
+    public Reader newReader( PackInput input )
+    {
+        return new ThrowingReader( delegate.newReader( input ), readerThrowableRef, readerFailureRef );
+    }
+
+    @Override
+    public int version()
+    {
+        return delegate.version();
+    }
+
+    private static class ThrowingWriter implements MessageFormat.Writer
+    {
+        final MessageFormat.Writer delegate;
+        final AtomicReference<Throwable> throwableRef;
+
+        ThrowingWriter( Writer delegate, AtomicReference<Throwable> throwableRef )
+        {
+            this.delegate = delegate;
+            this.throwableRef = throwableRef;
+        }
+
+        @Override
+        public Writer write( Message msg ) throws IOException
+        {
+            Throwable error = throwableRef.getAndSet( null );
+            if ( error != null )
+            {
+                PlatformDependent.throwException( error );
+            }
+            else
+            {
+                return delegate.write( msg );
+            }
+            return this;
+        }
+    }
+
+    private static class ThrowingReader implements MessageFormat.Reader
+    {
+        final MessageFormat.Reader delegate;
+        final AtomicReference<Throwable> throwableRef;
+        final AtomicReference<FailureMessage> failureRef;
+
+        ThrowingReader( Reader delegate, AtomicReference<Throwable> throwableRef,
+                AtomicReference<FailureMessage> failureRef )
+        {
+            this.delegate = delegate;
+            this.throwableRef = throwableRef;
+            this.failureRef = failureRef;
+        }
+
+        @Override
+        public void read( MessageHandler handler ) throws IOException
+        {
+            Throwable error = throwableRef.getAndSet( null );
+            if ( error != null )
+            {
+                PlatformDependent.throwException( error );
+                return;
+            }
+
+            FailureMessage failureMsg = failureRef.getAndSet( null );
+            if ( failureMsg != null )
+            {
+                failureMsg.dispatch( handler );
+                return;
+            }
+
+            delegate.read( handler );
+        }
+    }
+}


### PR DESCRIPTION
Fatal errors result in network channel being closed. Previously only some errors that originate in the driver were treated as fatal. However some errors received from the database mean communication is broken.

This PR makes protocol errors that start with `Neo.ClientError.Request` be treated as fatal. No ACK_FAILURE will be send for such errors and netty channel will be closed.