### PR TITLE
Redirect netty logging to driver logging

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -37,7 +37,7 @@ import org.neo4j.driver.internal.cluster.loadbalancing.LeastConnectedLoadBalanci
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancingStrategy;
 import org.neo4j.driver.internal.cluster.loadbalancing.RoundRobinLoadBalancingStrategy;
-import org.neo4j.driver.internal.logging.DelegateLogging;
+import org.neo4j.driver.internal.logging.NettyLogging;
 import org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -71,7 +71,7 @@ public class DriverFactory
         RoutingSettings newRoutingSettings = routingSettings.withRoutingContext( new RoutingContext( uri ) );
         SecurityPlan securityPlan = createSecurityPlan( address, config );
 
-        InternalLoggerFactory.setDefaultFactory( new DelegateLogging( config.logging() ) );
+        InternalLoggerFactory.setDefaultFactory( new NettyLogging( config.logging() ) );
         Bootstrap bootstrap = createBootstrap();
         EventExecutorGroup eventExecutorGroup = bootstrap.config().group();
         RetryLogic retryLogic = createRetryLogic( retrySettings, eventExecutorGroup, config.logging() );

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -36,6 +37,7 @@ import org.neo4j.driver.internal.cluster.loadbalancing.LeastConnectedLoadBalanci
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancingStrategy;
 import org.neo4j.driver.internal.cluster.loadbalancing.RoundRobinLoadBalancingStrategy;
+import org.neo4j.driver.internal.logging.DelegateLogging;
 import org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -69,6 +71,7 @@ public class DriverFactory
         RoutingSettings newRoutingSettings = routingSettings.withRoutingContext( new RoutingContext( uri ) );
         SecurityPlan securityPlan = createSecurityPlan( address, config );
 
+        InternalLoggerFactory.setDefaultFactory( new DelegateLogging( config.logging() ) );
         Bootstrap bootstrap = createBootstrap();
         EventExecutorGroup eventExecutorGroup = bootstrap.config().group();
         RetryLogic retryLogic = createRetryLogic( retrySettings, eventExecutorGroup, config.logging() );

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -112,7 +112,7 @@ public class InternalDriver implements Driver
     {
         if ( closed.compareAndSet( false, true ) )
         {
-            log.info( "Driver instance is closing" );
+            log.info( "Closing driver instance %s", this );
             return sessionFactory.close();
         }
         return completedFuture( null );

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -44,6 +44,7 @@ public class InternalDriver implements Driver
         this.securityPlan = securityPlan;
         this.sessionFactory = sessionFactory;
         this.log = logging.getLog( Driver.class.getSimpleName() );
+        log.info( "Driver instance %s created", this );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/BoltProtocolV1Util.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/BoltProtocolV1Util.java
@@ -24,7 +24,7 @@ import static io.netty.buffer.Unpooled.copyInt;
 import static io.netty.buffer.Unpooled.copyShort;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 
-public final class ProtocolUtil
+public final class BoltProtocolV1Util
 {
     public static final int HTTP = 1213486160; //== 0x48545450 == "HTTP"
 
@@ -36,24 +36,30 @@ public final class ProtocolUtil
 
     public static final int DEFAULT_MAX_OUTBOUND_CHUNK_SIZE_BYTES = Short.MAX_VALUE / 2;
 
-    private static final ByteBuf HANDSHAKE_BUF = unreleasableBuffer( copyInt(
+    private static final ByteBuf BOLT_V1_HANDSHAKE_BUF = unreleasableBuffer( copyInt(
             BOLT_MAGIC_PREAMBLE,
             PROTOCOL_VERSION_1,
             NO_PROTOCOL_VERSION,
             NO_PROTOCOL_VERSION,
-            NO_PROTOCOL_VERSION ) ).asReadOnly();
+            NO_PROTOCOL_VERSION ) )
+            .asReadOnly();
 
     private static final ByteBuf MESSAGE_BOUNDARY_BUF = unreleasableBuffer( copyShort( 0 ) ).asReadOnly();
 
     private static final ByteBuf CHUNK_HEADER_PLACEHOLDER_BUF = unreleasableBuffer( copyShort( 0 ) ).asReadOnly();
 
-    private ProtocolUtil()
+    private BoltProtocolV1Util()
     {
     }
 
-    public static ByteBuf handshake()
+    public static ByteBuf handshakeBuf()
     {
-        return HANDSHAKE_BUF.duplicate();
+        return BOLT_V1_HANDSHAKE_BUF.duplicate();
+    }
+
+    public static String handshakeString()
+    {
+        return "[0x6060B017, 1, 0, 0, 0]";
     }
 
     public static ByteBuf messageBoundary()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectorImpl.java
@@ -71,7 +71,7 @@ public class ChannelConnectorImpl implements ChannelConnector
     public ChannelFuture connect( BoltServerAddress address, Bootstrap bootstrap )
     {
         bootstrap.option( ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis );
-        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, clock ) );
+        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, clock, logging ) );
 
         ChannelFuture channelConnected = bootstrap.connect( address.toSocketAddress() );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeHandler.java
