### PR TITLE
Reduce code duplication in statement runners

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.internal.value.MapValue;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.StatementResultCursor;
+import org.neo4j.driver.v1.StatementRunner;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.types.TypeSystem;
+
+import static org.neo4j.driver.internal.util.Extract.assertParameter;
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
+import static org.neo4j.driver.v1.Values.value;
+
+abstract class AbstractStatementRunner implements StatementRunner
+{
+    @Override
+    public final StatementResult run( String statementTemplate, Value parameters )
+    {
+        return run( new Statement( statementTemplate, parameters ) );
+    }
+
+    @Override
+    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Value parameters )
+    {
+        return runAsync( new Statement( statementTemplate, parameters ) );
+    }
+
+    @Override
+    public final StatementResult run( String statementTemplate, Map<String,Object> statementParameters )
+    {
+        return run( statementTemplate, parameters( statementParameters ) );
+    }
+
+    @Override
+    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Map<String,Object> statementParameters )
+    {
+        return runAsync( statementTemplate, parameters( statementParameters ) );
+    }
+
+    @Override
+    public final StatementResult run( String statementTemplate, Record statementParameters )
+    {
+        return run( statementTemplate, parameters( statementParameters ) );
+    }
+
+    @Override
+    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Record statementParameters )
+    {
+        return runAsync( statementTemplate, parameters( statementParameters ) );
+    }
+
+    @Override
+    public final StatementResult run( String statementText )
+    {
+        return run( statementText, Values.EmptyMap );
+    }
+
+    @Override
+    public final CompletionStage<StatementResultCursor> runAsync( String statementText )
+    {
+        return runAsync( statementText, Values.EmptyMap );
+    }
+
+    @Override
+    public final TypeSystem typeSystem()
+    {
+        return InternalTypeSystem.TYPE_SYSTEM;
+    }
+
+    private static Value parameters( Record record )
+    {
+        return record == null ? Values.EmptyMap : parameters( record.asMap() );
+    }
+
+    private static Value parameters( Map<String,Object> map )
+    {
+        if ( map == null || map.isEmpty() )
+        {
+            return Values.EmptyMap;
+        }
+
+        Map<String,Value> asValues = newHashMapWithSize( map.size() );
+        for ( Map.Entry<String,Object> entry : map.entrySet() )
+        {
+            Object value = entry.getValue();
+            assertParameter( value );
+            asValues.put( entry.getKey(), value( value ) );
+        }
+        return new MapValue( asValues );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.driver.internal;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -29,29 +28,23 @@ import org.neo4j.driver.internal.logging.PrefixedLogger;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
-import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
-import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.TransactionWork;
-import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.types.TypeSystem;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.neo4j.driver.internal.util.Extract.parameters;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
-public class NetworkSession implements Session
+public class NetworkSession extends AbstractStatementRunner implements Session
 {
     private static final String LOG_NAME = "Session";
 
@@ -74,59 +67,6 @@ public class NetworkSession implements Session
         this.mode = mode;
         this.retryLogic = retryLogic;
         this.logger = new PrefixedLogger( "[" + hashCode() + "]", logging.getLog( LOG_NAME ) );
-    }
-
-    @Override
-    public StatementResult run( String statementText )
-    {
-        return run( statementText, Values.EmptyMap );
-    }
-
-    @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statementText )
-    {
-        return runAsync( statementText, Values.EmptyMap );
-    }
-
-    @Override
-    public StatementResult run( String statementText, Map<String,Object> statementParameters )
-    {
-        Value params = statementParameters == null ? Values.EmptyMap : parameters( statementParameters );
-        return run( statementText, params );
-    }
-
-    @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statementText,
-            Map<String,Object> statementParameters )
-    {
-        Value params = statementParameters == null ? Values.EmptyMap : parameters( statementParameters );
-        return runAsync( statementText, params );
-    }
-
-    @Override
-    public StatementResult run( String statementTemplate, Record statementParameters )
-    {
-        Value params = statementParameters == null ? Values.EmptyMap : parameters( statementParameters.asMap() );
-        return run( statementTemplate, params );
-    }
-
-    @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Record statementParameters )
-    {
-        Value params = statementParameters == null ? Values.EmptyMap : parameters( statementParameters.asMap() );
-        return runAsync( statementTemplate, params );
-    }
-
-    @Override
-    public StatementResult run( String statementText, Value statementParameters )
-    {
-        return run( new Statement( statementText, statementParameters ) );
-    }
-
-    @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statementText, Value parameters )
-    {
-        return runAsync( new Statement( statementText, parameters ) );
     }
 
     @Override
@@ -276,12 +216,6 @@ public class NetworkSession implements Session
                     }
                     return completedWithNull();
                 } );
-    }
-
-    @Override
-    public TypeSystem typeSystem()
-    {
-        return InternalTypeSystem.TYPE_SYSTEM;
     }
 
     CompletionStage<Boolean> currentConnectionIsOpen()

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Extract.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Extract.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.driver.internal.InternalPair;
-import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.internal.value.NodeValue;
 import org.neo4j.driver.internal.value.PathValue;
 import org.neo4j.driver.internal.value.RelationshipValue;
@@ -44,8 +43,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
-import static org.neo4j.driver.v1.Values.value;
 
 /**
  * Utility class for extracting data.
@@ -199,18 +196,6 @@ public final class Extract
                 return unmodifiableList( list );
             }
         }
-    }
-
-    public static Value parameters( Map<String,Object> val )
-    {
-        Map<String,Value> asValues = newHashMapWithSize( val.size() );
-        for ( Map.Entry<String,Object> entry : val.entrySet() )
-        {
-            Object value = entry.getValue();
-            assertParameter( value );
-            asValues.put( entry.getKey(), value( value ) );
-        }
-        return new MapValue( asValues );
     }
 
     public static void assertParameter( Object value )


### PR DESCRIPTION
Interface `StatementRunner` defines methods for running Cypher queries with different forms of parameters. It is implemented by both session and transaction. Both used to implement overloads of `#run()` and `#runAsync()` in a similar way.

This PR adds an abstract class for session and transaction so that they only need to implement a single `#run(Statement)` and `#runAsync(Statement)`.