### PR TITLE
Fixed auto-read problem with result summary

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -170,6 +170,10 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         {
             if ( summaryFuture == null )
             {
+                // neither SUCCESS nor FAILURE message has arrived, register future to be notified when it arrives
+                // future will be completed with summary on SUCCESS and completed exceptionally on FAILURE
+                // enable auto-read, otherwise we might not read SUCCESS/FAILURE if records are not consumed
+                connection.enableAutoRead();
                 summaryFuture = new CompletableFuture<>();
             }
             return summaryFuture;
@@ -190,6 +194,10 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         {
             if ( failureFuture == null )
             {
+                // neither SUCCESS nor FAILURE message has arrived, register future to be notified when it arrives
+                // future will be completed with null on SUCCESS and completed with Throwable on FAILURE
+                // enable auto-read, otherwise we might not read SUCCESS/FAILURE if records are not consumed
+                connection.enableAutoRead();
                 failureFuture = new CompletableFuture<>();
             }
             return failureFuture;


### PR DESCRIPTION
All result stream should be buffered/consumed when result summary is requested or when session is closed. This means underlying channel should read everything that's available. It did not do so when summary was requested after number of buffered records exceeded high watermark.

This PR makes fetching of summary or failure enable auto-read on the underlying channel. So SUCCESS and FAILURE messages will be read without waiting for all records to be consumed.