### PR TITLE
Do not limit TLS and Bolt handshakes by default

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/net/SocketClient.java
@@ -44,6 +44,8 @@ import static org.neo4j.driver.internal.util.ServerVersion.version;
 
 public class SocketClient
 {
+    public static final String TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY = "timeoutTlsAndBoltHandshakes";
+
     private static final int MAGIC_PREAMBLE = 0x6060B017;
     private static final int VERSION1 = 1;
     private static final int HTTP = 1213486160;//== 0x48545450 == "HTTP"
@@ -330,7 +332,8 @@ public class SocketClient
     }
 
     /**
-     * Creates new {@link Socket} object with {@link Socket#setSoTimeout(int) read timeout} set to the given value.
+     * Creates new {@link Socket} object. It's {@link Socket#setSoTimeout(int) read timeout} is set to the given value
+     * if {@link #TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY} system property is set to true.
      * Connection to bolt server includes:
      * <ol>
      * <li>TCP connect via {@link Socket#connect(SocketAddress, int)}</li>
@@ -355,8 +358,11 @@ public class SocketClient
         Socket socket = new Socket();
         socket.setReuseAddress( true );
         socket.setKeepAlive( true );
-        // set read timeout initially
-        socket.setSoTimeout( configuredConnectTimeout );
+        if ( Boolean.getBoolean( TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY ) )
+        {
+            // set read timeout initially
+            socket.setSoTimeout( configuredConnectTimeout );
+        }
         return socket;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/SocketClientTest.java
@@ -185,6 +185,7 @@ public class SocketClientTest
 
     private static void testReadTimeoutOnConnect( SecurityPlan securityPlan ) throws IOException
     {
+        System.setProperty( SocketClient.TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY, "true" );
         try ( ServerSocket server = new ServerSocket( 0 ) ) // server that does not reply
         {
             int timeoutMillis = 1_000;
@@ -200,6 +201,10 @@ public class SocketClientTest
             {
                 assertThat( e.getCause(), instanceOf( SocketTimeoutException.class ) );
             }
+        }
+        finally
+        {
+            System.setProperty( SocketClient.TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY, "false" );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
+import org.neo4j.driver.internal.net.SocketClient;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
 import org.neo4j.driver.internal.util.ServerVersion;
@@ -1194,6 +1195,7 @@ public class SessionIT
                 .withConnectionTimeout( connectionTimeoutMs, TimeUnit.MILLISECONDS )
                 .toConfig();
 
+        System.setProperty( SocketClient.TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY, "true" );
         try ( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(), config ) )
         {
             final Session session1 = driver.session();
@@ -1229,6 +1231,10 @@ public class SessionIT
 
             long hulkPower = powerFuture.get( 10, TimeUnit.SECONDS );
             assertEquals( 100, hulkPower );
+        }
+        finally
+        {
+            System.setProperty( SocketClient.TIMEOUT_TLS_AND_BOLT_HANDSHAKES_SYSTEM_PROPERTY, "false" );
         }
     }
 


### PR DESCRIPTION
Both can now timeout if server does not respond in 5 seconds. This is stricter than just connect timeout of 5 seconds and might result in more transient exceptions when database is under high load.

This PR disables timeout for TLS and Bolt handshakes, which makes behaviour exactly like in the previous driver version. Feature can still be enabled with "timeoutTlsAndBoltHandshakes" boolean system property. This feels like a safe thing to do in a maintenance branch.