### PR TITLE
Relax connection termination policy in routing driver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -78,16 +78,17 @@ public class ClusterRoutingTable implements RoutingTable
     public synchronized RoutingTableChange update( ClusterComposition cluster )
     {
         expirationTimeout = cluster.expirationTimestamp();
-        Set<BoltServerAddress> pre = servers();
+        Set<BoltServerAddress> previousServers = servers();
+
         readers.update( cluster.readers() );
         writers.update( cluster.writers() );
         routers.update( cluster.routers() );
-        Set<BoltServerAddress> cur = servers();
+        Set<BoltServerAddress> currentServers = servers();
 
-        Set<BoltServerAddress> added = new HashSet<>( cur );
-        Set<BoltServerAddress> removed = new HashSet<>( pre );
-        added.removeAll( pre );
-        removed.removeAll( cur );
+        Set<BoltServerAddress> added = new HashSet<>( currentServers );
+        Set<BoltServerAddress> removed = new HashSet<>( previousServers );
+        added.removeAll( previousServers );
+        removed.removeAll( currentServers );
         return new RoutingTableChange( added, removed );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -118,7 +118,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
         }
         else
         {
-            connections.passivate( address );
+            connections.deactivate( address );
         }
     }
 
@@ -159,7 +159,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
             }
             for ( BoltServerAddress removedAddress : routingTableChange.removed() )
             {
-                connections.passivate( removedAddress );
+                connections.deactivate( removedAddress );
             }
             connections.compact();
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import java.util.Set;
-
 import org.neo4j.driver.internal.RoutingErrorHandler;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -35,6 +33,7 @@ import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, AutoCloseable
 {
     private static final String LOAD_BALANCER_LOG_NAME = "LoadBalancer";
+    private static final boolean PURGE_ON_ERROR = Boolean.getBoolean( "purgeOnError" );
 
     private final ConnectionPool connections;
     private final RoutingTable routingTable;
@@ -113,8 +112,14 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
     {
         // First remove from the load balancer, to prevent concurrent threads from making connections to them.
         routingTable.forget( address );
-        // drop all current connections to the address
-        connections.purge( address );
+        if ( PURGE_ON_ERROR )
+        {
+            connections.purge( address );
+        }
+        else
+        {
+            connections.passivate( address );
+        }
     }
 
     synchronized void ensureRouting( AccessMode mode )
@@ -131,14 +136,33 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
 
         // get a new routing table
         ClusterComposition cluster = rediscovery.lookupClusterComposition( routingTable, connections );
-        Set<BoltServerAddress> removed = routingTable.update( cluster );
-        // purge connections to removed addresses
-        for ( BoltServerAddress address : removed )
-        {
-            connections.purge( address );
-        }
+        RoutingTableChange routingTableChange = routingTable.update( cluster );
+        updateConnectionPool( routingTableChange );
 
         log.info( "Refreshed routing information. %s", routingTable );
+    }
+
+    private void updateConnectionPool( RoutingTableChange routingTableChange )
+    {
+        if ( PURGE_ON_ERROR )
+        {
+            for ( BoltServerAddress removedAddress : routingTableChange.removed() )
+            {
+                connections.purge( removedAddress );
+            }
+        }
+        else
+        {
+            for ( BoltServerAddress addedAddress : routingTableChange.added() )
+            {
+                connections.activate( addedAddress );
+            }
+            for ( BoltServerAddress removedAddress : routingTableChange.removed() )
+            {
+                connections.passivate( removedAddress );
+            }
+            connections.compact();
+        }
     }
 
     private RoundRobinAddressSet addressSetFor( AccessMode mode )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSet.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSet.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.cluster;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,17 +56,20 @@ public class RoundRobinAddressSet
         return index % divisor;
     }
 
