### PR TITLE
Relax connection termination policy in routing driver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
@@ -93,22 +93,6 @@ public class ConnectionPoolImpl implements ConnectionPool
     }
 
     @Override
-    public void purge( BoltServerAddress address )
-    {
-        log.info( "Purging connections towards %s", address );
-
-        // purge active connections
-        activeChannelTracker.purge( address );
-
-        // purge idle connections in the pool and pool itself
-        ChannelPool pool = pools.remove( address );
-        if ( pool != null )
-        {
-            pool.close();
-        }
-    }
-
-    @Override
     public void retainAll( Set<BoltServerAddress> addressesToRetain )
     {
         for ( BoltServerAddress address : pools.keySet() )
@@ -124,18 +108,13 @@ public class ConnectionPoolImpl implements ConnectionPool
                     ChannelPool pool = pools.remove( address );
                     if ( pool != null )
                     {
-                        log.info( "Purging idle connections towards %s", address );
+                        log.info( "Closing connection pool towards %s, it has no active connections " +
+                                  "and is not in the routing table", address );
                         pool.close();
                     }
                 }
             }
         }
-    }
-
-    @Override
-    public boolean hasAddress( BoltServerAddress address )
-    {
-        return pools.containsKey( address );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/AddressSet.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/AddressSet.java
@@ -39,54 +39,9 @@ public class AddressSet
         return addresses.length;
     }
 
-    public synchronized void update( Set<BoltServerAddress> addresses, Set<BoltServerAddress> removed )
+    public synchronized void update( Set<BoltServerAddress> addresses )
     {
-        BoltServerAddress[] prev = this.addresses;
-        if ( addresses.isEmpty() )
-        {
-            this.addresses = NONE;
-            return;
-        }
-        if ( prev.length == 0 )
-        {
-            this.addresses = addresses.toArray( NONE );
-            return;
-        }
-        BoltServerAddress[] copy = null;
-        if ( addresses.size() != prev.length )
-        {
-            copy = new BoltServerAddress[addresses.size()];
-        }
-        int j = 0;
-        for ( int i = 0; i < prev.length; i++ )
-        {
-            if ( addresses.remove( prev[i] ) )
-            {
-                if ( copy != null )
-                {
-                    copy[j++] = prev[i];
-                }
-            }
-            else
-            {
-                removed.add( prev[i] );
-                if ( copy == null )
-                {
-                    copy = new BoltServerAddress[prev.length];
-                    System.arraycopy( prev, 0, copy, 0, i );
-                    j = i;
-                }
-            }
-        }
-        if ( copy == null )
-        {
-            return;
-        }
-        for ( BoltServerAddress address : addresses )
-        {
-            copy[j++] = address;
-        }
-        this.addresses = copy;
+        this.addresses = addresses.toArray( NONE );
     }
 
     public synchronized void remove( BoltServerAddress address )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -19,6 +19,7 @@
 
 package org.neo4j.driver.internal.cluster;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class ClusterRoutingTable implements RoutingTable
     public ClusterRoutingTable( Clock clock, BoltServerAddress... routingAddresses )
     {
         this( clock );
-        routers.update( new LinkedHashSet<>( asList( routingAddresses ) ), new HashSet<BoltServerAddress>() );
+        routers.update( new LinkedHashSet<>( asList( routingAddresses ) ) );
     }
 
     private ClusterRoutingTable( Clock clock )
@@ -66,14 +67,12 @@ public class ClusterRoutingTable implements RoutingTable
     }
 
     @Override
-    public synchronized Set<BoltServerAddress> update( ClusterComposition cluster )
+    public synchronized void update( ClusterComposition cluster )
     {
         expirationTimeout = cluster.expirationTimestamp();
-        Set<BoltServerAddress> removed = new HashSet<>();
-        readers.update( cluster.readers(), removed );
-        writers.update( cluster.writers(), removed );
-        routers.update( cluster.routers(), removed );
-        return removed;
+        readers.update( cluster.readers() );
+        writers.update( cluster.writers() );
+        routers.update( cluster.routers() );
     }
 
     @Override