@@ -28,7 +28,7 @@ import io.netty.handler.codec.ReplayingDecoder;
 import java.util.List;
 import javax.net.ssl.SSLHandshakeException;
 
-import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
 import org.neo4j.driver.internal.util.ErrorUtil;
@@ -38,9 +38,9 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.SecurityException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
-import static org.neo4j.driver.internal.async.ProtocolUtil.HTTP;
-import static org.neo4j.driver.internal.async.ProtocolUtil.NO_PROTOCOL_VERSION;
-import static org.neo4j.driver.internal.async.ProtocolUtil.PROTOCOL_VERSION_1;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.HTTP;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.NO_PROTOCOL_VERSION;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.PROTOCOL_VERSION_1;
 
 public class HandshakeHandler extends ReplayingDecoder<Void>
 {
@@ -62,7 +62,7 @@ public class HandshakeHandler extends ReplayingDecoder<Void>
     @Override
     public void handlerAdded( ChannelHandlerContext ctx )
     {
-        log = new PrefixedLogger( ctx.channel().toString(), logging, getClass() );
+        log = new ChannelActivityLogger( ctx.channel(), logging, getClass() );
     }
 
     @Override
@@ -112,7 +112,7 @@ public class HandshakeHandler extends ReplayingDecoder<Void>
     protected void decode( ChannelHandlerContext ctx, ByteBuf in, List<Object> out )
     {
         int serverSuggestedVersion = in.readInt();
-        log.debug( "Server suggested protocol version %s during handshake", serverSuggestedVersion );
+        log.debug( "S: [Bolt Handshake] %d", serverSuggestedVersion );
 
         ChannelPipeline pipeline = ctx.pipeline();
         // this is a one-time handler, remove it when protocol version has been read

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -29,23 +29,25 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.v1.Logging;
 
 import static org.neo4j.driver.internal.async.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
-import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 public class NettyChannelInitializer extends ChannelInitializer<Channel>
 {
     private final BoltServerAddress address;
     private final SecurityPlan securityPlan;
     private final Clock clock;
+    private final Logging logging;
 
-    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan, Clock clock )
+    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan, Clock clock, Logging logging )
     {
         this.address = address;
         this.securityPlan = securityPlan;
         this.clock = clock;
+        this.logging = logging;
     }
 
     @Override
@@ -78,6 +80,6 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
     {
         setServerAddress( channel, address );
         setCreationTimestamp( channel, clock.millis() );
-        setMessageDispatcher( channel, new InboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );
+        setMessageDispatcher( channel, new InboundMessageDispatcher( channel, logging ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
@@ -24,7 +24,7 @@ import io.netty.handler.codec.CodecException;
 
 import java.io.IOException;
 
-import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
 import org.neo4j.driver.internal.util.ErrorUtil;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
@@ -50,7 +50,7 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
     public void handlerAdded( ChannelHandlerContext ctx )
     {
         messageDispatcher = requireNonNull( messageDispatcher( ctx.channel() ) );
-        log = new PrefixedLogger( ctx.channel().toString(), logging, getClass() );
+        log = new ChannelActivityLogger( ctx.channel(), logging, getClass() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChunkDecoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChunkDecoder.java
@@ -19,14 +19,13 @@
 package org.neo4j.driver.internal.async.inbound;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
-import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
-
-import static io.netty.buffer.ByteBufUtil.prettyHexDump;
 
 public class ChunkDecoder extends LengthFieldBasedFrameDecoder
 {
@@ -48,7 +47,7 @@ public class ChunkDecoder extends LengthFieldBasedFrameDecoder
     @Override
     public void handlerAdded( ChannelHandlerContext ctx )
     {
-        log = new PrefixedLogger( ctx.channel().toString(), logging, getClass() );
+        log = new ChannelActivityLogger( ctx.channel(), logging, getClass() );
     }
 
     @Override
@@ -65,8 +64,8 @@ public class ChunkDecoder extends LengthFieldBasedFrameDecoder
             int originalReaderIndex = buffer.readerIndex();
             int readerIndexWithChunkHeader = originalReaderIndex - INITIAL_BYTES_TO_STRIP;
             int lengthWithChunkHeader = INITIAL_BYTES_TO_STRIP + buffer.readableBytes();
-            String hexDump = prettyHexDump( buffer, readerIndexWithChunkHeader, lengthWithChunkHeader );
-            log.trace( "S:\n%s", hexDump );
+            String hexDump = ByteBufUtil.hexDump( buffer, readerIndexWithChunkHeader, lengthWithChunkHeader );
+            log.trace( "S: %s", hexDump );
         }
         return super.extractFrame( ctx, buffer, index, length );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Queue;
 
 import org.neo4j.driver.internal.handlers.AckFailureResponseHandler;
-import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
 import org.neo4j.driver.internal.messaging.MessageHandler;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.ErrorUtil;
@@ -50,7 +50,7 @@ public class InboundMessageDispatcher implements MessageHandler
     public InboundMessageDispatcher( Channel channel, Logging logging )
     {
         this.channel = requireNonNull( channel );
-        this.log = new PrefixedLogger( channel.toString(), logging, getClass() );
+        this.log = new ChannelActivityLogger( channel, logging, getClass() );
     }
 
     public void queue( ResponseHandler handler )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/outbound/ChunkAwareByteBufOutput.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/outbound/ChunkAwareByteBufOutput.java
@@ -23,9 +23,9 @@ import io.netty.buffer.ByteBuf;
 import org.neo4j.driver.internal.packstream.PackOutput;
 
 import static java.util.Objects.requireNonNull;
-import static org.neo4j.driver.internal.async.ProtocolUtil.CHUNK_HEADER_SIZE_BYTES;
-import static org.neo4j.driver.internal.async.ProtocolUtil.DEFAULT_MAX_OUTBOUND_CHUNK_SIZE_BYTES;
-import static org.neo4j.driver.internal.async.ProtocolUtil.chunkHeaderPlaceholder;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.CHUNK_HEADER_SIZE_BYTES;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.DEFAULT_MAX_OUTBOUND_CHUNK_SIZE_BYTES;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.chunkHeaderPlaceholder;
 
 public class ChunkAwareByteBufOutput implements PackOutput
 {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandler.java
@@ -25,14 +25,14 @@ import io.netty.handler.codec.MessageToMessageEncoder;
 
 import java.util.List;
 
-import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
-import static io.netty.buffer.ByteBufUtil.prettyHexDump;
-import static org.neo4j.driver.internal.async.ProtocolUtil.messageBoundary;
+import static io.netty.buffer.ByteBufUtil.hexDump;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.messageBoundary;
 
 public class OutboundMessageHandler extends MessageToMessageEncoder<Message>
 {
@@ -61,7 +61,7 @@ public class OutboundMessageHandler extends MessageToMessageEncoder<Message>
     @Override
     public void handlerAdded( ChannelHandlerContext ctx )
     {
-        log = new PrefixedLogger( ctx.channel().toString(), logging, getClass() );
+        log = new ChannelActivityLogger( ctx.channel(), logging, getClass() );
     }
 
     @Override
@@ -92,7 +92,7 @@ public class OutboundMessageHandler extends MessageToMessageEncoder<Message>
 
         if ( log.isTraceEnabled() )
         {
-            log.trace( "C:\n%s", prettyHexDump( messageBuf ) );
+            log.trace( "C: %s", hexDump( messageBuf ) );
         }
 
         out.add( messageBuf );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
@@ -78,7 +78,7 @@ public class ConnectionPoolImpl implements ConnectionPool
     @Override
     public CompletionStage<Connection> acquire( BoltServerAddress address )
     {
-        log.debug( "Acquiring connection from pool towards %s", address );
+        log.trace( "Acquiring a connection from pool towards %s", address );
 
         assertNotClosed();
         ChannelPool pool = getOrCreatePool( address );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthChecker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthChecker.java
@@ -71,9 +71,11 @@ public class NettyChannelHealthChecker implements ChannelHealthChecker
             long maxAgeMillis = poolSettings.maxConnectionLifetime();
 
             boolean tooOld = ageMillis > maxAgeMillis;
-
-            log.trace( "Can't acquire channel %s from the pool because it is too old: %s > %s",
-                    channel, ageMillis, maxAgeMillis );
+            if ( tooOld )
+            {
+                log.trace( "Failed acquire channel %s from the pool because it is too old: %s > %s",
+                        channel, ageMillis, maxAgeMillis );
+            }
 
             return tooOld;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -72,7 +72,6 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
         }
 
         List<Record> records = response.records();
-        log.info( "Received response from %s procedure: %s", invokedProcedureString( response ), records );
 
         long now = clock.millis();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
@@ -138,7 +138,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler
         else if ( routingTable.isStaleFor( mode ) )
         {
             // existing routing table is not fresh and should be updated
-            log.info( "Routing information is stale. %s", routingTable );
+            log.info( "Routing table is stale. %s", routingTable );
 
             CompletableFuture<RoutingTable> resultFuture = new CompletableFuture<>();
             refreshRoutingTableFuture = resultFuture;
@@ -173,7 +173,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler
             routingTable.update( composition );
             connectionPool.retainAll( routingTable.servers() );
 
-            log.info( "Refreshed routing information. %s", routingTable );
+            log.info( "Updated routing table. %s", routingTable );
 
             CompletableFuture<RoutingTable> routingTableFuture = refreshRoutingTableFuture;
             refreshRoutingTableFuture = null;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ChannelActivityLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ChannelActivityLogger.java
@@ -18,30 +18,35 @@
  */
 package org.neo4j.driver.internal.logging;
 
+import io.netty.channel.Channel;
+
 import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
 
-public class PrefixedLogger extends ReformattedLogger
+import static java.lang.String.format;
+
+public class ChannelActivityLogger extends ReformattedLogger
 {
-    private final String messagePrefix;
+    private final Channel channel;
 
-    public PrefixedLogger( Logger delegate )
+    public ChannelActivityLogger( Channel channel, Logging logging, Class<?> owner )
     {
-        this( null, delegate );
+        this( channel, logging.getLog( owner.getSimpleName() ) );
     }
 
-    public PrefixedLogger( String messagePrefix, Logger delegate )
+    private ChannelActivityLogger( Channel channel, Logger delegate )
     {
-        super(delegate);
-        this.messagePrefix = messagePrefix;
+        super( delegate );
+        this.channel = channel;
     }
 
     @Override
     protected String reformat( String message )
     {
-        if ( messagePrefix == null )
+        if ( channel == null )
         {
             return message;
         }
-        return String.format( "%s %s", messagePrefix, message );
+        return format( "[0x%s] %s", channel.id(), message );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
@@ -94,10 +94,10 @@ public class ConsoleLogging implements Logging
             StringBuilder builder = new StringBuilder( 1000 );
             builder.append( dateFormat.format( new Date( record.getMillis() ) ) );
             builder.append(" ");
-            builder.append("[").append(record.getLoggerName()).append("] ");
-            // builder.append( "[" ).append( record.getSourceClassName() ).append( "." );
-            // builder.append( record.getSourceMethodName() ).append( "] - " );
-            // builder.append( "[" ).append( record.getLevel() ).append( "] - " );
+//            builder.append("[").append(record.getLoggerName()).append("] ");
+//            builder.append( "[" ).append( record.getSourceClassName() ).append( "." );
+//            builder.append( record.getSourceMethodName() ).append( "] - " );
+//            builder.append( "[" ).append( record.getLevel() ).append( "] - " );
             builder.append( formatMessage( record ) );
             builder.append( "\n" );
             return builder.toString();

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogger.java
@@ -55,19 +55,19 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void trace( String format, Object arg )
     {
-        log.trace( format, arg );
+        log.trace( toDriverLoggerFormat( format ), arg );
     }
 
     @Override
     public void trace( String format, Object argA, Object argB )
     {
-        log.trace( format, argA, argB );
+        log.trace( toDriverLoggerFormat( format ), argA, argB );
     }
 
     @Override
     public void trace( String format, Object... arguments )
     {
-        log.trace( format, arguments );
+        log.trace( toDriverLoggerFormat( format ), arguments );
     }
 
     @Override
@@ -97,19 +97,19 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void debug( String format, Object arg )
     {
-        log.debug( format, arg );
+        log.debug( toDriverLoggerFormat( format ), arg );
     }
 
     @Override
     public void debug( String format, Object argA, Object argB )
     {
-        log.debug( format, argA, argB );
+        log.debug( toDriverLoggerFormat( format ), argA, argB );
     }
 
     @Override
     public void debug( String format, Object... arguments )
     {
-        log.debug( format, arguments );
+        log.debug( toDriverLoggerFormat( format ), arguments );
     }
 
     @Override
@@ -139,19 +139,19 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void info( String format, Object arg )
     {
-        log.info( format, arg );
+        log.info( toDriverLoggerFormat( format ), arg );
     }
 
     @Override
     public void info( String format, Object argA, Object argB )
     {
-        log.info( format, argA, argB );
+        log.info( toDriverLoggerFormat( format ), argA, argB );
     }
 
     @Override
     public void info( String format, Object... arguments )
     {
-        log.info( format, arguments );
+        log.info( toDriverLoggerFormat( format ), arguments );
     }
 
     @Override
@@ -181,19 +181,19 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void warn( String format, Object arg )
     {
-        log.warn( format, arg );
+        log.warn( toDriverLoggerFormat( format ), arg );
     }
 
     @Override
     public void warn( String format, Object... arguments )
     {
-        log.warn( format, arguments );
+        log.warn( toDriverLoggerFormat( format ), arguments );
     }
 
     @Override
     public void warn( String format, Object argA, Object argB )
     {
-        log.warn( format, argA, argB );
+        log.warn( toDriverLoggerFormat( format ), argA, argB );
     }
 
     @Override
@@ -223,19 +223,32 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void error( String format, Object arg )
     {
-        error( format(format, arg) );
+        error( format, new Object[]{arg} );
     }
 
     @Override
     public void error( String format, Object argA, Object argB )
     {
-        error( format(format, argA, argB) );
+        error( format, new Object[]{argA, argB} );
     }
 
     @Override
     public void error( String format, Object... arguments )
     {
-        error( format(format, arguments) );
+        format = toDriverLoggerFormat(format);
+        if ( arguments.length == 0 )
+        {
+            log.error( format, null );
+            return;
+        }
+
+        Object arg = arguments[arguments.length - 1];
+        if ( arg instanceof Throwable )
+        {
+            // still give all arguments to string format,
+            // for the worst case, the redundant parameter will be ignored.
+            log.error( format(format, arguments), (Throwable) arg );
+        }
     }
 
     @Override
@@ -403,5 +416,10 @@ public class DelegateLogger implements InternalLogger
             error( t );
             break;
         }
+    }
+
+    private String toDriverLoggerFormat( String format )
+    {
+        return format.replaceAll( "\\{\\}", "%s" );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogger.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import io.netty.util.internal.logging.InternalLogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+
+import org.neo4j.driver.v1.Logger;
+
+import static java.lang.String.format;
+
+
+public class DelegateLogger implements InternalLogger
+{
+    private Logger log;
+    public DelegateLogger( Logger log )
+    {
+        this.log = log;
+    }
+
+    @Override
+    public String name()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return log.isTraceEnabled();
+    }
+
+    @Override
+    public void trace( String msg )
+    {
+        log.trace( msg );
+    }
+
+    @Override
+    public void trace( String format, Object arg )
+    {
+        log.trace( format, arg );
+    }
+
+    @Override
+    public void trace( String format, Object argA, Object argB )
+    {
+        log.trace( format, argA, argB );
+    }
+
+    @Override
+    public void trace( String format, Object... arguments )
+    {
+        log.trace( format, arguments );
+    }
+
+    @Override
+    public void trace( String msg, Throwable t )
+    {
+        log.trace( "%s%n%s", msg, t );
+    }
+
+    @Override
+    public void trace( Throwable t )
+    {
+        trace( t.getMessage(), t );
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public void debug( String msg )
+    {
+        log.debug( msg );
+    }
+
+    @Override
+    public void debug( String format, Object arg )
+    {
+        log.debug( format, arg );
+    }
+
+    @Override
+    public void debug( String format, Object argA, Object argB )
+    {
+        log.debug( format, argA, argB );
+    }
+
+    @Override
+    public void debug( String format, Object... arguments )
+    {
+        log.debug( format, arguments );
+    }
+
+    @Override
+    public void debug( String msg, Throwable t )
+    {
+        log.debug( "%s%n%s", msg, t );
+    }
+
+    @Override
+    public void debug( Throwable t )
+    {
+        debug( t.getMessage(), t );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void info( String msg )
+    {
+        log.info( msg );
+    }
+
+    @Override
+    public void info( String format, Object arg )
+    {
+        log.info( format, arg );
+    }
+
+    @Override
+    public void info( String format, Object argA, Object argB )
+    {
+        log.info( format, argA, argB );
+    }
+
+    @Override
+    public void info( String format, Object... arguments )
+    {
+        log.info( format, arguments );
+    }
+
+    @Override
+    public void info( String msg, Throwable t )
+    {
+        log.info( "%s%n%s", msg, t );
+    }
+
+    @Override
+    public void info( Throwable t )
+    {
+        info( t.getMessage(), t );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void warn( String msg )
+    {
+        log.warn( msg );
+    }
+
+    @Override
+    public void warn( String format, Object arg )
+    {
+        log.warn( format, arg );
+    }
+
+    @Override
+    public void warn( String format, Object... arguments )
+    {
+        log.warn( format, arguments );
+    }
+
+    @Override
+    public void warn( String format, Object argA, Object argB )
+    {
+        log.warn( format, argA, argB );
+    }
+
+    @Override
+    public void warn( String msg, Throwable t )
+    {
+        log.warn( "%s%n%s", msg, t );
+    }
+
+    @Override
+    public void warn( Throwable t )
+    {
+        warn( t.getMessage(), t );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void error( String msg )
+    {
+        log.error( msg, null );
+    }
+
+    @Override
+    public void error( String format, Object arg )
+    {
+        error( format(format, arg) );
+    }
+
+    @Override
+    public void error( String format, Object argA, Object argB )
+    {
+        error( format(format, argA, argB) );
+    }
+
+    @Override
+    public void error( String format, Object... arguments )
+    {
+        error( format(format, arguments) );
+    }
+
+    @Override
+    public void error( String msg, Throwable t )
+    {
+        log.error( msg, t );
+    }
+
+    @Override
+    public void error( Throwable t )
+    {
+        error( t.getMessage(), t );
+    }
+
+    @Override
+    public boolean isEnabled( InternalLogLevel level )
+    {
+        if ( level == InternalLogLevel.TRACE )
+        {
+            return isTraceEnabled();
+        }
+        else if ( level == InternalLogLevel.DEBUG )
+        {
+            return isDebugEnabled();
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, String msg )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( msg );
+            break;
+        case DEBUG:
+            debug( msg );
+            break;
+        case INFO:
+            info( msg );
+            break;
+        case WARN:
+            warn( msg );
+            break;
+        case ERROR:
+            error( msg );
+            break;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, String format, Object arg )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( format, arg );
+            break;
+        case DEBUG:
+            debug( format, arg );
+            break;
+        case INFO:
+            info( format, arg );
+            break;
+        case WARN:
+            warn( format, arg );
+            break;
+        case ERROR:
+            error( format, arg );
+            break;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, String format, Object argA, Object argB )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( format, argA, argB );
+            break;
+        case DEBUG:
+            debug( format, argA, argB );
+            break;
+        case INFO:
+            info( format, argA, argB );
+            break;
+        case WARN:
+            warn( format, argA, argB );
+            break;
+        case ERROR:
+            error( format, argA, argB );
+            break;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, String format, Object... arguments )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( format, arguments );
+            break;
+        case DEBUG:
+            debug( format, arguments );
+            break;
+        case INFO:
+            info( format, arguments );
+            break;
+        case WARN:
+            warn( format, arguments );
+            break;
+        case ERROR:
+            error( format, arguments );
+            break;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, String msg, Throwable t )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( msg, t );
+            break;
+        case DEBUG:
+            debug( msg, t );
+            break;
+        case INFO:
+            info( msg, t );
+            break;
+        case WARN:
+            warn( msg, t );
+            break;
+        case ERROR:
+            error( msg, t );
+            break;
+        }
+    }
+
+    @Override
+    public void log( InternalLogLevel level, Throwable t )
+    {
+        switch ( level )
+        {
+        case TRACE:
+            trace( t );
+            break;
+        case DEBUG:
+            debug( t );
+            break;
+        case INFO:
+            info( t );
+            break;
+        case WARN:
+            warn( t );
+            break;
+        case ERROR:
+            error( t );
+            break;
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DelegateLogging.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import org.neo4j.driver.v1.Logging;
+
+/**
+ * This is the logging factory to delegate netty's logging to our logging system
+ */
+public class DelegateLogging extends InternalLoggerFactory
+{
+    private Logging logging;
+
+    public DelegateLogging( Logging logging )
+    {
+        this.logging = logging;
+    }
+
+    @Override
+    protected InternalLogger newInstance( String name )
+    {
+        return new DelegateLogger( logging.getLog( name ) );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogger.java
@@ -18,26 +18,24 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import io.netty.util.internal.logging.InternalLogLevel;
-import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.AbstractInternalLogger;
+
+import java.util.regex.Pattern;
 
 import org.neo4j.driver.v1.Logger;
 
 import static java.lang.String.format;
 
 
-public class DelegateLogger implements InternalLogger
+public class NettyLogger extends AbstractInternalLogger
 {
     private Logger log;
-    public DelegateLogger( Logger log )
-    {
-        this.log = log;
-    }
+    private static final Pattern PLACE_HOLDER_PATTERN = Pattern.compile("\\{\\}");
 
-    @Override
-    public String name()
+    public NettyLogger( String name, Logger log )
     {
-        return null;
+        super( name );
+        this.log = log;
     }
 
     @Override
@@ -77,12 +75,6 @@ public class DelegateLogger implements InternalLogger
     }
 
     @Override
-    public void trace( Throwable t )
-    {
-        trace( t.getMessage(), t );
-    }
-
-    @Override
     public boolean isDebugEnabled()
     {
         return log.isDebugEnabled();
@@ -116,12 +108,6 @@ public class DelegateLogger implements InternalLogger
     public void debug( String msg, Throwable t )
     {
         log.debug( "%s%n%s", msg, t );
-    }
-
-    @Override
-    public void debug( Throwable t )
-    {
-        debug( t.getMessage(), t );
     }
 
     @Override
@@ -161,12 +147,6 @@ public class DelegateLogger implements InternalLogger
     }
 
     @Override
-    public void info( Throwable t )
-    {
-        info( t.getMessage(), t );
-    }
-
-    @Override
     public boolean isWarnEnabled()
     {
         return true;
@@ -203,12 +183,6 @@ public class DelegateLogger implements InternalLogger
     }
 
     @Override
-    public void warn( Throwable t )
-    {
-        warn( t.getMessage(), t );
-    }
-
-    @Override
     public boolean isErrorEnabled()
     {
         return true;
@@ -235,7 +209,7 @@ public class DelegateLogger implements InternalLogger
     @Override
     public void error( String format, Object... arguments )
     {
-        format = toDriverLoggerFormat(format);
+        format = toDriverLoggerFormat( format );
         if ( arguments.length == 0 )
         {
             log.error( format, null );
@@ -247,7 +221,7 @@ public class DelegateLogger implements InternalLogger
         {
             // still give all arguments to string format,
             // for the worst case, the redundant parameter will be ignored.
-            log.error( format(format, arguments), (Throwable) arg );
+            log.error( format( format, arguments ), (Throwable) arg );
         }
     }
 
@@ -257,169 +231,8 @@ public class DelegateLogger implements InternalLogger
         log.error( msg, t );
     }
 
-    @Override
-    public void error( Throwable t )
-    {
-        error( t.getMessage(), t );
-    }
-
-    @Override
-    public boolean isEnabled( InternalLogLevel level )
-    {
-        if ( level == InternalLogLevel.TRACE )
-        {
-            return isTraceEnabled();
-        }
-        else if ( level == InternalLogLevel.DEBUG )
-        {
-            return isDebugEnabled();
-        }
-        else
-        {
-            return true;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, String msg )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( msg );
-            break;
-        case DEBUG:
-            debug( msg );
-            break;
-        case INFO:
-            info( msg );
-            break;
-        case WARN:
-            warn( msg );
-            break;
-        case ERROR:
-            error( msg );
-            break;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, String format, Object arg )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( format, arg );
-            break;
-        case DEBUG:
-            debug( format, arg );
-            break;
-        case INFO:
-            info( format, arg );
-            break;
-        case WARN:
-            warn( format, arg );
-            break;
-        case ERROR:
-            error( format, arg );
-            break;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, String format, Object argA, Object argB )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( format, argA, argB );
-            break;
-        case DEBUG:
-            debug( format, argA, argB );
-            break;
-        case INFO:
-            info( format, argA, argB );
-            break;
-        case WARN:
-            warn( format, argA, argB );
-            break;
-        case ERROR:
-            error( format, argA, argB );
-            break;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, String format, Object... arguments )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( format, arguments );
-            break;
-        case DEBUG:
-            debug( format, arguments );
-            break;
-        case INFO:
-            info( format, arguments );
-            break;
-        case WARN:
-            warn( format, arguments );
-            break;
-        case ERROR:
-            error( format, arguments );
-            break;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, String msg, Throwable t )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( msg, t );
-            break;
-        case DEBUG:
-            debug( msg, t );
-            break;
-        case INFO:
-            info( msg, t );
-            break;
-        case WARN:
-            warn( msg, t );
-            break;
-        case ERROR:
-            error( msg, t );
-            break;
-        }
-    }
-
-    @Override
-    public void log( InternalLogLevel level, Throwable t )
-    {
-        switch ( level )
-        {
-        case TRACE:
-            trace( t );
-            break;
-        case DEBUG:
-            debug( t );
-            break;
-        case INFO:
-            info( t );
-            break;
-        case WARN:
-            warn( t );
-            break;
-        case ERROR:
-            error( t );
-            break;
-        }
-    }
-
     private String toDriverLoggerFormat( String format )
     {
-        return format.replaceAll( "\\{\\}", "%s" );
+        return PLACE_HOLDER_PATTERN.matcher( format ).replaceAll( "%s" );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogging.java
@@ -26,11 +26,11 @@ import org.neo4j.driver.v1.Logging;
 /**
  * This is the logging factory to delegate netty's logging to our logging system
  */
-public class DelegateLogging extends InternalLoggerFactory
+public class NettyLogging extends InternalLoggerFactory
 {
     private Logging logging;
 
-    public DelegateLogging( Logging logging )
+    public NettyLogging( Logging logging )
     {
         this.logging = logging;
     }
@@ -38,6 +38,6 @@ public class DelegateLogging extends InternalLoggerFactory
     @Override
     protected InternalLogger newInstance( String name )
     {
-        return new DelegateLogger( logging.getLog( name ) );
+        return new NettyLogger( name, logging.getLog( name ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ReformattedLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ReformattedLogger.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.neo4j.driver.v1.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class ReformattedLogger implements Logger
+{
+    private final Logger delegate;
+
+    protected ReformattedLogger(Logger delegate)
+    {
+        this.delegate = requireNonNull( delegate );
+    }
+
+    @Override
+    public void error( String message, Throwable cause )
+    {
+        delegate.error( reformat( message ), cause );
+    }
+
+    @Override
+    public void info( String message, Object... params )
+    {
+        delegate.info( reformat( message ), params );
+    }
+
+    @Override
+    public void warn( String message, Object... params )
+    {
+        delegate.warn( reformat( message ), params );
+    }
+
+    @Override
+    public void warn( String message, Throwable cause )
+    {
+        delegate.warn( reformat( message ), cause );
+    }
+
+    @Override
+    public void debug( String message, Object... params )
+    {
+        if ( isDebugEnabled() )
+        {
+            delegate.debug( reformat( message ), params );
+        }
+    }
+
+    @Override
+    public void trace( String message, Object... params )
+    {
+        if ( isTraceEnabled() )
+        {
+            delegate.trace( reformat( message ), params );
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return delegate.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return delegate.isDebugEnabled();
+    }
+
+    protected abstract String reformat( String message );
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
-import static org.neo4j.driver.internal.async.ProtocolUtil.handshake;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.handshakeBuf;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
@@ -85,7 +85,7 @@ public class ChannelConnectedListenerTest
 
         assertNotNull( channel.pipeline().get( HandshakeHandler.class ) );
         assertTrue( channel.finish() );
-        assertEquals( handshake(), channel.readOutbound() );
+        assertEquals( handshakeBuf(), channel.readOutbound() );
     }
 
     private static ChannelConnectedListener newListener( ChannelPromise handshakeCompletedPromise )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeHandlerTest.java
@@ -47,9 +47,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
-import static org.neo4j.driver.internal.async.ProtocolUtil.HTTP;
-import static org.neo4j.driver.internal.async.ProtocolUtil.NO_PROTOCOL_VERSION;
-import static org.neo4j.driver.internal.async.ProtocolUtil.PROTOCOL_VERSION_1;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.HTTP;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.NO_PROTOCOL_VERSION;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.PROTOCOL_VERSION_1;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
@@ -36,6 +36,7 @@ import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.async.ChannelAttributes.creationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
 import static org.neo4j.driver.internal.async.ChannelAttributes.serverAddress;
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 public class NettyChannelInitializerTest
 {
@@ -51,7 +52,8 @@ public class NettyChannelInitializerTest
     public void shouldAddSslHandlerWhenRequiresEncryption() throws Exception
     {
         SecurityPlan security = SecurityPlan.forAllCertificates();
-        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, new FakeClock() );
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, new FakeClock(),
+                DEV_NULL_LOGGING );
 
         initializer.initChannel( channel );
 
@@ -62,7 +64,8 @@ public class NettyChannelInitializerTest
     public void shouldNotAddSslHandlerWhenDoesNotRequireEncryption()
     {
         SecurityPlan security = SecurityPlan.insecure();
-        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, new FakeClock() );
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, new FakeClock(),
+                DEV_NULL_LOGGING );
 
         initializer.initChannel( channel );
 
@@ -75,7 +78,7 @@ public class NettyChannelInitializerTest
         Clock clock = mock( Clock.class );
         when( clock.millis() ).thenReturn( 42L );
         SecurityPlan security = SecurityPlan.insecure();
-        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, clock );
+        NettyChannelInitializer initializer = new NettyChannelInitializer( LOCAL_DEFAULT, security, clock, DEV_NULL_LOGGING );
 
         initializer.initChannel( channel );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ChunkDecoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ChunkDecoderTest.java
@@ -27,7 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
-import static io.netty.buffer.ByteBufUtil.prettyHexDump;
+import static io.netty.buffer.ByteBufUtil.hexDump;
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.buffer.Unpooled.copyShort;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -152,7 +152,7 @@ public class ChunkDecoderTest
         verify( logger ).trace( anyString(), messageCaptor.capture() );
 
         // pretty hex dump should be logged
-        assertEquals( prettyHexDump( buffer ), messageCaptor.getValue() );
+        assertEquals( hexDump( buffer ), messageCaptor.getValue() );
         // single empty chunk should be available for reading
         assertEquals( 1, channel.inboundMessages().size() );
         assertByteBufEquals( wrappedBuffer( new byte[0] ), channel.readInbound() );
@@ -176,7 +176,7 @@ public class ChunkDecoderTest
         verify( logger ).trace( anyString(), messageCaptor.capture() );
 
         // pretty hex dump should be logged
-        assertEquals( prettyHexDump( buffer ), messageCaptor.getValue() );
+        assertEquals( hexDump( buffer ), messageCaptor.getValue() );
         // single chunk should be available for reading
         assertEquals( 1, channel.inboundMessages().size() );
         assertByteBufEquals( wrappedBuffer( bytes ), channel.readInbound() );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/outbound/OutboundMessageHandlerTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.driver.internal.async.ProtocolUtil.messageBoundary;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.messageBoundary;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.messaging.MessageFormat.Writer;
 import static org.neo4j.driver.internal.messaging.PullAllMessage.PULL_ALL;

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/MessageFormatTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
-import static org.neo4j.driver.internal.async.ProtocolUtil.messageBoundary;
+import static org.neo4j.driver.internal.async.BoltProtocolV1Util.messageBoundary;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.Values.EmptyMap;
 import static org.neo4j.driver.v1.Values.ofValue;

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -26,9 +26,12 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 
@@ -55,6 +58,8 @@ public class Neo4jRunner
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final URI DEFAULT_URI = URI.create( "bolt://localhost:7687" );
     public static final BoltServerAddress DEFAULT_ADDRESS = new BoltServerAddress( DEFAULT_URI );
+    public static final Config DEFAULT_CONFIG = Config.build().withLogging( new ConsoleLogging( Level.INFO ) )
+            .toConfig();
 
     public static final String USER = "neo4j";
     public static final String PASSWORD = "password";
@@ -128,7 +133,7 @@ public class Neo4jRunner
 
         if ( driver == null )
         {
-            driver = GraphDatabase.driver( DEFAULT_URI, DEFAULT_AUTH_TOKEN );
+            driver = GraphDatabase.driver( DEFAULT_URI, DEFAULT_AUTH_TOKEN, DEFAULT_CONFIG );
         }
         return driver;
     }


### PR DESCRIPTION
An example of output on DEBUG (FINE) level using our `ConsoleLogging`:
```
2017-11-28 05:53:19,431 [0xb2d66fa6] S: SUCCESS {}
2017-11-28 05:53:19,431 Channel [id: 0xb2d66fa6, L:/127.0.0.1:55381 - R:localhost/127.0.0.1:7687] released back to the pool
2017-11-28 05:53:19,433 Channel [id: 0xb2d66fa6, L:/127.0.0.1:55381 - R:localhost/127.0.0.1:7687] acquired from the pool
2017-11-28 05:53:19,434 [0xb2d66fa6] C: RUN "MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)" {}
2017-11-28 05:53:19,434 [0xb2d66fa6] C: PULL_ALL
2017-11-28 05:53:19,438 [0xb2d66fa6] S: SUCCESS {fields=["count(n)"], result_available_after=1}
2017-11-28 05:53:19,438 [0xb2d66fa6] S: RECORD [0]
2017-11-28 05:53:19,438 [0xb2d66fa6] S: SUCCESS {result_consumed_after=0, type="rw"}
2017-11-28 05:53:19,438 [0xb2d66fa6] C: RESET
2017-11-28 05:53:19,440 [0xb2d66fa6] S: SUCCESS {}
2017-11-28 05:53:19,440 Channel [id: 0xb2d66fa6, L:/127.0.0.1:55381 - R:localhost/127.0.0.1:7687] released back to the pool
2017-11-28 05:53:19,468 [id: 0x796463d7, L:/127.0.0.1:55382 - R:localhost/127.0.0.1:7687] HANDSHAKEN: TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
2017-11-28 05:53:19,508 Closing driver instance org.neo4j.driver.internal.InternalDriver@3108bc
2017-11-28 05:53:19,509 Closing connection pool towards localhost:7687
2017-11-28 05:53:21,633 Freed 19 thread-local buffer(s) from thread: Neo4jDriverIO-4-2
```