-    public synchronized void update( Set<BoltServerAddress> addresses, Set<BoltServerAddress> removed )
+    public synchronized void update( Set<BoltServerAddress> addresses, Set<BoltServerAddress> added,
+            Set<BoltServerAddress> removed )
     {
         BoltServerAddress[] prev = this.addresses;
         if ( addresses.isEmpty() )
         {
             this.addresses = NONE;
+            Collections.addAll( removed, prev );
             return;
         }
         if ( prev.length == 0 )
         {
             this.addresses = addresses.toArray( NONE );
+            Collections.addAll( added, this.addresses );
             return;
         }
         BoltServerAddress[] copy = null;
@@ -101,6 +105,7 @@ public class RoundRobinAddressSet
         for ( BoltServerAddress address : addresses )
         {
             copy[j++] = address;
+            added.add( address );
         }
         this.addresses = copy;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import java.util.Set;
-
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.AccessMode;
 
@@ -27,7 +25,7 @@ public interface RoutingTable
 {
     boolean isStaleFor( AccessMode mode );
 
-    Set<BoltServerAddress> update( ClusterComposition cluster );
+    RoutingTableChange update( ClusterComposition cluster );
 
     void forget( BoltServerAddress address );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableChange.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableChange.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+
+import static java.util.Collections.unmodifiableSet;
+
+public class RoutingTableChange
+{
+    public static final RoutingTableChange EMPTY = new RoutingTableChange(
+            Collections.<BoltServerAddress>emptySet(), Collections.<BoltServerAddress>emptySet() );
+
+    private final Set<BoltServerAddress> added;
+    private final Set<BoltServerAddress> removed;
+
+    public RoutingTableChange( Set<BoltServerAddress> added, Set<BoltServerAddress> removed )
+    {
+        this.added = added;
+        this.removed = removed;
+    }
+
+    public Set<BoltServerAddress> added()
+    {
+        return unmodifiableSet( added );
+    }
+
+    public Set<BoltServerAddress> removed()
+    {
+        return unmodifiableSet( removed );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RoutingTableChange{" +
+               "added=" + added +
+               ", removed=" + removed +
+               '}';
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPool.java
@@ -103,12 +103,12 @@ public class SocketConnectionPool implements ConnectionPool
     }
 
     @Override
-    public void passivate( BoltServerAddress address )
+    public void deactivate( BoltServerAddress address )
     {
         BlockingPooledConnectionQueue connections = pools.get( address );
         if ( connections != null )
         {
-            connections.passivate();
+            connections.deactivate();
         }
     }
 
@@ -122,7 +122,7 @@ public class SocketConnectionPool implements ConnectionPool
 
             if ( !queue.isActive() && queue.activeConnections() == 0 )
             {
-                // queue has been in passive state and has no open connections by now
+                // queue has been in deactivated state and has no open connections by now
                 pools.remove( address );
             }
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -38,7 +38,7 @@ public interface ConnectionPool extends AutoCloseable
 
     void activate( BoltServerAddress address );
 
-    void passivate( BoltServerAddress address );
+    void deactivate( BoltServerAddress address );
 
     void compact();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -215,4 +215,20 @@ public class ClusterRoutingTableTest
         assertEquals( 2, change.removed().size() );
         assertThat( change.removed(), containsInAnyOrder( A, D ) );
     }
+
+    @Test
+    public void shouldNotRemoveServerIfPreWriterNowReader()
+    {
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+        routingTable.update( createClusterComposition( singletonList( A ), singletonList( B ), singletonList( C ) ) );
+
+        ClusterComposition newComposition =
+                createClusterComposition( singletonList( D ), singletonList( E ), singletonList( B ) );
+        RoutingTableChange change = routingTable.update( newComposition );
+
+        assertEquals( 2, change.added().size() );
+        assertThat( change.added(), containsInAnyOrder( D, E ) );
+        assertEquals( 2, change.removed().size() );
+        assertThat( change.removed(), containsInAnyOrder( A, C ) );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -27,8 +27,10 @@ import org.neo4j.driver.internal.util.FakeClock;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.B;
@@ -196,5 +198,21 @@ public class ClusterRoutingTableTest
 
         assertFalse( routingTable.isStaleFor( READ ) );
         assertFalse( routingTable.isStaleFor( WRITE ) );
+    }
+
+    @Test
+    public void shouldReturnCorrectChangeWhenUpdated()
+    {
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+        routingTable.update( createClusterComposition( asList( A, B ), asList( A, C ), asList( C, D ) ) );
+
+        ClusterComposition newComposition =
+                createClusterComposition( asList( E, B, F ), asList( E, C ), asList( C, F ) );
+        RoutingTableChange change = routingTable.update( newComposition );
+
+        assertEquals( 2, change.added().size() );
+        assertThat( change.added(), containsInAnyOrder( E, F ) );
+        assertEquals( 2, change.removed().size() );
+        assertThat( change.removed(), containsInAnyOrder( A, D ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
@@ -341,8 +341,7 @@ public class LoadBalancerTest
         when( routingTable.update( any( ClusterComposition.class ) ) ).thenReturn( RoutingTableChange.EMPTY );
 
         RoundRobinAddressSet addresses = new RoundRobinAddressSet();
-        addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ), new HashSet<BoltServerAddress>(),
-                new HashSet<BoltServerAddress>() );
+        addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ));
         when( routingTable.readers() ).thenReturn( addresses );
         when( routingTable.writers() ).thenReturn( addresses );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/LoadBalancerTest.java
@@ -71,7 +71,7 @@ import static org.neo4j.driver.v1.AccessMode.WRITE;
 public class LoadBalancerTest
 {
     @Test
-    public void ensureRoutingShouldUpdateRoutingTableAndPassivateConnectionPoolWhenStale() throws Exception
+    public void ensureRoutingShouldUpdateRoutingTableAndDeactivateConnectionPoolWhenStale() throws Exception
     {
         // given
         ConnectionPool conns = mock( ConnectionPool.class );
@@ -89,7 +89,7 @@ public class LoadBalancerTest
         InOrder inOrder = inOrder( rediscovery, routingTable, conns );
         inOrder.verify( rediscovery ).lookupClusterComposition( routingTable, conns );
         inOrder.verify( routingTable ).update( any( ClusterComposition.class ) );
-        inOrder.verify( conns ).passivate( new BoltServerAddress( "abc", 12 ) );
+        inOrder.verify( conns ).deactivate( new BoltServerAddress( "abc", 12 ) );
     }
 
     @Test
@@ -172,7 +172,7 @@ public class LoadBalancerTest
         }
 
         verify( routingTable ).forget( address );
-        verify( connectionPool ).passivate( address );
+        verify( connectionPool ).deactivate( address );
     }
 
     @Test
@@ -193,7 +193,7 @@ public class LoadBalancerTest
         session.close();
 
         verify( routingTable ).forget( address );
-        verify( connectionPool ).passivate( address );
+        verify( connectionPool ).deactivate( address );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal.cluster;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +28,6 @@ import java.util.Set;
 import org.neo4j.driver.internal.net.BoltServerAddress;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
@@ -57,7 +55,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
 
-        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( addresses );
 
         // when
         BoltServerAddress a = set.next();
@@ -85,7 +83,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 4 + 1; i-- > 0; )
@@ -100,7 +98,7 @@ public class RoundRobinAddressSetTest
 
         // when
         servers.add( new BoltServerAddress( "fyr" ) );