@@ -100,6 +99,16 @@ public class ClusterRoutingTable implements RoutingTable
     public AddressSet routers()
     {
         return routers;
+    }
+
+    @Override
+    public Set<BoltServerAddress> servers()
+    {
+        Set<BoltServerAddress> servers = new HashSet<>();
+        Collections.addAll( servers, readers.toArray() );
+        Collections.addAll( servers, writers.toArray() );
+        Collections.addAll( servers, routers.toArray() );
+        return servers;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -27,7 +27,7 @@ public interface RoutingTable
 {
     boolean isStaleFor( AccessMode mode );
 
-    Set<BoltServerAddress> update( ClusterComposition cluster );
+    void update( ClusterComposition cluster );
 
     void forget( BoltServerAddress address );
 
@@ -36,6 +36,8 @@ public interface RoutingTable
     AddressSet writers();
 
     AddressSet routers();
+
+    Set<BoltServerAddress> servers();
 
     void removeWriter( BoltServerAddress toRemove );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.BoltServerAddress;
@@ -27,6 +28,8 @@ public interface ConnectionPool
     CompletionStage<Connection> acquire( BoltServerAddress address );
 
     void purge( BoltServerAddress address );
+
+    void retainAll( Set<BoltServerAddress> addressesToRetain );
 
     boolean hasAddress( BoltServerAddress address );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -27,11 +27,7 @@ public interface ConnectionPool
 {
     CompletionStage<Connection> acquire( BoltServerAddress address );
 
-    void purge( BoltServerAddress address );
-
     void retainAll( Set<BoltServerAddress> addressesToRetain );
-
-    boolean hasAddress( BoltServerAddress address );
 
     int activeConnections( BoltServerAddress address );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -45,6 +45,10 @@ public final class Futures
         {
             result.complete( future.getNow() );
         }
+        else if ( future.cause() != null )
+        {
+            result.completeExceptionally( future.cause() );
+        }
         else
         {
             future.addListener( ignore ->

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
@@ -46,8 +46,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -136,44 +134,6 @@ public class ConnectionPoolImplTest
             assertThat( e, instanceOf( IllegalStateException.class ) );
             assertThat( e.getMessage(), startsWith( "Pool closed" ) );
         }
-    }
-
-    @Test
-    public void shouldPurgeAddressWithConnections()
-    {
-        Connection connection1 = await( pool.acquire( neo4j.address() ) );
-        Connection connection2 = await( pool.acquire( neo4j.address() ) );
-        Connection connection3 = await( pool.acquire( neo4j.address() ) );
-
-        assertNotNull( connection1 );
-        assertNotNull( connection2 );
-        assertNotNull( connection3 );
-
-        assertEquals( 3, pool.activeConnections( neo4j.address() ) );
-
-        pool.purge( neo4j.address() );
-
-        assertEquals( 0, pool.activeConnections( neo4j.address() ) );
-    }
-
-    @Test
-    public void shouldPurgeAddressWithoutConnections()
-    {
-        assertEquals( 0, pool.activeConnections( neo4j.address() ) );
-
-        pool.purge( neo4j.address() );
-
-        assertEquals( 0, pool.activeConnections( neo4j.address() ) );
-    }
-
-    @Test
-    public void shouldCheckIfPoolHasAddress()
-    {
-        assertFalse( pool.hasAddress( neo4j.address() ) );
-
-        await( pool.acquire( neo4j.address() ) );
-
-        assertTrue( pool.hasAddress( neo4j.address() ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
@@ -19,14 +19,22 @@
 package org.neo4j.driver.internal.async.pool;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.BootstrapFactory;
+import org.neo4j.driver.internal.async.ChannelConnector;
 import org.neo4j.driver.internal.async.ChannelConnectorImpl;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
@@ -34,6 +42,8 @@ import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -43,11 +53,22 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
 public class ConnectionPoolImplTest
 {
+    private static final BoltServerAddress ADDRESS_1 = new BoltServerAddress( "server:1" );
+    private static final BoltServerAddress ADDRESS_2 = new BoltServerAddress( "server:2" );
+    private static final BoltServerAddress ADDRESS_3 = new BoltServerAddress( "server:3" );
+
     @Rule
     public final TestNeo4j neo4j = new TestNeo4j();
 
@@ -60,13 +81,13 @@ public class ConnectionPoolImplTest
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown()
     {
         pool.close();
     }
 
     @Test
-    public void shouldAcquireConnectionWhenPoolIsEmpty() throws Exception
+    public void shouldAcquireConnectionWhenPoolIsEmpty()
     {
         Connection connection = await( pool.acquire( neo4j.address() ) );
 
@@ -74,7 +95,7 @@ public class ConnectionPoolImplTest
     }
 
     @Test
-    public void shouldAcquireIdleConnection() throws Exception
+    public void shouldAcquireIdleConnection()
     {
         Connection connection1 = await( pool.acquire( neo4j.address() ) );
         await( connection1.release() );
@@ -84,7 +105,7 @@ public class ConnectionPoolImplTest
     }
 
     @Test
-    public void shouldFailToAcquireConnectionToWrongAddress() throws Exception
+    public void shouldFailToAcquireConnectionToWrongAddress()
     {
         try
         {
@@ -99,7 +120,7 @@ public class ConnectionPoolImplTest
     }
 
     @Test
-    public void shouldFailToAcquireWhenPoolClosed() throws Exception
+    public void shouldFailToAcquireWhenPoolClosed()
     {
         Connection connection = await( pool.acquire( neo4j.address() ) );
         await( connection.release() );
@@ -162,15 +183,115 @@ public class ConnectionPoolImplTest
         assertTrue( pool.close().toCompletableFuture().isDone() );
     }
 
+    @Test
+    public void shouldDoNothingWhenRetainOnEmptyPool()
+    {
+        ActiveChannelTracker activeChannelTracker = mock( ActiveChannelTracker.class );
+        TestConnectionPool pool = new TestConnectionPool( activeChannelTracker );
+
+        pool.retainAll( singleton( LOCAL_DEFAULT ) );
+
+        verifyZeroInteractions( activeChannelTracker );
+    }
+
+    @Test
+    public void shouldRetainSpecifiedAddresses()
+    {
+        ActiveChannelTracker activeChannelTracker = mock( ActiveChannelTracker.class );
+        TestConnectionPool pool = new TestConnectionPool( activeChannelTracker );
+
+        pool.acquire( ADDRESS_1 );
+        pool.acquire( ADDRESS_2 );
+        pool.acquire( ADDRESS_3 );
+
+        pool.retainAll( new HashSet<>( asList( ADDRESS_1, ADDRESS_2, ADDRESS_3 ) ) );
+        for ( ChannelPool channelPool : pool.channelPoolsByAddress.values() )
+        {
+            verify( channelPool, never() ).close();
+        }
+    }
+
+    @Test
+    public void shouldClosePoolsWhenRetaining()
+    {
+        ActiveChannelTracker activeChannelTracker = mock( ActiveChannelTracker.class );
+        TestConnectionPool pool = new TestConnectionPool( activeChannelTracker );
+
+        pool.acquire( ADDRESS_1 );
+        pool.acquire( ADDRESS_2 );
+        pool.acquire( ADDRESS_3 );
+
+        when( activeChannelTracker.activeChannelCount( ADDRESS_1 ) ).thenReturn( 2 );
+        when( activeChannelTracker.activeChannelCount( ADDRESS_2 ) ).thenReturn( 0 );
+        when( activeChannelTracker.activeChannelCount( ADDRESS_3 ) ).thenReturn( 3 );
+
+        pool.retainAll( new HashSet<>( asList( ADDRESS_1, ADDRESS_3 ) ) );
+        verify( pool.getPool( ADDRESS_1 ), never() ).close();
+        verify( pool.getPool( ADDRESS_2 ) ).close();
+        verify( pool.getPool( ADDRESS_3 ), never() ).close();
+    }
+
+    @Test
+    public void shouldNotClosePoolsWithActiveConnectionsWhenRetaining()
+    {
+        ActiveChannelTracker activeChannelTracker = mock( ActiveChannelTracker.class );
+        TestConnectionPool pool = new TestConnectionPool( activeChannelTracker );
+
+        pool.acquire( ADDRESS_1 );
+        pool.acquire( ADDRESS_2 );
+        pool.acquire( ADDRESS_3 );
+
+        when( activeChannelTracker.activeChannelCount( ADDRESS_1 ) ).thenReturn( 1 );
+        when( activeChannelTracker.activeChannelCount( ADDRESS_2 ) ).thenReturn( 42 );
+        when( activeChannelTracker.activeChannelCount( ADDRESS_3 ) ).thenReturn( 0 );
+
+        pool.retainAll( singleton( ADDRESS_2 ) );
+        verify( pool.getPool( ADDRESS_1 ), never() ).close();
+        verify( pool.getPool( ADDRESS_2 ), never() ).close();
+        verify( pool.getPool( ADDRESS_3 ) ).close();
+    }
+
     private ConnectionPoolImpl newPool() throws Exception
     {
         FakeClock clock = new FakeClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( neo4j.authToken(), 5000 );
-        ChannelConnectorImpl connector =
-                new ChannelConnectorImpl( connectionSettings, SecurityPlan.forAllCertificates(),
+        ChannelConnector connector = new ChannelConnectorImpl( connectionSettings, SecurityPlan.forAllCertificates(),
                 DEV_NULL_LOGGING, clock );
-        PoolSettings poolSettings = new PoolSettings( 10, 5000, -1, -1 );
+        PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
         return new ConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_LOGGING, clock );
+    }
+
+    private static PoolSettings newSettings()
+    {
+        return new PoolSettings( 10, 5000, -1, -1 );
+    }
+
+    private static class TestConnectionPool extends ConnectionPoolImpl
+    {
+        final Map<BoltServerAddress,ChannelPool> channelPoolsByAddress = new HashMap<>();
+
+        TestConnectionPool( ActiveChannelTracker activeChannelTracker )
+        {
+            super( mock( ChannelConnector.class ), mock( Bootstrap.class ), activeChannelTracker, newSettings(),
+                    DEV_NULL_LOGGING, new FakeClock() );
+        }
+
+        ChannelPool getPool( BoltServerAddress address )
+        {
+            ChannelPool pool = channelPoolsByAddress.get( address );
+            assertNotNull( pool );
+            return pool;
+        }
+
+        @Override
+        ChannelPool newPool( BoltServerAddress address )
+        {
+            ChannelPool channelPool = mock( ChannelPool.class );
+            Channel channel = mock( Channel.class );
+            doReturn( ImmediateEventExecutor.INSTANCE.newSucceededFuture( channel ) ).when( channelPool ).acquire();
+            channelPoolsByAddress.put( address, channelPool );
+            return channelPool;
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
@@ -20,13 +20,11 @@ package org.neo4j.driver.internal.cluster;
 
 import org.junit.Test;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
-import static java.util.Collections.singleton;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -39,7 +37,7 @@ public class AddressSetTest
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
 
         AddressSet set = new AddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -48,7 +46,7 @@ public class AddressSetTest
 
         // when
         servers.add( new BoltServerAddress( "fyr" ) );
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         // then
         assertArrayEquals( new BoltServerAddress[]{
@@ -64,7 +62,7 @@ public class AddressSetTest
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
         AddressSet set = new AddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -86,7 +84,7 @@ public class AddressSetTest
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
         AddressSet set = new AddressSet();
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -95,27 +93,12 @@ public class AddressSetTest
 
         // when
         servers.remove( new BoltServerAddress( "one" ) );
-        set.update( servers, new HashSet<BoltServerAddress>() );
+        set.update( servers );
 
         // then
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "two" ),
                 new BoltServerAddress( "tre" )}, set.toArray() );
-    }
-
-    @Test
-    public void shouldRecordRemovedAddressesWhenUpdating() throws Exception
-    {
-        // given
-        AddressSet set = new AddressSet();
-        set.update( addresses( "one", "two", "tre" ), new HashSet<BoltServerAddress>() );
-
-        // when
-        HashSet<BoltServerAddress> removed = new HashSet<>();
-        set.update( addresses( "one", "two", "fyr" ), removed );
-
-        // then
-        assertEquals( singleton( new BoltServerAddress( "tre" ) ), removed );
     }
 
     @Test
@@ -132,7 +115,7 @@ public class AddressSetTest
     public void shouldExposeCorrectArray()
     {
         AddressSet addressSet = new AddressSet();
-        addressSet.update( addresses( "one", "two", "tre" ), new HashSet<BoltServerAddress>() );
+        addressSet.update( addresses( "one", "two", "tre" ) );
 
         BoltServerAddress[] addresses = addressSet.toArray();
 
@@ -154,7 +137,7 @@ public class AddressSetTest
     public void shouldHaveCorrectSize()
     {
         AddressSet addressSet = new AddressSet();
-        addressSet.update( addresses( "one", "two" ), new HashSet<BoltServerAddress>() );
+        addressSet.update( addresses( "one", "two" ) );
 
         assertEquals( 2, addressSet.size() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
@@ -398,7 +397,7 @@ public class RediscoveryTest
     {
         RoutingTable routingTable = mock( RoutingTable.class );
         AddressSet addressSet = new AddressSet();
-        addressSet.update( asOrderedSet( routers ), new HashSet<>() );
+        addressSet.update( asOrderedSet( routers ) );
         when( routingTable.routers() ).thenReturn( addressSet );
         return routingTable;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal.cluster.loadbalancing;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -41,6 +40,7 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -61,6 +61,9 @@ import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.C;
+import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.D;
+import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.E;
+import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.F;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.AccessMode.WRITE;
@@ -78,10 +81,10 @@ public class LoadBalancerTest
         BoltServerAddress writer1 = new BoltServerAddress( "writer-1", 4 );
         BoltServerAddress router1 = new BoltServerAddress( "router-1", 5 );
 
-        ConnectionPool connectionPool = newAsyncConnectionPoolMock();
+        ConnectionPool connectionPool = newConnectionPoolMock();
         ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock(), initialRouter );
 
-        Set<BoltServerAddress> readers = new LinkedHashSet<>( Arrays.asList( reader1, reader2 ) );
+        Set<BoltServerAddress> readers = new LinkedHashSet<>( asList( reader1, reader2 ) );
         Set<BoltServerAddress> writers = new LinkedHashSet<>( singletonList( writer1 ) );
         Set<BoltServerAddress> routers = new LinkedHashSet<>( singletonList( router1 ) );
         ClusterComposition clusterComposition = new ClusterComposition( 42, readers, writers, routers );
@@ -98,36 +101,6 @@ public class LoadBalancerTest
         assertArrayEquals( new BoltServerAddress[]{reader1, reader2}, routingTable.readers().toArray() );
         assertArrayEquals( new BoltServerAddress[]{writer1}, routingTable.writers().toArray() );
         assertArrayEquals( new BoltServerAddress[]{router1}, routingTable.routers().toArray() );
-    }
-
-    @Test
-    public void acquireShouldPurgeConnectionsWhenKnownRoutingTableIsStale()
-    {
-        BoltServerAddress initialRouter1 = new BoltServerAddress( "initialRouter-1", 1 );
-        BoltServerAddress initialRouter2 = new BoltServerAddress( "initialRouter-2", 1 );
-        BoltServerAddress reader = new BoltServerAddress( "reader", 2 );
-        BoltServerAddress writer = new BoltServerAddress( "writer", 3 );
-        BoltServerAddress router = new BoltServerAddress( "router", 4 );
-
-        ConnectionPool connectionPool = newAsyncConnectionPoolMock();
-        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock(), initialRouter1, initialRouter2 );
-
-        Set<BoltServerAddress> readers = new HashSet<>( singletonList( reader ) );
-        Set<BoltServerAddress> writers = new HashSet<>( singletonList( writer ) );
-        Set<BoltServerAddress> routers = new HashSet<>( singletonList( router ) );
-        ClusterComposition clusterComposition = new ClusterComposition( 42, readers, writers, routers );
-        Rediscovery rediscovery = mock( Rediscovery.class );
-        when( rediscovery.lookupClusterComposition( routingTable, connectionPool ) )
-                .thenReturn( completedFuture( clusterComposition ) );
-
-        LoadBalancer loadBalancer = new LoadBalancer( connectionPool, routingTable, rediscovery,
-                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
-
-        assertNotNull( await( loadBalancer.acquireConnection( READ ) ) );
-
-        verify( rediscovery ).lookupClusterComposition( routingTable, connectionPool );
-        verify( connectionPool ).purge( initialRouter1 );
-        verify( connectionPool ).purge( initialRouter2 );
     }
 
     @Test
@@ -157,7 +130,7 @@ public class LoadBalancerTest
     @Test
     public void shouldThrowWhenRediscoveryReturnsNoSuitableServers()
     {
-        ConnectionPool connectionPool = newAsyncConnectionPoolMock();
+        ConnectionPool connectionPool = newConnectionPoolMock();
         RoutingTable routingTable = mock( RoutingTable.class );
         when( routingTable.isStaleFor( any( AccessMode.class ) ) ).thenReturn( true );
         Rediscovery rediscovery = mock( Rediscovery.class );
@@ -196,7 +169,7 @@ public class LoadBalancerTest
     @Test
     public void shouldSelectLeastConnectedAddress()
     {
-        ConnectionPool connectionPool = newAsyncConnectionPoolMock();
+        ConnectionPool connectionPool = newConnectionPoolMock();
 
         when( connectionPool.activeConnections( A ) ).thenReturn( 0 );
         when( connectionPool.activeConnections( B ) ).thenReturn( 20 );
@@ -221,13 +194,13 @@ public class LoadBalancerTest
 
         // server B should never be selected because it has many active connections
         assertEquals( 2, seenAddresses.size() );
-        assertTrue( seenAddresses.containsAll( Arrays.asList( A, C ) ) );
+        assertTrue( seenAddresses.containsAll( asList( A, C ) ) );
     }
 
     @Test
     public void shouldRoundRobinWhenNoActiveConnections()
     {
-        ConnectionPool connectionPool = newAsyncConnectionPoolMock();
+        ConnectionPool connectionPool = newConnectionPoolMock();
 
         RoutingTable routingTable = mock( RoutingTable.class );
         AddressSet readerAddresses = mock( AddressSet.class );
@@ -247,7 +220,7 @@ public class LoadBalancerTest
         }
 
         assertEquals( 3, seenAddresses.size() );
-        assertTrue( seenAddresses.containsAll( Arrays.asList( A, B, C ) ) );
+        assertTrue( seenAddresses.containsAll( asList( A, B, C ) ) );
     }
 
     @Test
@@ -272,6 +245,51 @@ public class LoadBalancerTest
         assertEquals( B, connection.serverAddress() );
         // routing table should've forgotten A
         assertArrayEquals( new BoltServerAddress[]{B}, routingTable.readers().toArray() );
+    }
+
+    @Test
+    public void shouldRemoveAddressFromRoutingTableOnConnectionFailure()
+    {
+        RoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+        routingTable.update( new ClusterComposition(
+                42, asOrderedSet( A, B, C ), asOrderedSet( A, C, E ), asOrderedSet( B, D, F ) ) );
+
+        LoadBalancer loadBalancer = new LoadBalancer( newConnectionPoolMock(), routingTable, newRediscoveryMock(),
+                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
+
+        loadBalancer.onConnectionFailure( B );
+
+        assertArrayEquals( new BoltServerAddress[]{A, C}, routingTable.readers().toArray() );
+        assertArrayEquals( new BoltServerAddress[]{A, C, E}, routingTable.writers().toArray() );
+        assertArrayEquals( new BoltServerAddress[]{D, F}, routingTable.routers().toArray() );
+
+        loadBalancer.onConnectionFailure( A );
+
+        assertArrayEquals( new BoltServerAddress[]{C}, routingTable.readers().toArray() );
+        assertArrayEquals( new BoltServerAddress[]{C, E}, routingTable.writers().toArray() );
+        assertArrayEquals( new BoltServerAddress[]{D, F}, routingTable.routers().toArray() );
+    }
+
+    @Test
+    public void shouldRetainAllFetchedAddressesInConnectionPoolAfterFetchingOfRoutingTable()
+    {
+        RoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+        routingTable.update( new ClusterComposition(
+                42, asOrderedSet(), asOrderedSet( B, C ), asOrderedSet( D, E ) ) );
+
+        ConnectionPool connectionPool = newConnectionPoolMock();
+
+        Rediscovery rediscovery = newRediscoveryMock();
+        when( rediscovery.lookupClusterComposition( any(), any() ) ).thenReturn( completedFuture(
+                new ClusterComposition( 42, asOrderedSet( A, B ), asOrderedSet( B, C ), asOrderedSet( A, C ) ) ) );
+
+        LoadBalancer loadBalancer = new LoadBalancer( connectionPool, routingTable, rediscovery,
+                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
+
+        Connection connection = await( loadBalancer.acquireConnection( READ ) );
+        assertNotNull( connection );
+
+        verify( connectionPool ).retainAll( new HashSet<>( asList( A, B, C ) ) );
     }
 
     private void testRediscoveryWhenStale( AccessMode mode )
@@ -313,10 +331,9 @@ public class LoadBalancerTest
     {
         RoutingTable routingTable = mock( RoutingTable.class );
         when( routingTable.isStaleFor( mode ) ).thenReturn( true );
-        when( routingTable.update( any( ClusterComposition.class ) ) ).thenReturn( new HashSet<>() );
 
         AddressSet addresses = new AddressSet();
-        addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ), new HashSet<>() );
+        addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ) );
         when( routingTable.readers() ).thenReturn( addresses );
         when( routingTable.writers() ).thenReturn( addresses );
 
@@ -333,7 +350,7 @@ public class LoadBalancerTest
         return rediscovery;
     }
 
-    private static ConnectionPool newAsyncConnectionPoolMock()
+    private static ConnectionPool newConnectionPoolMock()
     {
         return newConnectionPoolMockWithFailures( emptySet() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -71,21 +71,9 @@ public class FailingConnectionDriverFactory extends DriverFactory
         }
 
         @Override
-        public void purge( BoltServerAddress address )
-        {
-            delegate.purge( address );
-        }
-
-        @Override
         public void retainAll( Set<BoltServerAddress> addressesToRetain )
         {
             delegate.retainAll( addressesToRetain );
-        }
-
-        @Override
-        public boolean hasAddress( BoltServerAddress address )
-        {
-            return delegate.hasAddress( address );
         }
 
         @Override

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import io.netty.bootstrap.Bootstrap;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.ConnectionPool;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Value;
+
+public class FailingConnectionDriverFactory extends DriverFactory
+{
+    private final AtomicReference<Throwable> nextRunFailure = new AtomicReference<>();
+
+    @Override
+    protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
+            Config config )
+    {
+        ConnectionPool pool = super.createConnectionPool( authToken, securityPlan, bootstrap, config );
+        return new ConnectionPoolWithFailingConnections( pool, nextRunFailure );
+    }
+
+    public void setNextRunFailure( Throwable failure )
+    {
+        nextRunFailure.set( failure );
+    }
+
+    private static class ConnectionPoolWithFailingConnections implements ConnectionPool
+    {
+        final ConnectionPool delegate;
+        final AtomicReference<Throwable> nextRunFailure;
+
+        ConnectionPoolWithFailingConnections( ConnectionPool delegate, AtomicReference<Throwable> nextRunFailure )
+        {
+            this.delegate = delegate;
+            this.nextRunFailure = nextRunFailure;
+        }
+
+        @Override
+        public CompletionStage<Connection> acquire( BoltServerAddress address )
+        {
+            return delegate.acquire( address )
+                    .thenApply( connection -> new FailingConnection( connection, nextRunFailure ) );
+        }
+
+        @Override
+        public void purge( BoltServerAddress address )
+        {
+            delegate.purge( address );
+        }
+
+        @Override
+        public void retainAll( Set<BoltServerAddress> addressesToRetain )
+        {
+            delegate.retainAll( addressesToRetain );
+        }
+
+        @Override
+        public boolean hasAddress( BoltServerAddress address )
+        {
+            return delegate.hasAddress( address );
+        }
+
+        @Override
+        public int activeConnections( BoltServerAddress address )
+        {
+            return delegate.activeConnections( address );
+        }
+
+        @Override
+        public CompletionStage<Void> close()
+        {
+            return delegate.close();
+        }
+    }
+
+    private static class FailingConnection implements Connection
+    {
+        final Connection delegate;
+        final AtomicReference<Throwable> nextRunFailure;
+
+        FailingConnection( Connection delegate, AtomicReference<Throwable> nextRunFailure )
+        {
+            this.delegate = delegate;
+            this.nextRunFailure = nextRunFailure;
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public void enableAutoRead()
+        {
+            delegate.enableAutoRead();
+        }
+
+        @Override
+        public void disableAutoRead()
+        {
+            delegate.disableAutoRead();
+        }
+
+        @Override
+        public void run( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
+                ResponseHandler pullAllHandler )
+        {
+            if ( tryFail( runHandler, pullAllHandler ) )
+            {
+                return;
+            }
+            delegate.run( statement, parameters, runHandler, pullAllHandler );
+        }
+
+        @Override
+        public void runAndFlush( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
+                ResponseHandler pullAllHandler )
+        {
+            if ( tryFail( runHandler, pullAllHandler ) )
+            {
+                return;
+            }
+            delegate.runAndFlush( statement, parameters, runHandler, pullAllHandler );
+        }
+
+        @Override
+        public CompletionStage<Void> release()
+        {
+            return delegate.release();
+        }
+
+        @Override
+        public BoltServerAddress serverAddress()
+        {
+            return delegate.serverAddress();
+        }
+
+        @Override
+        public ServerVersion serverVersion()
+        {
+            return delegate.serverVersion();
+        }
+
+        private boolean tryFail( ResponseHandler runHandler, ResponseHandler pullAllHandler )
+        {
+            Throwable failure = nextRunFailure.getAndSet( null );
+            if ( failure != null )
+            {
+                runHandler.onFailure( failure );
+                pullAllHandler.onFailure( failure );
+                return true;
+            }
+            return false;
+        }
+    }
+}
+

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.ChannelTrackingDriverFactory;
+import org.neo4j.driver.internal.util.FailingConnectionDriverFactory;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.AuthToken;
@@ -579,6 +580,70 @@ public class CausalClusteringIT
         }
     }
 
+    @Test
+    public void shouldAllowExistingTransactionToCompleteAfterDifferentConnectionBreaks()
+    {
+        Cluster cluster = clusterRule.getCluster();
+        ClusterMember leader = cluster.leader();
+
+        FailingConnectionDriverFactory driverFactory = new FailingConnectionDriverFactory();
+        RoutingSettings routingSettings = new RoutingSettings( 1, SECONDS.toMillis( 5 ), null );
+        Config config = Config.build().toConfig();
+
+        try ( Driver driver = driverFactory.newInstance( leader.getRoutingUri(), clusterRule.getDefaultAuthToken(),
+                routingSettings, RetrySettings.DEFAULT, config ) )
+        {
+            Session session1 = driver.session();
+            Transaction tx1 = session1.beginTransaction();
+            tx1.run( "CREATE (n:Node1 {name: 'Node1'})" ).consume();
+
+            Session session2 = driver.session();
+            Transaction tx2 = session2.beginTransaction();
+            tx2.run( "CREATE (n:Node2 {name: 'Node2'})" ).consume();
+
+            ServiceUnavailableException error = new ServiceUnavailableException( "Connection broke!" );
+            driverFactory.setNextRunFailure( error );
+            assertUnableToRunMoreStatementsInTx( tx2, error );
+
+            closeTx( tx2 );
+            closeTx( tx1 );
+
+            try ( Session session3 = driver.session( session1.lastBookmark() ) )
+            {
+                // tx1 should not be terminated and should commit successfully
+                assertEquals( 1, countNodes( session3, "Node1", "name", "Node1" ) );
+                // tx2 should not commit because of a connection failure
+                assertEquals( 0, countNodes( session3, "Node2", "name", "Node2" ) );
+            }
+
+            // rediscovery should happen for the new write query
+            String session4Bookmark = createNodeAndGetBookmark( driver.session(), "Node3", "name", "Node3" );
+            try ( Session session5 = driver.session( session4Bookmark ) )
+            {
+                assertEquals( 1, countNodes( session5, "Node3", "name", "Node3" ) );
+            }
+        }
+    }
+
+    private static void closeTx( Transaction tx )
+    {
+        tx.success();
+        tx.close();
+    }
+
+    private static void assertUnableToRunMoreStatementsInTx( Transaction tx, ServiceUnavailableException cause )
+    {
+        try
+        {
+            tx.run( "CREATE (n:Node3 {name: 'Node3'})" ).consume();
+            fail( "Exception expected" );
+        }
+        catch ( SessionExpiredException e )
+        {
+            assertEquals( cause, e.getCause() );
+        }
+    }
+
     private CompletionStage<List<RecordAndSummary>> combineCursors( StatementResultCursor cursor1,
             StatementResultCursor cursor2 )
     {
@@ -814,44 +879,33 @@ public class CausalClusteringIT
         }
     }
 
-    private static int countNodes( Session session, final String label, final String property, final String value )
+    private static int countNodes( Session session, String label, String property, String value )
     {
-        return session.readTransaction( new TransactionWork<Integer>()
+        return session.readTransaction( tx ->
         {
-            @Override
-            public Integer execute( Transaction tx )
-            {
-                StatementResult result = tx.run( "MATCH (n:" + label + " {" + property + ": $value}) RETURN count(n)",
-                        parameters( "value", value ) );
-                return result.single().get( 0 ).asInt();
-            }
+            String query = "MATCH (n:" + label + " {" + property + ": $value}) RETURN count(n)";
+            StatementResult result = tx.run( query, parameters( "value", value ) );
+            return result.single().get( 0 ).asInt();
         } );
     }
 
-    private static Callable<String> createNodeAndGetBookmark( final Driver driver, final String label,
-            final String property, final String value )
+    private static Callable<String> createNodeAndGetBookmark( Driver driver, String label, String property,
+            String value )
     {
-        return new Callable<String>()
+        return () -> createNodeAndGetBookmark( driver.session(), label, property, value );
+    }
+
+    private static String createNodeAndGetBookmark( Session session, String label, String property, String value )
+    {
+        try ( Session localSession = session )
         {
-            @Override
-            public String call()
+            localSession.writeTransaction( tx ->
             {
-                try ( Session session = driver.session() )
-                {
-                    session.writeTransaction( new TransactionWork<Void>()
-                    {
-                        @Override
-                        public Void execute( Transaction tx )
-                        {
-                            tx.run( "CREATE (n:" + label + ") SET n." + property + " = $value",
-                                    parameters( "value", value ) );
-                            return null;
-                        }
-                    } );
-                    return session.lastBookmark();
-                }
-            }
-        };
+                tx.run( "CREATE (n:" + label + ") SET n." + property + " = $value", parameters( "value", value ) );
+                return null;
+            } );
+            return localSession.lastBookmark();
+        }
     }
 
     private static class RecordAndSummary

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -52,6 +52,12 @@ public final class TestUtil
     {
     }
 
+    @SafeVarargs
+    public static <T> List<T> awaitAll( CompletionStage<T>... stages )
+    {
+        return awaitAll( Arrays.asList( stages ) );
+    }
+
     public static <T> List<T> awaitAll( List<CompletionStage<T>> stages )
     {
         List<T> result = new ArrayList<>();


### PR DESCRIPTION
Previously routing driver terminated all connections towards a particular address when one of active connections had a network error. Connections were also terminated when new routing table did not contain some address that was present in the previous routing table. Such behaviour might be problematic because it results in terminated queries. Network errors might have been temporary but always resulted in termination of active queries.

This PR makes driver keep connections towards machine that had failure but remove it from the routing table. This is done to prevent subsequent queries from using it until rediscovery. After rediscovery address can either appear again in the routing procedure response or not. If it is returned then driver will re-add it to routing table and old pool with all connections will be reused. If address is missing from routing table and pool has no active connections then driver will close the pool.