### PR TITLE
Better logging for Driver creation

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -158,7 +158,10 @@ public class DriverFactory
     {
         ConnectionProvider connectionProvider = new DirectConnectionProvider( address, connectionPool );
         SessionFactory sessionFactory = createSessionFactory( connectionProvider, retryLogic, config );
-        return createDriver( securityPlan, sessionFactory, metrics, config );
+        InternalDriver driver = createDriver(securityPlan, sessionFactory, metrics, config);
+        Logger log = config.logging().getLog( Driver.class.getSimpleName() );
+        log.info( "Direct driver instance %s created for server address %s", driver, address.toString() );
+        return driver;
     }
 
     /**
@@ -176,7 +179,10 @@ public class DriverFactory
         ConnectionProvider connectionProvider = createLoadBalancer( address, connectionPool, eventExecutorGroup,
                 config, routingSettings );
         SessionFactory sessionFactory = createSessionFactory( connectionProvider, retryLogic, config );
-        return createDriver( securityPlan, sessionFactory, metrics, config );
+        InternalDriver driver = createDriver(securityPlan, sessionFactory, metrics, config);
+        Logger log = config.logging().getLog( Driver.class.getSimpleName() );
+        log.info( "Routing driver instance %s created for server address %s", driver, address.toString() );
+        return driver;
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -47,7 +47,6 @@ public class InternalDriver implements Driver
         this.sessionFactory = sessionFactory;
         this.metrics = metrics;
         this.log = logging.getLog( Driver.class.getSimpleName() );
-        log.info( "Driver instance %s created", this );
     }
 
     @Override


### PR DESCRIPTION
When creating multiple Driver objects, the log detail is unhelpful:
```
Apr 13, 2018 3:28:58 PM org.neo4j.driver.internal.logging.JULogger info
INFO: Driver instance org.neo4j.driver.internal.InternalDriver@1ed4004b created
Apr 13, 2018 3:28:58 PM org.neo4j.driver.internal.logging.JULogger info
INFO: Driver instance org.neo4j.driver.internal.InternalDriver@59e5ddf created
```

This change adds extra detail (Direct/Routing and server address) but requires moving the `log.info` calls to where the address is available.