### PR TITLE
Use AccessMode correctly in NetworkSession

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -46,7 +46,7 @@ class LeakLoggingNetworkSession extends NetworkSession
 
     private void logLeakIfNeeded()
     {
-        Boolean isOpen = Futures.getBlocking( currentConnectionIsOpen() );
+        Boolean isOpen = Futures.getBlocking( hasOpenConnection() );
         if ( isOpen )
         {
             logger.error( "Neo4j Session object leaked, please ensure that your application" +

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -251,14 +251,13 @@ public class NetworkSession implements Session
 
     private CompletionStage<Void> resetAsync()
     {
-        return releaseConnections().thenCompose( ignore -> existingTransactionOrNull() )
-                .thenAccept( tx ->
-                {
-                    if ( tx != null )
-                    {
-                        tx.markTerminated();
-                    }
-                } );
+        return existingTransactionOrNull().thenAccept( tx ->
+        {
+            if ( tx != null )
+            {
+                tx.markTerminated();
+            }
+        } ).thenCompose( ignore -> releaseConnections() );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -602,6 +602,25 @@ public class NetworkSessionTest
     }
 
     @Test
+    public void shouldMarkTransactionAsTerminatedAndThenReleaseConnectionOnReset()
+    {
+        NetworkSession session = newSession( connectionProvider, READ );
+        Transaction tx = session.beginTransaction();
+
+        assertTrue( tx.isOpen() );
+        when( connection.releaseNow() ).then( invocation ->
+        {
+            // verify that tx is not open when connection is released
+            assertFalse( tx.isOpen() );
+            return completedFuture( null );
+        } );
+
+        session.reset();
+
+        verify( connection ).releaseNow();
+    }
+
+    @Test
     public void shouldHaveNullLastBookmarkInitially()
     {
         NetworkSession session = newSession( mock( ConnectionProvider.class ), READ );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -33,11 +33,13 @@ import java.util.concurrent.TimeoutException;
 
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 
 import static java.util.Collections.emptyMap;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -45,6 +47,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class TestUtil
 {
@@ -157,10 +160,12 @@ public final class TestUtil
         setupSuccessfulPullAll( connection, "COMMIT" );
         setupSuccessfulPullAll( connection, "ROLLBACK" );
         setupSuccessfulPullAll( connection, "BEGIN" );
+        when( connection.releaseNow() ).thenReturn( completedFuture( null ) );
+        when( connection.serverVersion() ).thenReturn( ServerVersion.vInDev );
         return connection;
     }
 
-    private static void setupSuccessfulPullAll( Connection connection, String statement )
+    public static void setupSuccessfulPullAll( Connection connection, String statement )
     {
         doAnswer( invocation ->
         {


### PR DESCRIPTION
PR consists of two commits:

**Separate connections for read/write access modes**
`NetworkSession` acquires connections from the connection pool for the given access mode. It can reuse an existing connection, when available. Previously session did not pay attention to access mode when reusing connections. This could result in READ connection being used for WRITE operation and vice versa.

This commit fixes the problem by making session hold at most two connections at the same time -
one read connection and one write connection. It will now continue using existing read/write connection for read/write operation when available.

**Session#reset() releases connection last**
Previously it tried to first release connection and them mark existing transaction as terminated. This could've been problematic because it allowed transaction to be used on the client after RESET, which clears connection state on the server.

This commit makes `Session#reset()` first mark existing transaction as terminated and only then release the connection. Releasing connection implies RESET.
