### PR TITLE
Support hostname verification for secure connections

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -287,31 +287,30 @@ public class DriverFactory
         if ( config.encrypted() )
         {
             Logger logger = config.logging().getLog( "SecurityPlan" );
-            switch ( config.trustStrategy().strategy() )
+            Config.TrustStrategy trustStrategy = config.trustStrategy();
+            boolean hostnameVerificationEnabled = trustStrategy.isHostnameVerificationEnabled();
+            switch ( trustStrategy.strategy() )
             {
-
-            // DEPRECATED CASES //
             case TRUST_ON_FIRST_USE:
                 logger.warn(
                         "Option `TRUST_ON_FIRST_USE` has been deprecated and will be removed in a future " +
                         "version of the driver. Please switch to use `TRUST_ALL_CERTIFICATES` instead." );
-                return SecurityPlan.forTrustOnFirstUse( config.trustStrategy().certFile(), address, logger );
+                return SecurityPlan.forTrustOnFirstUse( trustStrategy.certFile(), hostnameVerificationEnabled, address, logger );
             case TRUST_SIGNED_CERTIFICATES:
                 logger.warn(
                         "Option `TRUST_SIGNED_CERTIFICATE` has been deprecated and will be removed in a future " +
                         "version of the driver. Please switch to use `TRUST_CUSTOM_CA_SIGNED_CERTIFICATES` instead." );
                 // intentional fallthrough
-                // END OF DEPRECATED CASES //
 
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlan.forCustomCASignedCertificates( config.trustStrategy().certFile() );
+                return SecurityPlan.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlan.forSystemCASignedCertificates();
+                return SecurityPlan.forSystemCASignedCertificates( hostnameVerificationEnabled );
             case TRUST_ALL_CERTIFICATES:
-                return SecurityPlan.forAllCertificates();
+                return SecurityPlan.forAllCertificates( hostnameVerificationEnabled );
             default:
                 throw new ClientException(
-                        "Unknown TLS authentication strategy: " + config.trustStrategy().strategy().name() );
+                        "Unknown TLS authentication strategy: " + trustStrategy.strategy().name() );
             }
         }
         else

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.SslHandler;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
@@ -78,6 +79,12 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
         SSLContext sslContext = securityPlan.sslContext();
         SSLEngine sslEngine = sslContext.createSSLEngine( address.host(), address.port() );
         sslEngine.setUseClientMode( true );
+        if ( securityPlan.requiresHostnameVerification() )
+        {
+            SSLParameters sslParameters = sslEngine.getSSLParameters();
+            sslParameters.setEndpointIdentificationAlgorithm( "HTTPS" );
+            sslEngine.setSSLParameters( sslParameters );
+        }
         return sslEngine;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -765,6 +765,7 @@ public class Config
 
         private final Strategy strategy;
         private final File certFile;
+        private boolean hostnameVerificationEnabled;
 
         private TrustStrategy( Strategy strategy )
         {
@@ -787,9 +788,46 @@ public class Config
             return strategy;
         }
 
