### PR TITLE
Handle thread interruption by closing the channel

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -82,7 +82,9 @@ public class DriverFactory
         {
             InternalDriver driver = createDriver( uri, address, connectionPool, config, newRoutingSettings,
                     eventExecutorGroup, securityPlan, retryLogic );
-            Futures.blockingGet( driver.verifyConnectivity() );
+
+            // block to verify connectivity, close connection pool if thread gets interrupted
+            Futures.blockingGet( driver.verifyConnectivity(), connectionPool::close );
             return driver;
         }
         catch ( Throwable driverError )

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -47,7 +47,6 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.neo4j.driver.internal.util.Futures.blockingGet;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.Values.value;
 
@@ -148,7 +147,8 @@ public class ExplicitTransaction implements Transaction
     @Override
     public void close()
     {
-        blockingGet( closeAsync() );
+        Futures.blockingGet( closeAsync(),
+                () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while closing the transaction" ) );
     }
 
     CompletionStage<Void> closeAsync()
@@ -272,8 +272,9 @@ public class ExplicitTransaction implements Transaction
     @Override
     public StatementResult run( Statement statement )
     {
-        StatementResultCursor cursor = blockingGet( run( statement, false ) );
-        return new InternalStatementResult( cursor );
+        StatementResultCursor cursor = Futures.blockingGet( run( statement, false ),
+                () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while running query in transaction" ) );
+        return new InternalStatementResult( connection, cursor );
     }
 
     @Override
@@ -391,5 +392,10 @@ public class ExplicitTransaction implements Transaction
             connection.release(); // release in background
             session.setBookmark( bookmark );
         };
+    }
+
+    private void terminateConnectionOnThreadInterrupt( String reason )
+    {
+        connection.terminateAndRelease( reason );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -371,13 +371,13 @@ public class ExplicitTransaction implements Transaction
         {
             if ( cursorFailure != null && commitOrRollbackError != null )
             {
-                Throwable cause1 = completionErrorCause( cursorFailure );
-                Throwable cause2 = completionErrorCause( commitOrRollbackError );
+                Throwable cause1 = Futures.completionExceptionCause( cursorFailure );
+                Throwable cause2 = Futures.completionExceptionCause( commitOrRollbackError );
                 if ( cause1 != cause2 )
                 {
                     cause1.addSuppressed( cause2 );
                 }
-                throw new CompletionException( cause1 );
+                throw Futures.asCompletionException( cause1 );
             }
             else if ( cursorFailure != null )
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -369,7 +369,17 @@ public class ExplicitTransaction implements Transaction
     {
         return ( ignore, commitOrRollbackError ) ->
         {
-            if ( cursorFailure != null )
+            if ( cursorFailure != null && commitOrRollbackError != null )
+            {
+                Throwable cause1 = completionErrorCause( cursorFailure );
+                Throwable cause2 = completionErrorCause( commitOrRollbackError );
+                if ( cause1 != cause2 )
+                {
+                    cause1.addSuppressed( cause2 );
+                }
+                throw new CompletionException( cause1 );
+            }
+            else if ( cursorFailure != null )
             {
                 throw Futures.asCompletionException( cursorFailure );
             }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Logger;
@@ -29,7 +30,6 @@ import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.neo4j.driver.internal.util.Futures.blockingGet;
 
 public class InternalDriver implements Driver
 {
@@ -105,7 +105,7 @@ public class InternalDriver implements Driver
     @Override
     public void close()
     {
-        blockingGet( closeAsync() );
+        Futures.blockingGet( closeAsync() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -528,7 +528,7 @@ public class NetworkSession implements Session
 
     private void terminateConnectionOnThreadInterrupt( String reason )
     {
-        // try to get current connection in a blocking fashion
+        // try to get current connection if it has been acquired
         Connection connection = null;
         try
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelAttributes.java
@@ -34,6 +34,7 @@ public final class ChannelAttributes
     private static final AttributeKey<Long> CREATION_TIMESTAMP = newInstance( "creationTimestamp" );
     private static final AttributeKey<Long> LAST_USED_TIMESTAMP = newInstance( "lastUsedTimestamp" );
     private static final AttributeKey<InboundMessageDispatcher> MESSAGE_DISPATCHER = newInstance( "messageDispatcher" );
+    private static final AttributeKey<String> TERMINATION_REASON = newInstance( "terminationReason" );
 
     private ChannelAttributes()
     {
@@ -87,6 +88,16 @@ public final class ChannelAttributes
     public static void setMessageDispatcher( Channel channel, InboundMessageDispatcher messageDispatcher )
     {
         setOnce( channel, MESSAGE_DISPATCHER, messageDispatcher );
+    }
+
+    public static String terminationReason( Channel channel )
+    {
+        return get( channel, TERMINATION_REASON );
+    }
+
+    public static void setTerminationReason( Channel channel, String reason )
+    {
+        setOnce( channel, TERMINATION_REASON, reason );
     }
 
     private static <T> T get( Channel channel, AttributeKey<T> key )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
@@ -24,7 +24,7 @@ import io.netty.channel.pool.ChannelPool;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
@@ -51,7 +51,7 @@ public class NettyConnection implements Connection
     private final CompletableFuture<Void> releaseFuture;
     private final Clock clock;
 
-    private final AtomicBoolean open = new AtomicBoolean( true );
+    private final AtomicReference<Status> status = new AtomicReference<>( Status.OPEN );
 
     public NettyConnection( Channel channel, ChannelPool channelPool, Clock clock )
     {
@@ -67,7 +67,7 @@ public class NettyConnection implements Connection
     @Override
     public boolean isOpen()
     {
-        return open.get();
+        return status.get() == Status.OPEN;
     }
 
     @Override
@@ -92,22 +92,26 @@ public class NettyConnection implements Connection
     public void run( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
             ResponseHandler pullAllHandler )
     {
-        assertOpen();
-        run( statement, parameters, runHandler, pullAllHandler, false );
+        if ( verifyOpen( runHandler, pullAllHandler ) )
+        {
+            run( statement, parameters, runHandler, pullAllHandler, false );
+        }
     }
 
     @Override
     public void runAndFlush( String statement, Map<String,Value> parameters, ResponseHandler runHandler,
             ResponseHandler pullAllHandler )
     {
-        assertOpen();
-        run( statement, parameters, runHandler, pullAllHandler, true );
+        if ( verifyOpen( runHandler, pullAllHandler ) )
+        {
+            run( statement, parameters, runHandler, pullAllHandler, true );
+        }
     }
 
     @Override
     public CompletionStage<Void> release()
     {
-        if ( open.compareAndSet( true, false ) )
+        if ( status.compareAndSet( Status.OPEN, Status.RELEASED ) )
         {
             // auto-read could've been disabled, re-enable it to automatically receive response for RESET
             setAutoRead( true );
@@ -120,7 +124,7 @@ public class NettyConnection implements Connection
     @Override
     public void terminateAndRelease( String reason )
     {
-        if ( open.compareAndSet( true, false ) )
+        if ( status.compareAndSet( Status.OPEN, Status.TERMINATED ) )
         {
             setTerminationReason( channel, reason );
             channel.close();
@@ -192,11 +196,32 @@ public class NettyConnection implements Connection
         channel.config().setAutoRead( value );
     }
 
-    private void assertOpen()
+    private boolean verifyOpen( ResponseHandler runHandler, ResponseHandler pullAllHandler )
     {
-        if ( !isOpen() )
+        Status connectionStatus = this.status.get();
+        switch ( connectionStatus )
         {
-            throw new IllegalStateException( "Connection has been released to the pool and can't be reused" );
+        case OPEN:
+            return true;
+        case RELEASED:
+            Exception error = new IllegalStateException( "Connection has been released to the pool and can't be used" );
+            runHandler.onFailure( error );
+            pullAllHandler.onFailure( error );
+            return false;
+        case TERMINATED:
+            Exception terminatedError = new IllegalStateException( "Connection has been terminated and can't be used" );
+            runHandler.onFailure( terminatedError );
+            pullAllHandler.onFailure( terminatedError );
+            return false;
+        default:
+            throw new IllegalStateException( "Unknown status: " + connectionStatus );
         }
+    }
+
+    private enum Status
+    {
+        OPEN,
+        RELEASED,
+        TERMINATED
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/RoutingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/RoutingConnection.java
@@ -84,6 +84,12 @@ public class RoutingConnection implements Connection
     }
 
     @Override
+    public void terminateAndRelease( String reason )
+    {
+        delegate.terminateAndRelease( reason );
+    }
+
+    @Override
     public BoltServerAddress serverAddress()
     {
         return delegate.serverAddress();

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
@@ -32,6 +32,7 @@ import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatcher;
+import static org.neo4j.driver.internal.async.ChannelAttributes.terminationReason;
 
 public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
 {
@@ -69,8 +70,10 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
         if ( !failed )
         {
             // channel became inactive not because of a fatal exception that came from exceptionCaught
-            // it is most likely inactive because actual network connection broke
-            ServiceUnavailableException error = ErrorUtil.newConnectionTerminatedError();
+            // it is most likely inactive because actual network connection broke or was explicitly closed by the driver
+
+            String terminationReason = terminationReason( ctx.channel() );
+            ServiceUnavailableException error = ErrorUtil.newConnectionTerminatedError( terminationReason );
             fail( ctx, error );
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -41,6 +41,8 @@ public interface Connection
 
     CompletionStage<Void> release();
 
+    void terminateAndRelease( String reason );
+
     BoltServerAddress serverAddress();
 
     ServerVersion serverVersion();

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -31,6 +31,15 @@ public final class ErrorUtil
     {
     }
 
+    public static ServiceUnavailableException newConnectionTerminatedError( String reason )
+    {
+        if ( reason == null )
+        {
+            return newConnectionTerminatedError();
+        }
+        return new ServiceUnavailableException( "Connection to the database terminated. " + reason );
+    }
+
     public static ServiceUnavailableException newConnectionTerminatedError()
     {
         return new ServiceUnavailableException( "Connection to the database terminated. " +

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
@@ -408,7 +408,7 @@ public class InternalStatementResultTest
         pullAllHandler.onSuccess( emptyMap() );
 
         StatementResultCursor cursor = new InternalStatementResultCursor( runHandler, pullAllHandler );
-        return new InternalStatementResult( cursor );
+        return new InternalStatementResult( connection, cursor );
     }
 
     private List<Value> values( Record record )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
@@ -41,6 +41,8 @@ import static org.neo4j.driver.internal.async.ChannelAttributes.setLastUsedTimes
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerVersion;
+import static org.neo4j.driver.internal.async.ChannelAttributes.setTerminationReason;
+import static org.neo4j.driver.internal.async.ChannelAttributes.terminationReason;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 
 public class ChannelAttributesTest
@@ -152,6 +154,30 @@ public class ChannelAttributesTest
         try
         {
             setServerVersion( channel, version( "3.2.3" ) );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldSetAndGetTerminationReason()
+    {
+        String reason = "This channel has been terminated";
+        setTerminationReason( channel, reason );
+        assertEquals( reason, terminationReason( channel ) );
+    }
+
+    @Test
+    public void shouldFailToSetTerminationReasonTwice()
+    {
+        setTerminationReason( channel, "Reason 1" );
+
+        try
+        {
+            setTerminationReason( channel, "Reason 2" );
             fail( "Exception expected" );
         }
         catch ( Exception e )

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
@@ -26,14 +26,18 @@ import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.DatabaseException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.TransientException;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.driver.internal.util.ErrorUtil.isFatal;
+import static org.neo4j.driver.internal.util.ErrorUtil.newConnectionTerminatedError;
 import static org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError;
 
 public class ErrorUtilTest
@@ -133,5 +137,28 @@ public class ErrorUtilTest
     public void shouldTreatDatabaseExceptionAsFatal()
     {
         assertTrue( isFatal( new ClientException( "Neo.DatabaseError.Schema.ConstraintCreationFailed", "" ) ) );
+    }
+
+    @Test
+    public void shouldCreateConnectionTerminatedError()
+    {
+        ServiceUnavailableException error = newConnectionTerminatedError();
+        assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
+    }
+
+    @Test
+    public void shouldCreateConnectionTerminatedErrorWithNullReason()
+    {
+        ServiceUnavailableException error = newConnectionTerminatedError( null );
+        assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
+    }
+
+    @Test
+    public void shouldCreateConnectionTerminatedErrorWithReason()
+    {
+        String reason = "Thread interrupted";
+        ServiceUnavailableException error = newConnectionTerminatedError( reason );
+        assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
+        assertThat( error.getMessage(), containsString( reason ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -147,6 +147,12 @@ public class FailingConnectionDriverFactory extends DriverFactory
         }
 
         @Override
+        public void terminateAndRelease( String reason )
+        {
+            delegate.terminateAndRelease( reason );
+        }
+
+        @Override
         public BoltServerAddress serverAddress()
         {
             return delegate.serverAddress();

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
@@ -335,7 +335,7 @@ public class FuturesTest
         RuntimeException error = new RuntimeException( "Hello" );
         CompletionException completionException = new CompletionException( error );
 
-        assertEquals( error, Futures.completionErrorCause( completionException ) );
+        assertEquals( error, Futures.completionExceptionCause( completionException ) );
     }
 
     @Test
@@ -343,6 +343,21 @@ public class FuturesTest
     {
         RuntimeException error = new RuntimeException( "Hello" );
 
-        assertEquals( error, Futures.completionErrorCause( error ) );
+        assertEquals( error, Futures.completionExceptionCause( error ) );
+    }
+
+    @Test
+    public void shouldWrapWithCompletionException()
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+        CompletionException completionException = Futures.asCompletionException( error );
+        assertEquals( error, completionException.getCause() );
+    }
+
+    @Test
+    public void shouldKeepCompletionExceptionAsIs()
+    {
+        CompletionException error = new CompletionException( new RuntimeException( "Hello" ) );
+        assertEquals( error, Futures.asCompletionException( error ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.FailedFuture;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.SucceededFuture;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.neo4j.driver.internal.async.EventLoopGroupFactory;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.driver.internal.util.Matchers.blockingOperationInEventLoopError;
+import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
+import static org.neo4j.driver.v1.util.TestUtil.sleep;
+
+public class FuturesTest
+{
+    @Test
+    public void shouldConvertCanceledNettyFutureToCompletionStage() throws Exception
+    {
+        DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
+        promise.cancel( true );
+
+        CompletableFuture<String> future = Futures.asCompletionStage( promise ).toCompletableFuture();
+
+        assertTrue( future.isCancelled() );
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( CancellationException ignore )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldConvertSucceededNettyFutureToCompletionStage() throws Exception
+    {
+        SucceededFuture<String> nettyFuture = new SucceededFuture<>( ImmediateEventExecutor.INSTANCE, "Hello" );
+
+        CompletableFuture<String> future = Futures.asCompletionStage( nettyFuture ).toCompletableFuture();
+
+        assertTrue( future.isDone() );
+        assertFalse( future.isCompletedExceptionally() );
+        assertEquals( "Hello", future.get() );
+    }
+
+    @Test
+    public void shouldConvertFailedNettyFutureToCompletionStage() throws Exception
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+        FailedFuture<Object> nettyFuture = new FailedFuture<>( ImmediateEventExecutor.INSTANCE, error );
+
+        CompletableFuture<Object> future = Futures.asCompletionStage( nettyFuture ).toCompletableFuture();
+
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertEquals( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureCanceled() throws Exception
+    {
+        DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
+
+        CompletableFuture<String> future = Futures.asCompletionStage( promise ).toCompletableFuture();
+
+        assertFalse( future.isDone() );
+        promise.cancel( true );
+
+        assertTrue( future.isCancelled() );
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( CancellationException ignore )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureSucceeded() throws Exception
+    {
+        DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
+
+        CompletableFuture<String> future = Futures.asCompletionStage( promise ).toCompletableFuture();
+
+        assertFalse( future.isDone() );
+        promise.setSuccess( "Hello" );
+
+        assertTrue( future.isDone() );
+        assertFalse( future.isCompletedExceptionally() );
+        assertEquals( "Hello", future.get() );
+    }
+
+    @Test
+    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureFailed() throws Exception
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+        DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
+
+        CompletableFuture<String> future = Futures.asCompletionStage( promise ).toCompletableFuture();
+
+        assertFalse( future.isDone() );
+        promise.setFailure( error );
+
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertEquals( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldCreateFailedFutureWithUncheckedException() throws Exception
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+        CompletableFuture<Object> future = Futures.failedFuture( error ).toCompletableFuture();
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertEquals( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldCreateFailedFutureWithCheckedException() throws Exception
+    {
+        IOException error = new IOException( "Hello" );
+        CompletableFuture<Object> future = Futures.failedFuture( error ).toCompletableFuture();
+        assertTrue( future.isCompletedExceptionally() );
+        try
+        {
+            future.get();
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertEquals( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldFailBlockingGetInEventLoopThread() throws Exception
+    {
+        EventLoopGroup eventExecutor = EventLoopGroupFactory.newEventLoopGroup( 1 );
+        try
+        {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            Future<String> result = eventExecutor.submit( () -> Futures.blockingGet( future ) );
+
+            try
+            {
+                result.get();
+                fail( "Exception expected" );
+            }
+            catch ( ExecutionException e )
+            {
+                assertThat( e.getCause(), is( blockingOperationInEventLoopError() ) );
+            }
+        }
+        finally
+        {
+            eventExecutor.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void shouldThrowInBlockingGetWhenFutureThrowsUncheckedException()
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        future.completeExceptionally( error );
+
+        try
+        {
+            Futures.blockingGet( future );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+    }
+
+    @Test
+    public void shouldThrowInBlockingGetWhenFutureThrowsCheckedException()
+    {
+        IOException error = new IOException( "Hello" );
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        future.completeExceptionally( error );
+
+        try
+        {
+            Futures.blockingGet( future );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertEquals( error, e );
+        }
+    }
+
+    @Test
+    public void shouldReturnFromBlockingGetWhenFutureCompletes()
+    {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete( "Hello" );
+
+        assertEquals( "Hello", Futures.blockingGet( future ) );
+    }
+
+    @Test
+    public void shouldWaitForFutureInBlockingGetEvenWhenInterrupted()
+    {
+        ExecutorService executor = Executors.newSingleThreadExecutor( daemon( "InterruptThread" ) );
+        try
+        {
+            CompletableFuture<String> future = new CompletableFuture<>();
+
+            Thread.currentThread().interrupt();
+            executor.submit( () ->
+            {
+                sleep( 1_000 );
+                future.complete( "Hello" );
+            } );
+
+            assertEquals( "Hello", Futures.blockingGet( future ) );
+            assertTrue( Thread.currentThread().isInterrupted() );
+        }
+        finally
+        {
+            Thread.interrupted(); // clear interruption status
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldHandleInterruptsInBlockingGet()
+    {
+        try
+        {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            Thread.currentThread().interrupt();
+
+            Runnable interruptHandler = () -> future.complete( "Hello" );
+            assertEquals( "Hello", Futures.blockingGet( future, interruptHandler ) );
+            assertTrue( Thread.currentThread().isInterrupted() );
+        }
+        finally
+        {
+            Thread.interrupted(); // clear interruption status
+        }
+    }
+
+    @Test
+    public void shouldGetNowWhenFutureDone()
+    {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete( "Hello" );
+
+        assertEquals( "Hello", Futures.getNow( future ) );
+    }
+
+    @Test
+    public void shouldGetNowWhenFutureNotDone()
+    {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        assertNull( Futures.getNow( future ) );
+    }
+
+    @Test
+    public void shouldGetCauseFromCompletionException()
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+        CompletionException completionException = new CompletionException( error );
+
+        assertEquals( error, Futures.completionErrorCause( completionException ) );
+    }
+
+    @Test
+    public void shouldReturnSameExceptionWhenItIsNotCompletionException()
+    {
+        RuntimeException error = new RuntimeException( "Hello" );
+
+        assertEquals( error, Futures.completionErrorCause( error ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
@@ -171,7 +171,7 @@ public class GraphDatabaseTest
                 GraphDatabase.driver( "bolt://localhost:" + serverSocket.getLocalPort() );
                 fail( "Exception expected" );
             }
-            catch ( Exception ignore )
+            catch ( ServiceUnavailableException ignore )
             {
                 // expected
             }

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
@@ -21,11 +21,13 @@ package org.neo4j.driver.v1;
 import org.junit.Test;
 
 import java.io.File;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.util.List;
 
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.util.StubServer;
+import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
@@ -155,5 +157,29 @@ public class GraphDatabaseTest
 
         assertEquals( 0, server1.exitStatus() );
         assertEquals( 0, server2.exitStatus() );
+    }
+
+    @Test
+    public void shouldRespondToInterruptsWhenConnectingToUnresponsiveServer() throws Exception
+    {
+        try ( ServerSocket serverSocket = new ServerSocket( 0 ) )
+        {
+            // setup other thread to interrupt current thread when it blocks
+            TestUtil.interruptWhenInWaitingState( Thread.currentThread() );
+            try
+            {
+                GraphDatabase.driver( "bolt://localhost:" + serverSocket.getLocalPort() );
+                fail( "Exception expected" );
+            }
+            catch ( Exception ignore )
+            {
+                // expected
+            }
+            finally
+            {
+                // clear interrupted flag
+                Thread.interrupted();
+            }
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -30,14 +30,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,7 +46,6 @@ import org.neo4j.driver.internal.logging.DevNullLogging;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
-import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.AuthToken;
@@ -69,9 +66,9 @@ import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
 import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.lang.String.format;
-import static java.util.concurrent.CompletableFuture.runAsync;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -1456,7 +1453,7 @@ public class SessionIT
     }
 
     @Test
-    public void shouldBeResponsiveToThreadInterruptWhenWaitingForResult()
+    public void shouldBeResponsiveToThreadInterruptWhenWaitingForResult() throws Exception
     {
         try ( Session session1 = neo4j.driver().session();
               Session session2 = neo4j.driver().session() )
@@ -1468,28 +1465,8 @@ public class SessionIT
 
             // now 'Beta Ray Bill' node is locked
 
-            AtomicBoolean interruptedQueryFailed = new AtomicBoolean();
-            Thread testThread = Thread.currentThread();
-            CompletableFuture<Void> interruptFuture = runAsync( () ->
-            {
-                while ( !interruptedQueryFailed.get() )
-                {
-                    // spin until thread that executes the test goes to WAITING state
-                    do
-                    {
-                        try
-                        {
-                            Thread.sleep( 5_00 );
-                        }
-                        catch ( InterruptedException ignore )
-                        {
-                        }
-                    }
-                    while ( testThread.getState() != Thread.State.WAITING );
-
-                    testThread.interrupt();
-                }
-            } );
+            // setup other thread to interrupt current thread when it blocks
+            TestUtil.interruptWhenInWaitingState( Thread.currentThread() );
 
             try
             {
@@ -1503,10 +1480,6 @@ public class SessionIT
             }
             finally
             {
-                // stop task that perform interruptions
-                interruptedQueryFailed.set( true );
-                Futures.blockingGet( interruptFuture );
-
                 // clear interrupted flag
                 Thread.interrupted();
             }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -172,6 +172,34 @@ public final class TestUtil
         return connection;
     }
 
+    public static void sleep( int millis )
+    {
+        try
+        {
+            Thread.sleep( millis );
+        }
+        catch ( InterruptedException e )
+        {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException( e );
+        }
+    }
+
+    public static void interruptWhenInWaitingState( Thread thread )
+    {
+        CompletableFuture.runAsync( () ->
+        {
+            // spin until given thread moves to WAITING state
+            do
+            {
+                sleep( 500 );
+            }
+            while ( thread.getState() != Thread.State.WAITING );
+
+            thread.interrupt();
+        } );
+    }
+
     private static void setupSuccessfulPullAll( Connection connection, String statement )
     {
         doAnswer( invocation ->

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -44,6 +44,7 @@ import static java.util.Collections.unmodifiableSet;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
+import static org.neo4j.driver.v1.util.TestUtil.sleep;
 
 public class Cluster
 {
@@ -437,18 +438,5 @@ public class Cluster
             currentIndex++;
         }
         throw new AssertionError();
-    }
-
-    private static void sleep( int millis )
-    {
-        try
-        {
-            Thread.sleep( millis );
-        }
-        catch ( InterruptedException e )
-        {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException( e );
-        }
     }
 }


### PR DESCRIPTION
Blocking API like `Session#run()` is now implemented on top of async API, i.e. `Session#runAsync()`. Blocking calls simply invoke async ones and uninterruptibly wait for them to complete. Previously, with blocking IO, thread interruptions resulted in `ClosedByInterruptException` which terminated query/transaction in a harsh way. Right now interrupts will do nothing. Handling them is not strictly required because `Thread#interrupt()` is not a nice thing to do. However, interrupts are still used in some environments as a last resort thing.

This commit makes driver react on thread interrupts by closing the underlying Netty channel. It's only done in places where channel is actually available. Closing of channel results in exception and the waiting thread fails. It will also make database reset state for this connection, terminate transaction and query.

Such approach seems very similar to the previous one except it will result in `ServiceUnavailableException` instead of `ClosedByInterruptException`.