### PR TITLE
Improve handling of RESET and ACK_FAILURE errors

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -229,6 +229,18 @@ public class InboundMessageDispatcher implements MessageHandler
         ackFailureMuted = false;
     }
 
+    /**
+     * Check if ACK_FAILURE is muted.
+     * <p>
+     * <b>This method is not thread-safe</b> and should only be executed by the event loop thread.
+     *
+     * @return {@code true} if ACK_FAILURE has been muted via {@link #muteAckFailure()}, {@code false} otherwise.
+     */
+    public boolean isAckFailureMuted()
+    {
+        return ackFailureMuted;
+    }
+
     private void ackFailureIfNeeded()
     {
         if ( !ackFailureMuted )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/ResetResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/ResetResponseHandler.java
@@ -39,13 +39,13 @@ public class ResetResponseHandler implements ResponseHandler
     @Override
     public final void onSuccess( Map<String,Value> metadata )
     {
-        resetCompleted();
+        resetCompleted( true );
     }
 
     @Override
     public final void onFailure( Throwable error )
     {
-        resetCompleted();
+        resetCompleted( false );
     }
 
     @Override
@@ -54,13 +54,13 @@ public class ResetResponseHandler implements ResponseHandler
         throw new UnsupportedOperationException();
     }
 
-    private void resetCompleted()
+    private void resetCompleted( boolean success )
     {
         messageDispatcher.unMuteAckFailure();
-        resetCompleted( completionFuture );
+        resetCompleted( completionFuture, success );
     }
 
-    protected void resetCompleted( CompletableFuture<Void> completionFuture )
+    protected void resetCompleted( CompletableFuture<Void> completionFuture, boolean success )
     {
         completionFuture.complete( null );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
@@ -36,8 +36,10 @@ import org.neo4j.driver.v1.exceptions.Neo4jException;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -426,6 +428,19 @@ public class InboundMessageDispatcherTest
         {
             assertThat( e, instanceOf( UnsupportedOperationException.class ) );
         }
+    }
+
+    @Test
+    public void shouldMuteAndUnMuteAckFailure()
+    {
+        InboundMessageDispatcher dispatcher = newDispatcher();
+        assertFalse( dispatcher.isAckFailureMuted() );
+
+        dispatcher.muteAckFailure();
+        assertTrue( dispatcher.isAckFailureMuted() );
+
+        dispatcher.unMuteAckFailure();
+        assertFalse( dispatcher.isAckFailureMuted() );
     }
 
     private static void verifyFailure( ResponseHandler handler )

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/AckFailureResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/AckFailureResponseHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.handlers;
+
+import org.junit.Test;
+
+import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.ClientException;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AckFailureResponseHandlerTest
+{
+    private final InboundMessageDispatcher dispatcher = mock( InboundMessageDispatcher.class );
+    private final AckFailureResponseHandler handler = new AckFailureResponseHandler( dispatcher );
+
+    @Test
+    public void shouldClearCurrentErrorOnSuccess()
+    {
+        verify( dispatcher, never() ).clearCurrentError();
+        handler.onSuccess( emptyMap() );
+        verify( dispatcher ).clearCurrentError();
+    }
+
+    @Test
+    public void shouldThrowOnFailure()
+    {
+        RuntimeException error = new RuntimeException( "Unable to process ACK_FAILURE" );
+
+        try
+        {
+            handler.onFailure( error );
+            fail( "Exception expected" );
+        }
+        catch ( ClientException e )
+        {
+            assertSame( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldClearCurrentErrorWhenAckFailureMutedAndFailureReceived()
+    {
+        RuntimeException error = new RuntimeException( "Some error" );
+        when( dispatcher.isAckFailureMuted() ).thenReturn( true );
+
+        handler.onFailure( error );
+
+        verify( dispatcher ).clearCurrentError();
+    }
+
+    @Test
+    public void shouldThrowOnRecord()
+    {
+        try
+        {
+            handler.onRecord( new Value[0] );
+            fail( "Exception expected" );
+        }
+        catch ( UnsupportedOperationException ignore )
+        {
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/ChannelReleasingResetResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/ChannelReleasingResetResponseHandlerTest.java
@@ -71,7 +71,7 @@ public class ChannelReleasingResetResponseHandlerTest
     }
 
     @Test
-    public void shouldReleaseChannelOnFailure()
+    public void shouldCloseAndReleaseChannelOnFailure()
     {
         ChannelPool pool = newChannelPoolMock();
         FakeClock clock = new FakeClock();
@@ -81,7 +81,7 @@ public class ChannelReleasingResetResponseHandlerTest
 
         handler.onFailure( new RuntimeException() );
 
-        verifyLastUsedTimestamp( 100 );
+        assertTrue( channel.closeFuture().isDone() );
         verify( pool ).release( eq( channel ) );
         assertTrue( releaseFuture.isDone() );
         assertFalse( releaseFuture.isCompletedExceptionally() );

--- a/driver/src/test/resources/reset_error.script
+++ b/driver/src/test/resources/reset_error.script
@@ -1,0 +1,11 @@
+!: AUTO INIT
+
+C: RESET
+S: SUCCESS {}
+C: RUN "RETURN 42 AS answer" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["answer"]}
+   RECORD [42]
+   SUCCESS {}
+C: RESET
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to reset"}


### PR DESCRIPTION
This PR makes driver close the network channel when either `RESET` or `ACK_FAILURE` receive an error response. Message `RESET` is sent before release of the channel back to the channel pool. It might fail if database experiences a fatal error (like `OutOfMemoryError`) or a network failure occurs. In case of such errors channel will be closed and returned to the pool, which will drop it later. Message `ACK_FAILURE` is sent to acknowledge a `FAILURE` response. Failure to do so is unrecoverable and should result in a connection being dropped.

Backport of https://github.com/neo4j/neo4j-java-driver/pull/501