### PR TITLE
Close open transaction when session is closed

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -167,24 +167,23 @@ public class NetworkSession implements Session
         {
             return resultCursorStage.thenCompose( cursor ->
             {
-                if ( cursor == null )
+                if ( cursor != null )
                 {
-                    return completedWithNull();
+                    // there exists a cursor with potentially unconsumed error, try to extract and propagate it
+                    return cursor.failureAsync();
                 }
-                return cursor.failureAsync();
-            } ).thenCompose( error -> releaseResources().thenApply( ignore ->
+                // no result cursor exists so no error exists
+                return completedWithNull();
+            } ).thenCompose( cursorError -> closeTransactionAndReleaseConnection().thenApply( txCloseError ->
             {
-                if ( error != null )
+                // now we have cursor error, active transaction has been closed and connection has been released
+                // back to the pool; try to propagate cursor and transaction close errors, if any
+                CompletionException combinedError = Futures.combineErrors( cursorError, txCloseError );
+                if ( combinedError != null )
                 {
-                    // connection has been acquired and there is an unconsumed error in result cursor
-                    throw Futures.asCompletionException( error );
+                    throw combinedError;
                 }
-                else
-                {
-                    // either connection acquisition failed or
-                    // there are no unconsumed errors in the result cursor
-                    return null;
-                }
+                return null;
             } ) );
         }
         return completedWithNull();
@@ -520,26 +519,22 @@ public class NetworkSession implements Session
         return newConnectionStage;
     }
 
-    private CompletionStage<Void> releaseResources()
-    {
-        return rollbackTransaction().thenCompose( ignore -> releaseConnection() );
-    }
-
-    private CompletionStage<Void> rollbackTransaction()
+    private CompletionStage<Throwable> closeTransactionAndReleaseConnection()
     {
         return existingTransactionOrNull().thenCompose( tx ->
         {
             if ( tx != null )
             {
-                return tx.rollbackAsync();
+                // there exists an open transaction, let's close it and propagate the error, if any
+                return tx.closeAsync()
+                        .thenApply( ignore -> (Throwable) null )
+                        .exceptionally( error -> error );
             }
+            // no open transaction so nothing to close
             return completedWithNull();
-        } ).exceptionally( error ->
-        {
-            Throwable cause = Futures.completionExceptionCause( error );
-            logger.warn( "Active transaction rolled back with an error", cause );
-            return null;
-        } );
+        } ).thenCompose( txCloseError ->
+                // then release the connection and propagate transaction close error, if any
+                releaseConnection().thenApply( ignore -> txCloseError ) );
     }
 
     private CompletionStage<Void> releaseConnection()
@@ -548,8 +543,10 @@ public class NetworkSession implements Session
         {
             if ( connection != null )
             {
+                // there exists connection, try to release it back to the pool
                 return connection.release();
             }
+            // no connection so return null
             return completedWithNull();
         } );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -172,6 +172,40 @@ public final class Futures
         return new CompletionException( error );
     }
 
+    /**
+     * Combine given errors into a single {@link CompletionException} to be rethrown from inside a
+     * {@link CompletionStage} chain.
+     *
+     * @param error1 the first error or {@code null}.
+     * @param error2 the second error or {@code null}.
+     * @return {@code null} if both errors are null, {@link CompletionException} otherwise.
+     */
+    public static CompletionException combineErrors( Throwable error1, Throwable error2 )
+    {
+        if ( error1 != null && error2 != null )
+        {
+            Throwable cause1 = completionExceptionCause( error1 );
+            Throwable cause2 = completionExceptionCause( error2 );
+            if ( cause1 != cause2 )
+            {
+                cause1.addSuppressed( cause2 );
+            }
+            return asCompletionException( cause1 );
+        }
+        else if ( error1 != null )
+        {
+            return asCompletionException( error1 );
+        }
+        else if ( error2 != null )
+        {
+            return asCompletionException( error2 );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
     private static void safeRun( Runnable runnable )
     {
         try

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import org.neo4j.driver.internal.async.EventLoopGroupFactory;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -359,5 +360,44 @@ public class FuturesTest
     {
         CompletionException error = new CompletionException( new RuntimeException( "Hello" ) );
         assertEquals( error, Futures.asCompletionException( error ) );
+    }
+
+    @Test
+    public void shouldCombineTwoErrors()
+    {
+        RuntimeException error1 = new RuntimeException( "Error1" );
+        RuntimeException error2Cause = new RuntimeException( "Error2" );
+        CompletionException error2 = new CompletionException( error2Cause );
+
+        CompletionException combined = Futures.combineErrors( error1, error2 );
+
+        assertEquals( error1, combined.getCause() );
+        assertArrayEquals( new Throwable[]{error2Cause}, combined.getCause().getSuppressed() );
+    }
+
+    @Test
+    public void shouldCombineErrorAndNull()
+    {
+        RuntimeException error1 = new RuntimeException( "Error1" );
+
+        CompletionException combined = Futures.combineErrors( error1, null );
+
+        assertEquals( error1, combined.getCause() );
+    }
+
+    @Test
+    public void shouldCombineNullAndError()
+    {
+        RuntimeException error2 = new RuntimeException( "Error2" );
+
+        CompletionException combined = Futures.combineErrors( null, error2 );
+
+        assertEquals( error2, combined.getCause() );
+    }
+
+    @Test
+    public void shouldCombineNullAndNullErrors()
+    {
+        assertNull( Futures.combineErrors( null, null ) );
     }
 }


### PR DESCRIPTION
Instead of rolling it back. This was the previous behaviour that got unintentionally changed in 1.5.0 version of the driver. It makes more sense to close the transaction (which means commit or rollback based on it's state) than just silently rollback. So driver will adhere to `Transaction#success()` or `Transaction#failure()` markers when closing session with an open transaction.

Fixes #458 