### PR TITLE
Fixed a bug found on idle and inUse counters

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelPool.java
@@ -69,7 +69,6 @@ public class NettyChannelPool extends FixedChannelPool
                 // notify pool handler about a successful connection
                 Channel channel = channelFuture.channel();
                 handler.channelCreated( channel, creatingEvent );
-                channel.closeFuture().addListener( closeFuture -> handler.channelClosed( channel ) );
             }
             else
             {

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/spi/PoolStatus.java
@@ -20,18 +20,5 @@ package org.neo4j.driver.internal.metrics.spi;
 
 public enum PoolStatus
 {
-    OPEN( 0 ),
-    CLOSED( 1 );
-
-    private final int value;
-
-    PoolStatus( int value )
-    {
-        this.value = value;
-    }
-
-    public int value()
-    {
-        return value;
-    }
+    OPEN, CLOSED
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
@@ -120,7 +120,7 @@ public class NettyChannelTrackerTest
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
         // When closed before session.close
-        channel.close();
+        channel.close().sync();
 
         // Then
         assertEquals( 1, tracker.inUseChannelCount( address ) );
@@ -145,7 +145,7 @@ public class NettyChannelTrackerTest
         assertEquals( 1, tracker.idleChannelCount( address ) );
 
         // When closed before acquire
-        channel.close();
+        channel.close().sync();
         // Then
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
@@ -111,6 +111,48 @@ public class NettyChannelTrackerTest
     }
 
     @Test
+    public void shouldDecreaseIdleWhenClosedOutsidePool() throws Throwable
+    {
+        // Given
+        Channel channel = newChannel();
+        tracker.channelCreated( channel, null );
+        assertEquals( 1, tracker.inUseChannelCount( address ) );
+        assertEquals( 0, tracker.idleChannelCount( address ) );
+
+        // When closed before session.close
+        channel.close();
+
+        // Then
+        assertEquals( 1, tracker.inUseChannelCount( address ) );
+        assertEquals( 0, tracker.idleChannelCount( address ) );
+
+        tracker.channelReleased( channel );
+        assertEquals( 0, tracker.inUseChannelCount( address ) );
+        assertEquals( 0, tracker.idleChannelCount( address ) );
+    }
+
+    @Test
+    public void shouldDecreaseIdleWhenClosedInsidePool() throws Throwable
+    {
+        // Given
+        Channel channel = newChannel();
+        tracker.channelCreated( channel, null );
+        assertEquals( 1, tracker.inUseChannelCount( address ) );
+        assertEquals( 0, tracker.idleChannelCount( address ) );
+
+        tracker.channelReleased( channel );
+        assertEquals( 0, tracker.inUseChannelCount( address ) );
+        assertEquals( 1, tracker.idleChannelCount( address ) );
+
+        // When closed before acquire
+        channel.close();
+        // Then
+        assertEquals( 0, tracker.inUseChannelCount( address ) );
+        assertEquals( 0, tracker.idleChannelCount( address ) );
+
+    }
+
+    @Test
     public void shouldThrowWhenDecrementingForUnknownAddress()
     {
         Channel channel = newChannel();


### PR DESCRIPTION
Before we always decrement idle counters when a channel is closed. However, this is wrong when a channel is closed before it is returen to the pool.
So change the code to make sure that no matter the channel is closed inside or outside the pool, the idle and inUse counters should be correct.