### PR TITLE
Fixed issue with connection pool deactivation

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -64,7 +64,8 @@ public class ClusterRoutingTable implements RoutingTable
                mode == AccessMode.WRITE && writers.size() == 0;
     }
 
-    private Set<BoltServerAddress> servers()
+    @Override
+    public Set<BoltServerAddress> servers()
     {
         Set<BoltServerAddress> servers = new HashSet<>();
         servers.addAll( readers.servers() );

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/LoadBalancer.java
@@ -110,15 +110,12 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
 
     private synchronized void forget( BoltServerAddress address )
     {
-        // First remove from the load balancer, to prevent concurrent threads from making connections to them.
+        // remove from the routing table, to prevent concurrent threads from making connections to this address
         routingTable.forget( address );
+
         if ( PURGE_ON_ERROR )
         {
             connections.purge( address );
-        }
-        else
-        {
-            connections.deactivate( address );
         }
     }
 
@@ -153,15 +150,7 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler, Au
         }
         else
         {
-            for ( BoltServerAddress addedAddress : routingTableChange.added() )
-            {
-                connections.activate( addedAddress );
-            }
-            for ( BoltServerAddress removedAddress : routingTableChange.removed() )
-            {
-                connections.deactivate( removedAddress );
-            }
-            connections.compact();
+            connections.retainAll( routingTable.servers() );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import java.util.Set;
+
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.v1.AccessMode;
 
@@ -36,6 +38,8 @@ public interface RoutingTable
     BoltServerAddress nextRouter();
 
     int routerSize();
+
+    Set<BoltServerAddress> servers();
 
     void removeWriter( BoltServerAddress toRemove );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/TLSSocketChannel.java
@@ -372,6 +372,8 @@ public class TLSSocketChannel implements ByteChannel
                 cipherOut.compact();
             }
             break;
+        case CLOSED:
+            throw new IOException( "TLS socket channel is closed" );
         default:
             throw new ClientException( "Got unexpected status " + status );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.spi;
 
+import java.util.Set;
+
 import org.neo4j.driver.internal.net.BoltServerAddress;
 
 public interface ConnectionPool extends AutoCloseable
@@ -36,11 +38,7 @@ public interface ConnectionPool extends AutoCloseable
      */
     void purge( BoltServerAddress address );
 
-    void activate( BoltServerAddress address );
-
-    void deactivate( BoltServerAddress address );
-
-    void compact();
+    void retainAll( Set<BoltServerAddress> addressesToRetain );
 
     boolean hasAddress( BoltServerAddress address );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionUtil.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +41,7 @@ public final class ClusterCompositionUtil
     public static final BoltServerAddress E = new BoltServerAddress( "5555:55" );
     public static final BoltServerAddress F = new BoltServerAddress( "6666:66" );
 
