### PR TITLE
Metrics Enhancement

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
@@ -34,7 +34,7 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.PullAllMessage;
 import org.neo4j.driver.internal.messaging.ResetMessage;
 import org.neo4j.driver.internal.messaging.RunMessage;
-import org.neo4j.driver.internal.metrics.ListenerEvent;
+import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
 import org.neo4j.driver.internal.metrics.MetricsListener;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
@@ -57,7 +57,7 @@ public class NettyConnection implements Connection
 
     private final AtomicReference<Status> status = new AtomicReference<>( Status.OPEN );
     private final MetricsListener metricsListener;
-    private final ListenerEvent inUseEvent;
+    private final ConnectionListenerEvent inUseEvent;
 
     public NettyConnection( Channel channel, ChannelPool channelPool, Clock clock, MetricsListener metricsListener )
     {
@@ -69,7 +69,7 @@ public class NettyConnection implements Connection
         this.releaseFuture = new CompletableFuture<>();
         this.clock = clock;
         this.metricsListener = metricsListener;
-        this.inUseEvent = metricsListener.createListenerEvent();
+        this.inUseEvent = metricsListener.createConnectionListenerEvent();
         metricsListener.afterAcquiredOrCreated( this.serverAddress, this.inUseEvent );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
@@ -87,7 +87,7 @@ public class ConnectionPoolImpl implements ConnectionPool
         assertNotClosed();
         ChannelPool pool = getOrCreatePool( address );
 
-        ListenerEvent.PoolListenerEvent acquireEvent = metricsListener.createPoolListenerEvent();
+        ListenerEvent acquireEvent = metricsListener.createListenerEvent();
         metricsListener.beforeAcquiringOrCreating( address, acquireEvent );
         Future<Channel> connectionFuture = pool.acquire();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
@@ -26,7 +26,7 @@ import io.netty.channel.pool.FixedChannelPool;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.ChannelConnector;
-import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
+import org.neo4j.driver.internal.metrics.ListenerEvent;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +60,7 @@ public class NettyChannelPool extends FixedChannelPool
     @Override
     protected ChannelFuture connectChannel( Bootstrap bootstrap )
     {
-        ConnectionListenerEvent creatingEvent = handler.channelCreating( address );
+        ListenerEvent creatingEvent = handler.channelCreating( address );
         ChannelFuture channelFuture = connector.connect( address, bootstrap );
         channelFuture.addListener( future ->
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
@@ -26,7 +26,7 @@ import io.netty.channel.pool.FixedChannelPool;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.ChannelConnector;
-import org.neo4j.driver.internal.metrics.ListenerEvent;
+import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +60,7 @@ public class NettyChannelPool extends FixedChannelPool
     @Override
     protected ChannelFuture connectChannel( Bootstrap bootstrap )
     {
-        ListenerEvent creatingEvent = handler.beforeChannelCreating( address );
+        ConnectionListenerEvent creatingEvent = handler.channelCreating( address );
         ChannelFuture channelFuture = connector.connect( address, bootstrap );
         channelFuture.addListener( future ->
         {
@@ -68,14 +68,13 @@ public class NettyChannelPool extends FixedChannelPool
             {
                 // notify pool handler about a successful connection
                 Channel channel = channelFuture.channel();
-                handler.channelCreated( channel );
+                handler.channelCreated( channel, creatingEvent );
                 channel.closeFuture().addListener( closeFuture -> handler.channelClosed( channel ) );
             }
             else
             {
                 handler.channelFailedToCreate( address );
             }
-            handler.afterChannelCreating( address, creatingEvent );
         } );
         return channelFuture;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
+import org.neo4j.driver.internal.metrics.ListenerEvent;
 import org.neo4j.driver.internal.metrics.MetricsListener;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
@@ -65,20 +65,19 @@ public class NettyChannelTracker implements ChannelPoolHandler
     @Override
     public void channelCreated( Channel channel )
     {
-        throw new IllegalStateException( "A fatal error happened in this driver as this method should never be called. " +
-                "Contact the driver developer." );
+        throw new IllegalStateException( "Untraceable channel created." );
     }
 
-    public void channelCreated( Channel channel, ConnectionListenerEvent creatingEvent )
+    public void channelCreated( Channel channel, ListenerEvent creatingEvent )
     {
         log.debug( "Channel %s created", channel );
         incrementInUse( channel );
         metricsListener.afterCreated( serverAddress( channel ), creatingEvent );
     }
 
-    public ConnectionListenerEvent channelCreating( BoltServerAddress address )
+    public ListenerEvent channelCreating( BoltServerAddress address )
     {
-        ConnectionListenerEvent creatingEvent = metricsListener.createConnectionListenerEvent();
+        ListenerEvent creatingEvent = metricsListener.createListenerEvent();
         metricsListener.beforeCreating( address, creatingEvent );
         return creatingEvent;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionMetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionMetricsListener.java
@@ -23,7 +23,7 @@ public interface ConnectionMetricsListener
 {
     void beforeCreating( ListenerEvent listenerEvent );
 
-    void afterCreating( ListenerEvent listenerEvent );
+    void afterCreated( ListenerEvent listenerEvent );
 
     void acquiredOrCreated( ListenerEvent listenerEvent );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver.internal.metrics;
 
+import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
+
 public interface ConnectionPoolMetricsListener
 {
     void beforeCreating();
@@ -28,8 +30,10 @@ public interface ConnectionPoolMetricsListener
 
     void afterClosed();
 
-    void beforeAcquiringOrCreating( ListenerEvent listenerEvent );
+    void beforeAcquiringOrCreating( PoolListenerEvent listenerEvent );
 
-    void afterAcquiringOrCreating( ListenerEvent listenerEvent );
+    void afterAcquiredOrCreated( PoolListenerEvent listenerEvent );
+
+    void afterTimedOutToAcquireOrCreate();
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.driver.internal.metrics;
 
-import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
-
 public interface ConnectionPoolMetricsListener
 {
     void beforeCreating();
@@ -30,11 +28,11 @@ public interface ConnectionPoolMetricsListener
 
     void afterClosed();
 
-    void beforeAcquiringOrCreating( PoolListenerEvent listenerEvent );
+    void beforeAcquiringOrCreating( ListenerEvent listenerEvent );
 
     void afterAcquiringOrCreating();
 
-    void afterAcquiredOrCreated( PoolListenerEvent listenerEvent );
+    void afterAcquiredOrCreated( ListenerEvent listenerEvent );
 
     void afterTimedOutToAcquireOrCreate();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ConnectionPoolMetricsListener.java
@@ -32,6 +32,8 @@ public interface ConnectionPoolMetricsListener
 
     void beforeAcquiringOrCreating( PoolListenerEvent listenerEvent );
 
+    void afterAcquiringOrCreating();
+
     void afterAcquiredOrCreated( PoolListenerEvent listenerEvent );
 
     void afterTimedOutToAcquireOrCreate();

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
@@ -33,56 +33,70 @@ public abstract class InternalAbstractMetrics implements Metrics, MetricsListene
     {
 
         @Override
-        public void beforeCreating( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
+        public void beforeCreating( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent creatingEvent )
         {
+
         }
 
         @Override
-        public void afterCreating( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
+        public void afterCreated( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent creatingEvent )
         {
-        }
 
-        @Override
-        public void afterCreated( BoltServerAddress serverAddress )
-        {
         }
 
         @Override
         public void afterFailedToCreate( BoltServerAddress serverAddress )
         {
+
         }
 
         @Override
         public void afterClosed( BoltServerAddress serverAddress )
         {
+
         }
 
         @Override
-        public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent acquireEvent )
+        public void afterTimedOutToAcquireOrCreate( BoltServerAddress serverAddress )
         {
+
         }
 
         @Override
-        public void afterAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent acquireEvent )
+        public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent.PoolListenerEvent acquireEvent )
         {
+
         }
 
         @Override
-        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
+        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent.PoolListenerEvent acquireEvent )
         {
+
         }
 
         @Override
-        public void afterReleased( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
+        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent inUseEvent )
         {
+
         }
 
         @Override
-        public ListenerEvent createListenerEvent()
+        public void afterReleased( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent inUseEvent )
+        {
+
+        }
+
+        @Override
+        public ListenerEvent.PoolListenerEvent createPoolListenerEvent()
         {
             return null;
         }
 
+        @Override
+        public ListenerEvent.ConnectionListenerEvent createConnectionListenerEvent()
+        {
+            return null;
+        }
 
         @Override
         public void addMetrics( BoltServerAddress address, ConnectionPoolImpl connectionPool )

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
@@ -33,13 +33,13 @@ public abstract class InternalAbstractMetrics implements Metrics, MetricsListene
     {
 
         @Override
-        public void beforeCreating( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent creatingEvent )
+        public void beforeCreating( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
         {
 
         }
 
         @Override
-        public void afterCreated( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent creatingEvent )
+        public void afterCreated( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
         {
 
         }
@@ -63,7 +63,7 @@ public abstract class InternalAbstractMetrics implements Metrics, MetricsListene
         }
 
         @Override
-        public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent.PoolListenerEvent acquireEvent )
+        public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent acquireEvent )
         {
 
         }
@@ -75,31 +75,25 @@ public abstract class InternalAbstractMetrics implements Metrics, MetricsListene
         }
 
         @Override
-        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent.PoolListenerEvent acquireEvent )
+        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent acquireEvent )
         {
 
         }
 
         @Override
-        public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent inUseEvent )
+        public void afterConnectionCreated( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
         {
 
         }
 
         @Override
-        public void afterReleased( BoltServerAddress serverAddress, ListenerEvent.ConnectionListenerEvent inUseEvent )
+        public void afterConnectionReleased( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
         {
 
         }
 
         @Override
-        public ListenerEvent.PoolListenerEvent createPoolListenerEvent()
-        {
-            return null;
-        }
-
-        @Override
-        public ListenerEvent.ConnectionListenerEvent createConnectionListenerEvent()
+        public ListenerEvent createListenerEvent()
         {
             return null;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalAbstractMetrics.java
@@ -69,6 +69,12 @@ public abstract class InternalAbstractMetrics implements Metrics, MetricsListene
         }
 
         @Override
+        public void afterAcquiringOrCreating( BoltServerAddress serverAddress )
+        {
+
+        }
+
+        @Override
         public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent.PoolListenerEvent acquireEvent )
         {
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionMetrics.java
@@ -66,7 +66,7 @@ public class InternalConnectionMetrics implements ConnectionMetrics, ConnectionM
     }
 
     @Override
-    public void afterCreating( ListenerEvent connEvent )
+    public void afterCreated( ListenerEvent connEvent )
     {
         // finished conn creation
         long elapsed = connEvent.elapsed();

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionPoolMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionPoolMetrics.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
 import org.neo4j.driver.internal.metrics.spi.ConnectionPoolMetrics;
 import org.neo4j.driver.internal.metrics.spi.Histogram;
 import org.neo4j.driver.internal.metrics.spi.PoolStatus;
@@ -88,7 +87,7 @@ public class InternalConnectionPoolMetrics implements ConnectionPoolMetrics, Con
     }
 
     @Override
-    public void beforeAcquiringOrCreating( PoolListenerEvent listenerEvent )
+    public void beforeAcquiringOrCreating( ListenerEvent listenerEvent )
     {
         listenerEvent.start();
         acquiring.incrementAndGet();
@@ -101,7 +100,7 @@ public class InternalConnectionPoolMetrics implements ConnectionPoolMetrics, Con
     }
 
     @Override
-    public void afterAcquiredOrCreated( PoolListenerEvent listenerEvent )
+    public void afterAcquiredOrCreated( ListenerEvent listenerEvent )
     {
         long elapsed = listenerEvent.elapsed();
         acquisitionTimeHistogram.recordValue( elapsed );

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionPoolMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalConnectionPoolMetrics.java
@@ -126,11 +126,11 @@ public class InternalConnectionPoolMetrics implements ConnectionPoolMetrics, Con
     {
         if ( pool.isOpen( address ) )
         {
-            return PoolStatus.Open;
+            return PoolStatus.OPEN;
         }
         else
         {
-            return PoolStatus.Closed;
+            return PoolStatus.CLOSED;
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
@@ -24,8 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
-import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
-import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
 import org.neo4j.driver.internal.metrics.spi.ConnectionMetrics;
 import org.neo4j.driver.internal.metrics.spi.ConnectionPoolMetrics;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -33,6 +31,7 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.lang.String.format;
+import static java.util.Collections.unmodifiableMap;
 
 public class InternalMetrics extends InternalAbstractMetrics
 {
@@ -56,14 +55,14 @@ public class InternalMetrics extends InternalAbstractMetrics
     }
 
     @Override
-    public void beforeCreating( BoltServerAddress serverAddress, ConnectionListenerEvent creatingEvent )
+    public void beforeCreating( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
     {
         poolMetrics( serverAddress ).beforeCreating();
         connectionMetrics( serverAddress ).beforeCreating( creatingEvent );
     }
 
     @Override
-    public void afterCreated( BoltServerAddress serverAddress, ConnectionListenerEvent creatingEvent )
+    public void afterCreated( BoltServerAddress serverAddress, ListenerEvent creatingEvent )
     {
         poolMetrics( serverAddress ).afterCreated();
         connectionMetrics( serverAddress ).afterCreated( creatingEvent );
@@ -82,7 +81,7 @@ public class InternalMetrics extends InternalAbstractMetrics
     }
 
     @Override
-    public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, PoolListenerEvent listenerEvent )
+    public void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent listenerEvent )
     {
         poolMetrics( serverAddress ).beforeAcquiringOrCreating( listenerEvent );
     }
@@ -94,19 +93,19 @@ public class InternalMetrics extends InternalAbstractMetrics
     }
 
     @Override
-    public void afterAcquiredOrCreated( BoltServerAddress serverAddress, PoolListenerEvent listenerEvent )
+    public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent listenerEvent )
     {
         poolMetrics( serverAddress ).afterAcquiredOrCreated( listenerEvent );
     }
 
     @Override
-    public void afterAcquiredOrCreated( BoltServerAddress serverAddress, ConnectionListenerEvent inUseEvent )
+    public void afterConnectionCreated( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
     {
         connectionMetrics( serverAddress ).acquiredOrCreated( inUseEvent );
     }
 
     @Override
-    public void afterReleased( BoltServerAddress serverAddress, ConnectionListenerEvent inUseEvent )
+    public void afterConnectionReleased( BoltServerAddress serverAddress, ListenerEvent inUseEvent )
     {
         connectionMetrics( serverAddress ).released( inUseEvent );
     }
@@ -118,13 +117,7 @@ public class InternalMetrics extends InternalAbstractMetrics
     }
 
     @Override
-    public PoolListenerEvent createPoolListenerEvent()
-    {
-        return new NanoTimeBasedListenerEvent();
-    }
-
-    @Override
-    public ConnectionListenerEvent createConnectionListenerEvent()
+    public ListenerEvent createListenerEvent()
     {
         return new NanoTimeBasedListenerEvent();
     }
@@ -132,13 +125,13 @@ public class InternalMetrics extends InternalAbstractMetrics
     @Override
     public Map<String,ConnectionPoolMetrics> connectionPoolMetrics()
     {
-        return this.connectionPoolMetrics;
+        return unmodifiableMap( this.connectionPoolMetrics );
     }
 
     @Override
     public Map<String,ConnectionMetrics> connectionMetrics()
     {
-        return this.connectionMetrics;
+        return unmodifiableMap( this.connectionMetrics );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
@@ -88,6 +88,12 @@ public class InternalMetrics extends InternalAbstractMetrics
     }
 
     @Override
+    public void afterAcquiringOrCreating( BoltServerAddress serverAddress )
+    {
+        poolMetrics( serverAddress ).afterAcquiringOrCreating();
+    }
+
+    @Override
     public void afterAcquiredOrCreated( BoltServerAddress serverAddress, PoolListenerEvent listenerEvent )
     {
         poolMetrics( serverAddress ).afterAcquiredOrCreated( listenerEvent );

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ListenerEvent.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ListenerEvent.java
@@ -18,10 +18,18 @@
  */
 package org.neo4j.driver.internal.metrics;
 
-
 public interface ListenerEvent
 {
     void start();
+
     long elapsed();
+
+    interface PoolListenerEvent extends ListenerEvent
+    {
+    }
+
+    interface ConnectionListenerEvent extends ListenerEvent
+    {
+    }
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/ListenerEvent.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/ListenerEvent.java
@@ -21,15 +21,6 @@ package org.neo4j.driver.internal.metrics;
 public interface ListenerEvent
 {
     void start();
-
     long elapsed();
-
-    interface PoolListenerEvent extends ListenerEvent
-    {
-    }
-
-    interface ConnectionListenerEvent extends ListenerEvent
-    {
-    }
 }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/MetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/MetricsListener.java
@@ -69,6 +69,12 @@ public interface MetricsListener
     void beforeAcquiringOrCreating( BoltServerAddress serverAddress, PoolListenerEvent acquireEvent );
 
     /**
+     * After acquiring or creating a new netty channel from pool regardless successfully or not.
+     * @param serverAddress the server the netty channel binds to
+     */
+    void afterAcquiringOrCreating( BoltServerAddress serverAddress );
+
+    /**
      * After acquiring or creating a new netty channel from pool successfully.
      * @param serverAddress the server the netty channel binds to
      * @param acquireEvent a pool listener event registered in pool for this acquire event

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/MetricsListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/MetricsListener.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.NettyConnection;
 import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
-import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
-import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
 import org.neo4j.driver.v1.Config;
 
 public interface MetricsListener
@@ -34,13 +32,13 @@ public interface MetricsListener
      * @param serverAddress the server the netty channel binds to.
      * @param creatingEvent a connection listener event registered when a connection is creating.
      */
-    void beforeCreating( BoltServerAddress serverAddress, ConnectionListenerEvent creatingEvent );
+    void beforeCreating( BoltServerAddress serverAddress, ListenerEvent creatingEvent );
 
     /**
      * After a netty channel is created successfully
      * @param serverAddress the server the netty channel binds to
      */
-    void afterCreated( BoltServerAddress serverAddress, ConnectionListenerEvent creatingEvent );
+    void afterCreated( BoltServerAddress serverAddress, ListenerEvent creatingEvent );
 
     /**
      * After a netty channel is created with failure
@@ -66,7 +64,7 @@ public interface MetricsListener
      * @param serverAddress the server the netty channel binds to
      * @param acquireEvent a pool listener event registered in pool for this acquire event
      */
-    void beforeAcquiringOrCreating( BoltServerAddress serverAddress, PoolListenerEvent acquireEvent );
+    void beforeAcquiringOrCreating( BoltServerAddress serverAddress, ListenerEvent acquireEvent );
 
     /**
      * After acquiring or creating a new netty channel from pool regardless successfully or not.
@@ -79,24 +77,23 @@ public interface MetricsListener
      * @param serverAddress the server the netty channel binds to
      * @param acquireEvent a pool listener event registered in pool for this acquire event
      */
-    void afterAcquiredOrCreated( BoltServerAddress serverAddress, PoolListenerEvent acquireEvent );
+    void afterAcquiredOrCreated( BoltServerAddress serverAddress, ListenerEvent acquireEvent );
 
     /**
      * After acquiring or creating a new netty channel from pool successfully.
      * @param serverAddress the server the netty channel binds to
      * @param inUseEvent a connection listener registered with a {@link NettyConnection} when created
      */
-    void afterAcquiredOrCreated( BoltServerAddress serverAddress, ConnectionListenerEvent inUseEvent );
+    void afterConnectionCreated( BoltServerAddress serverAddress, ListenerEvent inUseEvent );
 
     /**
      * After releasing a netty channel back to pool successfully
      * @param serverAddress the server the netty channel binds to
      * @param inUseEvent a connection listener registered with a {@link NettyConnection} when destroyed
      */
-    void afterReleased( BoltServerAddress serverAddress, ConnectionListenerEvent inUseEvent );
+    void afterConnectionReleased( BoltServerAddress serverAddress, ListenerEvent inUseEvent );
 
-    PoolListenerEvent createPoolListenerEvent();
-    ConnectionListenerEvent createConnectionListenerEvent();
+    ListenerEvent createListenerEvent();
 
     void addMetrics( BoltServerAddress address, ConnectionPoolImpl connectionPool );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/NanoTimeBasedListenerEvent.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/NanoTimeBasedListenerEvent.java
@@ -19,7 +19,10 @@
 
 package org.neo4j.driver.internal.metrics;
 
-public class NanoTimeBasedListenerEvent implements ListenerEvent
+import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
+import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
+
+public class NanoTimeBasedListenerEvent implements PoolListenerEvent, ConnectionListenerEvent
 {
     private long startNanoTime;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/NanoTimeBasedListenerEvent.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/NanoTimeBasedListenerEvent.java
@@ -19,10 +19,7 @@
 
 package org.neo4j.driver.internal.metrics;
 
-import org.neo4j.driver.internal.metrics.ListenerEvent.ConnectionListenerEvent;
-import org.neo4j.driver.internal.metrics.ListenerEvent.PoolListenerEvent;
-
-public class NanoTimeBasedListenerEvent implements PoolListenerEvent, ConnectionListenerEvent
+public class NanoTimeBasedListenerEvent implements ListenerEvent
 {
     private long startNanoTime;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/ConnectionPoolMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/ConnectionPoolMetrics.java
@@ -31,30 +31,27 @@ public interface ConnectionPoolMetrics
     String uniqueName();
 
     /**
-     * The status of the pool
+     * The status of the pool.
      * @return The status of the pool.
      */
     PoolStatus poolStatus();
 
     /**
-     * The amount of channels that are in-use (borrowed out of the pool).
-     * The number is changing up and down from time to time.
-     * @return The amount of channels that are in-use
+     * The amount of channels that are currently in-use (borrowed out of the pool).
+     * @return The amount of channels that are currently in-use
      */
     int inUse();
 
     /**
-     * The amount of channels that are idle (buffered inside the pool).
-     * The number is changing up and down from time to time.
-     * @return The amount of channels that are idle.
+     * The amount of channels that are currently idle (buffered inside the pool).
+     * @return The amount of channels that are currently idle.
      */
     int idle();
 
     /**
-     * The amount of channels that are waiting to be created.
-     * The amount is increased by one when the pool noticed a request to create a new connection.
-     * The amount is decreased by one when the pool noticed a new connection is created regardless successfully or not.
-     * The number is changing up and down from time to time.
+     * The amount of channels that are currently waiting to be created.
+     * The amount is increased by one when the pool noticed a request to create a new channel.
+     * The amount is decreased by one when the pool noticed a new channel is created successfully or failed to create.
      * @return The amount of channels that are waiting to be created.
      */
     int creating();
@@ -78,7 +75,15 @@ public interface ConnectionPoolMetrics
     long closed();
 
     /**
-     * An increasing-only number to record how many connections have been acquired from the pool.
+     * The current count of application requests to wait for acquiring a connection from the pool.
+     * The reason to wait could be waiting for creating a new channel, or waiting for a channel to be free by application when the pool is full.
+     * @return The current amount of application request to wait for acquiring a connection from the pool.
+     */
+    int acquiring();
+
+    /**
+     * An increasing-only number to record how many connections have been acquired from the pool
+     * The connections acquired could hold either a newly created channel or a reused channel from the pool.
      * @return The amount of connections that have been acquired from the pool.
      */
     long acquired();
@@ -86,13 +91,14 @@ public interface ConnectionPoolMetrics
     /**
      * An increasing-only number to record how many times that we've failed to acquire a connection from the pool within configured maximum acquisition timeout
      * set by {@link Config.ConfigBuilder#withConnectionAcquisitionTimeout(long, TimeUnit)}.
+     * The connection acquired could hold either a newly created channel or a reused channel from the pool.
      * @return The amount of failures to acquire a connection from the pool within maximum connection acquisition timeout.
      */
     long timedOutToAcquire();
 
     /**
      * An acquisition time histogram records how long it takes to acquire an connection from this pool.
-     * The connection acquired from the pool could either be a connection idling inside the pool or a connection created by the pool.
+     * The connection acquired from the pool could contain either a channel idling inside the pool or a channel created by the pool.
      * @return The acquisition time histogram.
      */
     Histogram acquisitionTimeHistogram();

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/ConnectionPoolMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/ConnectionPoolMetrics.java
@@ -18,6 +18,10 @@
  */
 package org.neo4j.driver.internal.metrics.spi;
 
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.v1.Config;
+
 public interface ConnectionPoolMetrics
 {
     /**
@@ -28,50 +32,63 @@ public interface ConnectionPoolMetrics
 
     /**
      * The status of the pool
-     * @return The status of the pool in a string
+     * @return The status of the pool.
      */
     PoolStatus poolStatus();
 
     /**
-     * The amount of connections that is in-use (borrowed out of the pool).
+     * The amount of channels that are in-use (borrowed out of the pool).
      * The number is changing up and down from time to time.
-     * @return The amount of connections that is in-use
+     * @return The amount of channels that are in-use
      */
     int inUse();
 
     /**
-     * The amount of connections that is idle (buffered inside the pool).
+     * The amount of channels that are idle (buffered inside the pool).
      * The number is changing up and down from time to time.
-     * @return The amount of connections that is idle.
+     * @return The amount of channels that are idle.
      */
     int idle();
 
     /**
-     * The amount of connections that is going to be created.
+     * The amount of channels that are waiting to be created.
      * The amount is increased by one when the pool noticed a request to create a new connection.
      * The amount is decreased by one when the pool noticed a new connection is created regardless successfully or not.
      * The number is changing up and down from time to time.
-     * @return The amount of connection that is creating.
+     * @return The amount of channels that are waiting to be created.
      */
     int creating();
 
     /**
-     * An increasing-only number to record how many connections have been created by this pool successfully.
-     * @return The amount of connections have ever been created by this pool.
+     * An increasing-only number to record how many channels have been created by this pool successfully.
+     * @return The amount of channels have ever been created by this pool.
      */
     long created();
 
     /**
-     * An increasing-only number to record how many connections have been failed to create.
-     * @return The amount of connections have been failed to create by this pool.
+     * An increasing-only number to record how many channels have been failed to create.
+     * @return The amount of channels have been failed to create by this pool.
      */
     long failedToCreate();
 
     /**
-     * An increasing-only number to record how many connections have been closed by this pool.
-     * @return The amount of connections have been closed by this pool.
+     * An increasing-only number to record how many channels have been closed by this pool.
+     * @return The amount of channels have been closed by this pool.
      */
     long closed();
+
+    /**
+     * An increasing-only number to record how many connections have been acquired from the pool.
+     * @return The amount of connections that have been acquired from the pool.
+     */
+    long acquired();
+
+    /**
+     * An increasing-only number to record how many times that we've failed to acquire a connection from the pool within configured maximum acquisition timeout
+     * set by {@link Config.ConfigBuilder#withConnectionAcquisitionTimeout(long, TimeUnit)}.
+     * @return The amount of failures to acquire a connection from the pool within maximum connection acquisition timeout.
+     */
+    long timedOutToAcquire();
 
     /**
      * An acquisition time histogram records how long it takes to acquire an connection from this pool.

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
@@ -20,5 +20,18 @@ package org.neo4j.driver.internal.metrics.spi;
 
 public enum PoolStatus
 {
-    Open, Closed
+    Open( 0 ),
+    Closed( 1 );
+
+    private final int value;
+
+    PoolStatus( int value )
+    {
+        this.value = value;
+    }
+
+    public int value()
+    {
+        return value;
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
@@ -20,8 +20,8 @@ package org.neo4j.driver.internal.metrics.spi;
 
 public enum PoolStatus
 {
-    Open( 0 ),
-    Closed( 1 );
+    OPEN( 0 ),
+    CLOSED( 1 );
 
     private final int value;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/ConnectionPool.java
@@ -35,5 +35,5 @@ public interface ConnectionPool
 
     CompletionStage<Void> close();
 
-    boolean isOpen();
+    boolean isOpen( BoltServerAddress address );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -62,7 +62,7 @@ import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class ConnectionPoolImplTest
+public class ConnectionPoolImplIT
 {
     private static final BoltServerAddress ADDRESS_1 = new BoltServerAddress( "server:1" );
     private static final BoltServerAddress ADDRESS_2 = new BoltServerAddress( "server:2" );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
@@ -47,12 +47,14 @@ import org.neo4j.driver.v1.util.Neo4jRunner;
 import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,7 +62,7 @@ import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 import static org.neo4j.driver.v1.Values.value;
 
-public class NettyChannelPoolTest
+public class NettyChannelPoolIT
 {
     @Rule
     public final TestNeo4j neo4j = new TestNeo4j();
@@ -100,7 +102,7 @@ public class NettyChannelPoolTest
         assertTrue( acquireFuture.isSuccess() );
         Channel channel = acquireFuture.getNow();
         assertNotNull( channel );
-        verify( poolHandler ).channelCreated( channel );
+        verify( poolHandler ).channelCreated( argThat( is( channel ) ), any() );
         verify( poolHandler, never() ).channelReleased( channel );
 
         Future<Void> releaseFuture = pool.release( channel );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
@@ -44,7 +44,7 @@ public class NettyChannelTrackerTest
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
-        tracker.channelCreated( channel );
+        tracker.channelCreated( channel, null );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
     }
@@ -56,7 +56,7 @@ public class NettyChannelTrackerTest
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
-        tracker.channelCreated( channel );
+        tracker.channelCreated( channel, null );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
@@ -77,11 +77,11 @@ public class NettyChannelTrackerTest
         Channel channel3 = newChannel();
 
         assertEquals( 0, tracker.inUseChannelCount( address ) );
-        tracker.channelCreated( channel1 );
+        tracker.channelCreated( channel1, null );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
-        tracker.channelCreated( channel2 );
+        tracker.channelCreated( channel2, null );
         assertEquals( 2, tracker.inUseChannelCount( address ) );
-        tracker.channelCreated( channel3 );
+        tracker.channelCreated( channel3, null );
         assertEquals( 3, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
     }
@@ -93,9 +93,9 @@ public class NettyChannelTrackerTest
         Channel channel2 = newChannel();
         Channel channel3 = newChannel();
 
-        tracker.channelCreated( channel1 );
-        tracker.channelCreated( channel2 );
-        tracker.channelCreated( channel3 );
+        tracker.channelCreated( channel1, null );
+        tracker.channelCreated( channel2, null );
+        tracker.channelCreated( channel3, null );
         assertEquals( 3, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -95,9 +95,9 @@ public class FailingConnectionDriverFactory extends DriverFactory
         }
 
         @Override
-        public boolean isOpen()
+        public boolean isOpen( BoltServerAddress address )
         {
-            return delegate.isOpen();
+            return delegate.isOpen( address );
         }
     }
 


### PR DESCRIPTION
Based on #470 
Added connection `acquiring`, `acquired` count and `timedOutToAcquire` count on connection pool metrics
Change the histogram only record value generated by successful requests.
Fixed a bug where the pool status was showing the big pool rather than each small pool status.