### PR TITLE
Use AccessMode correctly in NetworkSession

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/RoutingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/RoutingConnection.java
@@ -42,12 +42,6 @@ public class RoutingConnection implements Connection
     }
 
     @Override
-    public boolean tryMarkInUse()
-    {
-        return delegate.tryMarkInUse();
-    }
-
-    @Override
     public void enableAutoRead()
     {
         delegate.enableAutoRead();
@@ -82,9 +76,9 @@ public class RoutingConnection implements Connection
     }
 
     @Override
-    public boolean isInUse()
+    public boolean isOpen()
     {
-        return delegate.isInUse();
+        return delegate.isOpen();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -27,9 +27,7 @@ import org.neo4j.driver.v1.Value;
 
 public interface Connection
 {
-    boolean isInUse();
-
-    boolean tryMarkInUse();
+    boolean isOpen();
 
     void enableAutoRead();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -95,24 +95,24 @@ public class LeakLoggingNetworkSessionTest
         finalizeMethod.invoke( session );
     }
 
-    private static LeakLoggingNetworkSession newSession( Logging logging, boolean inUseConnection )
+    private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
-        return new LeakLoggingNetworkSession( connectionProviderMock( inUseConnection ), READ,
+        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ,
                 new FixedRetryLogic( 0 ), logging );
     }
 
-    private static ConnectionProvider connectionProviderMock( boolean inUseConnection )
+    private static ConnectionProvider connectionProviderMock( boolean openConnection )
     {
         ConnectionProvider provider = mock( ConnectionProvider.class );
-        Connection connection = connectionMock( inUseConnection );
+        Connection connection = connectionMock( openConnection );
         when( provider.acquireConnection( any( AccessMode.class ) ) ).thenReturn( completedFuture( connection ) );
         return provider;
     }
 
-    private static Connection connectionMock( boolean inUse )
+    private static Connection connectionMock( boolean open )
     {
         Connection connection = mock( Connection.class );
-        when( connection.isInUse() ).thenReturn( inUse );
+        when( connection.isOpen() ).thenReturn( open );
         return connection;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
@@ -63,7 +63,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.v1.Config.defaultConfig;
 import static org.neo4j.driver.v1.Values.parameters;
@@ -199,39 +198,6 @@ public class ConnectionHandlingIT
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
         assertSame( connection1, connection2 );
-        verify( connection1 ).releaseInBackground();
-    }
-
-    @Test
-    public void activeConnectionFromSessionRunCanBeReusedForNextSessionRun()
-    {
-        Session session = driver.session();
-
-        StatementResult result1 = createNodes( 3, session );
-        Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
-
-        StatementResult result2 = createNodes( 2, session );
-
-        assertEquals( 3, result1.list().size() );
-        assertEquals( 2, result2.list().size() );
-
-        verify( connection1 ).tryMarkInUse();
-        verify( connection1, times( 2 ) ).releaseInBackground();
-    }
-
-    @Test
-    public void activeConnectionFromSessionRunCanBeReusedForNewTransaction()
-    {
-        Session session = driver.session();
-
-        StatementResult result1 = createNodes( 3, session );
-        Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
-
-        session.beginTransaction();
-
-        assertEquals( 3, result1.list().size() );
-
-        verify( connection1 ).tryMarkInUse();
         verify( connection1 ).releaseInBackground();
     }
 


### PR DESCRIPTION
`NetworkSession` acquires connections from the connection pool for the given access mode. Previously it tried to reuse existing connection when available. However, it did not pay attention to access mode when reusing connections. This could result in READ connection being used for WRITE operation and vice versa.

This PR fixes the problem by making session buffer existing result, if any. Buffering means that in-use connection will be released back to the pool. It also allows session propagate unconsumed failures from previous query executions.