### PR TITLE
Couple tweaks to generate less garbage

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.UnknownHostException;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Holds a host and port pair that denotes a Bolt server address.
@@ -49,23 +50,23 @@ public class BoltServerAddress
 
     public BoltServerAddress( String host, int port )
     {
-        this.host = host;
+        this.host = requireNonNull( host );
         this.port = port;
     }
 
     @Override
-    public boolean equals( Object obj )
+    public boolean equals( Object o )
     {
-        if ( this == obj )
+        if ( this == o )
         {
             return true;
         }
-        if ( !(obj instanceof BoltServerAddress) )
+        if ( o == null || getClass() != o.getClass() )
         {
             return false;
         }
-        BoltServerAddress address = (BoltServerAddress) obj;
-        return host.equals( address.host ) && port == address.port;
+        BoltServerAddress that = (BoltServerAddress) o;
+        return port == that.port && host.equals( that.host );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/Bookmark.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/Bookmark.java
@@ -19,7 +19,6 @@
 package org.neo4j.driver.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -28,6 +27,7 @@ import org.neo4j.driver.v1.Value;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
 import static org.neo4j.driver.v1.Values.value;
 
 public final class Bookmark
@@ -93,7 +93,7 @@ public final class Bookmark
         // {bookmarks: ["one", "two", "max"]} for backwards compatibility reasons. Old servers can only accept single
         // bookmark that is why driver has to parse and compare given list of bookmarks. This functionality will
         // eventually be removed.
-        Map<String,Value> parameters = new HashMap<>( 4 );
+        Map<String,Value> parameters = newHashMapWithSize( 2 );
         parameters.put( BOOKMARK_KEY, value( maxValue ) );
         parameters.put( BOOKMARKS_KEY, value( values ) );
         return parameters;

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -47,6 +47,7 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.Values.value;
 
@@ -163,7 +164,7 @@ public class ExplicitTransaction implements Transaction
         }
         else
         {
-            return completedFuture( null );
+            return completedWithNull();
         }
     }
 
