### PR TITLE
Log driver's hashCode during startup and shutdown

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -38,9 +38,9 @@ import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancingStrategy;
 import org.neo4j.driver.internal.cluster.loadbalancing.RoundRobinLoadBalancingStrategy;
 import org.neo4j.driver.internal.logging.NettyLogging;
-import org.neo4j.driver.internal.metrics.MetricsListener;
 import org.neo4j.driver.internal.metrics.InternalAbstractMetrics;
 import org.neo4j.driver.internal.metrics.InternalMetrics;
+import org.neo4j.driver.internal.metrics.MetricsListener;
 import org.neo4j.driver.internal.metrics.spi.Metrics;
 import org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic;
 import org.neo4j.driver.internal.retry.RetryLogic;
@@ -160,7 +160,7 @@ public class DriverFactory
         SessionFactory sessionFactory = createSessionFactory( connectionProvider, retryLogic, config );
         InternalDriver driver = createDriver(securityPlan, sessionFactory, metrics, config);
         Logger log = config.logging().getLog( Driver.class.getSimpleName() );
-        log.info( "Direct driver instance %s created for server address %s", driver, address.toString() );
+        log.info( "Direct driver instance %s created for server address %s", driver.hashCode(), address );
         return driver;
     }
 
@@ -181,7 +181,7 @@ public class DriverFactory
         SessionFactory sessionFactory = createSessionFactory( connectionProvider, retryLogic, config );
         InternalDriver driver = createDriver(securityPlan, sessionFactory, metrics, config);
         Logger log = config.logging().getLog( Driver.class.getSimpleName() );
-        log.info( "Routing driver instance %s created for server address %s", driver, address.toString() );
+        log.info( "Routing driver instance %s created for server address %s", driver.hashCode(), address );
         return driver;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -115,7 +115,7 @@ public class InternalDriver implements Driver
     {
         if ( closed.compareAndSet( false, true ) )
         {
-            log.info( "Closing driver instance %s", this );
+            log.info( "Closing driver instance %s", hashCode() );
             return sessionFactory.close();
         }
         return completedWithNull();


### PR DESCRIPTION
Previously, driver logged its fully qualified class name and hash code when created or closed. Example:

```
2018-04-24 03:45:48,607 Direct driver instance o.n.d.i.InternalDriver@30316b44 created for server address localhost:7687
2018-04-24 03:45:49,541 Closing driver instance o.n.d.i.InternalDriver@30316b44
```

Class name does not seem to be useful and this PR replaces it with logging of the hash code. Example:

```
2018-04-24 03:45:48,607 Direct driver instance 808545092 created for server address localhost:7687
2018-04-24 03:45:49,541 Closing driver instance 808545092
```