-        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         // then
         assertEquals( order.get( 1 ), set.next() );
@@ -126,7 +124,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 2 + 1; i-- > 0; )
@@ -158,7 +156,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 2 + 1; i-- > 0; )
@@ -173,7 +171,7 @@ public class RoundRobinAddressSetTest
 
         // when
         servers.remove( order.get( 1 ) );
-        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         // then
         assertEquals( order.get( 2 ), set.next() );
@@ -182,106 +180,7 @@ public class RoundRobinAddressSetTest
         assertEquals( order.get( 0 ), set.next() );
     }
 
-    @Test
-    public void shouldRecordRemovedAddressesWhenUpdating() throws Exception
-    {
-        // given
-        RoundRobinAddressSet set = new RoundRobinAddressSet();
-        Set<BoltServerAddress> addresses = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "tre" ) ) );
-        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
-        // when
-        Set<BoltServerAddress> removed = new HashSet<>();
-        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "fyr" ) ) );
-        set.update( newAddresses, new HashSet<BoltServerAddress>(), removed );
-
-        // then
-        assertEquals( singleton( new BoltServerAddress( "tre" ) ), removed );
-    }
-
-    @Test
-    public void shouldRecordRemovedAddressesWhenUpdateIsEmpty()
-    {
-        RoundRobinAddressSet set = new RoundRobinAddressSet();
-        Set<BoltServerAddress> addresses = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ) ) );
-        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
-
-        Set<BoltServerAddress> update = Collections.emptySet();
-        Set<BoltServerAddress> removed = new HashSet<>();
-        set.update( update, new HashSet<BoltServerAddress>(), removed );
-
-        assertEquals( addresses, removed );
-    }
-
-    @Test
-    public void shouldRecordAddedAddressesWhenUpdatingAnEmptySet()
-    {
-        RoundRobinAddressSet set = new RoundRobinAddressSet();
-
-        Set<BoltServerAddress> added1 = new HashSet<>();
-        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "tre" ) ) );
-        set.update( addresses1, added1, new HashSet<BoltServerAddress>() );
-
-        assertEquals( addresses1, added1 );
-    }
-
-    @Test
-    public void shouldRecordAddedAddressesWhenUpdating()
-    {
-        RoundRobinAddressSet set = new RoundRobinAddressSet();
-
-        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "tre" ) ) );
-        set.update( addresses1, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
-
-        Set<BoltServerAddress> added = new HashSet<>();
-        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "tre" ),
-                new BoltServerAddress( "four" ) ) );
-        set.update( newAddresses, added, new HashSet<BoltServerAddress>() );
-
-        assertEquals( singleton( new BoltServerAddress( "four" ) ), added );
-    }
-
-    @Test
-    public void shouldRecordBothAddedAndRemovedAddressesWhenUpdating()
-    {
-        RoundRobinAddressSet set = new RoundRobinAddressSet();
-
-        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
-                new BoltServerAddress( "one" ),
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "three" ) ) );
-        set.update( addresses1, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
-
-        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
-                new BoltServerAddress( "two" ),
-                new BoltServerAddress( "four" ),
-                new BoltServerAddress( "five" ) ) );
-
-        Set<BoltServerAddress> added = new HashSet<>();
-        Set<BoltServerAddress> removed = new HashSet<>();
-        set.update( newAddresses, added, removed );
-
-        assertEquals(
-                new HashSet<>( asList( new BoltServerAddress( "four" ), new BoltServerAddress( "five" ) ) ), added );
-        assertEquals(
-                new HashSet<>( asList( new BoltServerAddress( "one" ), new BoltServerAddress( "three" ) ) ), removed );
-    }
 
     @Test
     public void shouldPreserveOrderEvenWhenIntegerOverflows() throws Exception

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal.cluster;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -50,7 +50,7 @@ public class RoundRobinAddressSetTest
     {
         // given
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        Set<BoltServerAddress> addresses = new HashSet<>( asList(
+        Set<BoltServerAddress> addresses = new LinkedHashSet<>( asList(
                 new BoltServerAddress( "one" ),
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
@@ -78,7 +78,7 @@ public class RoundRobinAddressSetTest
     public void shouldPreserveOrderWhenAdding() throws Exception
     {
         // given
-        HashSet<BoltServerAddress> servers = new HashSet<>( asList(
+        Set<BoltServerAddress> servers = new LinkedHashSet<>( asList(
                 new BoltServerAddress( "one" ),
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
@@ -119,7 +119,7 @@ public class RoundRobinAddressSetTest
     public void shouldPreserveOrderWhenRemoving() throws Exception
     {
         // given
-        HashSet<BoltServerAddress> servers = new HashSet<>( asList(
+        Set<BoltServerAddress> servers = new LinkedHashSet<>( asList(
                 new BoltServerAddress( "one" ),
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
@@ -151,7 +151,7 @@ public class RoundRobinAddressSetTest
     public void shouldPreserveOrderWhenRemovingThroughUpdate() throws Exception
     {
         // given
-        HashSet<BoltServerAddress> servers = new HashSet<>( asList(
+        Set<BoltServerAddress> servers = new LinkedHashSet<>( asList(
                 new BoltServerAddress( "one" ),
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoundRobinAddressSetTest.java
@@ -18,11 +18,13 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-
-import org.junit.Test;
+import java.util.Set;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 
@@ -50,10 +52,12 @@ public class RoundRobinAddressSetTest
     {
         // given
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( new HashSet<>( asList(
+        Set<BoltServerAddress> addresses = new HashSet<>( asList(
                 new BoltServerAddress( "one" ),
                 new BoltServerAddress( "two" ),
-                new BoltServerAddress( "tre" ) ) ), new HashSet<BoltServerAddress>() );
+                new BoltServerAddress( "tre" ) ) );
+
+        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         // when
         BoltServerAddress a = set.next();
@@ -81,7 +85,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 4 + 1; i-- > 0; )
@@ -96,7 +100,7 @@ public class RoundRobinAddressSetTest
 
         // when
         servers.add( new BoltServerAddress( "fyr" ) );
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         // then
         assertEquals( order.get( 1 ), set.next() );
@@ -122,7 +126,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 2 + 1; i-- > 0; )
@@ -154,7 +158,7 @@ public class RoundRobinAddressSetTest
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" ) ) );
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         List<BoltServerAddress> order = new ArrayList<>();
         for ( int i = 3 * 2 + 1; i-- > 0; )
@@ -169,7 +173,7 @@ public class RoundRobinAddressSetTest
 
         // when
         servers.remove( order.get( 1 ) );
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         // then
         assertEquals( order.get( 2 ), set.next() );
@@ -183,24 +187,100 @@ public class RoundRobinAddressSetTest
     {
         // given
         RoundRobinAddressSet set = new RoundRobinAddressSet();
-        set.update(
-                new HashSet<>( asList(
-                        new BoltServerAddress( "one" ),
-                        new BoltServerAddress( "two" ),
-                        new BoltServerAddress( "tre" ) ) ),
-                new HashSet<BoltServerAddress>() );
+        Set<BoltServerAddress> addresses = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "tre" ) ) );
+        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
 
         // when
-        HashSet<BoltServerAddress> removed = new HashSet<>();
-        set.update(
-                new HashSet<>( asList(
-                        new BoltServerAddress( "one" ),
-                        new BoltServerAddress( "two" ),
-                        new BoltServerAddress( "fyr" ) ) ),
-                removed );
+        Set<BoltServerAddress> removed = new HashSet<>();
+        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "fyr" ) ) );
+        set.update( newAddresses, new HashSet<BoltServerAddress>(), removed );
 
         // then
         assertEquals( singleton( new BoltServerAddress( "tre" ) ), removed );
+    }
+
+    @Test
+    public void shouldRecordRemovedAddressesWhenUpdateIsEmpty()
+    {
+        RoundRobinAddressSet set = new RoundRobinAddressSet();
+        Set<BoltServerAddress> addresses = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ) ) );
+        set.update( addresses, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+
+        Set<BoltServerAddress> update = Collections.emptySet();
+        Set<BoltServerAddress> removed = new HashSet<>();
+        set.update( update, new HashSet<BoltServerAddress>(), removed );
+
+        assertEquals( addresses, removed );
+    }
+
+    @Test
+    public void shouldRecordAddedAddressesWhenUpdatingAnEmptySet()
+    {
+        RoundRobinAddressSet set = new RoundRobinAddressSet();
+
+        Set<BoltServerAddress> added1 = new HashSet<>();
+        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "tre" ) ) );
+        set.update( addresses1, added1, new HashSet<BoltServerAddress>() );
+
+        assertEquals( addresses1, added1 );
+    }
+
+    @Test
+    public void shouldRecordAddedAddressesWhenUpdating()
+    {
+        RoundRobinAddressSet set = new RoundRobinAddressSet();
+
+        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "tre" ) ) );
+        set.update( addresses1, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+
+        Set<BoltServerAddress> added = new HashSet<>();
+        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "tre" ),
+                new BoltServerAddress( "four" ) ) );
+        set.update( newAddresses, added, new HashSet<BoltServerAddress>() );
+
+        assertEquals( singleton( new BoltServerAddress( "four" ) ), added );
+    }
+
+    @Test
+    public void shouldRecordBothAddedAndRemovedAddressesWhenUpdating()
+    {
+        RoundRobinAddressSet set = new RoundRobinAddressSet();
+
+        Set<BoltServerAddress> addresses1 = new HashSet<>( asList(
+                new BoltServerAddress( "one" ),
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "three" ) ) );
+        set.update( addresses1, new HashSet<BoltServerAddress>(), new HashSet<BoltServerAddress>() );
+
+        Set<BoltServerAddress> newAddresses = new HashSet<>( asList(
+                new BoltServerAddress( "two" ),
+                new BoltServerAddress( "four" ),
+                new BoltServerAddress( "five" ) ) );
+
+        Set<BoltServerAddress> added = new HashSet<>();
+        Set<BoltServerAddress> removed = new HashSet<>();
+        set.update( newAddresses, added, removed );
+
+        assertEquals(
+                new HashSet<>( asList( new BoltServerAddress( "four" ), new BoltServerAddress( "five" ) ) ), added );
+        assertEquals(
+                new HashSet<>( asList( new BoltServerAddress( "one" ), new BoltServerAddress( "three" ) ) ), removed );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/BlockingPooledConnectionQueueTest.java
@@ -302,12 +302,12 @@ public class BlockingPooledConnectionQueueTest
     }
 
     @Test
-    public void shouldFailToAcquireConnectionWhenPassive()
+    public void shouldFailToAcquireConnectionWhenDeactivated()
     {
         Supplier<PooledConnection> connectionSupplier = connectionSupplierMock();
         when( connectionSupplier.get() ).thenReturn( mock( PooledConnection.class ) );
         BlockingPooledConnectionQueue queue = newConnectionQueue( 3 );
-        queue.passivate();
+        queue.deactivate();
 
         try
         {
@@ -316,15 +316,15 @@ public class BlockingPooledConnectionQueueTest
         }
         catch ( IllegalStateException e )
         {
-            assertThat( e.getMessage(), startsWith( "Pool is passivated" ) );
+            assertThat( e.getMessage(), startsWith( "Pool is deactivated" ) );
         }
     }
 
     @Test
-    public void shouldTerminateOfferedConnectionWhenPassive()
+    public void shouldTerminateOfferedConnectionWhenDeactivated()
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 3 );
-        queue.passivate();
+        queue.deactivate();
 
         PooledConnection connection = mock( PooledConnection.class );
         queue.offer( connection );
@@ -337,7 +337,7 @@ public class BlockingPooledConnectionQueueTest
     {
         BlockingPooledConnectionQueue queue = newConnectionQueue( 1 );
         assertTrue( queue.isActive() );
-        queue.passivate();
+        queue.deactivate();
         assertFalse( queue.isActive() );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledConnectionReleaseConsumerTest.java
@@ -46,7 +46,7 @@ public class PooledConnectionReleaseConsumerTest
 
         // connection should now be idle
         assertEquals( 0, queue.activeConnections() );
-        assertEquals( 1, queue.size() );
+        assertEquals( 1, queue.idleConnections() );
 
         verify( connection ).reset();
         verify( connection ).sync();
@@ -65,7 +65,7 @@ public class PooledConnectionReleaseConsumerTest
 
         // connection should've been disposed
         assertEquals( 0, queue.activeConnections() );
-        assertEquals( 0, queue.size() );
+        assertEquals( 0, queue.idleConnections() );
 
         verify( connection ).dispose();
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/PooledSocketConnectionTest.java
@@ -73,7 +73,7 @@ public class PooledSocketConnectionTest
         pooledConnection.close();
 
         // Then
-        assertThat( pool.size(), equalTo( 0 ) );
+        assertThat( pool.idleConnections(), equalTo( 0 ) );
         assertThat( flags[0], equalTo( true ) );
     }
 
@@ -102,7 +102,7 @@ public class PooledSocketConnectionTest
 
         // Then
         assertTrue( pool.contains(pooledConnection));
-        assertThat( pool.size(), equalTo( 1 ) );
+        assertThat( pool.idleConnections(), equalTo( 1 ) );
         assertThat( flags[0], equalTo( false ) );
     }
 
