### PR TITLE
Improve default config values for connection pool

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/PoolSettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/PoolSettings.java
@@ -18,17 +18,17 @@
  */
 package org.neo4j.driver.internal.async.pool;
 
+import java.util.concurrent.TimeUnit;
+
 public class PoolSettings
 {
-    public static final int NO_IDLE_CONNECTION_TEST = -1;
-    public static final int INFINITE_CONNECTION_LIFETIME = -1;
     public static final int NOT_CONFIGURED = -1;
 
-    public static final int DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE = 10;
-    public static final int DEFAULT_MAX_CONNECTION_POOL_SIZE = Integer.MAX_VALUE;
+    public static final int DEFAULT_MAX_CONNECTION_POOL_SIZE = 100;
+    public static final int DEFAULT_MAX_IDLE_CONNECTION_POOL_SIZE = DEFAULT_MAX_CONNECTION_POOL_SIZE;
     public static final long DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST = NOT_CONFIGURED;
-    public static final long DEFAULT_MAX_CONNECTION_LIFETIME = NOT_CONFIGURED;
-    public static final long DEFAULT_CONNECTION_ACQUISITION_TIMEOUT = Long.MAX_VALUE;
+    public static final long DEFAULT_MAX_CONNECTION_LIFETIME = TimeUnit.HOURS.toMillis( 1 );
+    public static final long DEFAULT_CONNECTION_ACQUISITION_TIMEOUT = TimeUnit.SECONDS.toMillis( 60 );
 
     private final int maxIdleConnectionPoolSize;
     private final long idleTimeBeforeConnectionTest;

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -107,6 +107,12 @@ public class ConfigTest
     }
 
     @Test
+    public void shouldHaveCorrectMaxConnectionLifetime()
+    {
+        assertEquals( TimeUnit.HOURS.toMillis( 1 ), Config.defaultConfig().maxConnectionLifetimeMillis() );
+    }
+
+    @Test
     public void shouldSupportMaxConnectionLifetimeSetting() throws Throwable
     {
         Config config = Config.build().withMaxConnectionLifetime( 42, TimeUnit.SECONDS ).toConfig();
@@ -223,6 +229,72 @@ public class ConfigTest
         Config config = Config.build().withMaxTransactionRetryTime( 42, TimeUnit.SECONDS ).toConfig();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.retrySettings().maxRetryTimeMs() );
+    }
+
+    @Test
+    public void shouldHaveCorrectDefaultMaxConnectionPoolSize()
+    {
+        assertEquals( 100, Config.defaultConfig().maxConnectionPoolSize() );
+    }
+
+    @Test
+    public void shouldAllowPositiveMaxConnectionPoolSize()
+    {
+        Config config = Config.build().withMaxConnectionPoolSize( 42 ).toConfig();
+
+        assertEquals( 42, config.maxConnectionPoolSize() );
+    }
+
+    @Test
+    public void shouldAllowNegativeMaxConnectionPoolSize()
+    {
+        Config config = Config.build().withMaxConnectionPoolSize( -42 ).toConfig();
+
+        assertEquals( Integer.MAX_VALUE, config.maxConnectionPoolSize() );
+    }
+
+    @Test
+    public void shouldDisallowZeroMaxConnectionPoolSize()
+    {
+        try
+        {
+            Config.build().withMaxConnectionPoolSize( 0 ).toConfig();
+            fail( "Exception expected" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( "Zero value is not supported", e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldHaveCorrectDefaultConnectionAcquisitionTimeout()
+    {
+        assertEquals( TimeUnit.SECONDS.toMillis( 60 ), Config.defaultConfig().connectionAcquisitionTimeoutMillis() );
+    }
+
+    @Test
+    public void shouldAllowPositiveConnectionAcquisitionTimeout()
+    {
+        Config config = Config.build().withConnectionAcquisitionTimeout( 42, TimeUnit.SECONDS ).toConfig();
+
+        assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.connectionAcquisitionTimeoutMillis() );
+    }
+
+    @Test
+    public void shouldAllowNegativeConnectionAcquisitionTimeout()
+    {
+        Config config = Config.build().withConnectionAcquisitionTimeout( -42, TimeUnit.HOURS ).toConfig();
+
+        assertEquals( -1, config.connectionAcquisitionTimeoutMillis() );
+    }
+
+    @Test
+    public void shouldAllowConnectionAcquisitionTimeoutOfZero()
+    {
+        Config config = Config.build().withConnectionAcquisitionTimeout( 0, TimeUnit.DAYS ).toConfig();
+
+        assertEquals( 0, config.connectionAcquisitionTimeoutMillis() );
     }
 
     public static void deleteDefaultKnownCertFileIfExists()


### PR DESCRIPTION
PR changes default values from "unlimited" to lower and more realistic values. Modified settings are:

  * `maxConnectionLifetime` - changed from unlimited to 1 hour because it seems
    reasonable to periodically "refresh" connections and make sure they are
    not affected by network infrastructure.

  * `maxConnectionPoolSize` - changed from `Integer.MAX_VALUE` to 100 because
    unlimited connection pool is dangerous and might result in excessive use
    of resources and OOMs in the database, if connections there are
    not limited.

  * `connectionAcquisitionTimeout` - changed from unlimited to 60 seconds
    to not cause infinite blocking.