### PR TITLE
Use connect timeout in Bolt and TLS handshake

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -20,6 +20,9 @@ package org.neo4j.driver.internal.net;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.util.Queue;
@@ -27,7 +30,9 @@ import java.util.Queue;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.security.TLSSocketChannel;
 import org.neo4j.driver.internal.util.BytePrinter;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
@@ -118,12 +123,15 @@ public class SocketClient
 
     public void start()
     {
+        Socket socket = null;
+        boolean connected = false;
         try
         {
             logger.debug( "Connecting to %s, secure: %s", address, securityPlan.requiresEncryption() );
             if( channel == null )
             {
-                setChannel( ChannelFactory.create( address, securityPlan, timeoutMillis, logger ) );
+                socket = newSocket( timeoutMillis );
+                setChannel( ChannelFactory.create( socket, address, securityPlan, timeoutMillis, logger ) );
                 logger.debug( "Connected to %s, secure: %s", address, securityPlan.requiresEncryption() );
             }
 
@@ -131,9 +139,15 @@ public class SocketClient
             SocketProtocol protocol = negotiateProtocol();
             setProtocol( protocol );
             logger.debug( "Selected protocol %s with %s", protocol.getClass(), address );
+
+            // reset read timeout (SO_TIMEOUT) to the original value of zero
+            // we do not want to permanently limit amount of time driver waits for database to execute query
+            socket.setSoTimeout( 0 );
+            connected = true;
         }
-        catch ( ConnectException e )
+        catch ( ConnectException | SocketTimeoutException e )
         {
+            // unable to connect socket or TLS/Bolt handshake took too much time
             throw new ServiceUnavailableException( format(
                     "Unable to connect to %s, ensure the database is running and that there is a " +
                     "working network connection to it.", address ), e );
@@ -141,6 +155,19 @@ public class SocketClient
         catch ( IOException e )
         {
             throw new ServiceUnavailableException( "Unable to process request: " + e.getMessage(), e );
+        }
+        finally
+        {
+            if ( !connected && socket != null )
+            {
+                try
+                {
+                    socket.close();
+                }
+                catch ( Throwable ignore )
+                {
+                }
+            }
         }
     }
 
@@ -300,5 +327,36 @@ public class SocketClient
     public BoltServerAddress address()
     {
         return address;
+    }
+
+    /**
+     * Creates new {@link Socket} object with {@link Socket#setSoTimeout(int) read timeout} set to the given value.
+     * Connection to bolt server includes:
+     * <ol>
+     * <li>TCP connect via {@link Socket#connect(SocketAddress, int)}</li>
+     * <li>Optional TLS handshake using {@link TLSSocketChannel}</li>
+     * <li>Bolt handshake</li>
+     * </ol>
+     * We do not want any of these steps to hang infinitely if server does not respond and thus:
+     * <ol>
+     * <li>Use {@link Socket#connect(SocketAddress, int)} with timeout, as configured in
+     * {@link Config#connectionTimeoutMillis()}</li>
+     * <li>Initially set {@link Socket#setSoTimeout(int) read timeout} on the socket. Same connection-timeout value
+     * from {@link Config#connectionTimeoutMillis()} is used. This way blocking reads during TLS and Bolt handshakes
+     * have limited waiting time</li>
+     * </ol>
+     *
+     * @param configuredConnectTimeout user-defined connection timeout to be initially used as read timeout.
+     * @return new socket.
+     * @throws IOException when creation or configuration of the socket fails.
+     */
+    private static Socket newSocket( int configuredConnectTimeout ) throws IOException
+    {
+        Socket socket = new Socket();
+        socket.setReuseAddress( true );
+        socket.setKeepAlive( true );
+        // set read timeout initially
+        socket.setSoTimeout( configuredConnectTimeout );
+        return socket;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/net/UnencryptedSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/UnencryptedSocketChannel.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+public class UnencryptedSocketChannel implements ByteChannel
+{
+    private final Socket socket;
+    private final ReadableByteChannel readableChannel;
+    private final WritableByteChannel writableChannel;
+
+    public UnencryptedSocketChannel( Socket socket ) throws IOException
+    {
+        this.socket = socket;
+        this.readableChannel = Channels.newChannel( socket.getInputStream() );
+        this.writableChannel = Channels.newChannel( socket.getOutputStream() );
+    }
+
+    @Override
+    public int read( ByteBuffer dst ) throws IOException
+    {
+        return readableChannel.read( dst );
+    }
+
+    @Override
+    public int write( ByteBuffer src ) throws IOException
+    {
+        return writableChannel.write( src );
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return !socket.isClosed();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        socket.close();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/net/UnencryptedSocketChannelTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/UnencryptedSocketChannelTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.net;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UnencryptedSocketChannelTest
+{
+    private static final byte[] EMPTY_INPUT = new byte[0];
+
+    @Test
+    public void shouldReadFromSocketInputStream() throws IOException
+    {
+        Socket socket = socketMock( new byte[]{1, 2, 3, 4, 5, 42} );
+        UnencryptedSocketChannel channel = newChannel( socket );
+
+        ByteBuffer buffer = ByteBuffer.allocate( 100 );
+        channel.read( buffer );
+        buffer.flip();
+
+        assertEquals( 1, buffer.get() );
+        assertEquals( 2, buffer.get() );
+        assertEquals( 3, buffer.get() );
+        assertEquals( 4, buffer.get() );
+        assertEquals( 5, buffer.get() );
+        assertEquals( 42, buffer.get() );
+        assertEquals( 0, buffer.remaining() );
+    }
+
+    @Test
+    public void shouldWriteToSocketOutputStream() throws IOException
+    {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Socket socket = socketMock( output );
+        UnencryptedSocketChannel channel = newChannel( socket );
+
+        byte[] array = {42, 34, 9, 99, 42, 1, 2};
+        ByteBuffer buffer = ByteBuffer.wrap( array );
+
+        channel.write( buffer );
+
+        assertArrayEquals( array, output.toByteArray() );
+    }
+
+    @Test
+    public void shouldKnowWhenOpen() throws IOException
+    {
+        Socket openSocket = socketMock( true );
+        Socket closedSocket = socketMock( false );
+
+        UnencryptedSocketChannel openChannel = newChannel( openSocket );
+        UnencryptedSocketChannel closedChannel = newChannel( closedSocket );
+
+        assertTrue( openChannel.isOpen() );
+        assertFalse( closedChannel.isOpen() );
+    }
+
+    @Test
+    public void shouldCloseSocket() throws IOException
+    {
+        Socket socket = socketMock( true );
+        UnencryptedSocketChannel channel = newChannel( socket );
+
+        channel.close();
+
+        verify( socket ).close();
+    }
+
+    private static Socket socketMock( boolean open ) throws IOException
+    {
+        return socketMock( open, EMPTY_INPUT, new ByteArrayOutputStream() );
+    }
+
+    private static Socket socketMock( byte[] input ) throws IOException
+    {
+        return socketMock( true, input, new ByteArrayOutputStream() );
+    }
+
+    private static Socket socketMock( OutputStream output ) throws IOException
+    {
+        return socketMock( true, EMPTY_INPUT, output );
+    }
+
+    private static Socket socketMock( boolean open, byte[] input, OutputStream output ) throws IOException
+    {
+        Socket socket = mock( Socket.class );
+        when( socket.getInputStream() ).thenReturn( new ByteArrayInputStream( input ) );
+        when( socket.getOutputStream() ).thenReturn( output );
+        when( socket.isClosed() ).thenReturn( !open );
+        return socket;
+    }
+
+    private static UnencryptedSocketChannel newChannel( Socket socket ) throws IOException
+    {
+        return new UnencryptedSocketChannel( socket );
+    }
+}


### PR DESCRIPTION
Previously configured connection timeout has only been applied to actual `Socket#connect()` call. This is not the only thing driver does to establish a connection. It also executes TLS handshake (if configured to use encryption) and Bolt handshake to negotiate protocol version with the database. Later two steps perform blocking reads without any timeout.

This could be a problem when database does not respond in time. Also driver might be simply connecting to something that is not the database and never responds.

This commit makes driver use configured value of connect timeout as blocking read timeout for TLS and Bolt handshakes. So both will not hang forever when other side does not respond. Default value of connection timeout is 5 seconds. With this commit driver will wait up to 5 seconds for TLS and Bolt handshake.