@@ -134,7 +134,7 @@ public class PooledSocketConnectionTest
 
         // Then
         assertTrue( pool.contains(pooledConnection) );
-        assertThat( pool.size(), equalTo( 1 ) );
+        assertThat( pool.idleConnections(), equalTo( 1 ) );
         assertThat( flags[0], equalTo( true ) );
     }
 
@@ -218,7 +218,7 @@ public class PooledSocketConnectionTest
         pooledConnection.close();
 
         // Then
-        assertThat( pool.size(), equalTo( 0 ) );
+        assertThat( pool.idleConnections(), equalTo( 0 ) );
         assertThat( flags[0], equalTo( true ) ); // make sure that the dispose is called
     }
 
@@ -247,7 +247,7 @@ public class PooledSocketConnectionTest
         pooledConnection.close();
 
         // Then
-        assertThat( pool.size(), equalTo( 0 ) );
+        assertThat( pool.idleConnections(), equalTo( 0 ) );
         assertThat( flags[0], equalTo( true ) ); // make sure that the dispose is called
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/pooling/SocketConnectionPoolTest.java
@@ -111,7 +111,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void passivateDoesNothingForNonExistingAddress()
+    public void deactivateDoesNothingForNonExistingAddress()
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         SocketConnectionPool pool = newPool( newMockConnector( connection ) );
@@ -119,12 +119,12 @@ public class SocketConnectionPoolTest
         pool.acquire( ADDRESS_1 ).close();
 
         assertTrue( pool.hasAddress( ADDRESS_1 ) );
