### PR TITLE
Execute blocking tx functions in caller thread

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -80,7 +80,48 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
     }
 
     @Override
-    public <T> CompletionStage<T> retry( Supplier<CompletionStage<T>> work )
+    public <T> T retry( Supplier<T> work )
+    {
+        List<Throwable> errors = null;
+        long startTime = -1;
+        long nextDelayMs = initialRetryDelayMs;
+
+        while ( true )
+        {
+            try
+            {
+                return work.get();
+            }
+            catch ( Throwable error )
+            {
+                if ( canRetryOn( error ) )
+                {
+                    long currentTime = clock.millis();
+                    if ( startTime == -1 )
+                    {
+                        startTime = currentTime;
+                    }
+
+                    long elapsedTime = currentTime - startTime;
+                    if ( elapsedTime < maxRetryTimeMs )
+                    {
+                        long delayWithJitterMs = computeDelayWithJitter( nextDelayMs );
+                        log.warn( "Transaction failed and will be retried in " + delayWithJitterMs + "ms", error );
+
+                        sleep( delayWithJitterMs );
+                        nextDelayMs = (long) (nextDelayMs * multiplier);
+                        errors = recordError( error, errors );
+                        continue;
+                    }
+                }
+                addSuppressed( error, errors );
+                throw error;
+            }
+        }
+    }
+
+    @Override
+    public <T> CompletionStage<T> retryAsync( Supplier<CompletionStage<T>> work )
     {
         CompletableFuture<T> resultFuture = new CompletableFuture<>();
         executeWorkInEventLoop( resultFuture, work );
@@ -109,7 +150,7 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
         EventExecutor eventExecutor = eventExecutorGroup.next();
 
         long delayWithJitterMs = computeDelayWithJitter( delayMs );
-        log.warn( "Transaction failed and is scheduled to retry in " + delayWithJitterMs + "ms", error );
+        log.warn( "Async transaction failed and is scheduled to retry in " + delayWithJitterMs + "ms", error );
 
         eventExecutor.schedule( () ->
         {
@@ -183,6 +224,19 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
         long min = delayMs - jitter;
         long max = delayMs + jitter;
         return ThreadLocalRandom.current().nextLong( min, max + 1 );
+    }
+
+    private void sleep( long delayMs )
+    {
+        try
+        {
+            clock.sleep( delayMs );
+        }
+        catch ( InterruptedException e )
+        {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException( "Retries interrupted", e );
+        }
     }
 
     private void verifyAfterConstruction()

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/RetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/RetryLogic.java
@@ -24,5 +24,7 @@ import org.neo4j.driver.internal.util.Supplier;
 
 public interface RetryLogic
 {
-    <T> CompletionStage<T> retry( Supplier<CompletionStage<T>> work );
+    <T> T retry( Supplier<T> work );
+
+    <T> CompletionStage<T> retryAsync( Supplier<CompletionStage<T>> work );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.retry;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,17 +41,23 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
+import static org.neo4j.driver.internal.util.Futures.getBlocking;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
 public class ExponentialBackoffRetryLogicTest
@@ -144,7 +151,22 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToMultiplier()
+    public void nextDelayCalculatedAccordingToMultiplier() throws Exception
+    {
+        int retries = 27;
+        int initialDelay = 1;
+        int multiplier = 3;
+        int noJitter = 0;
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( MAX_VALUE, initialDelay, multiplier, noJitter, clock );
+
+        retry( logic, retries );
+
+        assertEquals( delaysWithoutJitter( initialDelay, multiplier, retries ), sleepValues( clock, retries ) );
+    }
+
+    @Test
+    public void nextDelayCalculatedAccordingToMultiplierAsync()
     {
         String result = "The Result";
         int retries = 14;
@@ -155,14 +177,33 @@ public class ExponentialBackoffRetryLogicTest
         ExponentialBackoffRetryLogic retryLogic = newRetryLogic( MAX_VALUE, initialDelay, multiplier, noJitter,
                 Clock.SYSTEM );
 
-        CompletionStage<Object> future = retry( retryLogic, retries, result );
+        CompletionStage<Object> future = retryAsync( retryLogic, retries, result );
 
         assertEquals( result, Futures.getBlocking( future ) );
         assertEquals( delaysWithoutJitter( initialDelay, multiplier, retries ), eventExecutor.scheduleDelays() );
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToJitter()
+    public void nextDelayCalculatedAccordingToJitter() throws Exception
+    {
+        int retries = 32;
+        double jitterFactor = 0.2;
+        int initialDelay = 1;
+        int multiplier = 2;
+        Clock clock = mock( Clock.class );
+
+        ExponentialBackoffRetryLogic logic = newRetryLogic( MAX_VALUE, initialDelay, multiplier, jitterFactor, clock );
+
+        retry( logic, retries );
+
+        List<Long> sleepValues = sleepValues( clock, retries );
+        List<Long> delaysWithoutJitter = delaysWithoutJitter( initialDelay, multiplier, retries );
+
+        assertDelaysApproximatelyEqual( delaysWithoutJitter, sleepValues, jitterFactor );
+    }
+
+    @Test
+    public void nextDelayCalculatedAccordingToJitterAsync()
     {
         String result = "The Result";
         int retries = 24;
@@ -173,7 +214,7 @@ public class ExponentialBackoffRetryLogicTest
         ExponentialBackoffRetryLogic retryLogic = newRetryLogic( MAX_VALUE, initialDelay, multiplier, jitterFactor,
                 mock( Clock.class ) );
 
-        CompletionStage<Object> future = retry( retryLogic, retries, result );
+        CompletionStage<Object> future = retryAsync( retryLogic, retries, result );
         assertEquals( result, Futures.getBlocking( future ) );
 
         List<Long> scheduleDelays = eventExecutor.scheduleDelays();
@@ -183,7 +224,40 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryWhenMaxRetryTimeExceeded()
+    public void doesNotRetryWhenMaxRetryTimeExceeded() throws Exception
+    {
+        long retryStart = Clock.SYSTEM.millis();
+        int initialDelay = 100;
+        int multiplier = 2;
+        long maxRetryTimeMs = 45;
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( retryStart )
+                .thenReturn( retryStart + maxRetryTimeMs - 5 )
+                .thenReturn( retryStart + maxRetryTimeMs + 7 );
+
+        ExponentialBackoffRetryLogic logic = newRetryLogic( maxRetryTimeMs, initialDelay, multiplier, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        SessionExpiredException error = sessionExpired();
+        when( workMock.get() ).thenThrow( error );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+
+        verify( clock ).sleep( initialDelay );
+        verify( clock ).sleep( initialDelay * multiplier );
+        verify( workMock, times( 3 ) ).get();
+    }
+
+    @Test
+    public void doesNotRetryWhenMaxRetryTimeExceededAsync()
     {
         long retryStart = Clock.SYSTEM.millis();
         int initialDelay = 100;
@@ -200,7 +274,7 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenReturn( failedFuture( error ) );
 
-        CompletionStage<Object> future = retryLogic.retry( workMock );
+        CompletionStage<Object> future = retryLogic.retryAsync( workMock );
 
         try
         {
@@ -221,7 +295,23 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnServiceUnavailableException()
+    public void sleepsOnServiceUnavailableException() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 42, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        ServiceUnavailableException error = serviceUnavailable();
+        when( workMock.get() ).thenThrow( error ).thenReturn( null );
+
+        assertNull( logic.retry( workMock ) );
+
+        verify( workMock, times( 2 ) ).get();
+        verify( clock ).sleep( 42 );
+    }
+
+    @Test
+    public void schedulesRetryOnServiceUnavailableExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -232,7 +322,7 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenReturn( failedFuture( error ) ).thenReturn( completedFuture( result ) );
 
-        assertEquals( result, await( retryLogic.retry( workMock ) ) );
+        assertEquals( result, await( retryLogic.retryAsync( workMock ) ) );
 
         verify( workMock, times( 2 ) ).get();
         List<Long> scheduleDelays = eventExecutor.scheduleDelays();
@@ -241,7 +331,23 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnSessionExpiredException()
+    public void sleepsOnSessionExpiredException() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 4242, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        SessionExpiredException error = sessionExpired();
+        when( workMock.get() ).thenThrow( error ).thenReturn( null );
+
+        assertNull( logic.retry( workMock ) );
+
+        verify( workMock, times( 2 ) ).get();
+        verify( clock ).sleep( 4242 );
+    }
+
+    @Test
+    public void schedulesRetryOnSessionExpiredExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -252,7 +358,7 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenReturn( failedFuture( error ) ).thenReturn( completedFuture( result ) );
 
-        assertEquals( result, await( retryLogic.retry( workMock ) ) );
+        assertEquals( result, await( retryLogic.retryAsync( workMock ) ) );
 
         verify( workMock, times( 2 ) ).get();
         List<Long> scheduleDelays = eventExecutor.scheduleDelays();
@@ -261,7 +367,23 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnTransientException()
+    public void sleepsOnTransientException() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 23, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        TransientException error = transientException();
+        when( workMock.get() ).thenThrow( error ).thenReturn( null );
+
+        assertNull( logic.retry( workMock ) );
+
+        verify( workMock, times( 2 ) ).get();
+        verify( clock ).sleep( 23 );
+    }
+
+    @Test
+    public void schedulesRetryOnTransientExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -272,7 +394,7 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error = transientException();
         when( workMock.get() ).thenReturn( failedFuture( error ) ).thenReturn( completedFuture( result ) );
 
-        assertEquals( result, await( retryLogic.retry( workMock ) ) );
+        assertEquals( result, await( retryLogic.retryAsync( workMock ) ) );
 
         verify( workMock, times( 2 ) ).get();
         List<Long> scheduleDelays = eventExecutor.scheduleDelays();
@@ -281,7 +403,31 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryOnUnknownError()
+    public void throwsWhenUnknownError() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 1, 1, 1, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        IllegalStateException error = new IllegalStateException();
+        when( workMock.get() ).thenThrow( error );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+
+        verify( workMock ).get();
+        verify( clock, never() ).sleep( anyLong() );
+    }
+
+    @Test
+    public void doesNotRetryOnUnknownErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -293,7 +439,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            await( retryLogic.retry( workMock ) );
+            await( retryLogic.retryAsync( workMock ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -306,7 +452,31 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryOnTransactionTerminatedError()
+    public void throwsWhenTransactionTerminatedError() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 13, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        TransientException error = new TransientException( "Neo.TransientError.Transaction.Terminated", "" );
+        when( workMock.get() ).thenThrow( error ).thenReturn( null );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+
+        verify( workMock ).get();
+        verify( clock, never() ).sleep( 13 );
+    }
+
+    @Test
+    public void doesNotRetryOnTransactionTerminatedErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -318,7 +488,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            await( retryLogic.retry( workMock ) );
+            await( retryLogic.retryAsync( workMock ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -331,7 +501,31 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryOnTransactionLockClientStoppedError()
+    public void throwsWhenTransactionLockClientStoppedError() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 13, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        TransientException error = new TransientException( "Neo.TransientError.Transaction.LockClientStopped", "" );
+        when( workMock.get() ).thenThrow( error ).thenReturn( null );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+
+        verify( workMock ).get();
+        verify( clock, never() ).sleep( 13 );
+    }
+
+    @Test
+    public void doesNotRetryOnTransactionLockClientStoppedErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -343,7 +537,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            await( retryLogic.retry( workMock ) );
+            await( retryLogic.retryAsync( workMock ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -356,7 +550,74 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void collectsSuppressedErrors()
+    public void throwsWhenSleepInterrupted() throws Exception
+    {
+        Clock clock = mock( Clock.class );
+        doThrow( new InterruptedException() ).when( clock ).sleep( 1 );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 1, 1, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        when( workMock.get() ).thenThrow( serviceUnavailable() );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+            assertThat( e.getCause(), instanceOf( InterruptedException.class ) );
+        }
+        finally
+        {
+            // Clear the interruption flag so all subsequent tests do not see this thread as interrupted
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void collectsSuppressedErrors() throws Exception
+    {
+        long maxRetryTime = 20;
+        int initialDelay = 15;
+        int multiplier = 2;
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( 0L ).thenReturn( 10L ).thenReturn( 15L ).thenReturn( 25L );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( maxRetryTime, initialDelay, multiplier, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        SessionExpiredException error1 = sessionExpired();
+        SessionExpiredException error2 = sessionExpired();
+        ServiceUnavailableException error3 = serviceUnavailable();
+        TransientException error4 = transientException();
+        when( workMock.get() ).thenThrow( error1, error2, error3, error4 ).thenReturn( null );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error4, e );
+            Throwable[] suppressed = e.getSuppressed();
+            assertEquals( 3, suppressed.length );
+            assertEquals( error1, suppressed[0] );
+            assertEquals( error2, suppressed[1] );
+            assertEquals( error3, suppressed[2] );
+        }
+
+        verify( workMock, times( 4 ) ).get();
+
+        verify( clock, times( 3 ) ).sleep( anyLong() );
+        verify( clock ).sleep( initialDelay );
+        verify( clock ).sleep( initialDelay * multiplier );
+        verify( clock ).sleep( initialDelay * multiplier * multiplier );
+    }
+
+    @Test
+    public void collectsSuppressedErrorsAsync()
     {
         String result = "The Result";
         long maxRetryTime = 20;
@@ -381,7 +642,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            Futures.getBlocking( retryLogic.retry( workMock ) );
+            Futures.getBlocking( retryLogic.retryAsync( workMock ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -404,7 +665,39 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotCollectSuppressedErrorsWhenSameErrorIsThrown()
+    public void doesNotCollectSuppressedErrorsWhenSameErrorIsThrown() throws Exception
+    {
+        long maxRetryTime = 20;
+        int initialDelay = 15;
+        int multiplier = 2;
+        Clock clock = mock( Clock.class );
+        when( clock.millis() ).thenReturn( 0L ).thenReturn( 10L ).thenReturn( 25L );
+        ExponentialBackoffRetryLogic logic = newRetryLogic( maxRetryTime, initialDelay, multiplier, 0, clock );
+
+        Supplier<Void> workMock = newWorkMock();
+        SessionExpiredException error = sessionExpired();
+        when( workMock.get() ).thenThrow( error );
+
+        try
+        {
+            logic.retry( workMock );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+            assertEquals( 0, e.getSuppressed().length );
+        }
+
+        verify( workMock, times( 3 ) ).get();
+
+        verify( clock, times( 2 ) ).sleep( anyLong() );
+        verify( clock ).sleep( initialDelay );
+        verify( clock ).sleep( initialDelay * multiplier );
+    }
+
+    @Test
+    public void doesNotCollectSuppressedErrorsWhenSameErrorIsThrownAsync()
     {
         long maxRetryTime = 20;
         int initialDelay = 15;
@@ -420,7 +713,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            Futures.getBlocking( retryLogic.retry( workMock ) );
+            Futures.getBlocking( retryLogic.retryAsync( workMock ) );
             fail( "Exception expected" );
         }
         catch ( Exception e )
@@ -440,6 +733,25 @@ public class ExponentialBackoffRetryLogicTest
     @Test
     public void eachRetryIsLogged()
     {
+        int retries = 9;
+        Clock clock = mock( Clock.class );
+        Logging logging = mock( Logging.class );
+        Logger logger = mock( Logger.class );
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
+                clock, logging );
+
+        retry( logic, retries );
+
+        verify( logger, times( retries ) ).warn(
+                startsWith( "Transaction failed and will be retried" ),
+                any( ServiceUnavailableException.class )
+        );
+    }
+
+    @Test
+    public void eachRetryIsLoggedAsync()
+    {
         String result = "The Result";
         int retries = 9;
         Clock clock = mock( Clock.class );
@@ -450,18 +762,169 @@ public class ExponentialBackoffRetryLogicTest
         ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
                 clock, logging );
 
-        assertEquals( result, await( retry( logic, retries, result ) ) );
+        assertEquals( result, await( retryAsync( logic, retries, result ) ) );
 
         verify( logger, times( retries ) ).warn(
-                startsWith( "Transaction failed and is scheduled to retry" ),
+                startsWith( "Async transaction failed and is scheduled to retry" ),
                 any( ServiceUnavailableException.class )
         );
     }
 
-    private CompletionStage<Object> retry( ExponentialBackoffRetryLogic retryLogic, final int times,
-            final Object result )
+    @Test
+    public void nothingIsLoggedOnFatalFailure()
     {
-        return retryLogic.retry( new Supplier<CompletionStage<Object>>()
+        Logging logging = mock( Logging.class );
+        Logger logger = mock( Logger.class );
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
+                mock( Clock.class ), logging );
+
+        try
+        {
+            logic.retry( () ->
+            {
+                throw new RuntimeException( "Fatal blocking" );
+            } );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( "Fatal blocking", e.getMessage() );
+        }
+        verifyZeroInteractions( logger );
+    }
+
+    @Test
+    public void nothingIsLoggedOnFatalFailureAsync()
+    {
+        Logging logging = mock( Logging.class );
+        Logger logger = mock( Logger.class );
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
+                mock( Clock.class ), logging );
+
+        try
+        {
+            getBlocking( logic.retryAsync( () -> failedFuture( new RuntimeException( "Fatal async" ) ) ) );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( "Fatal async", e.getMessage() );
+        }
+        verifyZeroInteractions( logger );
+    }
+
+    @Test
+    public void correctNumberOfRetiesAreLoggedOnFailure()
+    {
+        Clock clock = mock( Clock.class );
+        Logging logging = mock( Logging.class );
+        Logger logger = mock( Logger.class );
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        RetrySettings settings = RetrySettings.DEFAULT;
+        RetryLogic logic = new ExponentialBackoffRetryLogic( settings, eventExecutor, clock, logging );
+
+        try
+        {
+            logic.retry( new Supplier<Long>()
+            {
+                boolean invoked;
+
+                @Override
+                public Long get()
+                {
+                    // work that always fails and moves clock forward after the first failure
+                    if ( invoked )
+                    {
+                        // move clock forward to stop retries
+                        when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                    }
+                    else
+                    {
+                        invoked = true;
+                    }
+                    throw new ServiceUnavailableException( "Error" );
+                }
+            } );
+            fail( "Exception expected" );
+        }
+        catch ( ServiceUnavailableException e )
+        {
+            assertEquals( "Error", e.getMessage() );
+        }
+        verify( logger ).warn(
+                startsWith( "Transaction failed and will be retried" ),
+                any( ServiceUnavailableException.class )
+        );
+    }
+
+    @Test
+    public void correctNumberOfRetiesAreLoggedOnFailureAsync()
+    {
+        Clock clock = mock( Clock.class );
+        Logging logging = mock( Logging.class );
+        Logger logger = mock( Logger.class );
+        when( logging.getLog( anyString() ) ).thenReturn( logger );
+        RetrySettings settings = RetrySettings.DEFAULT;
+        RetryLogic logic = new ExponentialBackoffRetryLogic( settings, eventExecutor, clock, logging );
+
+        try
+        {
+            getBlocking( logic.retryAsync( new Supplier<CompletionStage<Void>>()
+            {
+                volatile boolean invoked;
+
+                @Override
+                public CompletionStage<Void> get()
+                {
+                    // work that always returns failed future and moves clock forward after the first failure
+                    if ( invoked )
+                    {
+                        // move clock forward to stop retries
+                        when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                    }
+                    else
+                    {
+                        invoked = true;
+                    }
+                    return failedFuture( new SessionExpiredException( "Session no longer valid" ) );
+                }
+            } ) );
+            fail( "Exception expected" );
+        }
+        catch ( SessionExpiredException e )
+        {
+            assertEquals( "Session no longer valid", e.getMessage() );
+        }
+        verify( logger ).warn(
+                startsWith( "Async transaction failed and is scheduled to retry" ),
+                any( SessionExpiredException.class )
+        );
+    }
+
+    private static void retry( ExponentialBackoffRetryLogic retryLogic, final int times )
+    {
+        retryLogic.retry( new Supplier<Void>()
+        {
+            int invoked;
+
+            @Override
+            public Void get()
+            {
+                if ( invoked < times )
+                {
+                    invoked++;
+                    throw serviceUnavailable();
+                }
+                return null;
+            }
+        } );
+    }
+
+    private CompletionStage<Object> retryAsync( ExponentialBackoffRetryLogic retryLogic, int times, Object result )
+    {
+        return retryLogic.retryAsync( new Supplier<CompletionStage<Object>>()
         {
             int invoked;
 
@@ -489,6 +952,13 @@ public class ExponentialBackoffRetryLogicTest
         }
         while ( --count > 0 );
         return values;
+    }
+
+    private static List<Long> sleepValues( Clock clockMock, int expectedCount ) throws InterruptedException
+    {
+        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass( long.class );
+        verify( clockMock, times( expectedCount ) ).sleep( captor.capture() );
+        return captor.getAllValues();
     }
 
     private ExponentialBackoffRetryLogic newRetryLogic( long maxRetryTimeMs, long initialRetryDelayMs,


### PR DESCRIPTION
This PR brings back blocking retry logic that performs retries in the caller thread and uses `Thread#sleep()` between retries. It is needed because blocking tx functions can't run in event loop as they perform blocking operations. Event loop thread can deadlock waiting for itself to read from the network. Previously code used a "hack" and executed given function in `ForkJoinPool.commonPool()`.

Also added couple tests for retry logic and async transaction functions.