### PR TITLE
Use connect timeout in Bolt and TLS handshake

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ChannelConnectorImpl.java
@@ -22,12 +22,14 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 
 import java.util.Map;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.async.inbound.ConnectTimeoutHandler;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
@@ -71,7 +73,7 @@ public class ChannelConnectorImpl implements ChannelConnector
     public ChannelFuture connect( BoltServerAddress address, Bootstrap bootstrap )
     {
         bootstrap.option( ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis );
-        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, clock, logging ) );
+        bootstrap.handler( new NettyChannelInitializer( address, securityPlan, connectTimeoutMillis, clock, logging ) );
 
         ChannelFuture channelConnected = bootstrap.connect( address.toSocketAddress() );
 
@@ -79,12 +81,39 @@ public class ChannelConnectorImpl implements ChannelConnector
         ChannelPromise handshakeCompleted = channel.newPromise();
         ChannelPromise connectionInitialized = channel.newPromise();
 
-        channelConnected.addListener(
-                new ChannelConnectedListener( address, pipelineBuilder, handshakeCompleted, logging ) );
-        handshakeCompleted.addListener(
-                new HandshakeCompletedListener( userAgent, authToken, connectionInitialized ) );
+        installChannelConnectedListeners( address, channelConnected, handshakeCompleted );
+        installHandshakeCompletedListeners( handshakeCompleted, connectionInitialized );
 
         return connectionInitialized;
+    }
+
+    private void installChannelConnectedListeners( BoltServerAddress address, ChannelFuture channelConnected,
+            ChannelPromise handshakeCompleted )
+    {
+        ChannelPipeline pipeline = channelConnected.channel().pipeline();
+
+        // add timeout handler to the pipeline when channel is connected. it's needed to limit amount of time code
+        // spends in TLS and Bolt handshakes. prevents infinite waiting when database does not respond
+        channelConnected.addListener( future ->
+                pipeline.addFirst( new ConnectTimeoutHandler( connectTimeoutMillis ) ) );
+
+        // add listener that sends Bolt handshake bytes when channel is connected
+        channelConnected.addListener(
+                new ChannelConnectedListener( address, pipelineBuilder, handshakeCompleted, logging ) );
+    }
+
+    private void installHandshakeCompletedListeners( ChannelPromise handshakeCompleted,
+            ChannelPromise connectionInitialized )
+    {
+        ChannelPipeline pipeline = handshakeCompleted.channel().pipeline();
+
+        // remove timeout handler from the pipeline once TLS and Bolt handshakes are completed. regular protocol
+        // messages will flow next and we do not want to have read timeout for them
+        handshakeCompleted.addListener( future -> pipeline.remove( ConnectTimeoutHandler.class ) );
+
+        // add listener that sends an INIT message. connection is now fully established. channel pipeline if fully
+        // set to send/receive messages for a selected protocol version
+        handshakeCompleted.addListener( new HandshakeCompletedListener( userAgent, authToken, connectionInitialized ) );
     }
 
     private static Map<String,Value> tokenAsMap( AuthToken token )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -39,13 +39,16 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
 {
     private final BoltServerAddress address;
     private final SecurityPlan securityPlan;
+    private final int connectTimeoutMillis;
     private final Clock clock;
     private final Logging logging;
 
-    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan, Clock clock, Logging logging )
+    public NettyChannelInitializer( BoltServerAddress address, SecurityPlan securityPlan, int connectTimeoutMillis,
+            Clock clock, Logging logging )
     {
         this.address = address;
         this.securityPlan = securityPlan;
+        this.connectTimeoutMillis = connectTimeoutMillis;
         this.clock = clock;
         this.logging = logging;
     }
@@ -65,7 +68,9 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
     private SslHandler createSslHandler()
     {
         SSLEngine sslEngine = createSslEngine();
-        return new SslHandler( sslEngine );
+        SslHandler sslHandler = new SslHandler( sslEngine );
+        sslHandler.setHandshakeTimeoutMillis( connectTimeoutMillis );
+        return sslHandler;
     }
 
     private SSLEngine createSslEngine()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ConnectTimeoutHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ConnectTimeoutHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.inbound;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+
+/**
+ * Handler needed to limit amount of time connection performs TLS and Bolt handshakes.
+ * It should only be used when connection is established and removed from the pipeline afterwards.
+ * Otherwise it will make long running queries fail.
+ */
+public class ConnectTimeoutHandler extends ReadTimeoutHandler
+{
+    private final long timeoutMillis;
+    private boolean triggered;
+
+    public ConnectTimeoutHandler( long timeoutMillis )
+    {
+        super( timeoutMillis, TimeUnit.MILLISECONDS );
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    @Override
+    protected void readTimedOut( ChannelHandlerContext ctx )
+    {
+        if ( !triggered )
+        {
+            triggered = true;
+            ctx.fireExceptionCaught( unableToConnectError() );
+        }
+    }
+
+    private ServiceUnavailableException unableToConnectError()
+    {
+        return new ServiceUnavailableException( "Unable to establish connection in " + timeoutMillis + "ms" );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ConnectTimeoutHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ConnectTimeoutHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.inbound;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
+import org.junit.Test;
+
+import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ConnectTimeoutHandlerTest
+{
+    private final EmbeddedChannel channel = new EmbeddedChannel();
+
+    @After
+    public void tearDown()
+    {
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void shouldFireExceptionOnTimeout() throws Exception
+    {
+        int timeoutMillis = 100;
+        channel.pipeline().addLast( new ConnectTimeoutHandler( timeoutMillis ) );
+
+        // sleep for more than the timeout value
+        Thread.sleep( timeoutMillis * 4 );
+        channel.runPendingTasks();
+
+        try
+        {
+            channel.checkException();
+            fail( "Exception expected" );
+        }
+        catch ( ServiceUnavailableException e )
+        {
+            assertEquals( e.getMessage(), "Unable to establish connection in " + timeoutMillis + "ms" );
+        }
+    }
+
+    @Test
+    public void shouldNotFireExceptionMultipleTimes() throws Exception
+    {
+        int timeoutMillis = 70;
+        channel.pipeline().addLast( new ConnectTimeoutHandler( timeoutMillis ) );
+
+        // sleep for more than the timeout value
+        Thread.sleep( timeoutMillis * 4 );
+        channel.runPendingTasks();
+
+        try
+        {
+            channel.checkException();
+            fail( "Exception expected" );
+        }
+        catch ( ServiceUnavailableException e )
+        {
+            assertEquals( e.getMessage(), "Unable to establish connection in " + timeoutMillis + "ms" );
+        }
+
+        // sleep even more
+        Thread.sleep( timeoutMillis * 4 );
+        channel.runPendingTasks();
+
+        // no more exceptions should occur
+        channel.checkException();
+    }
+}


### PR DESCRIPTION
Previously configured connection timeout has only been used to limit amount of time it takes to establish a TCP connection. This is not the only thing driver does to establish a logical connection. It also executes TLS handshake (if configured to use encryption) and Bolt handshake to negotiate protocol version with the database. Later two steps perform reads without any timeout.

This could be a problem when database does not respond in time. Also driver might be simply connecting to something that is not the database and never responds.

This commit makes driver use configured value of connect timeout as read timeout for TLS and Bolt handshakes. So both will not hang forever when other side does not respond. Default value of connection timeout is 5 seconds. With this commit driver will wait up to 5 seconds for TLS and Bolt handshakes. Timeout is enforced by `ConnectTimeoutHandler` which is added to the channel pipeline when connection is established and removed from it when Bolt handshake completes.