-        pool.passivate( ADDRESS_2 );
+        pool.deactivate( ADDRESS_2 );
         assertTrue( pool.hasAddress( ADDRESS_1 ) );
     }
 
     @Test
-    public void passivateRemovesAddress()
+    public void deactivateRemovesAddress()
     {
         Connection connection = newConnectionMock( ADDRESS_1 );
         SocketConnectionPool pool = newPool( newMockConnector( connection ) );
@@ -132,12 +132,12 @@ public class SocketConnectionPoolTest
         pool.acquire( ADDRESS_1 ).close();
 
         assertTrue( pool.hasAddress( ADDRESS_1 ) );
-        pool.passivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_1 );
         assertFalse( pool.hasAddress( ADDRESS_1 ) );
     }
 
     @Test
-    public void passivateTerminatesIdleConnectionsInThePoolCorrespondingToTheAddress()
+    public void deactivateTerminatesIdleConnectionsInThePoolCorrespondingToTheAddress()
     {
         Connection connection1 = newConnectionMock( ADDRESS_1 );
         Connection connection2 = newConnectionMock( ADDRESS_1 );
@@ -152,7 +152,7 @@ public class SocketConnectionPoolTest
         pooledConnection1.close();
         pooledConnection2.close();
 
-        pool.passivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_1 );
 
         verify( connection1 ).close();
         verify( connection2 ).close();
