### PR TITLE
Fixed error when connection killed during transaction

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -158,7 +158,7 @@ public class ExplicitTransaction implements Transaction
         {
             return commitAsync();
         }
-        else if ( state == State.ACTIVE || state == State.MARKED_FAILED || state == State.TERMINATED )
+        else if ( state != State.COMMITTED && state != State.ROLLED_BACK )
         {
             return rollbackAsync();
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandler.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.handlers;
 
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.util.ErrorUtil;
 import org.neo4j.driver.v1.Statement;
 
 import static java.util.Objects.requireNonNull;
@@ -43,6 +44,13 @@ public class TransactionPullAllResponseHandler extends PullAllResponseHandler
     @Override
     protected void afterFailure( Throwable error )
     {
-        tx.failure();
+        if ( ErrorUtil.isFatal( error ) )
+        {
+            tx.markTerminated();
+        }
+        else
+        {
+            tx.failure();
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -256,6 +256,18 @@ public class ExplicitTransactionTest
         verify( connection, never() ).release();
     }
 
+    @Test
+    public void shouldReleaseConnectionWhenTerminatedAndRolledBack()
+    {
+        Connection connection = connectionMock();
+        ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
+
+        tx.markTerminated();
+        await( tx.rollbackAsync() );
+
+        verify( connection ).release();
+    }
+
     private static ExplicitTransaction beginTx( Connection connection )
     {
         return beginTx( connection, Bookmark.empty() );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ChannelTrackingDriverFactory.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.async.BootstrapFactory;
 import org.neo4j.driver.internal.async.ChannelConnector;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -36,11 +37,24 @@ import org.neo4j.driver.v1.Config;
 public class ChannelTrackingDriverFactory extends DriverFactoryWithClock
 {
     private final List<Channel> channels = new CopyOnWriteArrayList<>();
+    private final int eventLoopThreads;
     private ConnectionPool pool;
 
     public ChannelTrackingDriverFactory( Clock clock )
     {
+        this( 0, clock );
+    }
+
+    public ChannelTrackingDriverFactory( int eventLoopThreads, Clock clock )
+    {
         super( clock );
+        this.eventLoopThreads = eventLoopThreads;
+    }
+
+    @Override
+    protected Bootstrap createBootstrap()
+    {
+        return eventLoopThreads == 0 ? super.createBootstrap() : BootstrapFactory.newBootstrap( eventLoopThreads );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -263,8 +263,7 @@ public class SessionIT
             assertThat( tx2, notNullValue() );
 
             exception.expect( ClientException.class ); // errors differ depending of neo4j version
-            exception.expectMessage(
-                    "Cannot run more statements in this transaction, it has been terminated by `Session#reset()`" );
+            exception.expectMessage( "Cannot run more statements in this transaction, it has been terminated" );
 
             tx1.run( "RETURN 1" );
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -653,15 +653,16 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailWhenServerIsRestarted()
+    public void shouldFailToCommitWhenServerIsRestarted()
     {
         Transaction tx = await( session.beginTransactionAsync() );
+
+        await( tx.runAsync( "CREATE ()" ) );
 
         neo4j.killDb();
 
         try
         {
-            await( tx.runAsync( "CREATE ()" ) );
             await( tx.commitAsync() );
             fail( "Exception expected" );
         }
@@ -806,7 +807,7 @@ public class TransactionAsyncIT
         }
         catch ( ClientException e )
         {
-            assertEquals( "Can't commit, transaction has been terminated by `Session#reset()`", e.getMessage() );
+            assertEquals( "Can't commit, transaction has been terminated", e.getMessage() );
         }
         assertFalse( tx.isOpen() );
     }
@@ -924,8 +925,7 @@ public class TransactionAsyncIT
         }
         catch ( ClientException e )
         {
-            assertEquals( "Cannot run more statements in this transaction, it has been terminated by `Session#reset()`",
-                    e.getMessage() );
+            assertEquals( "Cannot run more statements in this transaction, it has been terminated", e.getMessage() );
         }
     }
 


### PR DESCRIPTION
Connection error can happen while transaction is executing. Closing transaction after such error should not perform rollback because connection is dead and database has cleaned up all resources.

Previously close operation tried to perform rollback and failed with same `ServiceUnavailable` exception as the unsuccessful `#run()`. Error thrown from `#close()` has to be added as a suppressed error to the one thrown from `#run()`, when used in try-with-resources block. So code attempted to add error to itself as suppressed. This resulted in an `IllegalArgumentException`.

This PR fixes the problem by making `#close()` not perform a rollback after a fatal connection error.