-    public static final List<BoltServerAddress> EMPTY = new ArrayList<>();
+    public static final List<BoltServerAddress> EMPTY = Collections.emptyList();
 
     public static final ClusterComposition VALID_CLUSTER_COMPOSITION =
             createClusterComposition( asList( A, B ), asList( C ), asList( D, E ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -20,7 +20,9 @@ package org.neo4j.driver.internal.cluster;
 
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.neo4j.driver.internal.net.BoltServerAddress;
 import org.neo4j.driver.internal.util.FakeClock;
@@ -230,5 +232,26 @@ public class ClusterRoutingTableTest
         assertThat( change.added(), containsInAnyOrder( D, E ) );
         assertEquals( 2, change.removed().size() );
         assertThat( change.removed(), containsInAnyOrder( A, C ) );
+    }
+
+    @Test
+    public void shouldReturnNoServersWhenEmpty()
+    {
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+
+        Set<BoltServerAddress> servers = routingTable.servers();
+
+        assertEquals( 0, servers.size() );
+    }
+
+    @Test
+    public void shouldReturnAllServers()
+    {
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
+        routingTable.update( createClusterComposition( asList( A, B, C ), asList( B, C, D ), asList( C, D, E, F ) ) );
+
+        Set<BoltServerAddress> servers = routingTable.servers();
+
+        assertEquals( new HashSet<>( asList( A, B, C, D, E, F ) ), servers );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingPooledConnectionErrorHandlingTest.java
@@ -46,7 +46,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -232,7 +231,7 @@ public class RoutingPooledConnectionErrorHandlingTest
             assertThat( routingTable, not( containsRouter( address ) ) );
             assertThat( routingTable, not( containsReader( address ) ) );
             assertThat( routingTable, not( containsWriter( address ) ) );
-            assertFalse( connectionPool.hasAddress( address ) );
+            assertTrue( connectionPool.hasAddress( address ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/TrustOnFirstUseTrustManagerTest.java
@@ -54,7 +54,7 @@ public class TrustOnFirstUseTrustManagerTest
     private String knownServer;
 
     @Rule
-    public TemporaryFolder testDir = new TemporaryFolder();
+    public TemporaryFolder testDir = new TemporaryFolder( new File( "target" ) );
     private X509Certificate knownCertificate;
 
     @Before

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ConnectionTrackingDriverFactory.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.util;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,8 +31,7 @@ import org.neo4j.driver.v1.Logging;
 
 public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
 {
-    private final Set<Connection> connections =
-            Collections.newSetFromMap( new ConcurrentHashMap<Connection,Boolean>() );
+    private final Set<Connection> connections = Collections.newSetFromMap( new ConcurrentHashMap<Connection,Boolean>() );
 
     public ConnectionTrackingDriverFactory( Clock clock )
     {
@@ -39,8 +39,7 @@ public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
     }
 
     @Override
-    protected Connector createConnector( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
-            Logging logging )
+    protected Connector createConnector( ConnectionSettings connectionSettings, SecurityPlan securityPlan, Logging logging )
     {
         Connector connector = super.createConnector( connectionSettings, securityPlan, logging );
         return new ConnectionTrackingConnector( connector, connections );
@@ -48,10 +47,11 @@ public class ConnectionTrackingDriverFactory extends DriverFactoryWithClock
 
     public void closeConnections()
     {
-        for ( Connection connection : connections )
+        Set<Connection> connectionsSnapshot = new HashSet<>( connections );
+        connections.clear();
+        for ( Connection connection : connectionsSnapshot )
         {
             connection.close();
         }
-        connections.clear();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -23,6 +23,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.util.HashMap;
 
 import org.neo4j.driver.internal.security.InternalAuthToken;
@@ -52,7 +53,7 @@ import static org.neo4j.driver.v1.Values.parameters;
 public class CredentialsIT
 {
     @ClassRule
-    public static TemporaryFolder tempDir = new TemporaryFolder();
+    public static TemporaryFolder tempDir = new TemporaryFolder( new File( "target" ) );
 
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TLSSocketChannelIT.java
@@ -66,7 +66,7 @@ public class TLSSocketChannelIT
     public TestNeo4j neo4j = new TestNeo4j();
 
     @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder( new File( "target" ) );
 
     @BeforeClass
     public static void setup() throws IOException, InterruptedException

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
@@ -20,8 +20,6 @@ package org.neo4j.driver.v1.tck;
 
 import cucumber.api.CucumberOptions;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -36,9 +34,6 @@ import org.neo4j.driver.v1.util.TestNeo4j;
         format = {"default_summary"})
 public class DriverComplianceIT
 {
-    @Rule
-    TemporaryFolder folder = new TemporaryFolder();
-
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterRule.java
@@ -92,7 +92,7 @@ public class LocalOrRemoteClusterRule extends ExternalResource
         }
         if ( uri != null && !BOLT_ROUTING_URI_SCHEME.equals( uri.getScheme() ) )
         {
-            throw new IllegalStateException( "CLuster uri should have bolt+routing scheme: '" + uri + "'" );
+            throw new IllegalStateException( "Cluster uri should have bolt+routing scheme: '" + uri + "'" );
         }
     }
 


### PR DESCRIPTION
Previously load balancer moved connection pool to deactivated state when corresponding cluster member had a network error. This was made to disallow any new connections towards that member. Member has also been removed from the routing table, so that callers never try to acquire connection from a deactivated pool. Deactivated pools were re-activated during rediscovery.

However, there was a case when deactivated pool towards the seed router would remain deactivated forever without a chance to be re-activated. It happened when connections to all cores failed and driver had to perform rediscovery using seed router. In this case all connections pools were deactivated, and rediscovery was not able to complete because it failed trying to obtain connection from a deactivated pool.

This PR fixes the problem by removing pool activation/deactivation. Instead driver will simply make instance non-routable by removing it's address from the routing table. Corresponding connection pool will not be changed. Later rediscovery will cleanup pools for non-routable addresses that have no active connections.

Same connection error handling logic is in 1.5. Only tests should be merged forward.