@@ -591,7 +591,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void shouldPassivateExistingPool()
+    public void shouldDeactivateExistingPool()
     {
         SocketConnectionPool pool = newPool( newMockConnector() );
 
@@ -599,20 +599,20 @@ public class SocketConnectionPoolTest
         assertTrue( pool.hasAddress( ADDRESS_1 ) );
         assertEquals( 1, pool.activeConnections( ADDRESS_1 ) );
 
-        pool.passivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_1 );
         assertFalse( pool.hasAddress( ADDRESS_1 ) );
         assertEquals( 0, pool.activeConnections( ADDRESS_1 ) );
     }
 
     @Test
-    public void shouldPassivateNothingWhenPoolDoesNotExist()
+    public void shouldDeactivateNothingWhenPoolDoesNotExist()
     {
         SocketConnectionPool pool = newPool( newMockConnector() );
 
         assertFalse( pool.hasAddress( ADDRESS_1 ) );
         assertEquals( 0, pool.activeConnections( ADDRESS_1 ) );
 
-        pool.passivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_1 );
 
         assertFalse( pool.hasAddress( ADDRESS_1 ) );
         assertEquals( 0, pool.activeConnections( ADDRESS_1 ) );
@@ -624,7 +624,7 @@ public class SocketConnectionPoolTest
         SocketConnectionPool pool = newPool( newMockConnector() );
         assertNotNull( pool.acquire( ADDRESS_1 ) );
 
