### PR TITLE
Fixing flaky tests

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -577,7 +577,7 @@ public class TransactionAsyncIT
     @Test
     public void shouldForEachWithNonEmptyCursor()
     {
-        testForEach( "UNWIND range(1, 12555) AS x CREATE (n:Node {id: x}) RETURN n", 12555 );
+        testForEach( "UNWIND range(1, 1255) AS x CREATE (n:Node {id: x}) RETURN n", 1255 );
     }
 
     @Test


### PR DESCRIPTION
This test is flaky because the result is too big to be returned in expected 1 min

Changed the returned value to be a smaller value as the test does not need to run with a big result.