@@ -172,7 +173,7 @@ public class ExplicitTransaction implements Transaction
     {
         if ( state == State.COMMITTED )
         {
-            return completedFuture( null );
+            return completedWithNull();
         }
         else if ( state == State.ROLLED_BACK )
         {
@@ -200,13 +201,13 @@ public class ExplicitTransaction implements Transaction
         }
         else if ( state == State.ROLLED_BACK )
         {
-            return completedFuture( null );
+            return completedWithNull();
         }
         else if ( state == State.TERMINATED )
         {
             // transaction has been terminated by RESET and should be rolled back by the database
             state = State.ROLLED_BACK;
-            return completedFuture( null );
+            return completedWithNull();
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 public class InternalDriver implements Driver
 {
@@ -116,7 +116,7 @@ public class InternalDriver implements Driver
             log.info( "Closing driver instance %s", this );
             return sessionFactory.close();
         }
-        return completedFuture( null );
+        return completedWithNull();
     }
 
     public CompletionStage<Void> verifyConnectivity()

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -46,7 +46,6 @@ import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.types.TypeSystem;
 
-import static org.neo4j.driver.internal.util.Futures.completedWithFalse;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.Values.value;
@@ -275,10 +274,6 @@ public class NetworkSession implements Session
 
     CompletionStage<Boolean> currentConnectionIsOpen()
     {
-        if ( connectionStage == null )
-        {
-            return completedWithFalse();
-        }
         return connectionStage.handle( ( connection, error ) ->
                 error == null && // no acquisition error
                 connection != null && // some connection has actually been acquired

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -520,7 +520,7 @@ public class NetworkSession implements Session
 
     private CompletionStage<Void> releaseConnection()
     {
-        return existingConnectionOrNull().thenCompose( connection ->
+        return connectionStage.thenCompose( connection ->
         {
             if ( connection != null )
             {
@@ -575,13 +575,8 @@ public class NetworkSession implements Session
     private CompletionStage<ExplicitTransaction> existingTransactionOrNull()
     {
         return transactionStage
-                .exceptionally( error -> null ) // handle previous acquisition failures
+                .exceptionally( error -> null ) // handle previous connection acquisition and tx begin failures
                 .thenApply( tx -> tx != null && tx.isOpen() ? tx : null );
-    }
-
-    private CompletionStage<Connection> existingConnectionOrNull()
-    {
-        return connectionStage.exceptionally( error -> null ); // handle previous acquisition failures
     }
 
     private void ensureSessionIsOpen()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ResultCursorsHolder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ResultCursorsHolder.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.internal.InternalStatementResultCursor;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 public class ResultCursorsHolder
 {
@@ -41,14 +42,14 @@ public class ResultCursorsHolder
     {
         return cursorStages.stream()
                 .map( this::retrieveFailure )
-                .reduce( completedFuture( null ), this::nonNullFailureFromEither );
+                .reduce( completedWithNull(), this::nonNullFailureFromEither );
     }
 
     private CompletionStage<Throwable> retrieveFailure( CompletionStage<InternalStatementResultCursor> cursorStage )
     {
         return cursorStage
                 .exceptionally( cursor -> null )
-                .thenCompose( cursor -> cursor == null ? completedFuture( null ) : cursor.failureAsync() );
+                .thenCompose( cursor -> cursor == null ? completedWithNull() : cursor.failureAsync() );
     }
 
     private CompletionStage<Throwable> nonNullFailureFromEither( CompletionStage<Throwable> stage1,

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 public class Rediscovery
 {
@@ -178,7 +179,7 @@ public class Rediscovery
     {
         BoltServerAddress[] addresses = routingTable.routers().toArray();
 
-        CompletableFuture<ClusterComposition> result = completedFuture( null );
+        CompletableFuture<ClusterComposition> result = completedWithNull();
         for ( BoltServerAddress address : addresses )
         {
             result = result.thenCompose( composition ->
@@ -203,7 +204,7 @@ public class Rediscovery
         Set<BoltServerAddress> addresses = hostNameResolver.resolve( initialRouter );
         addresses.removeAll( seenServers );
 
-        CompletableFuture<ClusterComposition> result = completedFuture( null );
+        CompletableFuture<ClusterComposition> result = completedWithNull();
         for ( BoltServerAddress address : addresses )
         {
             result = result.thenCompose( composition ->

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -36,6 +36,7 @@ import org.neo4j.driver.v1.summary.ResultSummary;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
 public abstract class PullAllResponseHandler implements ResponseHandler
@@ -136,7 +137,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
             if ( finished )
             {
-                return completedFuture( null );
+                return completedWithNull();
             }
 
             if ( recordFuture == null )
@@ -188,7 +189,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         }
         else if ( finished )
         {
-            return completedFuture( null );
+            return completedWithNull();
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.MetadataUtil;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -55,7 +56,6 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     private ResultSummary summary;
 
     private CompletableFuture<Record> recordFuture;
-    private CompletableFuture<ResultSummary> summaryFuture;
     private CompletableFuture<Throwable> failureFuture;
 
     public PullAllResponseHandler( Statement statement, RunResponseHandler runResponseHandler, Connection connection )
@@ -74,7 +74,6 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         afterSuccess();
 
         completeRecordFuture( null );
-        completeSummaryFuture( summary );
         completeFailureFuture( null );
     }
 
@@ -91,26 +90,16 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         boolean failedRecordFuture = failRecordFuture( error );
         if ( failedRecordFuture )
         {
-            // error propagated through record future, complete other two
-            completeSummaryFuture( summary );
+            // error propagated through the record future
             completeFailureFuture( null );
         }
         else
         {
-            boolean failedSummaryFuture = failSummaryFuture( error );
-            if ( failedSummaryFuture )
+            boolean completedFailureFuture = completeFailureFuture( error );
+            if ( !completedFailureFuture )
             {
-                // error propagated through summary future, complete other one
-                completeFailureFuture( null );
-            }
-            else
-            {
-                boolean completedFailureFuture = completeFailureFuture( error );
-                if ( !completedFailureFuture )
-                {
-                    // error has not been propagated to the user, remember it
-                    failure = error;
-                }
+                // error has not been propagated to the user, remember it
+                failure = error;
             }
         }
     }
@@ -121,7 +110,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     public synchronized void onRecord( Value[] fields )
     {
         Record record = new InternalRecord( runResponseHandler.statementKeys(), fields );
-        queueRecord( record );
+        enqueueRecord( record );
         completeRecordFuture( record );
     }
 
@@ -159,26 +148,14 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
     public synchronized CompletionStage<ResultSummary> summaryAsync()
     {
-        if ( failure != null )
+        return failureAsync().thenApply( error ->
         {
-            return failedFuture( extractFailure() );
-        }
-        else if ( summary != null )
-        {
-            return completedFuture( summary );
-        }
-        else
-        {
-            if ( summaryFuture == null )
+            if ( error != null )
             {
-                // neither SUCCESS nor FAILURE message has arrived, register future to be notified when it arrives
-                // future will be completed with summary on SUCCESS and completed exceptionally on FAILURE
-                // enable auto-read, otherwise we might not read SUCCESS/FAILURE if records are not consumed
-                connection.enableAutoRead();
-                summaryFuture = new CompletableFuture<>();
+                throw Futures.asCompletionException( error );
             }
-            return summaryFuture;
-        }
+            return summary;
+        } );
     }
 
     public synchronized CompletionStage<Throwable> failureAsync()
@@ -205,14 +182,14 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         }
     }
 
-    private void queueRecord( Record record )
+    private void enqueueRecord( Record record )
     {
         records.add( record );
 
-        boolean shouldBufferAllRecords = summaryFuture != null || failureFuture != null;
-        // when summary or failure is requested we have to buffer all remaining records and then return summary/failure
+        boolean shouldBufferAllRecords = failureFuture != null;
+        // when failure is requested we have to buffer all remaining records and then return the error
         // do not disable auto-read in this case, otherwise records will not be consumed and trailing
-        // SUCCESS or FAILURE message will not arrive as well, so callers will get stuck waiting for summary/failure
+        // SUCCESS or FAILURE message will not arrive as well, so callers will get stuck waiting for the error
         if ( !shouldBufferAllRecords && records.size() > RECORD_BUFFER_HIGH_WATERMARK )
         {
             // more than high watermark records are already queued, tell connection to stop auto-reading from network
@@ -264,28 +241,6 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         {
             CompletableFuture<Record> future = recordFuture;
             recordFuture = null;
-            future.completeExceptionally( error );
-            return true;
-        }
-        return false;
-    }
-
-    private void completeSummaryFuture( ResultSummary summary )
-    {
-        if ( summaryFuture != null )
-        {
-            CompletableFuture<ResultSummary> future = summaryFuture;
-            summaryFuture = null;
-            future.complete( summary );
-        }
-    }
-
-    private boolean failSummaryFuture( Throwable error )
-    {
-        if ( summaryFuture != null )
-        {
-            CompletableFuture<ResultSummary> future = summaryFuture;
-            summaryFuture = null;
             future.completeExceptionally( error );
             return true;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV1.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal.messaging;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,8 +72,6 @@ public class PackStreamMessageFormatV1 implements MessageFormat
     public static final int VERSION = 1;
 
     public static final int NODE_FIELDS = 3;
-
-    private static final Map<String,Value> EMPTY_STRING_VALUE_MAP = new HashMap<>( 0 );
 
     @Override
     public MessageFormat.Writer newWriter( PackOutput output, boolean byteArraySupportEnabled )
@@ -543,7 +541,7 @@ public class PackStreamMessageFormatV1 implements MessageFormat
                 labels.add( unpacker.unpackString() );
             }
             int numProps = (int) unpacker.unpackMapHeader();
-            Map<String,Value> props = new HashMap<>();
+            Map<String,Value> props = Iterables.newHashMapWithSize( numProps );
             for ( int j = 0; j < numProps; j++ )
             {
                 String key = unpacker.unpackString();
@@ -636,9 +634,9 @@ public class PackStreamMessageFormatV1 implements MessageFormat
             int size = (int) unpacker.unpackMapHeader();
             if ( size == 0 )
             {
-                return EMPTY_STRING_VALUE_MAP;
+                return Collections.emptyMap();
             }
-            Map<String,Value> map = new HashMap<>( size );
+            Map<String,Value> map = Iterables.newHashMapWithSize( size );
             for ( int i = 0; i < size; i++ )
             {
                 String key = unpacker.unpackString();

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -30,10 +30,26 @@ import java.util.function.BiFunction;
 
 import org.neo4j.driver.internal.async.EventLoopGroupFactory;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 public final class Futures
 {
+    private static final CompletableFuture<?> COMPLETED_WITH_NULL = completedFuture( null );
+    private static final CompletableFuture<Boolean> COMPLETED_WITH_FALSE = completedFuture( false );
+
     private Futures()
     {
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public static <T> CompletableFuture<T> completedWithNull()
+    {
+        return (CompletableFuture) COMPLETED_WITH_NULL;
+    }
+
+    public static CompletableFuture<Boolean> completedWithFalse()
+    {
+        return COMPLETED_WITH_FALSE;
     }
 
     public static <T> CompletionStage<T> asCompletionStage( io.netty.util.concurrent.Future<T> future )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -35,7 +35,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public final class Futures
 {
     private static final CompletableFuture<?> COMPLETED_WITH_NULL = completedFuture( null );
-    private static final CompletableFuture<Boolean> COMPLETED_WITH_FALSE = completedFuture( false );
 
     private Futures()
     {
@@ -45,11 +44,6 @@ public final class Futures
     public static <T> CompletableFuture<T> completedWithNull()
     {
         return (CompletableFuture) COMPLETED_WITH_NULL;
-    }
-
-    public static CompletableFuture<Boolean> completedWithFalse()
-    {
-        return COMPLETED_WITH_FALSE;
     }
 
     public static <T> CompletionStage<T> asCompletionStage( io.netty.util.concurrent.Future<T> future )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Iterables.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Iterables.java
@@ -29,6 +29,8 @@ import org.neo4j.driver.v1.util.Function;
 
 public class Iterables
 {
+    private static final float DEFAULT_HASH_MAP_LOAD_FACTOR = 0.75F;
+
     public static int count( Iterable<?> it )
     {
         if ( it instanceof Collection ) { return ((Collection) it).size(); }
@@ -68,7 +70,7 @@ public class Iterables
 
     public static Map<String, String> map( String ... alternatingKeyValue )
     {
-        Map<String, String> out = new HashMap<>();
+        Map<String,String> out = newHashMapWithSize( alternatingKeyValue.length / 2 );
         for ( int i = 0; i < alternatingKeyValue.length; i+=2 )
         {
             out.put( alternatingKeyValue[i], alternatingKeyValue[i+1] );
@@ -106,5 +108,23 @@ public class Iterables
                 };
             }
         };
+    }
+
+    public static <K, V> HashMap<K,V> newHashMapWithSize( int expectedSize )
+    {
+        return new HashMap<>( hashMapCapacity( expectedSize ) );
+    }
+
+    private static int hashMapCapacity( int expectedSize )
+    {
+        if ( expectedSize < 3 )
+        {
+            if ( expectedSize < 0 )
+            {
+                throw new IllegalArgumentException( "Illegal map size: " + expectedSize );
+            }
+            return expectedSize + 1;
+        }
+        return (int) ((float) expectedSize / DEFAULT_HASH_MAP_LOAD_FACTOR + 1.0F);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/Statement.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Statement.java
@@ -18,15 +18,15 @@
  */
 package org.neo4j.driver.v1;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.Immutable;
 
 import static java.lang.String.format;
-import static org.neo4j.driver.v1.Values.value;
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
 import static org.neo4j.driver.v1.Values.ofValue;
+import static org.neo4j.driver.v1.Values.value;
 
 /**
  * An executable statement, i.e. the statements' text and its parameters.
@@ -136,7 +136,7 @@ public class Statement
         }
         else
         {
-            Map<String, Value> newParameters = new HashMap<>( Math.max( parameters.size(), updates.size() ) );
+            Map<String,Value> newParameters = newHashMapWithSize( Math.max( parameters.size(), updates.size() ) );
             newParameters.putAll( parameters.asMap( ofValue() ) );
             for ( Map.Entry<String, Value> entry : updates.asMap( ofValue() ).entrySet() )
             {

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -44,6 +44,8 @@ import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.driver.v1.types.TypeSystem;
 import org.neo4j.driver.v1.util.Function;
 
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
+
 /**
  * Utility for wrapping regular Java types and exposing them as {@link Value}
  * objects, and vice versa.
@@ -247,7 +249,7 @@ public abstract class Values
 
     public static Value value( final Map<String,Object> val )
     {
-        Map<String,Value> asValues = new HashMap<>( val.size() );
+        Map<String,Value> asValues = newHashMapWithSize( val.size() );
         for ( Map.Entry<String,Object> entry : val.entrySet() )
         {
             asValues.put( entry.getKey(), value( entry.getValue() ) );
@@ -284,7 +286,7 @@ public abstract class Values
                                        "alternating key and value. Arguments were: " +
                                        Arrays.toString( keysAndValues ) + "." );
         }
-        HashMap<String,Value> map = new HashMap<>( keysAndValues.length / 2 );
+        HashMap<String,Value> map = newHashMapWithSize( keysAndValues.length / 2 );
         for ( int i = 0; i < keysAndValues.length; i += 2 )
         {
             Object value = keysAndValues[i + 1];

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.Config.defaultConfig;
@@ -143,8 +144,8 @@ public class DriverFactoryTest
     public void shouldVerifyConnectivity()
     {
         SessionFactory sessionFactory = mock( SessionFactory.class );
-        when( sessionFactory.verifyConnectivity() ).thenReturn( completedFuture( null ) );
-        when( sessionFactory.close() ).thenReturn( completedFuture( null ) );
+        when( sessionFactory.verifyConnectivity() ).thenReturn( completedWithNull() );
+        when( sessionFactory.close() ).thenReturn( completedWithNull() );
         DriverFactoryWithSessions driverFactory = new DriverFactoryWithSessions( sessionFactory );
 
         try ( Driver driver = createDriver( driverFactory ) )
@@ -160,7 +161,7 @@ public class DriverFactoryTest
         SessionFactory sessionFactory = mock( SessionFactory.class );
         ServiceUnavailableException error = new ServiceUnavailableException( "Hello" );
         when( sessionFactory.verifyConnectivity() ).thenReturn( failedFuture( error ) );
-        when( sessionFactory.close() ).thenReturn( completedFuture( null ) );
+        when( sessionFactory.close() ).thenReturn( completedWithNull() );
         DriverFactoryWithSessions driverFactory = new DriverFactoryWithSessions( sessionFactory );
 
         try
@@ -191,7 +192,7 @@ public class DriverFactoryTest
         ConnectionPool pool = mock( ConnectionPool.class );
         Connection connection = mock( Connection.class );
         when( pool.acquire( any( BoltServerAddress.class ) ) ).thenReturn( completedFuture( connection ) );
-        when( pool.close() ).thenReturn( completedFuture( null ) );
+        when( pool.close() ).thenReturn( completedWithNull() );
         return pool;
     }
 
@@ -234,7 +235,7 @@ public class DriverFactoryTest
         protected InternalDriver createDriver( SessionFactory sessionFactory, SecurityPlan securityPlan, Config config )
         {
             InternalDriver driver = mock( InternalDriver.class );
-            when( driver.verifyConnectivity() ).thenReturn( completedFuture( null ) );
+            when( driver.verifyConnectivity() ).thenReturn( completedWithNull() );
             return driver;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
@@ -24,13 +24,13 @@ import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.internal.security.SecurityPlan;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
 public class InternalDriverTest
@@ -62,7 +62,7 @@ public class InternalDriverTest
     public void shouldVerifyConnectivity()
     {
         SessionFactory sessionFactory = sessionFactoryMock();
-        CompletableFuture<Void> connectivityStage = completedFuture( null );
+        CompletableFuture<Void> connectivityStage = completedWithNull();
         when( sessionFactory.verifyConnectivity() ).thenReturn( connectivityStage );
 
         InternalDriver driver = newDriver( sessionFactory );
@@ -78,7 +78,7 @@ public class InternalDriverTest
     private static SessionFactory sessionFactoryMock()
     {
         SessionFactory sessionFactory = mock( SessionFactory.class );
-        when( sessionFactory.close() ).thenReturn( completedFuture( null ) );
+        when( sessionFactory.close() ).thenReturn( completedWithNull() );
         return sessionFactory;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 import static org.neo4j.driver.v1.util.TestUtil.await;
@@ -106,7 +107,7 @@ public class InternalStatementResultCursorTest
     public void shouldReturnNextNonExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -130,7 +131,7 @@ public class InternalStatementResultCursorTest
     public void shouldPeekNonExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.peekAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.peekAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -144,7 +145,7 @@ public class InternalStatementResultCursorTest
 
         Record record = new InternalRecord( asList( "key1", "key2" ), values( 42, 42 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -155,7 +156,7 @@ public class InternalStatementResultCursorTest
     public void shouldFailWhenAskedForSingleRecordButResultIsEmpty()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -203,7 +204,7 @@ public class InternalStatementResultCursorTest
         Record record3 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 3, 3, 3 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -221,7 +222,7 @@ public class InternalStatementResultCursorTest
 
         Record record = new InternalRecord( asList( "key1", "key2" ), values( 1, 1 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -236,7 +237,7 @@ public class InternalStatementResultCursorTest
     public void shouldConsumeAsyncWhenResultContainsNoRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -257,7 +258,7 @@ public class InternalStatementResultCursorTest
         Record record3 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 3, 3, 3 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -278,7 +279,7 @@ public class InternalStatementResultCursorTest
 
         Record record = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 1, 1 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -296,7 +297,7 @@ public class InternalStatementResultCursorTest
     public void shouldForEachAsyncWhenResultContainsNoRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
@@ -320,7 +321,7 @@ public class InternalStatementResultCursorTest
         Record record3 = new InternalRecord( asList( "key1", "key2" ), values( 3, 3 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -363,7 +364,7 @@ public class InternalStatementResultCursorTest
         Record record4 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 4, 4, 4 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( record4 ) ).thenReturn( completedFuture( null ) );
+                .thenReturn( completedFuture( record4 ) ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -377,7 +378,7 @@ public class InternalStatementResultCursorTest
 
         Record record = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 1, 1 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -388,7 +389,7 @@ public class InternalStatementResultCursorTest
     public void shouldListAsyncWhenResultContainsNoRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -406,7 +407,7 @@ public class InternalStatementResultCursorTest
         Record record4 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 4, 44, 444 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( record4 ) ).thenReturn( completedFuture( null ) );
+                .thenReturn( completedFuture( record4 ) ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -421,7 +422,7 @@ public class InternalStatementResultCursorTest
 
         Record singleRecord = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 11, 111 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( singleRecord ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -433,7 +434,7 @@ public class InternalStatementResultCursorTest
     public void shouldListAsyncWithFunctionWhenResultContainsNoRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -451,7 +452,7 @@ public class InternalStatementResultCursorTest
         Record record3 = new InternalRecord( asList( "key1", "key2" ), values( 3, 3 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( null ) );
+                .thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
@@ -501,7 +502,7 @@ public class InternalStatementResultCursorTest
     public void shouldReturnNullFailureWhenDoesNotExist()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.failureAsync() ).thenReturn( completedFuture( null ) );
+        when( pullAllHandler.failureAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
@@ -38,6 +38,8 @@ import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
+import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.Functions;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -54,6 +56,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
+import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 import static org.neo4j.driver.v1.util.TestUtil.await;
@@ -354,138 +357,6 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldListAsyncWhenResultContainsMultipleRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-
-        Record record1 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 1, 1 ) );
-        Record record2 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 2, 2, 2 ) );
-        Record record3 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 3, 3, 3 ) );
-        Record record4 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 4, 4, 4 ) );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
-                .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( record4 ) ).thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        assertEquals( asList( record1, record2, record3, record4 ), await( cursor.listAsync() ) );
-    }
-
-    @Test
-    public void shouldListAsyncWhenResultContainsOneRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-
-        Record record = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 1, 1 ) );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
-                .thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        assertEquals( singletonList( record ), await( cursor.listAsync() ) );
-    }
-
-    @Test
-    public void shouldListAsyncWhenResultContainsNoRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        assertEquals( 0, await( cursor.listAsync() ).size() );
-    }
-
-    @Test
-    public void shouldListAsyncWithFunctionWhenResultContainsMultipleRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-
-        Record record1 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 11, 111 ) );
-        Record record2 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 2, 22, 222 ) );
-        Record record3 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 3, 33, 333 ) );
-        Record record4 = new InternalRecord( asList( "key1", "key2", "key3" ), values( 4, 44, 444 ) );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
-                .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedFuture( record4 ) ).thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        List<Integer> values = await( cursor.listAsync( record -> record.get( "key2" ).asInt() ) );
-        assertEquals( asList( 11, 22, 33, 44 ), values );
-    }
-
-    @Test
-    public void shouldListAsyncWithFunctionWhenResultContainsOneRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-
-        Record singleRecord = new InternalRecord( asList( "key1", "key2", "key3" ), values( 1, 11, 111 ) );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( singleRecord ) )
-                .thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        List<Long> values = await( cursor.listAsync( record -> record.get( "key3" ).asLong() ) );
-        assertEquals( singletonList( 111L ), values );
-    }
-
-    @Test
-    public void shouldListAsyncWithFunctionWhenResultContainsNoRecords()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        List<String> values = await( cursor.listAsync( record -> record.get( "key42" ).asString() ) );
-        assertEquals( 0, values.size() );
-    }
-
-    @Test
-    public void shouldFailListAsyncWhenGivenFunctionThrows()
-    {
-        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-
-        Record record1 = new InternalRecord( asList( "key1", "key2" ), values( 1, 1 ) );
-        Record record2 = new InternalRecord( asList( "key1", "key2" ), values( 2, 2 ) );
-        Record record3 = new InternalRecord( asList( "key1", "key2" ), values( 3, 3 ) );
-        when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
-                .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
-                .thenReturn( completedWithNull() );
-
-        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
-
-        AtomicInteger recordsProcessed = new AtomicInteger();
-        RuntimeException error = new RuntimeException( "Hello" );
-
-        CompletionStage<List<Integer>> stage = cursor.listAsync( record ->
-        {
-            if ( record.get( "key1" ).asInt() == 2 )
-            {
-                throw error;
-            }
-            else
-            {
-                recordsProcessed.incrementAndGet();
-                return record.get( "key1" ).asInt();
-            }
-        } );
-
-        try
-        {
-            await( stage );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
-        assertEquals( 1, recordsProcessed.get() );
-        verify( pullAllHandler, times( 2 ) ).nextAsync();
-    }
-
-    @Test
     public void shouldReturnFailureWhenExists()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
@@ -507,6 +378,81 @@ public class InternalStatementResultCursorTest
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
         assertNull( await( cursor.failureAsync() ) );
+    }
+
+    @Test
+    public void shouldListAsyncWithoutMapFunction()
+    {
+        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
+
+        Record record1 = new InternalRecord( asList( "key1", "key2" ), values( 1, 1 ) );
+        Record record2 = new InternalRecord( asList( "key1", "key2" ), values( 2, 2 ) );
+        List<Record> records = asList( record1, record2 );
+
+        when( pullAllHandler.listAsync( Functions.identity() ) ).thenReturn( completedFuture( records ) );
+
+        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
+
+        assertEquals( records, await( cursor.listAsync() ) );
+        verify( pullAllHandler ).listAsync( Functions.identity() );
+    }
+
+    @Test
+    public void shouldListAsyncWithMapFunction()
+    {
+        Function<Record,String> mapFunction = record -> record.get( 0 ).asString();
+        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
+
+        List<String> values = asList( "a", "b", "c", "d", "e" );
+        when( pullAllHandler.listAsync( mapFunction ) ).thenReturn( completedFuture( values ) );
+
+        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
+
+        assertEquals( values, await( cursor.listAsync( mapFunction ) ) );
+        verify( pullAllHandler ).listAsync( mapFunction );
+    }
+
+    @Test
+    public void shouldPropagateFailureFromListAsyncWithoutMapFunction()
+    {
+        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
+        RuntimeException error = new RuntimeException( "Hi" );
+        when( pullAllHandler.listAsync( Functions.identity() ) ).thenReturn( failedFuture( error ) );
+
+        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
+
+        try
+        {
+            await( cursor.listAsync() );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( error, e );
+        }
+        verify( pullAllHandler ).listAsync( Functions.identity() );
+    }
+
+    @Test
+    public void shouldPropagateFailureFromListAsyncWithMapFunction()
+    {
+        Function<Record,String> mapFunction = record -> record.get( 0 ).asString();
+        PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
+        RuntimeException error = new RuntimeException( "Hi" );
+        when( pullAllHandler.listAsync( mapFunction ) ).thenReturn( failedFuture( error ) );
+
+        InternalStatementResultCursor cursor = newCursor( pullAllHandler );
+
+        try
+        {
+            await( cursor.listAsync( mapFunction ) );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( error, e );
+        }
+        verify( pullAllHandler ).listAsync( mapFunction );
     }
 
     private static InternalStatementResultCursor newCursor( PullAllResponseHandler pullAllHandler )

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.AccessMode.WRITE;
@@ -89,7 +90,7 @@ public class NetworkSessionTest
     public void setUp()
     {
         connection = connectionMock();
-        when( connection.release() ).thenReturn( completedFuture( null ) );
+        when( connection.release() ).thenReturn( completedWithNull() );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( ServerVersion.v3_2_0 );
         connectionProvider = mock( ConnectionProvider.class );
@@ -672,7 +673,7 @@ public class NetworkSessionTest
         {
             // verify that tx is not open when connection is released
             assertFalse( tx.isOpen() );
-            return completedFuture( null );
+            return completedWithNull();
         } );
 
         session.reset();

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectorImplTest.java
@@ -63,7 +63,7 @@ public class ChannelConnectorImplTest
 {
     private final TestNeo4j neo4j = new TestNeo4j();
     @Rule
-    public final RuleChain ruleChain = RuleChain.outerRule( Timeout.seconds( 20 ) ).around( neo4j );
+    public final RuleChain ruleChain = RuleChain.outerRule( Timeout.seconds( 60 ) ).around( neo4j );
 
     private Bootstrap bootstrap;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ActiveChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ActiveChannelTrackerTest.java
@@ -26,12 +26,10 @@ import org.neo4j.driver.internal.BoltServerAddress;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
-import static org.neo4j.driver.v1.util.TestUtil.await;
 
 public class ActiveChannelTrackerTest
 {
@@ -104,35 +102,6 @@ public class ActiveChannelTrackerTest
     public void shouldReturnZeroActiveCountForUnknownAddress()
     {
         assertEquals( 0, tracker.activeChannelCount( address ) );
-    }
-
-    @Test
-    public void shouldPruneForMissingAddress()
-    {
-        assertEquals( 0, tracker.activeChannelCount( address ) );
-        tracker.purge( address );
-        assertEquals( 0, tracker.activeChannelCount( address ) );
-    }
-
-    @Test
-    public void shouldPruneForExistingAddress()
-    {
-        Channel channel1 = newChannel();
-        Channel channel2 = newChannel();
-        Channel channel3 = newChannel();
-
-        tracker.channelAcquired( channel1 );
-        tracker.channelAcquired( channel2 );
-        tracker.channelAcquired( channel3 );
-
-        assertEquals( 3, tracker.activeChannelCount( address ) );
-
-        tracker.purge( address );
-
-        assertEquals( 0, tracker.activeChannelCount( address ) );
-        assertNull( await( channel1.closeFuture() ) );
-        assertNull( await( channel2.closeFuture() ) );
-        assertNull( await( channel3.closeFuture() ) );
     }
 
     private Channel newChannel()

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE_PARAM;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_SERVERS;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 import static org.neo4j.driver.v1.Values.parameters;
@@ -183,7 +184,7 @@ public class RoutingProcedureRunnerTest
 
     private static CompletionStage<Connection> connectionStage( String serverVersion )
     {
-        return connectionStage( serverVersion, completedFuture( null ) );
+        return connectionStage( serverVersion, completedWithNull() );
     }
 
     private static CompletionStage<Connection> connectionStage( String serverVersion,

--- a/driver/src/test/java/org/neo4j/driver/internal/util/IterablesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/IterablesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class IterablesTest
+{
+    @Test
+    public void shouldCreateHashMapWithExpectedSize()
+    {
+        assertNotNull( Iterables.newHashMapWithSize( 42 ) );
+    }
+
+    @Test
+    public void shouldThrowWhenNegativeHashMapSizeGiven()
+    {
+        try
+        {
+            Iterables.newHashMapWithSize( -42 );
+            fail( "Exception expected" );
+        }
+        catch ( IllegalArgumentException ignore )
+        {
+        }
+    }
+}


### PR DESCRIPTION
PR makes the following changes:
 * static final `CompletableFuture`s completed with `null` and `false`
 * improved initial sizing of `HashMap`s so that they do not resize
 * `BoltServerAddress#equals()` now checks port first and then host
 * `ActiveChannelTracker` only stores channel counts, not actual channels
 * improved `#listAsync()` to transform records buffered in the queue