### PR TITLE
Add `Value#asXXX(defalutValue)` for primary types

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -91,6 +91,42 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     }
 
     @Override
+    public boolean asBoolean( boolean defaultValue )
+    {
+        return computeOrDefault( Value:: asBoolean, defaultValue );
+    }
+
+    @Override
+    public String asString( String defaultValue )
+    {
+        return computeOrDefault( (Value::asString), defaultValue );
+    }
+
+    @Override
+    public long asLong( long defaultValue )
+    {
+        return computeOrDefault( Value::asLong, defaultValue );
+    }
+
+    @Override
+    public int asInt( int defaultValue )
+    {
+        return computeOrDefault( Value::asInt, defaultValue );
+    }
+
+    @Override
+    public double asDouble( double defaultValue )
+    {
+        return computeOrDefault( Value::asDouble, defaultValue );
+    }
+
+    @Override
+    public float asFloat( float defaultValue )
+    {
+        return computeOrDefault( Value::asFloat, defaultValue );
+    }
+
+    @Override
     public long asLong()
     {
         throw new Uncoercible( type().name(), "Java long" );
@@ -148,6 +184,22 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     public Object asObject()
     {
         throw new Uncoercible( type().name(), "Java Object" );
+    }
+
+    @Override
+    public <T> T computeOrDefault( Function<Value,T> mapper, T defaultValue )
+    {
+        if ( isNull() )
+        {
+            return defaultValue;
+        }
+        return mapper.apply( this );
+    }
+
+    @Override
+    public <T> T computeOrNull( Function<Value,T> mapper )
+    {
+        return computeOrDefault( mapper, null );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -197,9 +197,75 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     }
 
     @Override
-    public <T> T computeOrNull( Function<Value,T> mapper )
+    public Map<String,Object> asMap( Map<String,Object> defaultValue )
     {
-        return computeOrDefault( mapper, null );
+        return computeOrDefault( Value::asMap, defaultValue );
+    }
+
+    @Override
+    public <T> Map<String,T> asMap( Function<Value,T> mapFunction, Map<String,T> defaultValue )
+    {
+        return computeOrDefault( value -> value.asMap( mapFunction ), defaultValue );
+    }
+
+    @Override
+    public byte[] asByteArray( byte[] defaultValue )
+    {
+        return computeOrDefault( Value::asByteArray, defaultValue );
+    }
+
+    @Override
+    public List<Object> asList( List<Object> defaultValue )
+    {
+        return computeOrDefault( Value::asList, defaultValue );
+    }
+
+    @Override
+    public <T> List<T> asList( Function<Value,T> mapFunction, List<T> defaultValue )
+    {
+        return computeOrDefault( value -> value.asList( mapFunction ), defaultValue );
+    }
+
+    @Override
+    public LocalDate asLocalDate( LocalDate defaultValue )
+    {
+        return computeOrDefault( Value::asLocalDate, defaultValue );
+    }
+
+    @Override
+    public OffsetTime asOffsetTime( OffsetTime defaultValue )
+    {
+        return computeOrDefault( Value::asOffsetTime, defaultValue );
+    }
+
+    @Override
+    public LocalTime asLocalTime( LocalTime defaultValue )
+    {
+        return computeOrDefault( Value::asLocalTime, defaultValue );
+    }
+
+    @Override
+    public LocalDateTime asLocalDateTime( LocalDateTime defaultValue )
+    {
+        return computeOrDefault( Value::asLocalDateTime, defaultValue );
+    }
+
+    @Override
+    public ZonedDateTime asZonedDateTime( ZonedDateTime defaultValue )
+    {
+        return computeOrDefault( Value::asZonedDateTime, defaultValue );
+    }
+
+    @Override
+    public IsoDuration asIsoDuration( IsoDuration defaultValue )
+    {
+        return computeOrDefault( Value::asIsoDuration, defaultValue );
+    }
+
+    @Override
+    public Point asPoint( Point defaultValue )
+    {
+        return computeOrDefault( Value::asPoint, defaultValue );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -205,14 +205,6 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     <T>T computeOrDefault( Function<Value, T> mapper, T defaultValue );
 
     /**
-     * Apply the mapping function on the value if the value is not a {@link NullValue}, or null if the value is a {@link NullValue}.
-     * @param mapper The mapping function defines how to map a {@link Value} to T.
-     * @param <T> The return type
-     * @return The value after applying the given mapping function or null if the value is {@link NullValue}.
-     */
-    <T>T computeOrNull( Function<Value, T> mapper );
-
-    /**
      * @return the value as a Java boolean, if possible.
      * @throws Uncoercible if value types are incompatible.
      */
@@ -230,6 +222,13 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      *  @throws Uncoercible if value types are incompatible.
      */
     byte[] asByteArray();
+
+    /**
+     *  @param defaultValue default to this value if the original value is a {@link NullValue}
+     *  @return the value as a Java byte array, if possible.
+     *  @throws Uncoercible if value types are incompatible.
+     */
+    byte[] asByteArray( byte[] defaultValue );
 
     /**
      *  @return the value as a Java String, if possible.
@@ -331,6 +330,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      */
     List<Object> asList();
 
+
+    /**
+     * If the underlying type can be viewed as a list, returns a java list of
+     * values, where each value has been converted using {@link #asObject()}.
+     *
+     * @see #asObject()
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a Java list of values, if possible
+     */
+    List<Object> asList( List<Object> defaultValue );
+
     /**
      * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
      * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
@@ -338,7 +348,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @see Values for a long list of built-in conversion functions
      * @return the value as a list of T obtained by mapping from the list elements, if possible
      */
-    <T> List<T> asList( Function<Value, T> mapFunction );
+    <T> List<T> asList( Function<Value,T> mapFunction );
+
+    /**
+     * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
+     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param <T> the type of target list elements
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @see Values for a long list of built-in conversion functions
+     * @return the value as a list of T obtained by mapping from the list elements, if possible
+     */
+    <T> List<T> asList( Function<Value,T> mapFunction, List<T> defaultValue );
 
     /**
      * @return the value as a {@link Entity}, if possible.
@@ -405,6 +425,76 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @throws Uncoercible if value types are incompatible.
      */
     Point asPoint();
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link LocalDate}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    LocalDate asLocalDate( LocalDate defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link OffsetTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    OffsetTime asOffsetTime( OffsetTime defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link LocalTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    LocalTime asLocalTime( LocalTime defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link LocalDateTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    LocalDateTime asLocalDateTime( LocalDateTime defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link ZonedDateTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    ZonedDateTime asZonedDateTime( ZonedDateTime defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link IsoDuration}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    IsoDuration asIsoDuration( IsoDuration defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link Point}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    Point asPoint( Point defaultValue );
+
+    /**
+     * Return as a map of string keys and values converted using
+     * {@link Value#asObject()}.
+     *
+     * This is equivalent to calling {@link #asMap(Function, Map)} with {@link Values#ofObject()}.
+     *
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a Java map
+     */
+    Map<String, Object> asMap( Map<String,Object> defaultValue );
+
+    /**
+     * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
+     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param <T> the type of map values
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @see Values for a long list of built-in conversion functions
+     * @return the value as a map from string keys to values of type T obtained from mapping he original map values, if possible
+     */
+    <T> Map<String, T> asMap( Function<Value, T> mapFunction, Map<String, T> defaultValue );
 
     @Override
     boolean equals( Object other );

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -26,6 +26,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.value.LossyCoercion;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
@@ -195,10 +196,34 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     Object asObject();
 
     /**
+     * Apply the mapping function on the value if the value is not a {@link NullValue}, or the default value if the value is a {@link NullValue}.
+     * @param mapper The mapping function defines how to map a {@link Value} to T.
+     * @param defaultValue the value to return if the value is a {@link NullValue}
+     * @param <T> The return type
+     * @return The value after applying the given mapping function or the default value if the value is {@link NullValue}.
+     */
+    <T>T computeOrDefault( Function<Value, T> mapper, T defaultValue );
+
+    /**
+     * Apply the mapping function on the value if the value is not a {@link NullValue}, or null if the value is a {@link NullValue}.
+     * @param mapper The mapping function defines how to map a {@link Value} to T.
+     * @param <T> The return type
+     * @return The value after applying the given mapping function or null if the value is {@link NullValue}.
+     */
+    <T>T computeOrNull( Function<Value, T> mapper );
+
+    /**
      * @return the value as a Java boolean, if possible.
      * @throws Uncoercible if value types are incompatible.
      */
     boolean asBoolean();
+
+    /**
+     * @param defaultValue return this value if the value is a {@link NullValue}.
+     * @return the value as a Java boolean, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    boolean asBoolean( boolean defaultValue );
 
     /**
      *  @return the value as a Java byte array, if possible.
@@ -211,6 +236,12 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      *  @throws Uncoercible if value types are incompatible.
      */
     String asString();
+
+    /**
+     * @param defaultValue return this value if the value is null.
+     * @return the value as a Java String, if possible
+     */
+    String asString( String defaultValue );
 
     /**
      * @return the value as a Java Number, if possible.
@@ -228,6 +259,15 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     long asLong();
 
     /**
+     * Returns a Java long if no precision is lost in the conversion.
+     * @param defaultValue return this default value if the value is a {@link NullValue}.
+     * @return the value as a Java long.
+     * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    long asLong( long defaultValue );
+
+    /**
      * Returns a Java int if no precision is lost in the conversion.
      *
      * @return the value as a Java int.
@@ -235,6 +275,15 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @throws Uncoercible if value types are incompatible.
      */
     int asInt();
+
+    /**
+     * Returns a Java int if no precision is lost in the conversion.
+     * @param defaultValue return this default value if the value is a {@link NullValue}.
+     * @return the value as a Java int.
+     * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    int asInt( int defaultValue );
 
     /**
      * Returns a Java double if no precision is lost in the conversion.
@@ -246,6 +295,16 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     double asDouble();
 
     /**
+     * Returns a Java double if no precision is lost in the conversion.
+     * @param defaultValue default to this value if the value is a {@link NullValue}.
+     * @return the value as a Java double.
+     * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
+     * @throws Uncoercible if value types are incompatible.
+
+     */
+    double asDouble( double defaultValue );
+
+    /**
      * Returns a Java float if no precision is lost in the conversion.
      *
      * @return the value as a Java float.
@@ -253,6 +312,16 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @throws Uncoercible if value types are incompatible.
      */
     float asFloat();
+
+    /**
+     * Returns a Java float if no precision is lost in the conversion.
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a Java float.
+     * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
+     * @throws Uncoercible if value types are incompatible.
+
+     */
+    float asFloat( float defaultValue );
 
     /**
      * If the underlying type can be viewed as a list, returns a java list of

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -240,6 +240,7 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     /**
      * @param defaultValue return this value if the value is null.
      * @return the value as a Java String, if possible
+     * @throws Uncoercible if value types are incompatible.
      */
     String asString( String defaultValue );
 
@@ -300,7 +301,6 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @return the value as a Java double.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
      * @throws Uncoercible if value types are incompatible.
-
      */
     double asDouble( double defaultValue );
 
@@ -319,7 +319,6 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @return the value as a Java float.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
      * @throws Uncoercible if value types are incompatible.
-
      */
     float asFloat( float defaultValue );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
@@ -20,11 +20,23 @@ package org.neo4j.driver.internal.value;
 
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
 import org.neo4j.driver.internal.types.TypeConstructor;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.util.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.driver.v1.Values.point;
 
 public class NullValueTest
 {
@@ -44,5 +56,79 @@ public class NullValueTest
     public void shouldTypeAsNull()
     {
         assertThat( ((InternalValue) NullValue.NULL).typeConstructor(), equalTo( TypeConstructor.NULL ) );
+    }
+
+    @Test
+    public void shouldReturnNativeTypesAsDefaultValue() throws Throwable
+    {
+        Value value = NullValue.NULL;
+        assertThat( value.asBoolean( false ), equalTo( false ) );
+        assertThat( value.asBoolean( true ), equalTo( true ) );
+        assertThat( value.asString( "string value" ), equalTo( "string value" ) );
+        assertThat( value.asInt( 10 ), equalTo( 10 ) );
+        assertThat( value.asLong( 100L ), equalTo( 100L ) );
+        assertThat( value.asFloat( 10.4f ), equalTo( 10.4f ) );
+        assertThat( value.asDouble( 10.10 ), equalTo( 10.10 ) );
+    }
+
+    @Test
+    public void shouldReturnAsNull() throws Throwable
+    {
+        Value value = NullValue.NULL;
+
+        assertThat( value.computeOrNull( Value::asObject ), nullValue() );
+        assertThat( value.computeOrNull( Value::asNumber ), nullValue() );
+        assertThat( value.computeOrNull( Value::asByteArray ), nullValue() );
+
+        assertThat( value.computeOrNull( Value::asEntity ), nullValue() );
+        assertThat( value.computeOrNull( Value::asNode ), nullValue() );
+        assertThat( value.computeOrNull( Value::asRelationship ), nullValue() );
+        assertThat( value.computeOrNull( Value::asPath ), nullValue() );
+
+        assertThat( value.computeOrNull( Value::asPoint ), nullValue() );
+
+        assertThat( value.computeOrNull( Value::asLocalDate ), nullValue() );
+        assertThat( value.computeOrNull( Value::asOffsetTime ), nullValue() );
+        assertThat( value.computeOrNull( Value::asLocalTime ), nullValue() );
+        assertThat( value.computeOrNull( Value::asLocalDateTime ), nullValue() );
+        assertThat( value.computeOrNull( Value::asZonedDateTime ), nullValue() );
+        assertThat( value.computeOrNull( Value::asIsoDuration ), nullValue() );
+
+        assertThat( value.computeOrNull( Value::asList ), nullValue() );
+        assertThat( value.computeOrNull( Value::asMap ), nullValue() );
+    }
+
+    @Test
+    public void shouldReturnAsDefaultValue() throws Throwable
+    {
+        Value value = NullValue.NULL;
+
+        assertThat( value.computeOrDefault( Value::asObject, "null" ), equalTo( "null" ) );
+        assertThat( value.computeOrDefault( Value::asNumber, 10 ), equalTo( 10 ) );
+        assertThat( value.computeOrDefault( Value::asByteArray, new byte[0] ), equalTo( new byte[0] ) );
+
+        assertThat( value.computeOrDefault( Value::asEntity, null ), nullValue() );
+        assertThat( value.computeOrDefault( Value::asNode, null ), nullValue() );
+        assertThat( value.computeOrDefault( Value::asRelationship, null ), nullValue() );
+        assertThat( value.computeOrDefault( Value::asPath, null ), nullValue() );
+
+        assertComputeOrDefaultReturnsDefaultValue( Value::asPoint, point( 1234, 1, 2 ) );
+
+        assertComputeOrDefaultReturnsDefaultValue( Value::asLocalDate, LocalDate.now() );
+        assertComputeOrDefaultReturnsDefaultValue( Value::asOffsetTime, OffsetTime.now() );
+        assertComputeOrDefaultReturnsDefaultValue( Value::asLocalTime, LocalTime.now() );
+        assertComputeOrDefaultReturnsDefaultValue( Value::asLocalDateTime, LocalDateTime.now() );
+        assertComputeOrDefaultReturnsDefaultValue( Value::asZonedDateTime, ZonedDateTime.now() );
+        assertComputeOrDefaultReturnsDefaultValue( Value::asIsoDuration, Values.isoDuration( 1, 2, 3, 4 ) );
+
+        assertThat( value.computeOrDefault( Value::asList, Collections.emptyList() ), equalTo( Collections.emptyList() ) );
+        assertThat( value.computeOrDefault( Value::asMap, Collections.emptyMap() ), equalTo( Collections.emptyMap() ) );
+    }
+
+    private <T> void assertComputeOrDefaultReturnsDefaultValue( Function<Value, T> f, T defaultAndExpectedValue )
+    {
+        Value value = NullValue.NULL;
+        T returned = value.computeOrDefault( f, defaultAndExpectedValue );
+        assertThat( returned, equalTo( defaultAndExpectedValue ) );
     }
 }


### PR DESCRIPTION
Add `Value#computeOrDefault(Function<Value, T> mapper, T defaultValue)` for other types
Add `Value#computeOrNull(Function<Value, T> mapper)` for shortcuts to call `Value#computeOrDefault(Function<Value, T> mapper, T defaultValue=null)`