### PR TITLE
Fixed handling of empty byte arrays

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/BufferingChunkedInput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/BufferingChunkedInput.java
@@ -142,8 +142,11 @@ public class BufferingChunkedInput implements PackInput
     @Override
     public PackInput readBytes( byte[] into, int offset, int toRead ) throws IOException
     {
-        ByteBuffer dst = ByteBuffer.wrap( into, offset, toRead );
-        read( dst );
+        if ( toRead != 0 )
+        {
+            ByteBuffer dst = ByteBuffer.wrap( into, offset, toRead );
+            read( dst );
+        }
         return this;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
@@ -71,7 +71,8 @@ import static java.util.Collections.singletonList;
  * <tr><td><code>DB</code></td><td><code>11011011</code></td><td><em>RESERVED</em></td><td></td></tr>
  * <tr><td><code>DC</code></td><td><code>11011100</code></td><td>STRUCT_8</td><td>Structure (fewer than 2<sup>8</sup> fields)</td></tr>
  * <tr><td><code>DD</code></td><td><code>11011101</code></td><td>STRUCT_16</td><td>Structure (fewer than 2<sup>16</sup> fields)</td></tr>
- * <tr><td><code>DE</code></td><td><code>11011110</code></td><td>STRUCT_32</td><td>Structure (fewer than 2<sup>32</sup> fields)</td></tr>
+ * <tr><td><code>DE</code></td><td><code>11011110</code></td><td><em>RESERVED</em></td><td></td></tr>
+ * <tr><td><code>DF</code></td><td><code>11011111</code></td><td><em>RESERVED</em></td><td></td></tr>
  * <tr><td><code>DF</code></td><td><code>11011111</code></td><td><em>RESERVED</em></td><td></td></tr>
  * <tr><td><code>E0..EF</code></td><td><code>1110xxxx</code></td><td><em>RESERVED</em></td><td></td></tr>
  * <tr><td><code>F0..FF</code></td><td><code>1111xxxx</code></td><td>-TINY_INT</td><td>Integer -1 to -16</td></tr>
@@ -115,7 +116,7 @@ public class PackStream
     public static final byte RESERVED_DB = (byte) 0xDB;
     public static final byte STRUCT_8 = (byte) 0xDC;
     public static final byte STRUCT_16 = (byte) 0xDD;
-    public static final byte RESERVED_DE = (byte) 0xDE; // TODO STRUCT_32? or the class javadoc is wrong?
+    public static final byte RESERVED_DE = (byte) 0xDE;
     public static final byte RESERVED_DF = (byte) 0xDF;
     public static final byte RESERVED_E0 = (byte) 0xE0;
     public static final byte RESERVED_E1 = (byte) 0xE1;
@@ -144,6 +145,7 @@ public class PackStream
     private static final long MINUS_2_TO_THE_31 = -2147483648L;
 
     private static final String EMPTY_STRING = "";
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     private static final Charset UTF_8 = Charset.forName( "UTF-8" );
 
     private PackStream() {}
@@ -614,6 +616,10 @@ public class PackStream
 
         private byte[] unpackRawBytes(int size ) throws IOException
         {
+            if ( size == 0 )
+            {
+                return EMPTY_BYTE_ARRAY;
+            }
             byte[] heapBuffer = new byte[size];
             in.readBytes( heapBuffer, 0, heapBuffer.length );
             return heapBuffer;

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BufferingChunkedInputTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BufferingChunkedInputTest.java
@@ -41,6 +41,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class BufferingChunkedInputTest
@@ -513,6 +515,17 @@ public class BufferingChunkedInputTest
         assertEquals( buffer.limit(), 0 );
         assertEquals( buffer.capacity(), 8 );
         assertFalse( channel.isOpen() );
+    }
+
+    @Test
+    public void shouldNotReadFromChannelWhenEmptyByteBufferRequested() throws IOException
+    {
+        ReadableByteChannel channel = mock( ReadableByteChannel.class );
+        BufferingChunkedInput input = new BufferingChunkedInput( channel );
+
+        input.readBytes( new byte[0], 0, 0 );
+
+        verify( channel, never() ).read( any( ByteBuffer.class ) );
     }
 
     private ReadableByteChannel fillPacket( int size, int value )

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
@@ -326,26 +326,28 @@ public class PackStreamTest
     @Test
     public void testCanPackAndUnpackByteArrays() throws Throwable
     {
-        // Given
         Machine machine = new Machine( 17000000 );
 
+        testByteArrayPackingAndUnpacking( machine, 0 );
         for ( int i = 0; i < 24; i++ )
         {
-            byte[] array = new byte[(int) Math.pow( 2, i )];
-
-            // When
-            machine.reset();
-            machine.packer().pack( array );
-            machine.packer().flush();
-
-            // Then
-            PackStream.Unpacker unpacker = newUnpacker( machine.output() );
-            PackType packType = unpacker.peekNextType();
-
-            // Then
-            assertThat( packType, equalTo( PackType.BYTES ) );
-            assertArrayEquals( array, unpacker.unpackBytes() );
+            testByteArrayPackingAndUnpacking( machine, (int) Math.pow( 2, i ) );
         }
+    }
+
+    private void testByteArrayPackingAndUnpacking( Machine machine, int length ) throws Throwable
+    {
+        byte[] array = new byte[length];
+
+        machine.reset();
+        machine.packer().pack( array );
+        machine.packer().flush();
+
+        PackStream.Unpacker unpacker = newUnpacker( machine.output() );
+        PackType packType = unpacker.peekNextType();
+
+        assertThat( packType, equalTo( PackType.BYTES ) );
+        assertArrayEquals( array, unpacker.unpackBytes() );
     }
 
     @Test


### PR DESCRIPTION
Previously decoding of empty byte arrays caused an error because pack stream layer forced pack input to fill in an empty buffer. Later tried to fetch next chunk in such case and still fill the given buffer with nothing. This caused it to fail later on message boundary, when asserting that the whole chunk has been consumed.

This PR fixes the problem by making pack input do nothing when asked to fill in an empty buffer. It also adds a branch in pack stream to always return a single empty byte array and not even attempt to read.