+        /**
+         * Return the configured certificate file.
+         *
+         * @return configured certificate or {@code null} if trust strategy does not require a certificate.
+         */
         public File certFile()
         {
             return certFile;
+        }
+
+        /**
+         * Check if hostname verification is enabled for this trust strategy.
+         *
+         * @return {@code true} if hostname verification has been enabled via {@link #withHostnameVerification()}, {@code false} otherwise.
+         */
+        public boolean isHostnameVerificationEnabled()
+        {
+            return hostnameVerificationEnabled;
+        }
+
+        /**
+         * Enable hostname verification for this trust strategy.
+         *
+         * @return the current trust strategy.
+         */
+        public TrustStrategy withHostnameVerification()
+        {
+            hostnameVerificationEnabled = true;
+            return this;
+        }
+
+        /**
+         * Disable hostname verification for this trust strategy.
+         *
+         * @return the current trust strategy.
+         */
+        public TrustStrategy withoutHostnameVerification()
+        {
+            hostnameVerificationEnabled = false;
+            return this;
         }
 
         /**

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectorImplIT.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -97,7 +98,7 @@ public class ChannelConnectorImplIT
     @Test
     public void shouldSetupHandlers() throws Exception
     {
-        ChannelConnector connector = newConnector( neo4j.authToken(), SecurityPlan.forAllCertificates(), 10_000 );
+        ChannelConnector connector = newConnector( neo4j.authToken(), trustAllCertificates(), 10_000 );
 
         ChannelFuture channelFuture = connector.connect( neo4j.address(), bootstrap );
         assertTrue( channelFuture.await( 10, TimeUnit.SECONDS ) );
@@ -186,7 +187,7 @@ public class ChannelConnectorImplIT
     public void shouldFailWhenTLSHandshakeTakesTooLong() throws Exception
     {
         // run with TLS so that TLS handshake is the very first operation after connection is established
-        testReadTimeoutOnConnect( SecurityPlan.forAllCertificates() );
+        testReadTimeoutOnConnect( trustAllCertificates() );
     }
 
     @Test
@@ -253,7 +254,7 @@ public class ChannelConnectorImplIT
 
     private ChannelConnectorImpl newConnector( AuthToken authToken, int connectTimeoutMillis ) throws Exception
     {
-        return newConnector( authToken, SecurityPlan.forAllCertificates(), connectTimeoutMillis );
+        return newConnector( authToken, trustAllCertificates(), connectTimeoutMillis );
     }
 
     private ChannelConnectorImpl newConnector( AuthToken authToken, SecurityPlan securityPlan,
@@ -261,5 +262,10 @@ public class ChannelConnectorImplIT
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, connectTimeoutMillis );
         return new ChannelConnectorImpl( settings, securityPlan, DEV_NULL_LOGGING, new FakeClock() );
+    }
+
+    private static SecurityPlan trustAllCertificates() throws GeneralSecurityException
+    {
+        return SecurityPlan.forAllCertificates( false );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -216,7 +216,7 @@ public class ConnectionPoolImplIT
     {
         FakeClock clock = new FakeClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( neo4j.authToken(), 5000 );
-        ChannelConnector connector = new ChannelConnectorImpl( connectionSettings, SecurityPlan.forAllCertificates(),
+        ChannelConnector connector = new ChannelConnectorImpl( connectionSettings, SecurityPlan.forAllCertificates( false ),
                 DEV_NULL_LOGGING, clock );
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -23,21 +23,16 @@ import org.junit.Test;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.driver.v1.util.FileTools;
-
-import static java.lang.System.getProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ConfigTest
 {
-    private static final File DEFAULT_KNOWN_HOSTS = new File( getProperty( "user.home" ),
-            ".neo4j" + File.separator + "known_hosts" );
-
     @Test
     public void shouldDefaultToKnownCerts()
     {
@@ -297,12 +292,16 @@ public class ConfigTest
         assertEquals( 0, config.connectionAcquisitionTimeoutMillis() );
     }
 
-    public static void deleteDefaultKnownCertFileIfExists()
+    @Test
+    public void shouldEnableAndDisableHostnameVerificationOnTrustStrategy()
     {
-        if( DEFAULT_KNOWN_HOSTS.exists() )
-        {
-            FileTools.deleteFile( DEFAULT_KNOWN_HOSTS );
-        }
-    }
+        Config.TrustStrategy trustStrategy = Config.TrustStrategy.trustAllCertificates();
+        assertFalse( trustStrategy.isHostnameVerificationEnabled() );
 
+        assertSame( trustStrategy, trustStrategy.withHostnameVerification() );
+        assertTrue( trustStrategy.isHostnameVerificationEnabled() );
+
+        assertSame( trustStrategy, trustStrategy.withoutHostnameVerification() );
+        assertFalse( trustStrategy.isHostnameVerificationEnabled() );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
@@ -19,10 +19,11 @@
 package org.neo4j.driver.v1.tck;
 
 import cucumber.api.CucumberOptions;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
+import java.nio.file.Files;
 
 import org.neo4j.driver.v1.util.TestNeo4j;
 
@@ -37,8 +38,11 @@ public class DriverComplianceIT
     @ClassRule
     public static TestNeo4j neo4j = new TestNeo4j();
 
-    public DriverComplianceIT() throws IOException
+    @AfterClass
+    public static void tearDownClass() throws Exception
     {
+        neo4j.stopDb();
+        Files.deleteIfExists( neo4j.tlsCertFile().toPath() );
+        Files.deleteIfExists( neo4j.tlsKeyFile().toPath() );
     }
-
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -33,11 +33,11 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 
+import static java.lang.System.getProperty;
 import static java.util.Arrays.asList;
 import static java.util.logging.Level.INFO;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.driver.v1.AuthTokens.basic;
-import static org.neo4j.driver.v1.ConfigTest.deleteDefaultKnownCertFileIfExists;
 import static org.neo4j.driver.v1.Logging.console;
 import static org.neo4j.driver.v1.util.FileTools.moveFile;
 import static org.neo4j.driver.v1.util.FileTools.updateProperties;
@@ -51,6 +51,8 @@ import static org.neo4j.driver.v1.util.cc.CommandLineUtil.executeCommand;
 public class Neo4jRunner
 {
     private static Neo4jRunner globalInstance;
+
+    private static final File DEFAULT_KNOWN_HOSTS = new File( getProperty( "user.home" ), ".neo4j" + File.separator + "known_hosts" );
 
     private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.3.4";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
@@ -314,6 +316,14 @@ public class Neo4jRunner
     public static void debug( String text, Object... args )
     {
         System.out.println( String.format( text, args ) );
+    }
+
+    private static void deleteDefaultKnownCertFileIfExists()
+    {
+        if ( DEFAULT_KNOWN_HOSTS.exists() )
+        {
+            FileTools.deleteFile( DEFAULT_KNOWN_HOSTS );
+        }
     }
 }
 

--- a/examples/src/main/java/org/neo4j/docs/driver/HostnameVerificationExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/HostnameVerificationExample.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.docs.driver;
+
+import java.io.File;
+
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+
+import static org.neo4j.driver.v1.Config.TrustStrategy.trustCustomCertificateSignedBy;
+
+public class HostnameVerificationExample implements AutoCloseable
+{
+    private final Driver driver;
+
+    HostnameVerificationExample( String uri, String user, String password, File certFile )
+    {
+        Config config = Config.build()
+                .withEncryption()
+                .withTrustStrategy( trustCustomCertificateSignedBy( certFile ).withHostnameVerification() )
+                .toConfig();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
+    }
+
+    public boolean canConnect()
+    {
+        try ( Session session = driver.session() )
+        {
+            return session.run( "RETURN 42" ).single().get( 0 ).asInt() == 42;
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        driver.close();
+    }
+}

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -481,4 +481,13 @@ public class ExamplesIT
             assertThat( logFileContent, containsString( randomString ) );
         }
     }
+
+    @Test
+    public void testHostnameVerificationExample()
+    {
+        try ( HostnameVerificationExample example = new HostnameVerificationExample( uri, USER, PASSWORD, neo4j.tlsCertFile() ) )
+        {
+            assertTrue( example.canConnect() );
+        }
+    }
 }


### PR DESCRIPTION
Hostname verification makes client verify that server it is trying to connect to matches server specified in the returned certificate. This is a way to protect from man in the middle attack and make sure client is talking to the correct server. Hostname will be compared to all entries in `subjectAltName` field of the certificate.

This PR makes driver support configurable hostname verification. It can be configured together with the trust strategy:

```java
Config config = Config.build()
    .withTrustStrategy(trustAllCertificates().withHostnameVerification())
    .toConfig();
```

Method `#withHostnameVerification()` is available for all trust strategies. Verification is turned off by default.