### PR TITLE
Logging API improvements

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -34,6 +34,13 @@
       <artifactId>HdrHistogram</artifactId>
     </dependency>
 
+    <!-- Optional dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -29,6 +27,8 @@ import java.util.logging.LogRecord;
 
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 /**
  * Print all the logging messages into {@link System#err}.
@@ -59,11 +59,11 @@ public class ConsoleLogging implements Logging
         return new ConsoleLogger( name, level );
     }
 
-    public static class ConsoleLogger extends JULogger
+    static class ConsoleLogger extends JULogger
     {
         private final ConsoleHandler handler;
 
-        public ConsoleLogger( String name, Level level )
+        ConsoleLogger( String name, Level level )
         {
             super( name, level );
             java.util.logging.Logger logger = java.util.logging.Logger.getLogger( name );
@@ -71,9 +71,9 @@ public class ConsoleLogging implements Logging
             logger.setUseParentHandlers( false );
             // remove all other logging handlers
             Handler[] handlers = logger.getHandlers();
-            for ( int i = 0; i < handlers.length; i++ )
+            for ( Handler handlerToRemove : handlers )
             {
-                logger.removeHandler( handlers[i] );
+                logger.removeHandler( handlerToRemove );
             }
 
             handler = new ConsoleHandler();
@@ -81,36 +81,19 @@ public class ConsoleLogging implements Logging
             handler.setLevel( level );
             logger.addHandler( handler );
             logger.setLevel( level );
-
         }
     }
 
     private static class ShortFormatter extends Formatter
     {
-        private static final DateFormat dateFormat = new SimpleDateFormat( "yyyy-MM-dd hh:mm:ss,SSS" );
-
+        @Override
         public String format( LogRecord record )
         {
-            StringBuilder builder = new StringBuilder( 1000 );
-            builder.append( dateFormat.format( new Date( record.getMillis() ) ) );
-            builder.append(" ");
-//            builder.append("[").append(record.getLoggerName()).append("] ");
-//            builder.append( "[" ).append( record.getSourceClassName() ).append( "." );
-//            builder.append( record.getSourceMethodName() ).append( "] - " );
-//            builder.append( "[" ).append( record.getLevel() ).append( "] - " );
-            builder.append( formatMessage( record ) );
-            builder.append( "\n" );
-            return builder.toString();
-        }
-
-        public String getHead( Handler h )
-        {
-            return super.getHead( h );
-        }
-
-        public String getTail( Handler h )
-        {
-            return super.getTail( h );
+            return LocalDateTime.now().format( ISO_LOCAL_DATE_TIME ) + " " +
+                   record.getLevel() + " " +
+                   record.getLoggerName() + " - " +
+                   formatMessage( record ) +
+                   "\n";
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.logging;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -31,18 +32,10 @@ import org.neo4j.driver.v1.Logging;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 /**
- * Print all the logging messages into {@link System#err}.
- * <p>
- * To use this class for debugging:
- * <pre>
- * {@code
+ * Internal implementation of the console logging.
+ * <b>This class should not be used directly.</b> Please use {@link Logging#console(Level)} factory method instead.
  *
- *     Config config = Config.build()
- *                      .withLogging( new ConsoleLogging( Level.ALL ) )
- *                      .toConfig();
- *     Driver driver = GraphDatabase.driver( "bolt://localhost:7687", config );
- * }
- * </pre>
+ * @see Logging#console(Level)
  */
 public class ConsoleLogging implements Logging
 {
@@ -50,7 +43,7 @@ public class ConsoleLogging implements Logging
 
     public ConsoleLogging( Level level )
     {
-        this.level = level;
+        this.level = Objects.requireNonNull( level );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/NettyLogger.java
@@ -26,7 +26,6 @@ import org.neo4j.driver.v1.Logger;
 
 import static java.lang.String.format;
 
-
 public class NettyLogger extends AbstractInternalLogger
 {
     private Logger log;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import java.util.Objects;
+
+import org.neo4j.driver.v1.Logger;
+
+class Slf4jLogger implements Logger
+{
+    private final org.slf4j.Logger delegate;
+
+    Slf4jLogger( org.slf4j.Logger delegate )
+    {
+        this.delegate = Objects.requireNonNull( delegate );
+    }
+
+    @Override
+    public void error( String message, Throwable cause )
+    {
+        if ( delegate.isErrorEnabled() )
+        {
+            delegate.error( message, cause );
+        }
+    }
+
+    @Override
+    public void info( String message, Object... params )
+    {
+        if ( delegate.isInfoEnabled() )
+        {
+            delegate.info( formatMessage( message, params ) );
+        }
+    }
+
+    @Override
+    public void warn( String message, Object... params )
+    {
+        if ( delegate.isWarnEnabled() )
+        {
+            delegate.warn( formatMessage( message, params ) );
+        }
+    }
+
+    @Override
+    public void warn( String message, Throwable cause )
+    {
+        if ( delegate.isWarnEnabled() )
+        {
+            delegate.warn( message, cause );
+        }
+    }
+
+    @Override
+    public void debug( String message, Object... params )
+    {
+        if ( isDebugEnabled() )
+        {
+            delegate.debug( formatMessage( message, params ) );
+        }
+    }
+
+    @Override
+    public void trace( String message, Object... params )
+    {
+        if ( isTraceEnabled() )
+        {
+            delegate.trace( formatMessage( message, params ) );
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return delegate.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return delegate.isDebugEnabled();
+    }
+
+    /**
+     * Creates a fully formatted message. Such formatting is needed because driver uses {@link String#format(String, Object...)} parameters in message
+     * templates, i.e. '%s' or '%d' while SLF4J uses '{}'. Thus this logger passes fully formatted messages to SLF4J.
+     *
+     * @param messageTemplate the message template.
+     * @param params the parameters.
+     * @return fully formatted message string.
+     */
+    private static String formatMessage( String messageTemplate, Object... params )
+    {
+        return String.format( messageTemplate, params );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.slf4j.LoggerFactory;
+
+import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+
+/**
+ * Internal implementation of the SLF4J logging.
+ * <b>This class should not be used directly.</b> Please use {@link Logging#slf4j()} factory method instead.
+ *
+ * @see Logging#slf4j()
+ */
+public class Slf4jLogging implements Logging
+{
+    @Override
+    public Logger getLog( String name )
+    {
+        return new Slf4jLogger( LoggerFactory.getLogger( name ) );
+    }
+
+    public static RuntimeException checkAvailability()
+    {
+        try
+        {
+            Class.forName( "org.slf4j.LoggerFactory" );
+            return null;
+        }
+        catch ( Throwable error )
+        {
+            return new IllegalStateException(
+                    "SLF4J logging is not available. Please add dependencies on slf4j-api and SLF4J binding (Logback, Log4j, etc.)",
+                    error );
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -24,7 +24,6 @@ import java.util.logging.Level;
 
 import org.neo4j.driver.internal.async.pool.PoolSettings;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
-import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
@@ -34,6 +33,7 @@ import org.neo4j.driver.v1.util.Immutable;
 import org.neo4j.driver.v1.util.Resource;
 
 import static org.neo4j.driver.v1.Config.TrustStrategy.trustAllCertificates;
+import static org.neo4j.driver.v1.Logging.javaUtilLogging;
 
 /**
  * A configuration class to config driver properties.
@@ -258,7 +258,7 @@ public class Config
      */
     public static class ConfigBuilder
     {
-        private Logging logging = new JULogging( Level.INFO );
+        private Logging logging = javaUtilLogging( Level.INFO );
         private boolean logLeakedSessions;
         private int maxConnectionPoolSize = PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
@@ -275,10 +275,15 @@ public class Config
         private ConfigBuilder() {}
 
         /**
-         * Provide an alternative logging implementation for the driver to use. By default we use
-         * java util logging.
+         * Provide a logging implementation for the driver to use. Java logging framework {@link java.util.logging} with {@link Level#INFO} is used by default.
+         * Callers are expected to either implement {@link Logging} interface or provide one of the existing implementations available from static factory
+         * methods in the {@link Logging} interface.
+         * <p>
+         * Please see documentation in {@link Logging} for more information.
+         *
          * @param logging the logging instance to use
          * @return this builder
+         * @see Logging
          */
         public ConfigBuilder withLogging( Logging logging )
         {

--- a/driver/src/main/java/org/neo4j/driver/v1/Logger.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Logger.java
@@ -24,31 +24,57 @@ package org.neo4j.driver.v1;
 public interface Logger
 {
     /**
-     * Logs errors from this driver
+     * Logs errors from this driver.
+     * <p>
+     * Examples of errors logged using this method:
+     * <ul>
+     * <li>Network connection errors</li>
+     * <li>DNS resolution errors</li>
+     * <li>Cluster discovery errors</li>
+     * </ul>
      *
-     * @param message the error message
-     * @param cause the cause of the error
+     * @param message the error message.
+     * @param cause the cause of the error.
      */
     void error( String message, Throwable cause );
 
     /**
-     * Logs information from the driver
+     * Logs information from the driver.
+     * <p>
+     * Example of info messages logged using this method:
+     * <ul>
+     * <li>Driver creation and shutdown</li>
+     * <li>Cluster discovery progress</li>
+     * </ul>
      *
-     * @param message the information message
-     * @param params parameters used in the information message
+     * @param message the information message.
+     * @param params parameters used in the information message.
      */
     void info( String message, Object... params );
 
     /**
-     * Logs warnings that happened during using the driver
+     * Logs warnings that happened when using the driver.
+     * <p>
+     * Example of info messages logged using this method:
+     * <ul>
+     * <li>Usage of deprecated APIs</li>
+     * <li>Transaction retry failures</li>
+     * </ul>
      *
-     * @param message the warning message
-     * @param params parameters used in the warning message
+     * @param message the warning message.
+     * @param params parameters used in the warning message.
      */
     void warn( String message, Object... params );
 
     /**
      * Logs warnings that happened during using the driver
+     *
+     * <p>
+     * Example of info messages logged using this method:
+     * <ul>
+     * <li>Usage of deprecated APIs</li>
+     * <li>Transaction retry failures</li>
+     * </ul>
      *
      * @param message the warning message
      * @param cause the cause of the warning
@@ -57,8 +83,15 @@ public interface Logger
 
     /**
      * Logs bolt messages sent and received by this driver.
-     * It is only enabled when {@link Logger#isDebugEnabled()} returns {@code True}.
+     * It is only enabled when {@link Logger#isDebugEnabled()} returns {@code true}.
      * This logging level generates a lot of log entries.
+     * <p>
+     * Example of debug messages logged using this method:
+     * <ul>
+     * <li>Connection pool events, like creation, acquire and release of connections</li>
+     * <li>Messages sent to the database</li>
+     * <li>Messages received from the database</li>
+     * </ul>
      *
      * @param message the bolt message
      * @param params parameters used in generating the bolt message
@@ -67,8 +100,17 @@ public interface Logger
 
     /**
      * Logs binary sent and received by this driver.
-     * It is only enabled when {@link Logger#isTraceEnabled()} returns {@code True}.
+     * It is only enabled when {@link Logger#isTraceEnabled()} returns {@code true}.
      * This logging level generates huge amount of log entries.
+     *
+     * <p>
+     * Example of debug messages logged using this method:
+     * <ul>
+     * <li>Idle connection pings</li>
+     * <li>Server selection for load balancing</li>
+     * <li>Messages sent to the database with bytes in hex</li>
+     * <li>Messages received from the database with bytes in hex</li>
+     * </ul>
      *
      * @param message the bolt message in hex
      * @param params parameters used in generating the hex message

--- a/driver/src/main/java/org/neo4j/driver/v1/Logging.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Logging.java
@@ -18,8 +18,71 @@
  */
 package org.neo4j.driver.v1;
 
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+
+import org.neo4j.driver.internal.logging.ConsoleLogging;
+import org.neo4j.driver.internal.logging.JULogging;
+import org.neo4j.driver.internal.logging.Slf4jLogging;
+
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+
 /**
- * Accessor for {@link Logger} instances.
+ * Accessor for {@link Logger} instances. Configured once for a driver instance using {@link Config.ConfigBuilder#withLogging(Logging)} builder method.
+ * Users are expected to either implement this interface or use one of the existing implementations (available via static methods in this interface):
+ * <ul>
+ * <li>{@link #slf4j() SLF4J logging} - uses available SLF4J binding (Logback, Log4j, etc.) fails when no SLF4J implementation is available. Uses
+ * application's logging configuration from XML or other type of configuration file. This logging method is the preferred one and relies on the SLF4J
+ * implementation available in the classpath or modulepath.</li>
+ * <li>{@link #javaUtilLogging(Level) Java Logging API (JUL)} - uses {@link java.util.logging.Logger} created via
+ * {@link java.util.logging.Logger#getLogger(String)}. Global java util logging configuration applies. This logging method is suitable when application
+ * uses JUL for logging and explicitly configures it.</li>
+ * <li>{@link #console(Level) Console logging} - uses {@link ConsoleHandler} with the specified {@link Level logging level} to print messages to {@code
+ * System.err}. This logging method is suitable for quick debugging or prototyping.</li>
+ * <li>{@link #none() No logging} - implementation that discards all logged messages. This logging method is suitable for testing to make driver produce
+ * no output.</li>
+ * </ul>
+ * <p>
+ * Driver logging API defines the following log levels: ERROR, INFO, WARN, DEBUG and TRACE. They are similar to levels defined by SLF4J but different from
+ * log levels defined for {@link java.util.logging}. The following mapping takes place:
+ * <table border="1" cellpadding="4" summary="Driver and JUL log levels">
+ * <tr>
+ * <th>Driver</th>
+ * <th>java.util.logging</th>
+ * </tr>
+ * <tr>
+ * <td>ERROR</td>
+ * <td>SEVERE</td>
+ * </tr>
+ * <tr>
+ * <td>INFO</td>
+ * <td>INFO, CONFIG</td>
+ * </tr>
+ * <tr>
+ * <td>WARN</td>
+ * <td>WARNING</td>
+ * </tr>
+ * <tr>
+ * <td>DEBUG</td>
+ * <td>FINE, FINER</td>
+ * </tr>
+ * <tr>
+ * <td>TRACE</td>
+ * <td>FINEST</td>
+ * </tr>
+ * </table>
+ * <p>
+ * Example of driver configuration with SLF4J logging:
+ * <pre>
+ * {@code
+ * Driver driver = GraphDatabase.driver("bolt://localhost:7687",
+ *                                         AuthTokens.basic("neo4j", "password"),
+ *                                         Config.build().withLogging(Logging.slf4j()).toConfig());
+ * }
+ * </pre>
+ *
+ * @see Logger
+ * @see Config.ConfigBuilder#withLogging(Logging)
  */
 public interface Logging
 {
@@ -30,4 +93,52 @@ public interface Logging
      * @return {@link Logger} instance
      */
     Logger getLog( String name );
+
+    /**
+     * Create logging implementation that uses SLF4J.
+     *
+     * @return new logging implementation.
+     * @throws IllegalStateException if SLF4J is not available.
+     */
+    static Logging slf4j()
+    {
+        RuntimeException unavailabilityError = Slf4jLogging.checkAvailability();
+        if ( unavailabilityError != null )
+        {
+            throw unavailabilityError;
+        }
+        return new Slf4jLogging();
+    }
+
+    /**
+     * Create logging implementation that uses {@link java.util.logging}.
+     *
+     * @param level the log level.
+     * @return new logging implementation.
+     */
+    static Logging javaUtilLogging( Level level )
+    {
+        return new JULogging( level );
+    }
+
+    /**
+     * Create logging implementation that uses {@link java.util.logging} to log to {@code System.err}.
+     *
+     * @param level the log level.
+     * @return new logging implementation.
+     */
+    static Logging console( Level level )
+    {
+        return new ConsoleLogging( level );
+    }
+
+    /**
+     * Create logging implementation that discards all messages and logs nothing.
+     *
+     * @return new logging implementation.
+     */
+    static Logging none()
+    {
+        return DEV_NULL_LOGGING;
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
@@ -28,10 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import org.neo4j.driver.internal.cluster.RoutingSettings;
-import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.DriverFactoryWithClock;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
@@ -53,6 +51,7 @@ import org.neo4j.driver.v1.util.Function;
 import org.neo4j.driver.v1.util.StubServer;
 
 import static java.util.Arrays.asList;
+import static java.util.logging.Level.INFO;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -62,6 +61,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.driver.v1.Logging.console;
 
 public class RoutingDriverBoltKitTest
 {
@@ -70,7 +70,7 @@ public class RoutingDriverBoltKitTest
 
     private static final Config config = Config.build()
             .withoutEncryption()
-            .withLogging( new ConsoleLogging( Level.INFO ) ).toConfig();
+            .withLogging( console( INFO ) ).toConfig();
 
     @Test
     public void shouldHandleAcquireReadSession() throws IOException, InterruptedException, StubServer.ForceKilled

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Slf4jLoggerTest
+{
+    private final Logger logger = mock( Logger.class );
+    private final Slf4jLogger slf4jLogger = new Slf4jLogger( logger );
+
+    @Test
+    public void shouldLogErrorWithMessageAndThrowable()
+    {
+        when( logger.isErrorEnabled() ).thenReturn( true );
+        String message = "Hello";
+        IllegalArgumentException error = new IllegalArgumentException( "World" );
+
+        slf4jLogger.error( message, error );
+
+        verify( logger ).error( message, error );
+    }
+
+    @Test
+    public void shouldLogInfoWithMessageAndParams()
+    {
+        when( logger.isInfoEnabled() ).thenReturn( true );
+        String message = "One %s, two %s, three %s";
+        Object[] params = {"111", "222", "333"};
+
+        slf4jLogger.info( message, params );
+
+        verify( logger ).info( "One 111, two 222, three 333" );
+    }
+
+    @Test
+    public void shouldLogWarnWithMessageAndParams()
+    {
+        when( logger.isWarnEnabled() ).thenReturn( true );
+        String message = "C for %s, d for %s";
+        Object[] params = {"cat", "dog"};
+
+        slf4jLogger.warn( message, params );
+
+        verify( logger ).warn( "C for cat, d for dog" );
+    }
+
+    @Test
+    public void shouldLogWarnWithMessageAndThrowable()
+    {
+        when( logger.isWarnEnabled() ).thenReturn( true );
+        String message = "Hello";
+        RuntimeException error = new RuntimeException( "World" );
+
+        slf4jLogger.warn( message, error );
+
+        verify( logger ).warn( message, error );
+    }
+
+    @Test
+    public void shouldLogDebugWithMessageAndParams()
+    {
+        when( logger.isDebugEnabled() ).thenReturn( true );
+        String message = "Hello%s%s!";
+        Object[] params = {" ", "World"};
+
+        slf4jLogger.debug( message, params );
+
+        verify( logger ).debug( "Hello World!" );
+    }
+
+    @Test
+    public void shouldLogTraceWithMessageAndParams()
+    {
+        when( logger.isTraceEnabled() ).thenReturn( true );
+        String message = "I'll be %s!";
+        Object[] params = {"back"};
+
+        slf4jLogger.trace( message, params );
+
+        verify( logger ).trace( "I'll be back!" );
+    }
+
+    @Test
+    public void shouldCheckIfDebugIsEnabled()
+    {
+        when( logger.isDebugEnabled() ).thenReturn( false );
+        assertFalse( slf4jLogger.isDebugEnabled() );
+
+        when( logger.isDebugEnabled() ).thenReturn( true );
+        assertTrue( slf4jLogger.isDebugEnabled() );
+    }
+
+    @Test
+    public void shouldCheckIfTraceIsEnabled()
+    {
+        when( logger.isTraceEnabled() ).thenReturn( false );
+        assertFalse( slf4jLogger.isTraceEnabled() );
+
+        when( logger.isTraceEnabled() ).thenReturn( true );
+        assertTrue( slf4jLogger.isTraceEnabled() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2018 "Neo4j,"
- * Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *
@@ -18,29 +17,29 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import java.util.logging.Level;
+import org.junit.Test;
 
 import org.neo4j.driver.v1.Logger;
-import org.neo4j.driver.v1.Logging;
 
-/**
- * Internal implementation of the JUL.
- * <b>This class should not be used directly.</b> Please use {@link Logging#javaUtilLogging(Level)} factory method instead.
- *
- * @see Logging#javaUtilLogging(Level)
- */
-public class JULogging implements Logging
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class Slf4jLoggingTest
 {
-    private final Level loggingLevel;
-
-    public JULogging( Level loggingLevel )
+    @Test
+    public void shouldCreateLoggers()
     {
-        this.loggingLevel = loggingLevel;
+        Slf4jLogging logging = new Slf4jLogging();
+
+        Logger logger = logging.getLog( "My Log" );
+
+        assertThat( logger, instanceOf( Slf4jLogger.class ) );
     }
 
-    @Override
-    public Logger getLog( String name )
+    @Test
+    public void shouldCheckIfAvailable()
     {
-        return new JULogger( name, loggingLevel );
+        assertNull( Slf4jLogging.checkAvailability() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/DriverCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/DriverCloseIT.java
@@ -26,9 +26,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.util.List;
-import java.util.logging.Level;
 
-import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
@@ -42,6 +40,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.neo4j.driver.v1.Logging.none;
 import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 
 @RunWith( Enclosed.class )
@@ -171,7 +170,7 @@ public class DriverCloseIT
         {
             Config config = Config.build()
                     .withoutEncryption()
-                    .withLogging( new ConsoleLogging( Level.OFF ) )
+                    .withLogging( none() )
                     .toConfig();
 
             return GraphDatabase.driver( "bolt+routing://127.0.0.1:9001", DEFAULT_AUTH_TOKEN, config );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -37,12 +37,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
-import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
@@ -71,6 +69,7 @@ import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static java.util.logging.Level.INFO;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -94,6 +93,7 @@ import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 import static org.neo4j.driver.internal.util.Matchers.connectionAcquisitionTimeoutError;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.v1.Logging.console;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
@@ -1589,7 +1589,7 @@ public class SessionIT
         {
             Config config = Config.build()
                     .withLogging( DEV_NULL_LOGGING )
-                    .withLogging( new ConsoleLogging( Level.INFO ) )
+                    .withLogging( console( INFO ) )
                     .withoutEncryption()
                     .toConfig();
             try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", AuthTokens.none(), config ) )

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -601,6 +601,7 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
 
     private static class LoggerNameTrackingLogging implements Logging
     {
+        private final ConsoleLogging consoleLogging = new ConsoleLogging( Level.FINE );
         private final Set<String> acquiredLoggerNames = new ConcurrentSet<>();
 
         @Override
@@ -609,7 +610,7 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
             acquiredLoggerNames.add( name );
             if ( DEBUG_LOGGING_ENABLED )
             {
-                return new ConsoleLogging.ConsoleLogger( name, Level.FINE );
+                return consoleLogging.getLog( name );
             }
             return DevNullLogger.DEV_NULL_LOGGER;
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.neo4j.driver.internal.InternalDriver;
-import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.logging.DevNullLogger;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.Iterables;
@@ -601,7 +600,7 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
 
     private static class LoggerNameTrackingLogging implements Logging
     {
-        private final ConsoleLogging consoleLogging = new ConsoleLogging( Level.FINE );
+        private final Logging consoleLogging = Logging.console( Level.FINE );
         private final Set<String> acquiredLoggerNames = new ConcurrentSet<>();
 
         @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -26,19 +26,19 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 
 import static java.util.Arrays.asList;
+import static java.util.logging.Level.INFO;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.driver.v1.AuthTokens.basic;
 import static org.neo4j.driver.v1.ConfigTest.deleteDefaultKnownCertFileIfExists;
+import static org.neo4j.driver.v1.Logging.console;
 import static org.neo4j.driver.v1.util.FileTools.moveFile;
 import static org.neo4j.driver.v1.util.FileTools.updateProperties;
 import static org.neo4j.driver.v1.util.cc.CommandLineUtil.boltKitAvailable;
@@ -56,8 +56,7 @@ public class Neo4jRunner
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final URI DEFAULT_URI = URI.create( "bolt://localhost:7687" );
     public static final BoltServerAddress DEFAULT_ADDRESS = new BoltServerAddress( DEFAULT_URI );
-    public static final Config DEFAULT_CONFIG = Config.build().withLogging( new ConsoleLogging( Level.INFO ) )
-            .toConfig();
+    public static final Config DEFAULT_CONFIG = Config.build().withLogging( console( INFO ) ).toConfig();
 
     public static final String USER = "neo4j";
     public static final String PASSWORD = "password";

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -53,6 +53,10 @@
       <groupId>org.rauschig</groupId>
       <artifactId>jarchivelib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2018 Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.docs.driver;
+
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+
+import static java.util.Collections.singletonMap;
+import static org.neo4j.driver.v1.Logging.slf4j;
+
+public class Slf4jLoggingExample implements AutoCloseable
+{
+    private final Driver driver;
+
+    public Slf4jLoggingExample( String uri, String user, String password )
+    {
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), Config.build().withLogging( slf4j() ).toConfig() );
+    }
+
+    public Object runReturnQuery( Object value )
+    {
+        try ( Session session = driver.session() )
+        {
+            return session.run( "RETURN $x", singletonMap( "x", value ) ).single().get( 0 ).asObject();
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        driver.close();
+    }
+}

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -22,9 +22,13 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
@@ -36,6 +40,7 @@ import org.neo4j.driver.v1.util.StdIOCapture;
 import org.neo4j.driver.v1.util.TestNeo4j;
 import org.neo4j.driver.v1.util.TestUtil;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -453,6 +458,27 @@ public class ExamplesIT
 
             assertEquals( 1, stdIOCapture.stdout().size() );
             assertEquals( "Mind Gem", stdIOCapture.stdout().get( 0 ) );
+        }
+    }
+
+    @Test
+    public void testSlf4jLogging() throws Exception
+    {
+        // log file is defined in logback-test.xml configuration file
+        Path logFile = Paths.get( "target", "test.log" );
+        Files.deleteIfExists( logFile );
+
+        try ( Slf4jLoggingExample example = new Slf4jLoggingExample( uri, USER, PASSWORD ) )
+        {
+            String randomString = UUID.randomUUID().toString();
+            Object result = example.runReturnQuery( randomString );
+            assertEquals( randomString, result );
+
+            assertTrue( Files.exists( logFile ) );
+
+            String logFileContent = new String( Files.readAllBytes( logFile ), UTF_8 );
+            assertThat( logFileContent, containsString( "RETURN $x" ) );
+            assertThat( logFileContent, containsString( randomString ) );
         }
     }
 }

--- a/examples/src/test/resources/logback-test.xml
+++ b/examples/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>target/test.log</file>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,13 @@
         <version>2.1.10</version>
       </dependency>
 
+      <!-- Optional dependencies -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.25</version>
+      </dependency>
+
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -121,6 +128,12 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>2.9.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
1. Cleanup console logging to not use not thread-safe `SimpleDateFormat` and include level and logger name in the message
2. SLF4J support via an optional Maven dependency and new logging implementation
3. More javadocs around `Logging`, `Logger` and corresponding config
4. New public API to create instances of `Logging`:
    * `Logging#slf4j()`
    * `Logging#console(Level)`
    * `Logging#javaUtilLogging(Level)`
    * `Logging#none()`