### PR TITLE
Omit zero nanoseconds in `IsoDuration#toString()`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalIsoDuration.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalIsoDuration.java
@@ -193,6 +193,7 @@ public class InternalIsoDuration implements IsoDuration
     @Override
     public String toString()
     {
-        return String.format( "P%sM%sDT%s.%sS", months, days, seconds, String.format( "%09d", nanoseconds ) );
+        String nanosecondsString = nanoseconds == 0 ? "" : String.format( ".%09d", nanoseconds );
+        return String.format( "P%sM%sDT%s%sS", months, days, seconds, nanosecondsString );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
@@ -156,16 +156,16 @@ public class InternalIsoDurationTest
     @Test
     public void toStringShouldPrintInIsoStandardFormat() throws Throwable
     {
-        assertThat( new InternalIsoDuration( 0, 0, 0, 0 ).toString(), equalTo( "P0M0DT0.000000000S" ) );
+        assertThat( new InternalIsoDuration( 0, 0, 0, 0 ).toString(), equalTo( "P0M0DT0S" ) );
         assertThat( new InternalIsoDuration( 2, 45, 59, 11 ).toString(), equalTo( "P2M45DT59.000000011S" ) );
         assertThat( new InternalIsoDuration( 4, -101, 1, 999 ).toString(), equalTo( "P4M-101DT1.000000999S" ) );
         assertThat( new InternalIsoDuration( -1, 12, -19, 1 ).toString(), equalTo( "P-1M12DT-19.000000001S" ) );
 
-        assertThat( new InternalIsoDuration( Period.parse( "P356D" ) ).toString(), equalTo( "P0M356DT0.000000000S" ) );
-        assertThat( new InternalIsoDuration( Duration.parse( "PT45S" ) ).toString(), equalTo( "P0M0DT45.000000000S" ) );
+        assertThat( new InternalIsoDuration( Period.parse( "P356D" ) ).toString(), equalTo( "P0M356DT0S" ) );
+        assertThat( new InternalIsoDuration( Duration.parse( "PT45S" ) ).toString(), equalTo( "P0M0DT45S" ) );
 
-        assertThat( new InternalIsoDuration( Period.parse( "P14D" ), Duration.parse( "PT16H12M" ) ).toString(), equalTo( "P0M14DT58320.000000000S" ) );
-        assertThat( new InternalIsoDuration( Period.parse( "P5M1D" ), Duration.parse( "PT12H" ) ).toString(), equalTo( "P5M1DT43200.000000000S" ) );
+        assertThat( new InternalIsoDuration( Period.parse( "P14D" ), Duration.parse( "PT16H12M" ) ).toString(), equalTo( "P0M14DT58320S" ) );
+        assertThat( new InternalIsoDuration( Period.parse( "P5M1D" ), Duration.parse( "PT12H" ) ).toString(), equalTo( "P5M1DT43200S" ) );
         assertThat( new InternalIsoDuration( Period.parse( "P2W3D" ), Duration.parse( "PT2H0.111222333S" ) ).toString(), equalTo( "P0M17DT7200.111222333S" ) );
     }
 


### PR DESCRIPTION
Returned string still remains a valid ISO string and represents the same duration value.