-        pool.passivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_1 );
         pool.activate( ADDRESS_1 );
 
         assertTrue( pool.hasAddress( ADDRESS_1 ) );
@@ -646,7 +646,7 @@ public class SocketConnectionPoolTest
     }
 
     @Test
-    public void shouldRemovePassivePoolsWithoutConnectionsWhenCompacting()
+    public void shouldRemoveDeactivatedPoolsWithoutConnectionsWhenCompacting()
     {
         SocketConnectionPool pool = newPool( newMockConnector( newConnectionMock( ADDRESS_1 ),
                 newConnectionMock( ADDRESS_1 ), newConnectionMock( ADDRESS_2 ), newConnectionMock( ADDRESS_3 ) ) );
@@ -658,8 +658,8 @@ public class SocketConnectionPoolTest
 
         assertEquals( new HashSet<>( asList( ADDRESS_1, ADDRESS_2, ADDRESS_3 ) ), pool.addresses() );
 
-        pool.passivate( ADDRESS_1 );
-        pool.passivate( ADDRESS_3 );
+        pool.deactivate( ADDRESS_1 );
+        pool.deactivate( ADDRESS_3 );
 
         connection1.close();
         connection2.close();

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnection.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnection.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import java.util.Map;
+
+import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.Collector;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.summary.ServerInfo;
+
+public class ThrowingConnection implements Connection
+{
+    private final Connection realConnection;
+    private RuntimeException nextRunFailure;
+
+    public ThrowingConnection( Connection realConnection )
+    {
+        this.realConnection = realConnection;
+    }
+
+    @Override
+    public void init( String clientName, Map<String,Value> authToken )
+    {
+        realConnection.init( clientName, authToken );
+    }
+
+    @Override
+    public void run( String statement, Map<String,Value> parameters, Collector collector )
+    {
+        if ( nextRunFailure != null )
+        {
+            RuntimeException error = nextRunFailure;
+            nextRunFailure = null;
+            throw error;
+        }
+        realConnection.run( statement, parameters, collector );
+    }
+
+    @Override
+    public void discardAll( Collector collector )
+    {
+        realConnection.discardAll( collector );
+    }
+
+    @Override
+    public void pullAll( Collector collector )
+    {
+        realConnection.pullAll( collector );
+    }
+
+    @Override
+    public void reset()
+    {
+        realConnection.reset();
+    }
+
+    @Override
+    public void ackFailure()
+    {
+        realConnection.ackFailure();
+    }
+
+    @Override
+    public void sync()
+    {
+        realConnection.sync();
+    }
+
+    @Override
+    public void flush()
+    {
+        realConnection.flush();
+    }
+
+    @Override
+    public void receiveOne()
+    {
+        realConnection.receiveOne();
+    }
+
+    @Override
+    public void close()
+    {
+        realConnection.close();
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return realConnection.isOpen();
+    }
+
+    @Override
+    public void resetAsync()
+    {
+        realConnection.resetAsync();
+    }
+
+    @Override
+    public boolean isAckFailureMuted()
+    {
+        return realConnection.isAckFailureMuted();
+    }
+
+    @Override
+    public ServerInfo server()
+    {
+        return realConnection.server();
+    }
+
+    @Override
+    public BoltServerAddress boltServerAddress()
+    {
+        return realConnection.boltServerAddress();
+    }
+
+    public void setNextRunFailure( RuntimeException nextRunFailure )
+    {
+        this.nextRunFailure = nextRunFailure;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnectionConnector.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnectionConnector.java
@@ -16,31 +16,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.spi;
+package org.neo4j.driver.internal.util;
+
+import java.util.List;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
+import org.neo4j.driver.internal.spi.Connector;
 
-public interface ConnectionPool extends AutoCloseable
+public class ThrowingConnectionConnector implements Connector
 {
-    /**
-     * Acquire a connection - if a live connection exists in the pool, it will
-     * be used, otherwise a new connection will be created.
-     *
-     * @param address The address to acquire
-     */
-    PooledConnection acquire( BoltServerAddress address );
+    private final Connector realConnector;
+    private final List<ThrowingConnection> connections;
 
-    /**
-     * Removes all connections to a given address from the pool.
-     * @param address The address to remove.
-     */
-    void purge( BoltServerAddress address );
+    public ThrowingConnectionConnector( Connector realConnector, List<ThrowingConnection> connections )
+    {
+        this.realConnector = realConnector;
+        this.connections = connections;
+    }
 
-    void activate( BoltServerAddress address );
-
-    void passivate( BoltServerAddress address );
-
-    void compact();
-
-    boolean hasAddress( BoltServerAddress address );
+    @Override
+    public ThrowingConnection connect( BoltServerAddress address )
+    {
+        ThrowingConnection connection = new ThrowingConnection( realConnector.connect( address ) );
+        connections.add( connection );
+        return connection;
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ThrowingConnectionDriverFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.spi.Connector;
+import org.neo4j.driver.v1.Logging;
+
+public class ThrowingConnectionDriverFactory extends DriverFactory
+{
+    private final List<ThrowingConnection> connections = new CopyOnWriteArrayList<>();
+
+    @Override
+    protected Connector createConnector( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
+            Logging logging )
+    {
+        Connector connector = super.createConnector( connectionSettings, securityPlan, logging );
+        return new ThrowingConnectionConnector( connector, connections );
+    }
+
+    public List<ThrowingConnection> getConnections()
+    {
+        return new ArrayList<>( connections );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -37,6 +37,8 @@ import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.ConnectionTrackingDriverFactory;
 import org.neo4j.driver.internal.util.FakeClock;
+import org.neo4j.driver.internal.util.ThrowingConnection;
+import org.neo4j.driver.internal.util.ThrowingConnectionDriverFactory;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.Config;
@@ -487,6 +489,74 @@ public class CausalClusteringIT
                 assertEquals( count, threadCount );
             }
         }
+    }
+
+    @Test
+    public void shouldAllowExistingTransactionToCompleteAfterDifferentConnectionBreaks()
+    {
+        Cluster cluster = clusterRule.getCluster();
+        ClusterMember leader = cluster.leader();
+
+        ThrowingConnectionDriverFactory driverFactory = new ThrowingConnectionDriverFactory();
+        RoutingSettings routingSettings = new RoutingSettings( 1, SECONDS.toMillis( 5 ), null );
+        Config config = Config.build().toConfig();
+
+        try ( Driver driver = driverFactory.newInstance( leader.getRoutingUri(), clusterRule.getDefaultAuthToken(),
+                routingSettings, RetrySettings.DEFAULT, config ) )
+        {
+            Session session1 = driver.session();
+            Transaction tx1 = session1.beginTransaction();
+            tx1.run( "CREATE (n:Node1 {name: 'Node1'})" ).consume();
+
+            Session session2 = driver.session();
+            Transaction tx2 = session2.beginTransaction();
+            tx2.run( "CREATE (n:Node2 {name: 'Node2'})" ).consume();
+
+            ServiceUnavailableException error = new ServiceUnavailableException( "Connection broke!" );
+            setupLastConnectionToThrow( driverFactory, error );
+            assertUnableToRunMoreStatementsInTx( tx2, error );
+
+            closeTx( tx2 );
+            closeTx( tx1 );
+
+            // tx1 should not be terminated and should commit successfully
+            assertEquals( 1, countNodes( session1, "Node1", "name", "Node1" ) );
+            // tx2 should not commit because of a connection failure
+            assertEquals( 0, countNodes( session1, "Node2", "name", "Node2" ) );
+
+            // rediscovery should happen for the new write query
+            try ( Session session3 = driver.session() )
+            {
+                session3.run( "CREATE (n:Node3 {name: 'Node3'})" ).consume();
+            }
+            assertEquals( 1, countNodes( session1, "Node3", "name", "Node3" ) );
+        }
+    }
+
+    private static void closeTx( Transaction tx )
+    {
+        tx.success();
+        tx.close();
+    }
+
+    private static void assertUnableToRunMoreStatementsInTx( Transaction tx, ServiceUnavailableException cause )
+    {
+        try
+        {
+            tx.run( "CREATE (n:Node3 {name: 'Node3'})" ).consume();
+            fail( "Exception expected" );
+        }
+        catch ( SessionExpiredException e )
+        {
+            assertEquals( cause, e.getCause() );
+        }
+    }
+
+    private static void setupLastConnectionToThrow( ThrowingConnectionDriverFactory factory, RuntimeException error )
+    {
+        List<ThrowingConnection> connections = factory.getConnections();
+        ThrowingConnection lastConnection = connections.get( connections.size() - 1 );
+        lastConnection.setNextRunFailure( error );
     }
 
     private int executeWriteAndReadThroughBolt( ClusterMember member ) throws TimeoutException, InterruptedException


### PR DESCRIPTION
Previously routing driver terminated all connections towards a particular address when one of active connections had a network error. Connections were also terminated when new routing table did not contain some address that was present in the previous routing table. Such behaviour might be problematic because it results in terminated queries. Network errors might have been temporary but always resulted in termination of active queries.

This commit makes driver keep existing connections and terminate only idle ones on network error. Address will still be excluded from the routing table and subsequent queries will not be pointed on it. Corresponding connection pool is transferred into a "passive" state where it does not serve new connections and disposes returned connections immediately. Pool is transferred back to "active" state during next rediscovery only if corresponding address is present in the new routing table.

Old behaviour still remains and can be activated using `-DpurgeOnError=true` system property. It exists as a fallback only for exceptional cases and will most likely be silently removed in future.