### PR TITLE
Migrate simple unit tests to JUnit 5

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/BookmarkTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/BookmarkTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,58 +29,58 @@ import org.neo4j.driver.v1.Value;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.Values.value;
 
-public class BookmarkTest
+class BookmarkTest
 {
     @Test
-    public void isEmptyForEmptyBookmark()
+    void isEmptyForEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.empty();
         assertTrue( bookmark.isEmpty() );
     }
 
     @Test
-    public void maxBookmarkAsStringForEmptyBookmark()
+    void maxBookmarkAsStringForEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.empty();
         assertNull( bookmark.maxBookmarkAsString() );
     }
 
     @Test
-    public void asBeginTransactionParametersForEmptyBookmark()
+    void asBeginTransactionParametersForEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.empty();
         assertEquals( emptyMap(), bookmark.asBeginTransactionParameters() );
     }
 
     @Test
-    public void isEmptyForNonEmptyBookmark()
+    void isEmptyForNonEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.from( "SomeBookmark" );
         assertFalse( bookmark.isEmpty() );
     }
 
     @Test
-    public void maxBookmarkAsStringForNonEmptyBookmark()
+    void maxBookmarkAsStringForNonEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.from( "SomeBookmark" );
         assertEquals( "SomeBookmark", bookmark.maxBookmarkAsString() );
     }
 
     @Test
-    public void asBeginTransactionParametersForNonEmptyBookmark()
+    void asBeginTransactionParametersForNonEmptyBookmark()
     {
         Bookmark bookmark = Bookmark.from( "SomeBookmark" );
         verifyParameters( bookmark, "SomeBookmark", "SomeBookmark" );
     }
 
     @Test
-    public void bookmarkFromString()
+    void bookmarkFromString()
     {
         Bookmark bookmark = Bookmark.from( "Cat" );
         assertEquals( "Cat", bookmark.maxBookmarkAsString() );
@@ -88,14 +88,14 @@ public class BookmarkTest
     }
 
     @Test
-    public void bookmarkFromNullString()
+    void bookmarkFromNullString()
     {
         Bookmark bookmark = Bookmark.from( (String) null );
         assertTrue( bookmark.isEmpty() );
     }
 
     @Test
-    public void bookmarkFromIterable()
+    void bookmarkFromIterable()
     {
         Bookmark bookmark = Bookmark.from( asList(
                 "neo4j:bookmark:v1:tx42", "neo4j:bookmark:v1:tx10", "neo4j:bookmark:v1:tx12" ) );
@@ -106,21 +106,21 @@ public class BookmarkTest
     }
 
     @Test
-    public void bookmarkFromNullIterable()
+    void bookmarkFromNullIterable()
     {
         Bookmark bookmark = Bookmark.from( (Iterable<String>) null );
         assertTrue( bookmark.isEmpty() );
     }
 
     @Test
-    public void bookmarkFromEmptyIterable()
+    void bookmarkFromEmptyIterable()
     {
         Bookmark bookmark = Bookmark.from( Collections.<String>emptyList() );
         assertTrue( bookmark.isEmpty() );
     }
 
     @Test
-    public void asBeginTransactionParametersForBookmarkWithInvalidValue()
+    void asBeginTransactionParametersForBookmarkWithInvalidValue()
     {
         Bookmark bookmark = Bookmark.from( asList(
                 "neo4j:bookmark:v1:tx1", "neo4j:bookmark:v1:txcat", "neo4j:bookmark:v1:tx3" ) );
@@ -131,7 +131,7 @@ public class BookmarkTest
     }
 
     @Test
-    public void asBeginTransactionParametersForBookmarkWithEmptyStringValue()
+    void asBeginTransactionParametersForBookmarkWithEmptyStringValue()
     {
         Bookmark bookmark = Bookmark.from( asList( "neo4j:bookmark:v1:tx9", "", "neo4j:bookmark:v1:tx3" ) );
         assertEquals( "neo4j:bookmark:v1:tx9", bookmark.maxBookmarkAsString() );
@@ -141,7 +141,7 @@ public class BookmarkTest
     }
 
     @Test
-    public void asBeginTransactionParametersForBookmarkWithNullValue()
+    void asBeginTransactionParametersForBookmarkWithNullValue()
     {
         Bookmark bookmark = Bookmark.from( asList( "neo4j:bookmark:v1:tx41", null, "neo4j:bookmark:v1:tx42" ) );
         assertEquals( "neo4j:bookmark:v1:tx42", bookmark.maxBookmarkAsString() );

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectConnectionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectConnectionProviderTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -27,8 +27,8 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,10 +36,10 @@ import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.AccessMode.WRITE;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class DirectConnectionProviderTest
+class DirectConnectionProviderTest
 {
     @Test
-    public void acquiresConnectionsFromThePool()
+    void acquiresConnectionsFromThePool()
     {
         BoltServerAddress address = BoltServerAddress.LOCAL_DEFAULT;
         Connection connection1 = mock( Connection.class );
@@ -53,7 +53,7 @@ public class DirectConnectionProviderTest
     }
 
     @Test
-    public void closesPool()
+    void closesPool()
     {
         BoltServerAddress address = BoltServerAddress.LOCAL_DEFAULT;
         ConnectionPool pool = poolMock( address, mock( Connection.class ) );
@@ -65,7 +65,7 @@ public class DirectConnectionProviderTest
     }
 
     @Test
-    public void returnsCorrectAddress()
+    void returnsCorrectAddress()
     {
         BoltServerAddress address = new BoltServerAddress( "server-1", 25000 );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.util.function.Consumer;
@@ -29,10 +29,10 @@ import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -43,10 +43,10 @@ import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 import static org.neo4j.driver.v1.util.TestUtil.connectionMock;
 
-public class ExplicitTransactionTest
+class ExplicitTransactionTest
 {
     @Test
-    public void shouldRollbackOnImplicitFailure()
+    void shouldRollbackOnImplicitFailure()
     {
         // Given
         Connection connection = connectionMock();
@@ -63,7 +63,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldRollbackOnExplicitFailure()
+    void shouldRollbackOnExplicitFailure()
     {
         // Given
         Connection connection = connectionMock();
@@ -82,7 +82,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldCommitOnSuccess()
+    void shouldCommitOnSuccess()
     {
         // Given
         Connection connection = connectionMock();
@@ -100,7 +100,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldOnlyQueueMessagesWhenNoBookmarkGiven()
+    void shouldOnlyQueueMessagesWhenNoBookmarkGiven()
     {
         Connection connection = connectionMock();
 
@@ -111,7 +111,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldFlushWhenBookmarkGiven()
+    void shouldFlushWhenBookmarkGiven()
     {
         Bookmark bookmark = Bookmark.from( "hi, I'm bookmark" );
         Connection connection = connectionMock();
@@ -123,7 +123,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeOpenAfterConstruction()
+    void shouldBeOpenAfterConstruction()
     {
         Transaction tx = beginTx( connectionMock() );
 
@@ -131,7 +131,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeOpenWhenMarkedForSuccess()
+    void shouldBeOpenWhenMarkedForSuccess()
     {
         Transaction tx = beginTx( connectionMock() );
 
@@ -141,7 +141,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeOpenWhenMarkedForFailure()
+    void shouldBeOpenWhenMarkedForFailure()
     {
         Transaction tx = beginTx( connectionMock() );
 
@@ -151,7 +151,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeClosedWhenMarkedAsTerminated()
+    void shouldBeClosedWhenMarkedAsTerminated()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
 
@@ -161,7 +161,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeClosedAfterCommit()
+    void shouldBeClosedAfterCommit()
     {
         Transaction tx = beginTx( connectionMock() );
 
@@ -172,7 +172,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeClosedAfterRollback()
+    void shouldBeClosedAfterRollback()
     {
         Transaction tx = beginTx( connectionMock() );
 
@@ -183,7 +183,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldBeClosedWhenMarkedTerminatedAndClosed()
+    void shouldBeClosedWhenMarkedTerminatedAndClosed()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
 
@@ -194,21 +194,21 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldHaveEmptyBookmarkInitially()
+    void shouldHaveEmptyBookmarkInitially()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
         assertTrue( tx.bookmark().isEmpty() );
     }
 
     @Test
-    public void shouldNotKeepInitialBookmark()
+    void shouldNotKeepInitialBookmark()
     {
         ExplicitTransaction tx = beginTx( connectionMock(), Bookmark.from( "Dog" ) );
         assertTrue( tx.bookmark().isEmpty() );
     }
 
     @Test
-    public void shouldNotOverwriteBookmarkWithNull()
+    void shouldNotOverwriteBookmarkWithNull()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
         tx.setBookmark( Bookmark.from( "Cat" ) );
@@ -218,7 +218,7 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldNotOverwriteBookmarkWithEmptyBookmark()
+    void shouldNotOverwriteBookmarkWithEmptyBookmark()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
         tx.setBookmark( Bookmark.from( "Cat" ) );
@@ -228,27 +228,20 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldReleaseConnectionWhenBeginFails()
+    void shouldReleaseConnectionWhenBeginFails()
     {
         RuntimeException error = new RuntimeException( "Wrong bookmark!" );
         Connection connection = connectionWithBegin( handler -> handler.onFailure( error ) );
         ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
 
-        try
-        {
-            await( tx.beginAsync( Bookmark.from( "SomeBookmark" ) ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( tx.beginAsync( Bookmark.from( "SomeBookmark" ) ) ) );
+        assertEquals( error, e );
 
         verify( connection ).release();
     }
 
     @Test
-    public void shouldNotReleaseConnectionWhenBeginSucceeds()
+    void shouldNotReleaseConnectionWhenBeginSucceeds()
     {
         Connection connection = connectionWithBegin( handler -> handler.onSuccess( emptyMap() ) );
         ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
@@ -258,27 +251,21 @@ public class ExplicitTransactionTest
     }
 
     @Test
-    public void shouldReleaseConnectionWhenTerminatedAndCommitted()
+    void shouldReleaseConnectionWhenTerminatedAndCommitted()
     {
         Connection connection = connectionMock();
         ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
 
         tx.markTerminated();
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException ignore )
-        {
-        }
+
+        assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
 
         assertFalse( tx.isOpen() );
         verify( connection ).release();
     }
 
     @Test
-    public void shouldReleaseConnectionWhenTerminatedAndRolledBack()
+    void shouldReleaseConnectionWhenTerminatedAndRolledBack()
     {
         Connection connection = connectionMock();
         ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,47 +40,42 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.v1.Values.value;
 
-public class ExtractTest
+class ExtractTest
 {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
-    public void extractEmptyArrayShouldNotBeModifiable() throws Exception
+    void extractEmptyArrayShouldNotBeModifiable()
     {
         List<Value> list = Extract.list( new Value[]{} );
 
         assertThat( list, empty() );
-        exception.expect( UnsupportedOperationException.class );
-        list.add( null );
+        assertThrows( UnsupportedOperationException.class, () -> list.add( null ) );
     }
 
     @Test
-    public void extractSingletonShouldNotBeModifiable() throws Exception
+    void extractSingletonShouldNotBeModifiable()
     {
         List<Value> list = Extract.list( new Value[]{value( 42 )} );
 
         assertThat( list, equalTo( singletonList( value( 42 ) ) ) );
-        exception.expect( UnsupportedOperationException.class );
-        list.add( null );
+        assertThrows( UnsupportedOperationException.class, () -> list.add( null ) );
     }
 
     @Test
-    public void extractMultipleShouldNotBeModifiable() throws Exception
+    void extractMultipleShouldNotBeModifiable()
     {
         List<Value> list = Extract.list( new Value[]{value( 42 ), value( 43 )} );
 
         assertThat( list, equalTo( asList( value( 42 ), value( 43 ) ) ) );
-        exception.expect( UnsupportedOperationException.class );
-        list.add( null );
+        assertThrows( UnsupportedOperationException.class, () -> list.add( null ) );
     }
 
     @Test
-    public void testMapOverList() throws Exception
+    void testMapOverList()
     {
         List<Integer> mapped = Extract.list( new Value[]{value( 42 ), value( 43 )}, integerExtractor() );
 
@@ -90,7 +83,7 @@ public class ExtractTest
     }
 
     @Test
-    public void testMapShouldNotBeModifiable() throws Exception
+    void testMapShouldNotBeModifiable()
     {
         // GIVEN
         Map<String,Value> map = new HashMap<>();
@@ -101,12 +94,11 @@ public class ExtractTest
         Map<String,Value> valueMap = Extract.map( map );
 
         // THEN
-        exception.expect( UnsupportedOperationException.class );
-        valueMap.put( "foo", value( "bar" ) );
+        assertThrows( UnsupportedOperationException.class, () -> valueMap.put( "foo", value( "bar" ) ) );
     }
 
     @Test
-    public void testMapValues() throws Exception
+    void testMapValues()
     {
         // GIVEN
         Map<String,Value> map = new HashMap<>();
@@ -123,7 +115,7 @@ public class ExtractTest
     }
 
     @Test
-    public void testShouldPreserveMapOrderMapValues() throws Exception
+    void testShouldPreserveMapOrderMapValues()
     {
         // GIVEN
         Map<String,Value> map = Iterables.newLinkedHashMapWithSize( 2 );
@@ -140,7 +132,7 @@ public class ExtractTest
     }
 
     @Test
-    public void testProperties() throws Exception
+    void testProperties()
     {
         // GIVEN
         Map<String,Value> props = new HashMap<>();
@@ -159,7 +151,7 @@ public class ExtractTest
     }
 
     @Test
-    public void testFields() throws Exception
+    void testFields()
     {
         // GIVEN
         InternalRecord record = new InternalRecord( Arrays.asList( "k1" ), new Value[]{value( 42 )} );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalDriverTest.java
@@ -18,14 +18,14 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.internal.security.SecurityPlan;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,10 +34,10 @@ import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class InternalDriverTest
+class InternalDriverTest
 {
     @Test
-    public void shouldCloseSessionFactory()
+    void shouldCloseSessionFactory()
     {
         SessionFactory sessionFactory = sessionFactoryMock();
         InternalDriver driver = newDriver( sessionFactory );
@@ -47,7 +47,7 @@ public class InternalDriverTest
     }
 
     @Test
-    public void shouldNotCloseSessionFactoryMultipleTimes()
+    void shouldNotCloseSessionFactoryMultipleTimes()
     {
         SessionFactory sessionFactory = sessionFactoryMock();
         InternalDriver driver = newDriver( sessionFactory );
@@ -60,7 +60,7 @@ public class InternalDriverTest
     }
 
     @Test
-    public void shouldVerifyConnectivity()
+    void shouldVerifyConnectivity()
     {
         SessionFactory sessionFactory = sessionFactoryMock();
         CompletableFuture<Void> connectivityStage = completedWithNull();

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -35,14 +35,14 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class InternalIsoDurationTest
+class InternalIsoDurationTest
 {
     @Test
-    public void shouldExposeMonths()
+    void shouldExposeMonths()
     {
         IsoDuration duration = newDuration( 42, 1, 2, 3 );
         assertEquals( 42, duration.months() );
@@ -50,7 +50,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldExposeDays()
+    void shouldExposeDays()
     {
         IsoDuration duration = newDuration( 1, 42, 2, 3 );
         assertEquals( 42, duration.days() );
@@ -58,7 +58,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldExposeSeconds()
+    void shouldExposeSeconds()
     {
         IsoDuration duration = newDuration( 1, 2, 42, 3 );
         assertEquals( 42, duration.seconds() );
@@ -66,7 +66,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldExposeNanoseconds()
+    void shouldExposeNanoseconds()
     {
         IsoDuration duration = newDuration( 1, 2, 3, 42 );
         assertEquals( 42, duration.nanoseconds() );
@@ -74,29 +74,22 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldFailToGetUnsupportedTemporalUnit()
+    void shouldFailToGetUnsupportedTemporalUnit()
     {
         IsoDuration duration = newDuration( 1, 2, 3, 4 );
 
-        try
-        {
-            duration.get( YEARS );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedTemporalTypeException ignore )
-        {
-        }
+        assertThrows( UnsupportedTemporalTypeException.class, () -> duration.get( YEARS ) );
     }
 
     @Test
-    public void shouldExposeSupportedTemporalUnits()
+    void shouldExposeSupportedTemporalUnits()
     {
         IsoDuration duration = newDuration( 1, 2, 3, 4 );
         assertEquals( asList( MONTHS, DAYS, SECONDS, NANOS ), duration.getUnits() );
     }
 
     @Test
-    public void shouldAddTo()
+    void shouldAddTo()
     {
         IsoDuration duration = newDuration( 1, 2, 3, 4 );
         LocalDateTime dateTime = LocalDateTime.of( 1990, 1, 1, 0, 0, 0, 0 );
@@ -107,7 +100,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldSubtractFrom()
+    void shouldSubtractFrom()
     {
         IsoDuration duration = newDuration( 4, 3, 2, 1 );
         LocalDateTime dateTime = LocalDateTime.of( 1990, 7, 19, 0, 0, 59, 999 );
@@ -118,7 +111,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldImplementEqualsAndHashCode()
+    void shouldImplementEqualsAndHashCode()
     {
         IsoDuration duration1 = newDuration( 1, 2, 3, 4 );
         IsoDuration duration2 = newDuration( 1, 2, 3, 4 );
@@ -128,7 +121,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldCreateFromPeriod()
+    void shouldCreateFromPeriod()
     {
         Period period = Period.of( 3, 5, 12 );
 
@@ -141,7 +134,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void shouldCreateFromDuration()
+    void shouldCreateFromDuration()
     {
         Duration duration = Duration.ofSeconds( 391784, 4879173 );
 
@@ -154,7 +147,7 @@ public class InternalIsoDurationTest
     }
 
     @Test
-    public void toStringShouldPrintInIsoStandardFormat()
+    void toStringShouldPrintInIsoStandardFormat()
     {
         assertThat( newDuration( 0, 0, 0, 0 ).toString(), equalTo( "P0M0DT0S" ) );
         assertThat( newDuration( 2, 45, 59, 11 ).toString(), equalTo( "P2M45DT59.000000011S" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,16 +46,16 @@ import org.neo4j.driver.v1.types.Relationship;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.ofInteger;
 import static org.neo4j.driver.v1.Values.value;
 
-public class InternalMapAccessorWithDefaultValueTest
+class InternalMapAccessorWithDefaultValueTest
 {
     private static final String wrongKey = "wrong_key";
 
     @Test
-    public void shouldGetValueFromRecord() throws Throwable
+    void shouldGetValueFromRecord()
     {
         Record record = createRecord();
 
@@ -110,7 +110,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetObjectFromRecord() throws Throwable
+    void shouldGetObjectFromRecord()
     {
         Record record = createRecord();
 
@@ -120,7 +120,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetNumberFromRecord() throws Throwable
+    void shouldGetNumberFromRecord()
     {
         Record record = createRecord();
 
@@ -130,7 +130,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetEntityFromRecord() throws Throwable
+    void shouldGetEntityFromRecord()
     {
         Record record = createRecord();
 
@@ -144,7 +144,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetNodeFromRecord() throws Throwable
+    void shouldGetNodeFromRecord()
     {
         Record record = createRecord();
 
@@ -154,7 +154,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetRelFromRecord() throws Throwable
+    void shouldGetRelFromRecord()
     {
         Record record = createRecord();
 
@@ -164,7 +164,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetPathFromRecord() throws Throwable
+    void shouldGetPathFromRecord()
     {
         Record record = createRecord();
 
@@ -177,7 +177,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetListOfObjectsFromRecord() throws Throwable
+    void shouldGetListOfObjectsFromRecord()
     {
         Record record = createRecord();
 
@@ -188,7 +188,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetListOfTFromRecord() throws Throwable
+    void shouldGetListOfTFromRecord()
     {
         Record record = createRecord();
         List<Integer> defaultValue = new ArrayList<>();
@@ -198,7 +198,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetMapOfStringObjectFromRecord() throws Throwable
+    void shouldGetMapOfStringObjectFromRecord()
     {
         Record record = createRecord();
 
@@ -212,7 +212,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetMapOfStringTFromRecord() throws Throwable
+    void shouldGetMapOfStringTFromRecord()
     {
         Record record = createRecord();
 
@@ -226,7 +226,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetPrimitiveTypesFromRecord() throws Throwable
+    void shouldGetPrimitiveTypesFromRecord()
     {
         Record record = createRecord();
 
@@ -256,7 +256,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetFromMap() throws Throwable
+    void shouldGetFromMap()
     {
         MapValue mapValue = new MapValue( createMap() );
         assertThat( mapValue.get( "key1", 0L ), equalTo( 1L ) );
@@ -265,7 +265,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetFromNode() throws Throwable
+    void shouldGetFromNode()
     {
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 43 ) );
@@ -278,7 +278,7 @@ public class InternalMapAccessorWithDefaultValueTest
     }
 
     @Test
-    public void shouldGetFromRel() throws Throwable
+    void shouldGetFromRel()
     {
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 43 ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalNodeTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalNodeTest.java
@@ -18,38 +18,30 @@
  */
 package org.neo4j.driver.internal;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.junit.Test;
-
-import org.neo4j.driver.v1.util.Function;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.util.Function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.v1.Values.NULL;
 import static org.neo4j.driver.v1.Values.value;
 
-public class InternalNodeTest
+class InternalNodeTest
 {
     @Test
-    public void extractValuesFromNode()
+    void extractValuesFromNode()
     {
         // GIVEN
         InternalNode node = createNode();
-        Function<Value,Integer> extractor = new Function<Value,Integer>()
-        {
-            @Override
-            public Integer apply( Value value )
-            {
-                return value.asInt();
-            }
-        };
+        Function<Value,Integer> extractor = Value::asInt;
 
         //WHEN
         Iterable<Integer> values = node.values( extractor );
@@ -62,7 +54,7 @@ public class InternalNodeTest
     }
 
     @Test
-    public void accessUnknownKeyShouldBeNull()
+    void accessUnknownKeyShouldBeNull()
     {
         InternalNode node = createNode();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalPairTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalPairTest.java
@@ -18,21 +18,19 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import org.neo4j.driver.v1.util.Pair;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.util.Pair;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.value;
 
-
-public class InternalPairTest
+class InternalPairTest
 {
     @Test
-    public void testMethods()
+    void testMethods()
     {
         Pair<String, Value> pair = InternalPair.of( "k", value( "v" ) );
         assertThat( pair.key(), equalTo("k"));

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalPathTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalPathTest.java
@@ -19,9 +19,7 @@
 package org.neo4j.driver.internal;
 
 import org.hamcrest.MatcherAssert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,13 +30,11 @@ import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class InternalPathTest
+class InternalPathTest
 {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     // (A)-[AB:KNOWS]->(B)<-[CB:KNOWS]-(C)-[CD:KNOWS]->(D)
     private InternalPath testPath()
     {
@@ -54,7 +50,7 @@ public class InternalPathTest
     }
 
     @Test
-    public void pathSizeShouldReturnNumberOfRelationships()
+    void pathSizeShouldReturnNumberOfRelationships()
     {
         // When
         InternalPath path = testPath();
@@ -64,7 +60,7 @@ public class InternalPathTest
     }
 
     @Test
-    public void shouldBeAbleToCreatePathWithSingleNode()
+    void shouldBeAbleToCreatePathWithSingleNode()
     {
         // When
         InternalPath path = new InternalPath( new InternalNode( 1 ) );
@@ -74,7 +70,7 @@ public class InternalPathTest
     }
 
     @Test
-    public void shouldBeAbleToIterateOverPathAsSegments() throws Exception
+    void shouldBeAbleToIterateOverPathAsSegments()
     {
         // Given
         InternalPath path = testPath();
@@ -104,7 +100,7 @@ public class InternalPathTest
     }
 
     @Test
-    public void shouldBeAbleToIterateOverPathNodes() throws Exception
+    void shouldBeAbleToIterateOverPathNodes()
     {
         // Given
         InternalPath path = testPath();
@@ -121,7 +117,7 @@ public class InternalPathTest
     }
 
     @Test
-    public void shouldBeAbleToIterateOverPathRelationships() throws Exception
+    void shouldBeAbleToIterateOverPathRelationships()
     {
         // Given
         InternalPath path = testPath();
@@ -137,68 +133,45 @@ public class InternalPathTest
     }
 
     @Test
-    public void shouldNotBeAbleToCreatePathWithNoEntities()
+    void shouldNotBeAbleToCreatePathWithNoEntities()
     {
-        // Expect
-        thrown.expect( IllegalArgumentException.class );
-
-        // When
-        new InternalPath();
-
+        assertThrows( IllegalArgumentException.class, InternalPath::new );
     }
 
     @Test
-    public void shouldNotBeAbleToCreatePathWithEvenNumberOfEntities()
+    void shouldNotBeAbleToCreatePathWithEvenNumberOfEntities()
     {
-        // Expect
-        thrown.expect( IllegalArgumentException.class );
-
-        // When
-        new InternalPath(
-                new InternalNode( 1 ),
-                new InternalRelationship( 2, 3, 4, "KNOWS" ) );
-
+        assertThrows( IllegalArgumentException.class,
+                () -> new InternalPath(
+                        new InternalNode( 1 ),
+                        new InternalRelationship( 2, 3, 4, "KNOWS" ) ) );
     }
 
     @Test
-    public void shouldNotBeAbleToCreatePathWithNullEntities()
+    void shouldNotBeAbleToCreatePathWithNullEntities()
     {
-        // Expect
-        thrown.expect( IllegalArgumentException.class );
-
-        // When
         InternalNode nullNode = null;
-        //noinspection ConstantConditions
-        new InternalPath( nullNode );
-
+        assertThrows( IllegalArgumentException.class, () -> new InternalPath( nullNode ) );
     }
 
     @Test
-    public void shouldNotBeAbleToCreatePathWithNodeThatDoesNotConnect()
+    void shouldNotBeAbleToCreatePathWithNodeThatDoesNotConnect()
     {
-        // Expect
-        thrown.expect( IllegalArgumentException.class );
-
-        // When
-        new InternalPath(
-                new InternalNode( 1 ),
-                new InternalRelationship( 2, 1, 3, "KNOWS" ),
-                new InternalNode( 4 ) );
-
+        assertThrows( IllegalArgumentException.class,
+                () -> new InternalPath(
+                        new InternalNode( 1 ),
+                        new InternalRelationship( 2, 1, 3, "KNOWS" ),
+                        new InternalNode( 4 ) ) );
     }
 
     @Test
-    public void shouldNotBeAbleToCreatePathWithRelationshipThatDoesNotConnect()
+    void shouldNotBeAbleToCreatePathWithRelationshipThatDoesNotConnect()
     {
-        // Expect
-        thrown.expect( IllegalArgumentException.class );
-
-        // When
-        new InternalPath(
-                new InternalNode( 1 ),
-                new InternalRelationship( 2, 3, 4, "KNOWS" ),
-                new InternalNode( 3 ) );
-
+        assertThrows( IllegalArgumentException.class,
+                () -> new InternalPath(
+                        new InternalNode( 1 ),
+                        new InternalRelationship( 2, 3, 4, "KNOWS" ),
+                        new InternalNode( 3 ) ) );
     }
 
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalRecordTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalRecordTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,16 +35,16 @@ import org.neo4j.driver.v1.util.Function;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.Values.value;
 
-public class InternalRecordTest
+class InternalRecordTest
 {
     @Test
-    public void accessingUnknownKeyShouldBeNull()
+    void accessingUnknownKeyShouldBeNull()
     {
         InternalRecord record = createRecord();
 
@@ -54,14 +54,14 @@ public class InternalRecordTest
     }
 
     @Test
-    public void shouldHaveCorrectSize()
+    void shouldHaveCorrectSize()
     {
         InternalRecord record = createRecord();
         assertThat( record.size(), equalTo( 2 ) );
     }
 
     @Test
-    public void shouldHaveCorrectFieldIndices()
+    void shouldHaveCorrectFieldIndices()
     {
         InternalRecord record = createRecord();
         assertThat( record.index( "k1" ), equalTo( 0 ) );
@@ -69,22 +69,14 @@ public class InternalRecordTest
     }
 
     @Test
-    public void shouldThrowWhenAskingForIndexOfUnknownField()
+    void shouldThrowWhenAskingForIndexOfUnknownField()
     {
         InternalRecord record = createRecord();
-        try
-        {
-            record.index( "BATMAN" );
-            fail( "Expected NoSuchElementException to be thrown" );
-        }
-        catch ( NoSuchElementException e )
-        {
-            // yay
-        }
+        assertThrows( NoSuchElementException.class, () -> record.index( "BATMAN" ) );
     }
 
     @Test
-    public void accessingOutOfBoundsShouldBeNull()
+    void accessingOutOfBoundsShouldBeNull()
     {
         InternalRecord record = createRecord();
 
@@ -95,7 +87,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void testContainsKey()
+    void testContainsKey()
     {
         InternalRecord record = createRecord();
 
@@ -105,7 +97,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void testIndex()
+    void testIndex()
     {
         InternalRecord record = createRecord();
 
@@ -114,7 +106,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void testAsMap()
+    void testAsMap()
     {
         // GIVEN
         InternalRecord record = createRecord();
@@ -124,23 +116,16 @@ public class InternalRecordTest
 
         // THEN
         assertThat( map.keySet(), containsInAnyOrder( "k1", "k2" ) );
-        assertThat( map.get( "k1" ), equalTo( (Object)0L ) );
-        assertThat( map.get( "k2" ), equalTo( (Object)1L ) );
+        assertThat( map.get( "k1" ), equalTo( 0L ) );
+        assertThat( map.get( "k2" ), equalTo( 1L ) );
     }
 
     @Test
-    public void testMapExtraction()
+    void testMapExtraction()
     {
         // GIVEN
         InternalRecord record = createRecord();
-        Function<Value,Integer> addOne = new Function<Value,Integer>()
-        {
-            @Override
-            public Integer apply( Value value )
-            {
-                return value.asInt() + 1;
-            }
-        };
+        Function<Value,Integer> addOne = value -> value.asInt() + 1;
 
         // WHEN
         Map<String,Integer> map = Extract.map( record, addOne );
@@ -152,19 +137,12 @@ public class InternalRecordTest
     }
 
     @Test
-    public void mapExtractionShouldPreserveIterationOrder()
+    void mapExtractionShouldPreserveIterationOrder()
     {
         // GIVEN
         List<String> keys = Arrays.asList( "k2", "k1" );
         InternalRecord record =  new InternalRecord( keys, new Value[]{value( 0 ), value( 1 )} );
-        Function<Value,Integer> addOne = new Function<Value,Integer>()
-        {
-            @Override
-            public Integer apply( Value value )
-            {
-                return value.asInt() + 1;
-            }
-        };
+        Function<Value,Integer> addOne = value -> value.asInt() + 1;
 
         // WHEN
         Map<String,Integer> map = Extract.map( record, addOne );
@@ -177,7 +155,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void testToString()
+    void testToString()
     {
         InternalRecord record = createRecord();
 
@@ -185,7 +163,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void shouldHaveMethodToGetKeys()
+    void shouldHaveMethodToGetKeys()
     {
         //GIVEN
         List<String> keys = Arrays.asList( "k2", "k1" );
@@ -199,7 +177,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void emptyKeysShouldGiveEmptyList()
+    void emptyKeysShouldGiveEmptyList()
     {
         //GIVEN
         List<String> keys = Collections.emptyList();
@@ -214,7 +192,7 @@ public class InternalRecordTest
 
 
     @Test
-    public void shouldHaveMethodToGetValues()
+    void shouldHaveMethodToGetValues()
     {
         //GIVEN
         List<String> keys = Arrays.asList( "k2", "k1" );
@@ -229,7 +207,7 @@ public class InternalRecordTest
     }
 
     @Test
-    public void emptyValuesShouldGiveEmptyList()
+    void emptyValuesShouldGiveEmptyList()
     {
         //GIVEN
         List<String> keys = Collections.emptyList();

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalRelationshipTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalRelationshipTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,26 +28,19 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.util.Function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.v1.Values.NULL;
 import static org.neo4j.driver.v1.Values.value;
 
-public class InternalRelationshipTest
+class InternalRelationshipTest
 {
     @Test
-    public void extractValuesFromNode()
+    void extractValuesFromNode()
     {
         // GIVEN
         InternalRelationship relationship = createRelationship();
-        Function<Value,Integer> extractor = new Function<Value,Integer>()
-        {
-            @Override
-            public Integer apply( Value value )
-            {
-                return value.asInt();
-            }
-        };
+        Function<Value,Integer> extractor = Value::asInt;
 
         //WHEN
         Iterable<Integer> values = relationship.values( extractor );
@@ -60,7 +53,7 @@ public class InternalRelationshipTest
     }
 
     @Test
-    public void accessUnknownKeyShouldBeNull()
+    void accessUnknownKeyShouldBeNull()
     {
         InternalRelationship relationship = createRelationship();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultCursorTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -47,10 +47,10 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,10 +61,10 @@ import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class InternalStatementResultCursorTest
+class InternalStatementResultCursorTest
 {
     @Test
-    public void shouldReturnStatementKeys()
+    void shouldReturnStatementKeys()
     {
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>() );
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
@@ -78,7 +78,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldReturnSummary()
+    void shouldReturnSummary()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -94,7 +94,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldReturnNextExistingRecord()
+    void shouldReturnNextExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -107,7 +107,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldReturnNextNonExistingRecord()
+    void shouldReturnNextNonExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
@@ -118,7 +118,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldPeekExistingRecord()
+    void shouldPeekExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -131,7 +131,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldPeekNonExistingRecord()
+    void shouldPeekNonExistingRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.peekAsync() ).thenReturn( completedWithNull() );
@@ -142,7 +142,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldReturnSingleRecord()
+    void shouldReturnSingleRecord()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -156,26 +156,19 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldFailWhenAskedForSingleRecordButResultIsEmpty()
+    void shouldFailWhenAskedForSingleRecordButResultIsEmpty()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( NoSuchRecordException e )
-        {
-            assertThat( e.getMessage(), containsString( "result is empty" ) );
-        }
+        NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), containsString( "result is empty" ) );
     }
 
     @Test
-    public void shouldFailWhenAskedForSingleRecordButResultContainsMore()
+    void shouldFailWhenAskedForSingleRecordButResultContainsMore()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -186,19 +179,12 @@ public class InternalStatementResultCursorTest
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( NoSuchRecordException e )
-        {
-            assertThat( e.getMessage(), containsString( "Ensure your query returns only one record" ) );
-        }
+        NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), containsString( "Ensure your query returns only one record" ) );
     }
 
     @Test
-    public void shouldForEachAsyncWhenResultContainsMultipleRecords()
+    void shouldForEachAsyncWhenResultContainsMultipleRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -222,7 +208,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldForEachAsyncWhenResultContainsOneRecords()
+    void shouldForEachAsyncWhenResultContainsOneRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -243,7 +229,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldForEachAsyncWhenResultContainsNoRecords()
+    void shouldForEachAsyncWhenResultContainsNoRecords()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
@@ -261,7 +247,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldFailForEachWhenGivenActionThrows()
+    void shouldFailForEachWhenGivenActionThrows()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -289,21 +275,15 @@ public class InternalStatementResultCursorTest
             }
         } );
 
-        try
-        {
-            await( stage );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( stage ) );
+        assertEquals( error, e );
+
         assertEquals( 1, recordsProcessed.get() );
         verify( pullAllHandler, times( 2 ) ).nextAsync();
     }
 
     @Test
-    public void shouldReturnFailureWhenExists()
+    void shouldReturnFailureWhenExists()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -316,7 +296,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldReturnNullFailureWhenDoesNotExist()
+    void shouldReturnNullFailureWhenDoesNotExist()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.failureAsync() ).thenReturn( completedWithNull() );
@@ -327,7 +307,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldListAsyncWithoutMapFunction()
+    void shouldListAsyncWithoutMapFunction()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
@@ -344,7 +324,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldListAsyncWithMapFunction()
+    void shouldListAsyncWithMapFunction()
     {
         Function<Record,String> mapFunction = record -> record.get( 0 ).asString();
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
@@ -359,7 +339,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldPropagateFailureFromListAsyncWithoutMapFunction()
+    void shouldPropagateFailureFromListAsyncWithoutMapFunction()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         RuntimeException error = new RuntimeException( "Hi" );
@@ -367,20 +347,13 @@ public class InternalStatementResultCursorTest
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
-        try
-        {
-            await( cursor.listAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.listAsync() ) );
+        assertEquals( error, e );
         verify( pullAllHandler ).listAsync( Functions.identity() );
     }
 
     @Test
-    public void shouldPropagateFailureFromListAsyncWithMapFunction()
+    void shouldPropagateFailureFromListAsyncWithMapFunction()
     {
         Function<Record,String> mapFunction = record -> record.get( 0 ).asString();
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
@@ -389,20 +362,14 @@ public class InternalStatementResultCursorTest
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
-        try
-        {
-            await( cursor.listAsync( mapFunction ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.listAsync( mapFunction ) ) );
+        assertEquals( error, e );
+
         verify( pullAllHandler ).listAsync( mapFunction );
     }
 
     @Test
-    public void shouldConsumeAsync()
+    void shouldConsumeAsync()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         ResultSummary summary = mock( ResultSummary.class );
@@ -414,7 +381,7 @@ public class InternalStatementResultCursorTest
     }
 
     @Test
-    public void shouldPropagateFailureInConsumeAsync()
+    void shouldPropagateFailureInConsumeAsync()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         RuntimeException error = new RuntimeException( "Hi" );
@@ -422,15 +389,8 @@ public class InternalStatementResultCursorTest
 
         InternalStatementResultCursor cursor = newCursor( pullAllHandler );
 
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.consumeAsync() ) );
+        assertEquals( error, e );
     }
 
     private static InternalStatementResultCursor newCursor( PullAllResponseHandler pullAllHandler )

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,12 +44,11 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
@@ -59,13 +56,10 @@ import static org.neo4j.driver.v1.Records.column;
 import static org.neo4j.driver.v1.Values.ofString;
 import static org.neo4j.driver.v1.Values.value;
 
-public class InternalStatementResultTest
+class InternalStatementResultTest
 {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void iterationShouldWorksAsExpected()
+    void iterationShouldWorksAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -83,14 +77,11 @@ public class InternalStatementResultTest
         assertThat( values( result.next() ), equalTo( asList( value( "v1-3" ), value( "v2-3" ) ) ) );
         assertFalse( result.hasNext() );
 
-        expectedException.expect( NoSuchRecordException.class );
-
-        // WHEN
-        assertNull( result.next() );
+        assertThrows( NoSuchRecordException.class, result::next );
     }
 
     @Test
-    public void firstOfFieldNameShouldWorkAsExpected()
+    void firstOfFieldNameShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -101,7 +92,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void firstOfFieldIndexShouldWorkAsExpected()
+    void firstOfFieldIndexShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -112,51 +103,39 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void singlePastFirstShouldFail()
+    void singlePastFirstShouldFail()
     {
         // GIVEN
         StatementResult result = createResult( 2 );
         result.next();
         result.next();
 
-
         // THEN
-        expectedException.expect( NoSuchRecordException.class );
-
-        // THEN
-        result.single();
+        assertThrows( NoSuchRecordException.class, result::single );
     }
 
     @Test
-    public void singleNoneShouldFail()
+    void singleNoneShouldFail()
     {
         // GIVEN
         StatementResult result = createResult( 0 );
 
-
         // THEN
-        expectedException.expect( NoSuchRecordException.class );
-
-        // THEN
-        result.single();
+        assertThrows( NoSuchRecordException.class, result::single );
     }
 
     @Test
-    public void singleWhenMoreThanOneShouldFail()
+    void singleWhenMoreThanOneShouldFail()
     {
         // GIVEN
         StatementResult result = createResult( 2 );
 
-
         // THEN
-        expectedException.expect( NoSuchRecordException.class );
-
-        // THEN
-        result.single();
+        assertThrows( NoSuchRecordException.class, result::single );
     }
 
     @Test
-    public void singleOfFieldNameShouldWorkAsExpected()
+    void singleOfFieldNameShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 1 );
@@ -167,7 +146,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void singleOfFieldIndexShouldWorkAsExpected()
+    void singleOfFieldIndexShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 1 );
@@ -178,45 +157,36 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void singleShouldWorkAsExpected()
+    void singleShouldWorkAsExpected()
     {
         assertNotNull( createResult( 1 ).single() );
     }
 
     @Test
-    public void singleShouldThrowOnBigResult()
+    void singleShouldThrowOnBigResult()
     {
-        // Expect
-        expectedException.expect( NoSuchRecordException.class );
-
-        // When
-        createResult( 42 ).single();
+        assertThrows( NoSuchRecordException.class, () -> createResult( 42 ).single() );
     }
 
     @Test
-    public void singleShouldThrowOnEmptyResult()
+    void singleShouldThrowOnEmptyResult()
     {
-        // Expect
-        expectedException.expect( NoSuchRecordException.class );
-
-        // When
-        createResult( 0 ).single();
+        assertThrows( NoSuchRecordException.class, () -> createResult( 0 ).single() );
     }
 
     @Test
-    public void singleShouldThrowOnConsumedResult()
+    void singleShouldThrowOnConsumedResult()
     {
-        // Expect
-        expectedException.expect( NoSuchRecordException.class );
-
-        // When
-        StatementResult result = createResult( 2 );
-        result.consume();
-        result.single();
+        assertThrows( NoSuchRecordException.class, () ->
+        {
+            StatementResult result = createResult( 2 );
+            result.consume();
+            result.single();
+        } );
     }
 
     @Test
-    public void shouldConsumeTwice()
+    void shouldConsumeTwice()
     {
         // GIVEN
         StatementResult result = createResult( 2 );
@@ -230,7 +200,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void shouldList()
+    void shouldList()
     {
         // GIVEN
         StatementResult result = createResult( 2 );
@@ -241,7 +211,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void shouldListTwice()
+    void shouldListTwice()
     {
         // GIVEN
         StatementResult result = createResult( 2 );
@@ -254,7 +224,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void singleShouldNotThrowOnPartiallyConsumedResult()
+    void singleShouldNotThrowOnPartiallyConsumedResult()
     {
         // Given
         StatementResult result = createResult( 2 );
@@ -265,24 +235,16 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void singleShouldConsumeIfFailing()
+    void singleShouldConsumeIfFailing()
     {
-        // Given
         StatementResult result = createResult( 2 );
 
-        try
-        {
-            result.single();
-            fail( "Exception expected" );
-        }
-        catch ( NoSuchRecordException e )
-        {
-            assertFalse( result.hasNext() );
-        }
+        assertThrows( NoSuchRecordException.class, result::single );
+        assertFalse( result.hasNext() );
     }
 
     @Test
-    public void retainShouldWorkAsExpected()
+    void retainShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -296,7 +258,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void retainAndMapByKeyShouldWorkAsExpected()
+    void retainAndMapByKeyShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -310,7 +272,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void retainAndMapByIndexShouldWorkAsExpected()
+    void retainAndMapByIndexShouldWorkAsExpected()
     {
         // GIVEN
         StatementResult result = createResult( 3 );
@@ -324,7 +286,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void accessingOutOfBoundsShouldBeNull()
+    void accessingOutOfBoundsShouldBeNull()
     {
         // GIVEN
         StatementResult result = createResult( 1 );
@@ -340,7 +302,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void accessingKeysWithoutCallingNextShouldNotFail()
+    void accessingKeysWithoutCallingNextShouldNotFail()
     {
         // GIVEN
         StatementResult result = createResult( 11 );
@@ -353,7 +315,7 @@ public class InternalStatementResultTest
     }
 
     @Test
-    public void shouldPeekIntoTheFuture()
+    void shouldPeekIntoTheFuture()
     {
         // WHEN
         StatementResult result = createResult( 2 );
@@ -371,23 +333,17 @@ public class InternalStatementResultTest
         result.next();
 
         // THEN
-        expectedException.expect( NoSuchRecordException.class );
-
-        // WHEN
-        result.peek();
+        assertThrows( NoSuchRecordException.class, result::peek );
     }
 
     @Test
-    public void shouldNotPeekIntoTheFutureWhenResultIsEmpty()
+    void shouldNotPeekIntoTheFutureWhenResultIsEmpty()
     {
         // GIVEN
         StatementResult result = createResult( 0 );
 
         // THEN
-        expectedException.expect( NoSuchRecordException.class );
-
-        // WHEN
-        Record future = result.peek();
+        assertThrows( NoSuchRecordException.class, result::peek );
     }
 
     private StatementResult createResult( int numberOfRecords )

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -18,9 +18,8 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
@@ -35,8 +34,8 @@ import org.neo4j.driver.v1.Session;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -45,13 +44,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.v1.AccessMode.READ;
 
-public class LeakLoggingNetworkSessionTest
+class LeakLoggingNetworkSessionTest
 {
-    @Rule
-    public final TestName testName = new TestName();
-
     @Test
-    public void logsNothingDuringFinalizationIfClosed() throws Exception
+    void logsNothingDuringFinalizationIfClosed() throws Exception
     {
         Logging logging = mock( Logging.class );
         Logger log = mock( Logger.class );
@@ -64,7 +60,7 @@ public class LeakLoggingNetworkSessionTest
     }
 
     @Test
-    public void logsMessageWithStacktraceDuringFinalizationIfLeaked() throws Exception
+    void logsMessageWithStacktraceDuringFinalizationIfLeaked( TestInfo testInfo ) throws Exception
     {
         Logging logging = mock( Logging.class );
         Logger log = mock( Logger.class );
@@ -84,7 +80,7 @@ public class LeakLoggingNetworkSessionTest
         assertThat( loggedMessage, containsString( "Neo4j Session object leaked" ) );
         assertThat( loggedMessage, containsString( "Session was create at" ) );
         assertThat( loggedMessage, containsString(
-                getClass().getSimpleName() + "." + testName.getMethodName() )
+                getClass().getSimpleName() + "." + testInfo.getTestMethod().get().getName() )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/SelfContainedNodeTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SelfContainedNodeTest.java
@@ -18,23 +18,22 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import org.neo4j.driver.internal.util.Iterables;
-import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.types.Node;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.Values.ofValue;
+import static org.neo4j.driver.v1.Values.parameters;
 
-public class SelfContainedNodeTest
+class SelfContainedNodeTest
 {
-
     private Node adamTheNode()
     {
         return new InternalNode( 1, singletonList( "Person" ),
@@ -42,7 +41,7 @@ public class SelfContainedNodeTest
     }
 
     @Test
-    public void testIdentity()
+    void testIdentity()
     {
         // Given
         Node node = adamTheNode();
@@ -52,7 +51,7 @@ public class SelfContainedNodeTest
     }
 
     @Test
-    public void testLabels()
+    void testLabels()
     {
         // Given
         Node node = adamTheNode();
@@ -64,7 +63,7 @@ public class SelfContainedNodeTest
     }
 
     @Test
-    public void testKeys()
+    void testKeys()
     {
         // Given
         Node node = adamTheNode();
@@ -76,7 +75,7 @@ public class SelfContainedNodeTest
     }
 
     @Test
-    public void testValue()
+    void testValue()
     {
         // Given
         Node node = adamTheNode();

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.retry.FixedRetryLogic;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -31,10 +31,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class SessionFactoryImplTest
+class SessionFactoryImplTest
 {
     @Test
-    public void createsNetworkSessions()
+    void createsNetworkSessions()
     {
         Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
         SessionFactory factory = newSessionFactory( config );
@@ -47,7 +47,7 @@ public class SessionFactoryImplTest
     }
 
     @Test
-    public void createsLeakLoggingNetworkSessions()
+    void createsLeakLoggingNetworkSessions()
     {
         Config config = Config.build().withLogging( DEV_NULL_LOGGING ).withLeakedSessionsLogging().toConfig();
         SessionFactory factory = newSessionFactory( config );

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -19,9 +19,7 @@
 package org.neo4j.driver.internal;
 
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -63,9 +61,10 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
@@ -84,49 +83,42 @@ import static org.neo4j.driver.v1.Values.point;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 
-public class ValuesTest
+class ValuesTest
 {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
-    public void shouldConvertPrimitiveArrays() throws Throwable
+    void shouldConvertPrimitiveArrays()
     {
         assertThat( value( new int[]{1, 2, 3} ),
-                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
 
         assertThat( value( new long[]{1, 2, 3} ),
-                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
 
         assertThat( value( new float[]{1.1f, 2.2f, 3.3f} ),
-                equalTo( (Value) new ListValue( values( 1.1f, 2.2f, 3.3f ) ) ) );
+                equalTo( new ListValue( values( 1.1f, 2.2f, 3.3f ) ) ) );
 
         assertThat( value( new double[]{1.1, 2.2, 3.3} ),
-                equalTo( (Value) new ListValue( values( 1.1, 2.2, 3.3 ) ) ) );
+                equalTo( new ListValue( values( 1.1, 2.2, 3.3 ) ) ) );
 
         assertThat( value( new boolean[]{true, false, true} ),
-                equalTo( (Value) new ListValue( values( true, false, true ) ) ) );
+                equalTo( new ListValue( values( true, false, true ) ) ) );
 
         assertThat( value( new char[]{'a', 'b', 'c'} ),
-                equalTo( (Value) new ListValue( values( 'a', 'b', 'c' ) ) ) );
+                equalTo( new ListValue( values( 'a', 'b', 'c' ) ) ) );
 
         assertThat( value( new String[]{"a", "b", "c"} ),
-                equalTo( (Value) new ListValue( values( "a", "b", "c" ) ) ) );
+                equalTo( new ListValue( values( "a", "b", "c" ) ) ) );
     }
 
     @Test
-    public void shouldComplainAboutStrangeTypes() throws Throwable
+    void shouldComplainAboutStrangeTypes()
     {
-        // Expect
-        exception.expect( ClientException.class );
-        exception.expectMessage( "Unable to convert java.lang.Object to Neo4j Value." );
-
-        // When
-        value( new Object() );
+        ClientException e = assertThrows( ClientException.class, () -> value( new Object() ) );
+        assertEquals( "Unable to convert java.lang.Object to Neo4j Value.", e.getMessage() );
     }
 
     @Test
-    public void equalityRules() throws Throwable
+    void equalityRules()
     {
         assertEquals( value( 1 ), value( 1 ) );
         assertEquals( value( Long.MAX_VALUE ), value( Long.MAX_VALUE ) );
@@ -149,12 +141,12 @@ public class ValuesTest
         assertNotEquals( value( "This åäö string ?? contains strange " ),
                 value( "This åäö string ?? contains strange Ü" ) );
 
-        assertEquals( value ( 'A' ), value( 'A' ));
-        assertEquals( value ( 'A' ), value( "A" ));
+        assertEquals( value( 'A' ), value( 'A' ) );
+        assertEquals( value( 'A' ), value( "A" ) );
     }
 
     @Test
-    public void shouldMapDriverComplexTypesToListOfJavaPrimitiveTypes() throws Throwable
+    void shouldMapDriverComplexTypesToListOfJavaPrimitiveTypes()
     {
         // Given
         Map<String,Value> map = new HashMap<>();
@@ -182,7 +174,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldMapDriverMapsToJavaMaps() throws Throwable
+    void shouldMapDriverMapsToJavaMaps()
     {
         // Given
         Map<String,Value> map = new HashMap<>();
@@ -191,7 +183,7 @@ public class ValuesTest
         MapValue values = new MapValue( map );
 
         // When
-        Map<String, String> result = values.asMap( Values.ofToString() );
+        Map<String,String> result = values.asMap( Values.ofToString() );
 
         // Then
         assertThat( result.size(), equalTo( 2 ) );
@@ -200,62 +192,50 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldNotBeAbleToGetKeysFromNonKeyedValue() throws Throwable
+    void shouldNotBeAbleToGetKeysFromNonKeyedValue()
     {
-        // expect
-        exception.expect( ClientException.class );
-
-        // when
-        value( "asd" ).get(1);
+        assertThrows( ClientException.class, () -> value( "asd" ).get( 1 ) );
     }
 
     @Test
-    public void shouldNotBeAbleToDoCrazyCoercions() throws Throwable
+    void shouldNotBeAbleToDoCrazyCoercions()
     {
-        // expect
-        exception.expect( ClientException.class );
-
-        // when
-        value(1).asPath();
+        assertThrows( ClientException.class, () -> value( 1 ).asPath() );
     }
 
     @Test
-    public void shouldNotBeAbleToGetSizeOnNonSizedValues() throws Throwable
+    void shouldNotBeAbleToGetSizeOnNonSizedValues()
     {
-        // expect
-        exception.expect( ClientException.class );
-
-        // when
-        value(1).size();
+        assertThrows( ClientException.class, () -> value( 1 ).size() );
     }
 
     @Test
-    public void shouldMapInteger() throws Throwable
+    void shouldMapInteger()
     {
         // Given
         Value val = value( 1, 2, 3 );
 
         // When/Then
-        assertThat( val.asList( ofInteger() ), contains(1,2,3) );
-        assertThat( val.asList( ofLong() ), contains(1L,2L,3L) );
-        assertThat( val.asList( ofNumber() ), contains((Number)1L,2L,3L) );
-        assertThat( val.asList( ofObject() ), contains((Object)1L,2L,3L) );
+        assertThat( val.asList( ofInteger() ), contains( 1, 2, 3 ) );
+        assertThat( val.asList( ofLong() ), contains( 1L, 2L, 3L ) );
+        assertThat( val.asList( ofNumber() ), contains( 1L, 2L, 3L ) );
+        assertThat( val.asList( ofObject() ), contains( 1L, 2L, 3L ) );
     }
 
     @Test
-    public void shouldMapFloat() throws Throwable
+    void shouldMapFloat()
     {
         // Given
         Value val = value( 1.0, 1.2, 3.2 );
 
         // When/Then
-        assertThat( val.asList( ofDouble() ), contains(1.0, 1.2, 3.2) );
-        assertThat( val.asList( ofNumber() ), contains((Number)1.0, 1.2, 3.2) );
-        assertThat( val.asList( ofObject() ), contains((Object)1.0, 1.2, 3.2) );
+        assertThat( val.asList( ofDouble() ), contains( 1.0, 1.2, 3.2 ) );
+        assertThat( val.asList( ofNumber() ), contains( 1.0, 1.2, 3.2 ) );
+        assertThat( val.asList( ofObject() ), contains( 1.0, 1.2, 3.2 ) );
     }
 
     @Test
-    public void shouldMapFloatToJavaFloat() throws Throwable
+    void shouldMapFloatToJavaFloat()
     {
         // Given all double -> float conversions other than integers
         //       loose precision, as far as java is concerned, so we
@@ -263,60 +243,60 @@ public class ValuesTest
         Value val = value( 1.0, 2.0, 3.0 );
 
         // When/Then
-        assertThat( val.asList( ofFloat() ), contains(1.0F, 2.0F, 3.0F) );
+        assertThat( val.asList( ofFloat() ), contains( 1.0F, 2.0F, 3.0F ) );
     }
 
     @Test
-    public void shouldMapString() throws Throwable
+    void shouldMapString()
     {
         // Given
         Value val = value( "hello", "world" );
 
         // When/Then
-        assertThat( val.asList( ofString() ), contains("hello", "world") );
-        assertThat( val.asList( ofObject() ), contains((Object)"hello", "world") );
+        assertThat( val.asList( ofString() ), contains( "hello", "world" ) );
+        assertThat( val.asList( ofObject() ), contains( "hello", "world" ) );
     }
 
     @SuppressWarnings( "unchecked" )
     @Test
-    public void shouldMapMapOfString() throws Throwable
+    void shouldMapMapOfString()
     {
         // Given
-        Map<String, Object> map = new HashMap<>();
+        Map<String,Object> map = new HashMap<>();
         map.put( "hello", "world" );
-        Value val = value( asList(map, map) );
+        Value val = value( asList( map, map ) );
 
         // When/Then
-        assertThat( val.asList( ofMap() ), contains(map, map) );
-        assertThat( val.asList( ofObject() ), contains((Object)map, map) );
+        assertThat( val.asList( ofMap() ), contains( map, map ) );
+        assertThat( val.asList( ofObject() ), contains( map, map ) );
     }
 
     @Test
-    public void shouldHandleCollection() throws Throwable
+    void shouldHandleCollection()
     {
         // Given
         Collection<String> collection = new ArrayDeque<>();
-        collection.add( "hello");
-        collection.add( "world");
+        collection.add( "hello" );
+        collection.add( "world" );
         Value val = value( collection );
 
         // When/Then
-        assertThat( val.asList(), Matchers.<Object>containsInAnyOrder( "hello", "world" ));
+        assertThat( val.asList(), Matchers.<Object>containsInAnyOrder( "hello", "world" ) );
     }
 
     @Test
-    public void shouldHandleIterator() throws Throwable
+    void shouldHandleIterator()
     {
         // Given
         Iterator<String> iterator = asList( "hello", "world" ).iterator();
         Value val = value( iterator );
 
         // When/Then
-        assertThat( val.asList(), Matchers.<Object>containsInAnyOrder( "hello", "world" ));
+        assertThat( val.asList(), Matchers.<Object>containsInAnyOrder( "hello", "world" ) );
     }
 
     @Test
-    public void shouldCreateDateValueFromLocalDate()
+    void shouldCreateDateValueFromLocalDate()
     {
         LocalDate localDate = LocalDate.now();
         Value value = value( localDate );
@@ -326,7 +306,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateDateValue()
+    void shouldCreateDateValue()
     {
         Object localDate = LocalDate.now();
         Value value = value( localDate );
@@ -336,7 +316,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateTimeValueFromOffsetTime()
+    void shouldCreateTimeValueFromOffsetTime()
     {
         OffsetTime offsetTime = OffsetTime.now();
         Value value = value( offsetTime );
@@ -346,7 +326,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateTimeValue()
+    void shouldCreateTimeValue()
     {
         OffsetTime offsetTime = OffsetTime.now();
         Value value = value( offsetTime );
@@ -356,7 +336,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateLocalTimeValueFromLocalTime()
+    void shouldCreateLocalTimeValueFromLocalTime()
     {
         LocalTime localTime = LocalTime.now();
         Value value = value( localTime );
@@ -366,7 +346,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateLocalTimeValue()
+    void shouldCreateLocalTimeValue()
     {
         LocalTime localTime = LocalTime.now();
         Value value = value( localTime );
@@ -376,7 +356,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateLocalDateTimeValueFromLocalDateTime()
+    void shouldCreateLocalDateTimeValueFromLocalDateTime()
     {
         LocalDateTime localDateTime = LocalDateTime.now();
         Value value = value( localDateTime );
@@ -386,7 +366,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateLocalDateTimeValue()
+    void shouldCreateLocalDateTimeValue()
     {
         LocalDateTime localDateTime = LocalDateTime.now();
         Value value = value( localDateTime );
@@ -396,7 +376,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateDateTimeValueFromZonedDateTime()
+    void shouldCreateDateTimeValueFromZonedDateTime()
     {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
         Value value = value( zonedDateTime );
@@ -406,7 +386,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateDateTimeValue()
+    void shouldCreateDateTimeValue()
     {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
         Value value = value( zonedDateTime );
@@ -416,7 +396,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateIsoDurationValue()
+    void shouldCreateIsoDurationValue()
     {
         Value value = isoDuration( 42_1, 42_2, 42_3, 42_4 );
 
@@ -430,7 +410,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromIsoDuration()
+    void shouldCreateValueFromIsoDuration()
     {
         Value durationValue1 = isoDuration( 1, 2, 3, 4 );
         IsoDuration duration = durationValue1.asIsoDuration();
@@ -442,7 +422,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromPeriod()
+    void shouldCreateValueFromPeriod()
     {
         Period period = Period.of( 5, 11, 190 );
 
@@ -456,7 +436,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromDuration()
+    void shouldCreateValueFromDuration()
     {
         Duration duration = Duration.ofSeconds( 183951, 4384718937L );
 
@@ -470,7 +450,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromPoint2D()
+    void shouldCreateValueFromPoint2D()
     {
         Value point2DValue1 = point( 1, 2, 3 );
         Point point2D = point2DValue1.asPoint();
@@ -482,7 +462,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromPoint3D()
+    void shouldCreateValueFromPoint3D()
     {
         Value point3DValue1 = point( 1, 2, 3, 4 );
         Point point3D = point3DValue1.asPoint();
@@ -494,7 +474,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromNodeValue()
+    void shouldCreateValueFromNodeValue()
     {
         NodeValue node = emptyNodeValue();
         Value value = value( node );
@@ -502,7 +482,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromNode()
+    void shouldCreateValueFromNode()
     {
         Node node = emptyNodeValue().asNode();
         Value value = value( node );
@@ -510,7 +490,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromRelationshipValue()
+    void shouldCreateValueFromRelationshipValue()
     {
         RelationshipValue rel = emptyRelationshipValue();
         Value value = value( rel );
@@ -518,7 +498,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromRelationship()
+    void shouldCreateValueFromRelationship()
     {
         Relationship rel = emptyRelationshipValue().asRelationship();
         Value value = value( rel );
@@ -526,7 +506,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromPathValue()
+    void shouldCreateValueFromPathValue()
     {
         PathValue path = filledPathValue();
         Value value = value( path );
@@ -534,7 +514,7 @@ public class ValuesTest
     }
 
     @Test
-    public void shouldCreateValueFromPath()
+    void shouldCreateValueFromPath()
     {
         Path path = filledPathValue().asPath();
         Value value = value( path );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/BoltProtocolUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/BoltProtocolUtilTest.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.internal.async.BoltProtocolUtil.BOLT_MAGIC_PREAMBLE;
 import static org.neo4j.driver.internal.async.BoltProtocolUtil.NO_PROTOCOL_VERSION;
 import static org.neo4j.driver.internal.async.BoltProtocolUtil.PROTOCOL_VERSION_1;
@@ -34,10 +34,10 @@ import static org.neo4j.driver.internal.async.BoltProtocolUtil.writeEmptyChunkHe
 import static org.neo4j.driver.internal.async.BoltProtocolUtil.writeMessageBoundary;
 import static org.neo4j.driver.v1.util.TestUtil.assertByteBufContains;
 
-public class BoltProtocolUtilTest
+class BoltProtocolUtilTest
 {
     @Test
-    public void shouldReturnHandshakeBuf()
+    void shouldReturnHandshakeBuf()
     {
         assertByteBufContains(
                 handshakeBuf(),
@@ -46,13 +46,13 @@ public class BoltProtocolUtilTest
     }
 
     @Test
-    public void shouldReturnHandshakeString()
+    void shouldReturnHandshakeString()
     {
         assertEquals( "[0x6060b017, 2, 1, 0, 0]", handshakeString() );
     }
 
     @Test
-    public void shouldWriteMessageBoundary()
+    void shouldWriteMessageBoundary()
     {
         ByteBuf buf = Unpooled.buffer();
 
@@ -65,7 +65,7 @@ public class BoltProtocolUtilTest
     }
 
     @Test
-    public void shouldWriteEmptyChunkHeader()
+    void shouldWriteEmptyChunkHeader()
     {
         ByteBuf buf = Unpooled.buffer();
 
@@ -78,7 +78,7 @@ public class BoltProtocolUtilTest
     }
 
     @Test
-    public void shouldWriteChunkHeader()
+    void shouldWriteChunkHeader()
     {
         ByteBuf buf = Unpooled.buffer();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
@@ -19,17 +19,15 @@
 package org.neo4j.driver.internal.async;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.util.ServerVersion;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.async.ChannelAttributes.creationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.lastUsedTimestamp;
@@ -45,12 +43,12 @@ import static org.neo4j.driver.internal.async.ChannelAttributes.setTerminationRe
 import static org.neo4j.driver.internal.async.ChannelAttributes.terminationReason;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 
-public class ChannelAttributesTest
+class ChannelAttributesTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
     @Test
-    public void shouldSetAndGetAddress()
+    void shouldSetAndGetAddress()
     {
         BoltServerAddress address = new BoltServerAddress( "local:42" );
         setServerAddress( channel, address );
@@ -58,46 +56,30 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldFailToSetAddressTwice()
+    void shouldFailToSetAddressTwice()
     {
         setServerAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
 
-        try
-        {
-            setServerAddress( channel, BoltServerAddress.LOCAL_DEFAULT );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> setServerAddress( channel, BoltServerAddress.LOCAL_DEFAULT ) );
     }
 
     @Test
-    public void shouldSetAndGetCreationTimestamp()
+    void shouldSetAndGetCreationTimestamp()
     {
         setCreationTimestamp( channel, 42L );
         assertEquals( 42L, creationTimestamp( channel ) );
     }
 
     @Test
-    public void shouldFailToSetCreationTimestampTwice()
+    void shouldFailToSetCreationTimestampTwice()
     {
         setCreationTimestamp( channel, 42L );
 
-        try
-        {
-            setCreationTimestamp( channel, 42L );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> setCreationTimestamp( channel, 42L ) );
     }
 
     @Test
-    public void shouldSetAndGetLastUsedTimestamp()
+    void shouldSetAndGetLastUsedTimestamp()
     {
         assertNull( lastUsedTimestamp( channel ) );
         setLastUsedTimestamp( channel, 42L );
@@ -105,7 +87,7 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldAllowSettingLastUsedTimestampMultipleTimes()
+    void shouldAllowSettingLastUsedTimestampMultipleTimes()
     {
         setLastUsedTimestamp( channel, 42L );
         setLastUsedTimestamp( channel, 4242L );
@@ -115,7 +97,7 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldSetAndGetMessageDispatcher()
+    void shouldSetAndGetMessageDispatcher()
     {
         InboundMessageDispatcher dispatcher = mock( InboundMessageDispatcher.class );
         setMessageDispatcher( channel, dispatcher );
@@ -123,23 +105,15 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldFailToSetMessageDispatcherTwice()
+    void shouldFailToSetMessageDispatcherTwice()
     {
         setMessageDispatcher( channel, mock( InboundMessageDispatcher.class ) );
 
-        try
-        {
-            setMessageDispatcher( channel, mock( InboundMessageDispatcher.class ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> setMessageDispatcher( channel, mock( InboundMessageDispatcher.class ) ) );
     }
 
     @Test
-    public void shouldSetAndGetServerVersion()
+    void shouldSetAndGetServerVersion()
     {
         ServerVersion version = version( "3.2.1" );
         setServerVersion( channel, version );
@@ -147,23 +121,15 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldFailToSetServerVersionTwice()
+    void shouldFailToSetServerVersionTwice()
     {
         setServerVersion( channel, version( "3.2.2" ) );
 
-        try
-        {
-            setServerVersion( channel, version( "3.2.3" ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> setServerVersion( channel, version( "3.2.3" ) ) );
     }
 
     @Test
-    public void shouldSetAndGetTerminationReason()
+    void shouldSetAndGetTerminationReason()
     {
         String reason = "This channel has been terminated";
         setTerminationReason( channel, reason );
@@ -171,18 +137,10 @@ public class ChannelAttributesTest
     }
 
     @Test
-    public void shouldFailToSetTerminationReasonTwice()
+    void shouldFailToSetTerminationReasonTwice()
     {
         setTerminationReason( channel, "Reason 1" );
 
-        try
-        {
-            setTerminationReason( channel, "Reason 2" );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> setTerminationReason( channel, "Reason 2" ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelConnectedListenerTest.java
@@ -20,36 +20,34 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.async.BoltProtocolUtil.handshakeBuf;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class ChannelConnectedListenerTest
+class ChannelConnectedListenerTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldFailPromiseWhenChannelConnectionFails()
+    void shouldFailPromiseWhenChannelConnectionFails()
     {
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
         ChannelConnectedListener listener = newListener( handshakeCompletedPromise );
@@ -60,20 +58,12 @@ public class ChannelConnectedListenerTest
 
         listener.operationComplete( channelConnectedPromise );
 
-        try
-        {
-            await( handshakeCompletedPromise );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ServiceUnavailableException.class ) );
-            assertEquals( cause, e.getCause() );
-        }
+        ServiceUnavailableException error = assertThrows( ServiceUnavailableException.class, () -> await( handshakeCompletedPromise ) );
+        assertEquals( cause, error.getCause() );
     }
 
     @Test
-    public void shouldWriteHandshakeWhenChannelConnected()
+    void shouldWriteHandshakeWhenChannelConnected()
     {
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
         ChannelConnectedListener listener = newListener( handshakeCompletedPromise );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelErrorHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelErrorHandlerTest.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -33,20 +33,20 @@ import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setTerminationReason;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class ChannelErrorHandlerTest
+class ChannelErrorHandlerTest
 {
     private EmbeddedChannel channel;
     private InboundMessageDispatcher messageDispatcher;
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         channel = new EmbeddedChannel();
         messageDispatcher = new InboundMessageDispatcher( channel, DEV_NULL_LOGGING );
@@ -54,8 +54,8 @@ public class ChannelErrorHandlerTest
         channel.pipeline().addLast( new ChannelErrorHandler( DEV_NULL_LOGGING ) );
     }
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         if ( channel != null )
         {
@@ -64,7 +64,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleChannelInactive()
+    void shouldHandleChannelInactive()
     {
         channel.pipeline().fireChannelInactive();
 
@@ -76,7 +76,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleChannelInactiveAfterExceptionCaught()
+    void shouldHandleChannelInactiveAfterExceptionCaught()
     {
         RuntimeException originalError = new RuntimeException( "Hi!" );
         channel.pipeline().fireExceptionCaught( originalError );
@@ -89,7 +89,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleChannelInactiveWhenTerminationReasonSet()
+    void shouldHandleChannelInactiveWhenTerminationReasonSet()
     {
         String terminationReason = "Something really bad happened";
         setTerminationReason( channel, terminationReason );
@@ -105,7 +105,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleCodecException()
+    void shouldHandleCodecException()
     {
         RuntimeException cause = new RuntimeException( "Hi!" );
         CodecException codecException = new CodecException( "Unable to encode or decode message", cause );
@@ -118,7 +118,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleCodecExceptionWithoutCause()
+    void shouldHandleCodecExceptionWithoutCause()
     {
         CodecException codecException = new CodecException( "Unable to encode or decode message" );
         channel.pipeline().fireExceptionCaught( codecException );
@@ -130,7 +130,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleIOException()
+    void shouldHandleIOException()
     {
         IOException ioException = new IOException( "Write or read failed" );
         channel.pipeline().fireExceptionCaught( ioException );
@@ -143,7 +143,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleException()
+    void shouldHandleException()
     {
         RuntimeException originalError = new RuntimeException( "Random failure" );
         channel.pipeline().fireExceptionCaught( originalError );
@@ -155,7 +155,7 @@ public class ChannelErrorHandlerTest
     }
 
     @Test
-    public void shouldHandleMultipleExceptions()
+    void shouldHandleMultipleExceptions()
     {
         RuntimeException error1 = new RuntimeException( "Failure 1" );
         RuntimeException error2 = new RuntimeException( "Failure 2" );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelPipelineBuilderImplTest.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -34,14 +34,14 @@ import org.neo4j.driver.internal.async.outbound.OutboundMessageHandler;
 import org.neo4j.driver.internal.messaging.PackStreamMessageFormatV1;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class ChannelPipelineBuilderImplTest
+class ChannelPipelineBuilderImplTest
 {
     @Test
-    public void shouldBuildPipeline()
+    void shouldBuildPipeline()
     {
         EmbeddedChannel channel = new EmbeddedChannel();
         ChannelAttributes.setMessageDispatcher( channel, new InboundMessageDispatcher( channel, DEV_NULL_LOGGING ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/EventLoopGroupFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/EventLoopGroupFactoryTest.java
@@ -22,40 +22,40 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.Future;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.Iterables.count;
 import static org.neo4j.driver.internal.util.Matchers.blockingOperationInEventLoopError;
 
-public class EventLoopGroupFactoryTest
+class EventLoopGroupFactoryTest
 {
     private EventLoopGroup eventLoopGroup;
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         shutdown( eventLoopGroup );
     }
 
     @Test
-    public void shouldReturnCorrectChannelClass()
+    void shouldReturnCorrectChannelClass()
     {
         assertEquals( NioSocketChannel.class, EventLoopGroupFactory.channelClass() );
     }
 
     @Test
-    public void shouldCreateEventLoopGroupWithSpecifiedThreadCount()
+    void shouldCreateEventLoopGroupWithSpecifiedThreadCount()
     {
         int threadCount = 2;
         eventLoopGroup = EventLoopGroupFactory.newEventLoopGroup( threadCount );
@@ -64,14 +64,14 @@ public class EventLoopGroupFactoryTest
     }
 
     @Test
-    public void shouldCreateEventLoopGroup()
+    void shouldCreateEventLoopGroup()
     {
         eventLoopGroup = EventLoopGroupFactory.newEventLoopGroup();
         assertThat( eventLoopGroup, instanceOf( NioEventLoopGroup.class ) );
     }
 
     @Test
-    public void shouldAssertNotInEventLoopThread() throws Exception
+    void shouldAssertNotInEventLoopThread() throws Exception
     {
         eventLoopGroup = EventLoopGroupFactory.newEventLoopGroup( 1 );
 
@@ -80,19 +80,13 @@ public class EventLoopGroupFactoryTest
 
         // submit assertion to the event loop thread, it should fail there
         Future<?> assertFuture = eventLoopGroup.submit( EventLoopGroupFactory::assertNotInEventLoopThread );
-        try
-        {
-            assertFuture.get( 30, SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            assertThat( e.getCause(), is( blockingOperationInEventLoopError() ) );
-        }
+
+        ExecutionException error = assertThrows( ExecutionException.class, () -> assertFuture.get( 30, SECONDS ) );
+        assertThat( error.getCause(), is( blockingOperationInEventLoopError() ) );
     }
 
     @Test
-    public void shouldCheckIfEventLoopThread() throws Exception
+    void shouldCheckIfEventLoopThread() throws Exception
     {
         eventLoopGroup = EventLoopGroupFactory.newEventLoopGroup( 1 );
 
@@ -107,7 +101,7 @@ public class EventLoopGroupFactoryTest
      * It's needed because default Netty setup has good performance.
      */
     @Test
-    public void shouldUseSameThreadClassAsNioEventLoopGroupDoesByDefault() throws Exception
+    void shouldUseSameThreadClassAsNioEventLoopGroupDoesByDefault() throws Exception
     {
         NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup( 1 );
         eventLoopGroup = EventLoopGroupFactory.newEventLoopGroup( 1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeCompletedListenerTest.java
@@ -20,8 +20,8 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,10 +33,10 @@ import org.neo4j.driver.internal.messaging.InitMessage;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,18 +44,18 @@ import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispat
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class HandshakeCompletedListenerTest
+class HandshakeCompletedListenerTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldFailConnectionInitializedPromiseWhenHandshakeFails()
+    void shouldFailConnectionInitializedPromiseWhenHandshakeFails()
     {
         ChannelPromise channelInitializedPromise = channel.newPromise();
         HandshakeCompletedListener listener = new HandshakeCompletedListener( "user-agent", authToken(),
@@ -67,19 +67,12 @@ public class HandshakeCompletedListenerTest
 
         listener.operationComplete( handshakeCompletedPromise );
 
-        try
-        {
-            await( channelInitializedPromise );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( cause, e );
-        }
+        Exception error = assertThrows( Exception.class, () -> await( channelInitializedPromise ) );
+        assertEquals( cause, error );
     }
 
     @Test
-    public void shouldWriteInitMessageWhenHandshakeCompleted()
+    void shouldWriteInitMessageWhenHandshakeCompleted()
     {
         InboundMessageDispatcher messageDispatcher = mock( InboundMessageDispatcher.class );
         setMessageDispatcher( channel, messageDispatcher );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
@@ -20,8 +20,8 @@ package org.neo4j.driver.internal.async;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.ssl.SslHandler;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.GeneralSecurityException;
 import java.util.List;
@@ -38,10 +38,10 @@ import org.neo4j.driver.internal.util.FakeClock;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
@@ -50,18 +50,18 @@ import static org.neo4j.driver.internal.async.ChannelAttributes.messageDispatche
 import static org.neo4j.driver.internal.async.ChannelAttributes.serverAddress;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class NettyChannelInitializerTest
+class NettyChannelInitializerTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldAddSslHandlerWhenRequiresEncryption() throws Exception
+    void shouldAddSslHandlerWhenRequiresEncryption() throws Exception
     {
         SecurityPlan security = trustAllCertificates();
         NettyChannelInitializer initializer = newInitializer( security );
@@ -72,7 +72,7 @@ public class NettyChannelInitializerTest
     }
 
     @Test
-    public void shouldNotAddSslHandlerWhenDoesNotRequireEncryption()
+    void shouldNotAddSslHandlerWhenDoesNotRequireEncryption()
     {
         SecurityPlan security = SecurityPlan.insecure();
         NettyChannelInitializer initializer = newInitializer( security );
@@ -83,7 +83,7 @@ public class NettyChannelInitializerTest
     }
 
     @Test
-    public void shouldAddSslHandlerWithHandshakeTimeout() throws Exception
+    void shouldAddSslHandlerWithHandshakeTimeout() throws Exception
     {
         int timeoutMillis = 424242;
         SecurityPlan security = trustAllCertificates();
@@ -97,7 +97,7 @@ public class NettyChannelInitializerTest
     }
 
     @Test
-    public void shouldUpdateChannelAttributes()
+    void shouldUpdateChannelAttributes()
     {
         Clock clock = mock( Clock.class );
         when( clock.millis() ).thenReturn( 42L );
@@ -112,7 +112,7 @@ public class NettyChannelInitializerTest
     }
 
     @Test
-    public void shouldIncludeSniHostName() throws Exception
+    void shouldIncludeSniHostName() throws Exception
     {
         BoltServerAddress address = new BoltServerAddress( "database.neo4j.com", 8989 );
         NettyChannelInitializer initializer = new NettyChannelInitializer( address, trustAllCertificates(), 10000, Clock.SYSTEM, DEV_NULL_LOGGING );
@@ -129,13 +129,13 @@ public class NettyChannelInitializerTest
     }
 
     @Test
-    public void shouldEnableHostnameVerificationWhenConfigured() throws Exception
+    void shouldEnableHostnameVerificationWhenConfigured() throws Exception
     {
         testHostnameVerificationSetting( true, "HTTPS" );
     }
 
     @Test
-    public void shouldNotEnableHostnameVerificationWhenNotConfigured() throws Exception
+    void shouldNotEnableHostnameVerificationWhenNotConfigured() throws Exception
     {
         testHostnameVerificationSetting( false, null );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyConnectionTest.java
@@ -24,8 +24,8 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.util.internal.ConcurrentSet;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Set;
@@ -45,10 +45,10 @@ import org.neo4j.driver.internal.util.ServerVersion;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -64,28 +64,28 @@ import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 
-public class NettyConnectionTest
+class NettyConnectionTest
 {
     private static final NoOpResponseHandler NO_OP_HANDLER = NoOpResponseHandler.INSTANCE;
 
     private ExecutorService executor;
     private EventLoop eventLoop;
 
-    @After
-    public void tearDown() throws Exception
+    @AfterEach
+    void tearDown() throws Exception
     {
         shutdownEventLoop();
     }
 
     @Test
-    public void shouldBeOpenAfterCreated()
+    void shouldBeOpenAfterCreated()
     {
         NettyConnection connection = newConnection( newChannel() );
         assertTrue( connection.isOpen() );
     }
 
     @Test
-    public void shouldNotBeOpenAfterRelease()
+    void shouldNotBeOpenAfterRelease()
     {
         NettyConnection connection = newConnection( newChannel() );
         connection.release();
@@ -93,7 +93,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldSendResetOnRelease()
+    void shouldSendResetOnRelease()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -106,27 +106,27 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldEnqueueRunHandlerFromEventLoopThread() throws Exception
+    void shouldEnqueueRunHandlerFromEventLoopThread() throws Exception
     {
         testWriteInEventLoop( "RunTestEventLoop",
                 connection -> connection.run( "RETURN 1", emptyMap(), NO_OP_HANDLER, NO_OP_HANDLER ) );
     }
 
     @Test
-    public void shouldWriteRunAndFlushInEventLoopThread() throws Exception
+    void shouldWriteRunAndFlushInEventLoopThread() throws Exception
     {
         testWriteInEventLoop( "RunAndFlushTestEventLoop",
                 connection -> connection.runAndFlush( "RETURN 1", emptyMap(), NO_OP_HANDLER, NO_OP_HANDLER ) );
     }
 
     @Test
-    public void shouldWriteForceReleaseInEventLoopThread() throws Exception
+    void shouldWriteForceReleaseInEventLoopThread() throws Exception
     {
         testWriteInEventLoop( "ReleaseTestEventLoop", NettyConnection::release );
     }
 
     @Test
-    public void shouldEnableAutoReadWhenReleased()
+    void shouldEnableAutoReadWhenReleased()
     {
         EmbeddedChannel channel = newChannel();
         channel.config().setAutoRead( false );
@@ -140,7 +140,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotDisableAutoReadWhenReleased()
+    void shouldNotDisableAutoReadWhenReleased()
     {
         EmbeddedChannel channel = newChannel();
         channel.config().setAutoRead( true );
@@ -153,7 +153,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotRunWhenReleased()
+    void shouldNotRunWhenReleased()
     {
         ResponseHandler runHandler = mock( ResponseHandler.class );
         ResponseHandler pullAllHandler = mock( ResponseHandler.class );
@@ -168,7 +168,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotRunAndFlushWhenReleased()
+    void shouldNotRunAndFlushWhenReleased()
     {
         ResponseHandler runHandler = mock( ResponseHandler.class );
         ResponseHandler pullAllHandler = mock( ResponseHandler.class );
@@ -183,7 +183,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotRunWhenTerminated()
+    void shouldNotRunWhenTerminated()
     {
         ResponseHandler runHandler = mock( ResponseHandler.class );
         ResponseHandler pullAllHandler = mock( ResponseHandler.class );
@@ -198,7 +198,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotRunAndFlushWhenTerminated()
+    void shouldNotRunAndFlushWhenTerminated()
     {
         ResponseHandler runHandler = mock( ResponseHandler.class );
         ResponseHandler pullAllHandler = mock( ResponseHandler.class );
@@ -213,7 +213,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldReturnServerAddressWhenReleased()
+    void shouldReturnServerAddressWhenReleased()
     {
         EmbeddedChannel channel = newChannel();
         BoltServerAddress address = new BoltServerAddress( "host", 4242 );
@@ -226,7 +226,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldReturnServerVersionWhenReleased()
+    void shouldReturnServerVersionWhenReleased()
     {
         EmbeddedChannel channel = newChannel();
         ServerVersion version = ServerVersion.v3_2_0;
@@ -239,7 +239,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldReturnSameCompletionStageFromRelease()
+    void shouldReturnSameCompletionStageFromRelease()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -260,7 +260,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldEnableAutoRead()
+    void shouldEnableAutoRead()
     {
         EmbeddedChannel channel = newChannel();
         channel.config().setAutoRead( false );
@@ -272,7 +272,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldDisableAutoRead()
+    void shouldDisableAutoRead()
     {
         EmbeddedChannel channel = newChannel();
         channel.config().setAutoRead( true );
@@ -284,7 +284,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldSetTerminationReasonOnChannelWhenTerminated()
+    void shouldSetTerminationReasonOnChannelWhenTerminated()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -296,7 +296,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldCloseChannelWhenTerminated()
+    void shouldCloseChannelWhenTerminated()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -308,7 +308,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldReleaseChannelWhenTerminated()
+    void shouldReleaseChannelWhenTerminated()
     {
         EmbeddedChannel channel = newChannel();
         ChannelPool pool = mock( ChannelPool.class );
@@ -321,7 +321,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotReleaseChannelMultipleTimesWhenTerminatedMultipleTimes()
+    void shouldNotReleaseChannelMultipleTimesWhenTerminatedMultipleTimes()
     {
         EmbeddedChannel channel = newChannel();
         ChannelPool pool = mock( ChannelPool.class );
@@ -339,7 +339,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldNotReleaseAfterTermination()
+    void shouldNotReleaseAfterTermination()
     {
         EmbeddedChannel channel = newChannel();
         ChannelPool pool = mock( ChannelPool.class );
@@ -356,7 +356,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldSendResetMessageWhenReset()
+    void shouldSendResetMessageWhenReset()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -369,7 +369,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldCompleteResetFutureWhenSuccessResponseArrives()
+    void shouldCompleteResetFutureWhenSuccessResponseArrives()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -384,7 +384,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldCompleteResetFutureWhenFailureResponseArrives()
+    void shouldCompleteResetFutureWhenFailureResponseArrives()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -399,7 +399,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldDoNothingInResetWhenClosed()
+    void shouldDoNothingInResetWhenClosed()
     {
         EmbeddedChannel channel = newChannel();
         NettyConnection connection = newConnection( channel );
@@ -417,7 +417,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldMuteAckFailureWhenReset()
+    void shouldMuteAckFailureWhenReset()
     {
         InboundMessageDispatcher messageDispatcher = mock( InboundMessageDispatcher.class );
         EmbeddedChannel channel = newChannel( messageDispatcher );
@@ -430,7 +430,7 @@ public class NettyConnectionTest
     }
 
     @Test
-    public void shouldEnableAutoReadWhenDoingReset()
+    void shouldEnableAutoReadWhenDoingReset()
     {
         EmbeddedChannel channel = newChannel();
         channel.config().setAutoRead( false );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/QueryRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/QueryRunnerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.async;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
@@ -38,10 +38,10 @@ import org.neo4j.driver.v1.Value;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,44 +49,44 @@ import static org.neo4j.driver.internal.async.QueryRunner.runInSession;
 import static org.neo4j.driver.internal.async.QueryRunner.runInTransaction;
 import static org.neo4j.driver.v1.Values.value;
 
-public class QueryRunnerTest
+class QueryRunnerTest
 {
     private static final String QUERY = "RETURN $x";
     private static final Map<String,Value> PARAMS = singletonMap( "x", value( 42 ) );
     private static final Statement STATEMENT = new Statement( QUERY, value( PARAMS ) );
 
     @Test
-    public void shouldRunInSessionWithoutWaitingForRunResponse() throws Exception
+    void shouldRunInSessionWithoutWaitingForRunResponse() throws Exception
     {
         testNotWaitingForRunResponse( true );
     }
 
     @Test
-    public void shouldRunInSessionAndWaitForSuccessRunResponse() throws Exception
+    void shouldRunInSessionAndWaitForSuccessRunResponse() throws Exception
     {
         testWaitingForRunResponse( true, true );
     }
 
     @Test
-    public void shouldRunInSessionAndWaitForFailureRunResponse() throws Exception
+    void shouldRunInSessionAndWaitForFailureRunResponse() throws Exception
     {
         testWaitingForRunResponse( false, true );
     }
 
     @Test
-    public void shouldRunInTransactionWithoutWaitingForRunResponse() throws Exception
+    void shouldRunInTransactionWithoutWaitingForRunResponse() throws Exception
     {
         testNotWaitingForRunResponse( false );
     }
 
     @Test
-    public void shouldRunInTransactionAndWaitForSuccessRunResponse() throws Exception
+    void shouldRunInTransactionAndWaitForSuccessRunResponse() throws Exception
     {
         testWaitingForRunResponse( true, false );
     }
 
     @Test
-    public void shouldRunInTransactionAndWaitForFailureRunResponse() throws Exception
+    void shouldRunInTransactionAndWaitForFailureRunResponse() throws Exception
     {
         testWaitingForRunResponse( false, false );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.async;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
@@ -28,17 +28,17 @@ import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.util.Futures;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class ResultCursorsHolderTest
+class ResultCursorsHolderTest
 {
     @Test
-    public void shouldReturnNoErrorWhenNoCursorStages()
+    void shouldReturnNoErrorWhenNoCursorStages()
     {
         ResultCursorsHolder holder = new ResultCursorsHolder();
 
@@ -47,23 +47,15 @@ public class ResultCursorsHolderTest
     }
 
     @Test
-    public void shouldFailToAddNullCursorStage()
+    void shouldFailToAddNullCursorStage()
     {
         ResultCursorsHolder holder = new ResultCursorsHolder();
 
-        try
-        {
-            holder.add( null );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            // expected
-        }
+        assertThrows( NullPointerException.class, () -> holder.add( null ) );
     }
 
     @Test
-    public void shouldReturnNoErrorWhenCursorStagesHaveNoErrors()
+    void shouldReturnNoErrorWhenCursorStagesHaveNoErrors()
     {
         ResultCursorsHolder holder = new ResultCursorsHolder();
 
@@ -77,7 +69,7 @@ public class ResultCursorsHolderTest
     }
 
     @Test
-    public void shouldNotReturnStageErrors()
+    void shouldNotReturnStageErrors()
     {
         ResultCursorsHolder holder = new ResultCursorsHolder();
 
@@ -91,7 +83,7 @@ public class ResultCursorsHolderTest
     }
 
     @Test
-    public void shouldReturnErrorWhenOneCursorFailed()
+    void shouldReturnErrorWhenOneCursorFailed()
     {
         IOException error = new IOException( "IO failed" );
         ResultCursorsHolder holder = new ResultCursorsHolder();
@@ -106,7 +98,7 @@ public class ResultCursorsHolderTest
     }
 
     @Test
-    public void shouldReturnFirstError()
+    void shouldReturnFirstError()
     {
         RuntimeException error1 = new RuntimeException( "Error 1" );
         IOException error2 = new IOException( "Error 2" );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/RoutingConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/RoutingConnectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.async;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.neo4j.driver.internal.RoutingErrorHandler;
@@ -28,22 +28,22 @@ import org.neo4j.driver.internal.spi.ResponseHandler;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.v1.AccessMode.READ;
 
-public class RoutingConnectionTest
+class RoutingConnectionTest
 {
     @Test
-    public void shouldWrapGivenHandlersInRun()
+    void shouldWrapGivenHandlersInRun()
     {
         testHandlersWrapping( false );
     }
 
     @Test
-    public void shouldWrapGivenHandlersInRunAndFlush()
+    void shouldWrapGivenHandlersInRunAndFlush()
     {
         testHandlersWrapping( true );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/RoutingResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/RoutingResponseHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.async;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.CompletionException;
@@ -33,17 +33,17 @@ import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.exceptions.TransientException;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 
-public class RoutingResponseHandlerTest
+class RoutingResponseHandlerTest
 {
     @Test
-    public void shouldUnwrapCompletionException()
+    void shouldUnwrapCompletionException()
     {
         RuntimeException error = new RuntimeException( "Hi" );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
@@ -55,7 +55,7 @@ public class RoutingResponseHandlerTest
     }
 
     @Test
-    public void shouldHandleServiceUnavailableException()
+    void shouldHandleServiceUnavailableException()
     {
         ServiceUnavailableException error = new ServiceUnavailableException( "Hi" );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
@@ -67,7 +67,7 @@ public class RoutingResponseHandlerTest
     }
 
     @Test
-    public void shouldHandleDatabaseUnavailableError()
+    void shouldHandleDatabaseUnavailableError()
     {
         TransientException error = new TransientException( "Neo.TransientError.General.DatabaseUnavailable", "Hi" );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
@@ -79,7 +79,7 @@ public class RoutingResponseHandlerTest
     }
 
     @Test
-    public void shouldHandleTransientException()
+    void shouldHandleTransientException()
     {
         TransientException error = new TransientException( "Neo.TransientError.Transaction.DeadlockDetected", "Hi" );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
@@ -91,31 +91,31 @@ public class RoutingResponseHandlerTest
     }
 
     @Test
-    public void shouldHandleNotALeaderErrorWithReadAccessMode()
+    void shouldHandleNotALeaderErrorWithReadAccessMode()
     {
         testWriteFailureWithReadAccessMode( "Neo.ClientError.Cluster.NotALeader" );
     }
 
     @Test
-    public void shouldHandleNotALeaderErrorWithWriteAccessMode()
+    void shouldHandleNotALeaderErrorWithWriteAccessMode()
     {
         testWriteFailureWithWriteAccessMode( "Neo.ClientError.Cluster.NotALeader" );
     }
 
     @Test
-    public void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithReadAccessMode()
+    void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithReadAccessMode()
     {
         testWriteFailureWithReadAccessMode( "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase" );
     }
 
     @Test
-    public void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithWriteAccessMode()
+    void shouldHandleForbiddenOnReadOnlyDatabaseErrorWithWriteAccessMode()
     {
         testWriteFailureWithWriteAccessMode( "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase" );
     }
 
     @Test
-    public void shouldHandleClientException()
+    void shouldHandleClientException()
     {
         ClientException error = new ClientException( "Neo.ClientError.Request.Invalid", "Hi" );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthCheckerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthCheckerTest.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.async.pool;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.concurrent.Future;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -32,9 +32,9 @@ import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setLastUsedTimestamp;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setMessageDispatcher;
@@ -46,25 +46,25 @@ import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class NettyChannelHealthCheckerTest
+class NettyChannelHealthCheckerTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
     private final InboundMessageDispatcher dispatcher = new InboundMessageDispatcher( channel, DEV_NULL_LOGGING );
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         setMessageDispatcher( channel, dispatcher );
     }
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldDropTooOldChannelsWhenMaxLifetimeEnabled()
+    void shouldDropTooOldChannelsWhenMaxLifetimeEnabled()
     {
         int maxLifetime = 1000;
         PoolSettings settings = new PoolSettings( DEFAULT_MAX_CONNECTION_POOL_SIZE,
@@ -79,7 +79,7 @@ public class NettyChannelHealthCheckerTest
     }
 
     @Test
-    public void shouldAllowVeryOldChannelsWhenMaxLifetimeDisabled()
+    void shouldAllowVeryOldChannelsWhenMaxLifetimeDisabled()
     {
         PoolSettings settings = new PoolSettings( DEFAULT_MAX_CONNECTION_POOL_SIZE,
                 DEFAULT_CONNECTION_ACQUISITION_TIMEOUT, NOT_CONFIGURED, DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST );
@@ -92,25 +92,25 @@ public class NettyChannelHealthCheckerTest
     }
 
     @Test
-    public void shouldKeepIdleConnectionWhenPingSucceeds()
+    void shouldKeepIdleConnectionWhenPingSucceeds()
     {
         testPing( true );
     }
 
     @Test
-    public void shouldDropIdleConnectionWhenPingFails()
+    void shouldDropIdleConnectionWhenPingFails()
     {
         testPing( false );
     }
 
     @Test
-    public void shouldKeepActiveConnections()
+    void shouldKeepActiveConnections()
     {
         testActiveConnectionCheck( true );
     }
 
     @Test
-    public void shouldDropInactiveConnections()
+    void shouldDropInactiveConnections()
     {
         testActiveConnectionCheck( false );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
@@ -20,25 +20,23 @@ package org.neo4j.driver.internal.async.pool;
 
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerAddress;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 
-public class NettyChannelTrackerTest
+class NettyChannelTrackerTest
 {
     private final BoltServerAddress address = BoltServerAddress.LOCAL_DEFAULT;
     private final NettyChannelTracker tracker = new NettyChannelTracker( DEV_NULL_METRICS, DEV_NULL_LOGGING );
 
     @Test
-    public void shouldIncrementInUseCountWhenChannelCreated()
+    void shouldIncrementInUseCountWhenChannelCreated()
     {
         Channel channel = newChannel();
         assertEquals( 0, tracker.inUseChannelCount( address ) );
@@ -50,7 +48,7 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldIncrementInUseCountWhenChannelAcquired()
+    void shouldIncrementInUseCountWhenChannelAcquired()
     {
         Channel channel = newChannel();
         assertEquals( 0, tracker.inUseChannelCount( address ) );
@@ -70,7 +68,7 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldIncrementInuseCountForAddress()
+    void shouldIncrementInuseCountForAddress()
     {
         Channel channel1 = newChannel();
         Channel channel2 = newChannel();
@@ -87,7 +85,7 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldDecrementCountForAddress()
+    void shouldDecrementCountForAddress()
     {
         Channel channel1 = newChannel();
         Channel channel2 = newChannel();
@@ -111,7 +109,7 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldDecreaseIdleWhenClosedOutsidePool() throws Throwable
+    void shouldDecreaseIdleWhenClosedOutsidePool() throws Throwable
     {
         // Given
         Channel channel = newChannel();
@@ -132,7 +130,7 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldDecreaseIdleWhenClosedInsidePool() throws Throwable
+    void shouldDecreaseIdleWhenClosedInsidePool() throws Throwable
     {
         // Given
         Channel channel = newChannel();
@@ -153,23 +151,15 @@ public class NettyChannelTrackerTest
     }
 
     @Test
-    public void shouldThrowWhenDecrementingForUnknownAddress()
+    void shouldThrowWhenDecrementingForUnknownAddress()
     {
         Channel channel = newChannel();
 
-        try
-        {
-            tracker.channelReleased( channel );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, () -> tracker.channelReleased( channel ) );
     }
 
     @Test
-    public void shouldReturnZeroActiveCountForUnknownAddress()
+    void shouldReturnZeroActiveCountForUnknownAddress()
     {
         assertEquals( 0, tracker.inUseChannelCount( address ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/PoolSettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/PoolSettingsTest.java
@@ -18,16 +18,16 @@
  */
 package org.neo4j.driver.internal.async.pool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PoolSettingsTest
+class PoolSettingsTest
 {
     @Test
-    public void idleTimeBeforeConnectionTestWhenConfigured()
+    void idleTimeBeforeConnectionTestWhenConfigured()
     {
         PoolSettings settings = new PoolSettings( 5, -1, 10, 42 );
         assertTrue( settings.idleTimeBeforeConnectionTestEnabled() );
@@ -35,7 +35,7 @@ public class PoolSettingsTest
     }
 
     @Test
-    public void idleTimeBeforeConnectionTestWhenSetToZero()
+    void idleTimeBeforeConnectionTestWhenSetToZero()
     {
         //Always test idle time during acquisition
         PoolSettings settings = new PoolSettings( 5, -1, 10, 0 );
@@ -44,7 +44,7 @@ public class PoolSettingsTest
     }
 
     @Test
-    public void idleTimeBeforeConnectionTestWhenSetToNegativeValue()
+    void idleTimeBeforeConnectionTestWhenSetToNegativeValue()
     {
         //Never test idle time during acquisition
         testIdleTimeBeforeConnectionTestWithIllegalValue( -1 );
@@ -53,7 +53,7 @@ public class PoolSettingsTest
     }
 
     @Test
-    public void maxConnectionLifetimeWhenConfigured()
+    void maxConnectionLifetimeWhenConfigured()
     {
         PoolSettings settings = new PoolSettings( 5, -1, 42, 10 );
         assertTrue( settings.maxConnectionLifetimeEnabled() );
@@ -61,7 +61,7 @@ public class PoolSettingsTest
     }
 
     @Test
-    public void maxConnectionLifetimeWhenSetToZeroOrNegativeValue()
+    void maxConnectionLifetimeWhenSetToZeroOrNegativeValue()
     {
         testMaxConnectionLifetimeWithIllegalValue( 0 );
         testMaxConnectionLifetimeWithIllegalValue( -1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
@@ -18,20 +18,20 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AddressSetTest
+class AddressSetTest
 {
     @Test
-    public void shouldPreserveOrderWhenAdding() throws Exception
+    void shouldPreserveOrderWhenAdding() throws Exception
     {
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
@@ -57,7 +57,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldPreserveOrderWhenRemoving() throws Exception
+    void shouldPreserveOrderWhenRemoving() throws Exception
     {
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
@@ -79,7 +79,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldPreserveOrderWhenRemovingThroughUpdate() throws Exception
+    void shouldPreserveOrderWhenRemovingThroughUpdate() throws Exception
     {
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
@@ -102,7 +102,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldExposeEmptyArrayWhenEmpty()
+    void shouldExposeEmptyArrayWhenEmpty()
     {
         AddressSet addressSet = new AddressSet();
 
@@ -112,7 +112,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldExposeCorrectArray()
+    void shouldExposeCorrectArray()
     {
         AddressSet addressSet = new AddressSet();
         addressSet.update( addresses( "one", "two", "tre" ) );
@@ -126,7 +126,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldHaveSizeZeroWhenEmpty()
+    void shouldHaveSizeZeroWhenEmpty()
     {
         AddressSet addressSet = new AddressSet();
 
@@ -134,7 +134,7 @@ public class AddressSetTest
     }
 
     @Test
-    public void shouldHaveCorrectSize()
+    void shouldHaveCorrectSize()
     {
         AddressSet addressSet = new AddressSet();
         addressSet.update( addresses( "one", "two" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,10 +34,10 @@ import org.neo4j.driver.v1.Value;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.C;
@@ -46,10 +46,10 @@ import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.E;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.F;
 import static org.neo4j.driver.v1.Values.value;
 
-public class ClusterCompositionTest
+class ClusterCompositionTest
 {
     @Test
-    public void hasWritersReturnsFalseWhenNoWriters()
+    void hasWritersReturnsFalseWhenNoWriters()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses(), addresses( C, D ) );
 
@@ -57,7 +57,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void hasWritersReturnsTrueWhenSomeWriters()
+    void hasWritersReturnsTrueWhenSomeWriters()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -65,7 +65,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void hasRoutersAndReadersReturnsFalseWhenNoRouters()
+    void hasRoutersAndReadersReturnsFalseWhenNoRouters()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses() );
 
@@ -73,7 +73,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void hasRoutersAndReadersReturnsFalseWhenNoReaders()
+    void hasRoutersAndReadersReturnsFalseWhenNoReaders()
     {
         ClusterComposition composition = newComposition( 1, addresses(), addresses( A, B ), addresses( C, D ) );
 
@@ -81,7 +81,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void hasRoutersAndReadersWhenSomeReadersAndRouters()
+    void hasRoutersAndReadersWhenSomeReadersAndRouters()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -89,7 +89,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void readersWhenEmpty()
+    void readersWhenEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses(), addresses( A, B ), addresses( C, D ) );
 
@@ -97,7 +97,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void writersWhenEmpty()
+    void writersWhenEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses(), addresses( C, D ) );
 
@@ -105,7 +105,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void routersWhenEmpty()
+    void routersWhenEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses() );
 
@@ -113,7 +113,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void readersWhenNonEmpty()
+    void readersWhenNonEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -121,7 +121,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void writersWhenNonEmpty()
+    void writersWhenNonEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -129,7 +129,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void routersWhenNonEmpty()
+    void routersWhenNonEmpty()
     {
         ClusterComposition composition = newComposition( 1, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -137,7 +137,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void expirationTimestamp()
+    void expirationTimestamp()
     {
         ClusterComposition composition = newComposition( 42, addresses( A, B ), addresses( C, D ), addresses( E, F ) );
 
@@ -145,7 +145,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void parseCorrectRecord()
+    void parseCorrectRecord()
     {
         Value[] values = {
                 value( 42L ),
@@ -166,7 +166,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void parsePreservesOrderOfReaders()
+    void parsePreservesOrderOfReaders()
     {
         Value[] values = {
                 value( 42L ),
@@ -184,7 +184,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void parsePreservesOrderOfWriters()
+    void parsePreservesOrderOfWriters()
     {
         Value[] values = {
                 value( 42L ),
@@ -202,7 +202,7 @@ public class ClusterCompositionTest
     }
 
     @Test
-    public void parsePreservesOrderOfRouters()
+    void parsePreservesOrderOfRouters()
     {
         Value[] values = {
                 value( 42L ),

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -27,9 +27,9 @@ import org.neo4j.driver.internal.util.FakeClock;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.C;
@@ -41,10 +41,10 @@ import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.createClu
 import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.AccessMode.WRITE;
 
-public class ClusterRoutingTableTest
+class ClusterRoutingTableTest
 {
     @Test
-    public void shouldReturnStaleIfTtlExpired() throws Exception
+    void shouldReturnStaleIfTtlExpired()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -61,7 +61,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldReturnStaleIfNoRouter() throws Exception
+    void shouldReturnStaleIfNoRouter()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -76,7 +76,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldBeStaleForReadsButNotWritesWhenNoReaders() throws Exception
+    void shouldBeStaleForReadsButNotWritesWhenNoReaders()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -91,7 +91,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldBeStaleForWritesButNotReadsWhenNoWriters() throws Exception
+    void shouldBeStaleForWritesButNotReadsWhenNoWriters()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -106,7 +106,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldBeNotStaleWithReadersWritersAndRouters() throws Exception
+    void shouldBeNotStaleWithReadersWritersAndRouters()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -121,7 +121,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldBeStaleForReadsAndWritesAfterCreation() throws Throwable
+    void shouldBeStaleForReadsAndWritesAfterCreation()
     {
         // Given
         FakeClock clock = new FakeClock();
@@ -135,7 +135,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldPreserveOrderingOfRouters()
+    void shouldPreserveOrderingOfRouters()
     {
         ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
         List<BoltServerAddress> routers = asList( A, C, D, F, B, E );
@@ -146,7 +146,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldPreserveOrderingOfWriters()
+    void shouldPreserveOrderingOfWriters()
     {
         ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
         List<BoltServerAddress> writers = asList( D, F, A, C, E );
@@ -157,7 +157,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldPreserveOrderingOfReaders()
+    void shouldPreserveOrderingOfReaders()
     {
         ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
         List<BoltServerAddress> readers = asList( B, A, F, C, D );
@@ -168,7 +168,7 @@ public class ClusterRoutingTableTest
     }
 
     @Test
-    public void shouldTreatOneRouterAsValid()
+    void shouldTreatOneRouterAsValid()
     {
         ClusterRoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/DnsResolverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/DnsResolverTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.UnknownHostException;
 import java.util.Set;
@@ -27,45 +27,45 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class DnsResolverTest
+class DnsResolverTest
 {
     private DnsResolver resolver = new DnsResolver( mock( Logger.class ) );
 
     @Test
-    public void shouldResolveDNSToIPs()
+    void shouldResolveDNSToIPs()
     {
         Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "google.com", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
-    public void shouldResolveLocalhostIPDNSToIPs()
+    void shouldResolveLocalhostIPDNSToIPs()
     {
         Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "127.0.0.1", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
-    public void shouldResolveLocalhostDNSToIPs()
+    void shouldResolveLocalhostDNSToIPs()
     {
         Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "localhost", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
-    public void shouldResolveIPv6LocalhostDNSToIPs()
+    void shouldResolveIPv6LocalhostDNSToIPs()
     {
         Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "[::1]", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
-    public void shouldExceptionAndGiveDefaultValue()
+    void shouldExceptionAndGiveDefaultValue()
     {
         Logger logger = mock( Logger.class );
         DnsResolver resolver = new DnsResolver( logger );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
@@ -18,49 +18,47 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RoutingContextTest
+class RoutingContextTest
 {
     @Test
-    public void emptyContextIsNotDefined()
+    void emptyContextIsNotDefined()
     {
         assertFalse( RoutingContext.EMPTY.isDefined() );
     }
 
     @Test
-    public void emptyContextInEmptyMap()
+    void emptyContextInEmptyMap()
     {
         assertTrue( RoutingContext.EMPTY.asMap().isEmpty() );
     }
 
     @Test
-    public void uriWithoutQueryIsParsedToEmptyContext()
+    void uriWithoutQueryIsParsedToEmptyContext()
     {
         testEmptyRoutingContext( URI.create( "bolt+routing://localhost:7687/" ) );
     }
 
     @Test
-    public void uriWithEmptyQueryIsParsedToEmptyContext()
+    void uriWithEmptyQueryIsParsedToEmptyContext()
     {
         testEmptyRoutingContext( URI.create( "bolt+routing://localhost:7687?" ) );
         testEmptyRoutingContext( URI.create( "bolt+routing://localhost:7687/?" ) );
     }
 
     @Test
-    public void uriWithQueryIsParsed()
+    void uriWithQueryIsParsed()
     {
         URI uri = URI.create( "bolt+routing://localhost:7687/?key1=value1&key2=value2&key3=value3" );
         RoutingContext context = new RoutingContext( uri );
@@ -74,61 +72,44 @@ public class RoutingContextTest
     }
 
     @Test
-    public void throwsForInvalidUriQuery()
+    void throwsForInvalidUriQuery()
     {
         testIllegalUri( URI.create( "bolt+routing://localhost:7687/?justKey" ) );
     }
 
     @Test
-    public void throwsForInvalidUriQueryKey()
+    void throwsForInvalidUriQueryKey()
     {
         testIllegalUri( URI.create( "bolt+routing://localhost:7687/?=value1&key2=value2" ) );
     }
 
     @Test
-    public void throwsForInvalidUriQueryValue()
+    void throwsForInvalidUriQueryValue()
     {
         testIllegalUri( URI.create( "bolt+routing://localhost:7687/key1?=value1&key2=" ) );
     }
 
     @Test
-    public void throwsForDuplicatedUriQueryParameters()
+    void throwsForDuplicatedUriQueryParameters()
     {
         testIllegalUri( URI.create( "bolt+routing://localhost:7687/?key1=value1&key2=value2&key1=value2" ) );
     }
 
     @Test
-    public void mapRepresentationIsUnmodifiable()
+    void mapRepresentationIsUnmodifiable()
     {
         URI uri = URI.create( "bolt+routing://localhost:7687/?key1=value1" );
         RoutingContext context = new RoutingContext( uri );
 
         assertEquals( singletonMap( "key1", "value1" ), context.asMap() );
 
-        try
-        {
-            context.asMap().put( "key2", "value2" );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( UnsupportedOperationException.class ) );
-        }
-
+        assertThrows( UnsupportedOperationException.class, () -> context.asMap().put( "key2", "value2" ) );
         assertEquals( singletonMap( "key1", "value1" ), context.asMap() );
     }
 
     private static void testIllegalUri( URI uri )
     {
-        try
-        {
-            new RoutingContext( uri );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertThrows( IllegalArgumentException.class, () -> new RoutingContext( uri ) );
     }
 
     private static void testEmptyRoutingContext( URI uri )

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,8 +42,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,10 +51,10 @@ import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class RoutingProcedureClusterCompositionProviderTest
+class RoutingProcedureClusterCompositionProviderTest
 {
     @Test
-    public void shouldProtocolErrorWhenNoRecord()
+    void shouldProtocolErrorWhenNoRecord()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -70,20 +70,12 @@ public class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertThat( response, instanceOf( ClusterCompositionResponse.Failure.class ) );
-        try
-        {
-            response.clusterComposition();
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ProtocolException.class ) );
-            assertThat( e.getMessage(), containsString( "records received '0' is too few or too many." ) );
-        }
+        ProtocolException error = assertThrows( ProtocolException.class, response::clusterComposition );
+        assertThat( error.getMessage(), containsString( "records received '0' is too few or too many." ) );
     }
 
     @Test
-    public void shouldProtocolErrorWhenMoreThanOneRecord()
+    void shouldProtocolErrorWhenMoreThanOneRecord()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -100,20 +92,12 @@ public class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertThat( response, instanceOf( ClusterCompositionResponse.Failure.class ) );
-        try
-        {
-            response.clusterComposition();
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ProtocolException.class ) );
-            assertThat( e.getMessage(), containsString( "records received '2' is too few or too many." ) );
-        }
+        ProtocolException error = assertThrows( ProtocolException.class, response::clusterComposition );
+        assertThat( error.getMessage(), containsString( "records received '2' is too few or too many." ) );
     }
 
     @Test
-    public void shouldProtocolErrorWhenUnparsableRecord()
+    void shouldProtocolErrorWhenUnparsableRecord()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -130,20 +114,12 @@ public class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertThat( response, instanceOf( ClusterCompositionResponse.Failure.class ) );
-        try
-        {
-            response.clusterComposition();
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ProtocolException.class ) );
-            assertThat( e.getMessage(), containsString( "unparsable record received." ) );
-        }
+        ProtocolException error = assertThrows( ProtocolException.class, response::clusterComposition );
+        assertThat( error.getMessage(), containsString( "unparsable record received." ) );
     }
 
     @Test
-    public void shouldProtocolErrorWhenNoRouters()
+    void shouldProtocolErrorWhenNoRouters()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -166,20 +142,12 @@ public class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertThat( response, instanceOf( ClusterCompositionResponse.Failure.class ) );
-        try
-        {
-            response.clusterComposition();
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ProtocolException.class ) );
-            assertThat( e.getMessage(), containsString( "no router or reader found in response." ) );
-        }
+        ProtocolException error = assertThrows( ProtocolException.class, response::clusterComposition );
+        assertThat( error.getMessage(), containsString( "no router or reader found in response." ) );
     }
 
     @Test
-    public void shouldProtocolErrorWhenNoReaders()
+    void shouldProtocolErrorWhenNoReaders()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -202,21 +170,13 @@ public class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertThat( response, instanceOf( ClusterCompositionResponse.Failure.class ) );
-        try
-        {
-            response.clusterComposition();
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ProtocolException.class ) );
-            assertThat( e.getMessage(), containsString( "no router or reader found in response." ) );
-        }
+        ProtocolException error = assertThrows( ProtocolException.class, response::clusterComposition );
+        assertThat( error.getMessage(), containsString( "no router or reader found in response." ) );
     }
 
 
     @Test
-    public void shouldPropagateConnectionFailureExceptions()
+    void shouldPropagateConnectionFailureExceptions()
     {
         // Given
         RoutingProcedureRunner mockedRunner = newProcedureRunnerMock();
@@ -228,20 +188,12 @@ public class RoutingProcedureClusterCompositionProviderTest
                 new ServiceUnavailableException( "Connection breaks during cypher execution" ) ) );
 
         // When & Then
-        try
-        {
-            await( provider.getClusterComposition( connectionStage ) );
-            fail( "Expecting a failure but not triggered." );
-        }
-        catch( Exception e )
-        {
-            assertThat( e, instanceOf( ServiceUnavailableException.class ) );
-            assertThat( e.getMessage(), containsString( "Connection breaks during cypher execution" ) );
-        }
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> await( provider.getClusterComposition( connectionStage ) ) );
+        assertThat( e.getMessage(), containsString( "Connection breaks during cypher execution" ) );
     }
 
     @Test
-    public void shouldReturnSuccessResultWhenNoError()
+    void shouldReturnSuccessResultWhenNoError()
     {
         // Given
         Clock mockedClock = mock( Clock.class );
@@ -274,7 +226,7 @@ public class RoutingProcedureClusterCompositionProviderTest
 
     @Test
     @SuppressWarnings( "unchecked" )
-    public void shouldReturnFailureWhenProcedureRunnerFails()
+    void shouldReturnFailureWhenProcedureRunnerFails()
     {
         RoutingProcedureRunner procedureRunner = newProcedureRunnerMock();
         RuntimeException error = new RuntimeException( "hi" );
@@ -287,18 +239,11 @@ public class RoutingProcedureClusterCompositionProviderTest
         CompletionStage<Connection> connectionStage = completedFuture( mock( Connection.class ) );
         ClusterCompositionResponse response = await( provider.getClusterComposition( connectionStage ) );
 
-        try
-        {
-            response.clusterComposition();
-            fail( "Exception expected" );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            assertEquals( error, e.getCause() );
-        }
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, response::clusterComposition );
+        assertEquals( error, e.getCause() );
     }
 
-    public static Map<String,Object> serverInfo( String role, String... addresses )
+    private static Map<String,Object> serverInfo( String role, String... addresses )
     {
         Map<String,Object> map = new HashMap<>();
         map.put( "role", role );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.value.StringValue;
@@ -27,14 +27,12 @@ import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Value;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RoutingProcedureResponseTest
+class RoutingProcedureResponseTest
 {
     private static final Statement PROCEDURE = new Statement( "procedure" );
 
@@ -44,55 +42,39 @@ public class RoutingProcedureResponseTest
             new Value[]{new StringValue( "aa" ), new StringValue( "bb" )} );
 
     @Test
-    public void shouldBeSuccessfulWithRecords()
+    void shouldBeSuccessfulWithRecords()
     {
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
         assertTrue( response.isSuccess() );
     }
 
     @Test
-    public void shouldNotBeSuccessfulWithError()
+    void shouldNotBeSuccessfulWithError()
     {
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, new RuntimeException() );
         assertFalse( response.isSuccess() );
     }
 
     @Test
-    public void shouldThrowWhenFailedAndAskedForRecords()
+    void shouldThrowWhenFailedAndAskedForRecords()
     {
         RuntimeException error = new RuntimeException();
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, error );
 
-        try
-        {
-            response.records();
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-            assertEquals( e.getCause(), error );
-        }
+        IllegalStateException e = assertThrows( IllegalStateException.class, response::records );
+        assertEquals( e.getCause(), error );
     }
 
     @Test
-    public void shouldThrowWhenSuccessfulAndAskedForError()
+    void shouldThrowWhenSuccessfulAndAskedForError()
     {
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
 
-        try
-        {
-            response.error();
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
-        }
+        assertThrows( IllegalStateException.class, response::error );
     }
 
     @Test
-    public void shouldHaveErrorWhenFailed()
+    void shouldHaveErrorWhenFailed()
     {
         RuntimeException error = new RuntimeException( "Hi!" );
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, error );
@@ -100,14 +82,14 @@ public class RoutingProcedureResponseTest
     }
 
     @Test
-    public void shouldHaveRecordsWhenSuccessful()
+    void shouldHaveRecordsWhenSuccessful()
     {
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
         assertEquals( asList( RECORD_1, RECORD_2 ), response.records() );
     }
 
     @Test
-    public void shouldHaveProcedure()
+    void shouldHaveProcedure()
     {
         RoutingProcedureResponse response = new RoutingProcedureResponse( PROCEDURE, asList( RECORD_1, RECORD_2 ) );
         assertEquals( PROCEDURE, response.procedure() );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.List;
@@ -35,10 +35,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,10 +51,10 @@ import static org.neo4j.driver.internal.util.ServerVersion.version;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class RoutingProcedureRunnerTest
+class RoutingProcedureRunnerTest
 {
     @Test
-    public void shouldCallGetRoutingTableWithEmptyMap()
+    void shouldCallGetRoutingTableWithEmptyMap()
     {
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY,
                 completedFuture( asList( mock( Record.class ), mock( Record.class ) ) ) );
@@ -68,7 +68,7 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
-    public void shouldCallGetRoutingTableWithParam()
+    void shouldCallGetRoutingTableWithParam()
     {
         URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
         RoutingContext context = new RoutingContext( uri );
@@ -85,7 +85,7 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
-    public void shouldCallGetServers()
+    void shouldCallGetServers()
     {
         URI uri = URI.create( "bolt+routing://localhost/?key1=value1&key2=value2" );
         RoutingContext context = new RoutingContext( uri );
@@ -101,7 +101,7 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
-    public void shouldReturnFailedResponseOnClientException()
+    void shouldReturnFailedResponseOnClientException()
     {
         ClientException error = new ClientException( "Hi" );
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
@@ -113,41 +113,27 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
-    public void shouldReturnFailedStageOnError()
+    void shouldReturnFailedStageOnError()
     {
         Exception error = new Exception( "Hi" );
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
 
-        try
-        {
-            await( runner.run( connectionStage( "Neo4j/3.2.2" ) ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( runner.run( connectionStage( "Neo4j/3.2.2" ) ) ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldPropagateErrorFromConnectionStage()
+    void shouldPropagateErrorFromConnectionStage()
     {
         RuntimeException error = new RuntimeException( "Hi" );
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY );
 
-        try
-        {
-            await( runner.run( failedFuture( error ) ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( runner.run( failedFuture( error ) ) ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldReleaseConnectionOnSuccess()
+    void shouldReleaseConnectionOnSuccess()
     {
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY,
                 completedFuture( singletonList( mock( Record.class ) ) ) );
@@ -161,7 +147,7 @@ public class RoutingProcedureRunnerTest
     }
 
     @Test
-    public void shouldPropagateReleaseError()
+    void shouldPropagateReleaseError()
     {
         RoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY,
                 completedFuture( singletonList( mock( Record.class ) ) ) );
@@ -170,15 +156,8 @@ public class RoutingProcedureRunnerTest
         CompletionStage<Connection> connectionStage = connectionStage( "Neo4j/3.3.3", failedFuture( releaseError ) );
         Connection connection = await( connectionStage );
 
-        try
-        {
-            await( runner.run( connectionStage ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( releaseError, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( runner.run( connectionStage ) ) );
+        assertEquals( releaseError, e );
         verify( connection ).release();
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategyTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LeastConnectedLoadBalancingStrategyTest.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import org.neo4j.driver.internal.BoltServerAddress;
@@ -27,8 +27,8 @@ import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,33 +40,33 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class LeastConnectedLoadBalancingStrategyTest
+class LeastConnectedLoadBalancingStrategyTest
 {
     @Mock
     private ConnectionPool connectionPool;
     private LeastConnectedLoadBalancingStrategy strategy;
 
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    void setUp()
     {
         initMocks( this );
         strategy = new LeastConnectedLoadBalancingStrategy( connectionPool, DEV_NULL_LOGGING );
     }
 
     @Test
-    public void shouldHandleEmptyReadersArray()
+    void shouldHandleEmptyReadersArray()
     {
         assertNull( strategy.selectReader( new BoltServerAddress[0] ) );
     }
 
     @Test
-    public void shouldHandleEmptyWritersArray()
+    void shouldHandleEmptyWritersArray()
     {
         assertNull( strategy.selectWriter( new BoltServerAddress[0] ) );
     }
 
     @Test
-    public void shouldHandleSingleReaderWithoutActiveConnections()
+    void shouldHandleSingleReaderWithoutActiveConnections()
     {
         BoltServerAddress address = new BoltServerAddress( "reader", 9999 );
 
@@ -74,7 +74,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleSingleWriterWithoutActiveConnections()
+    void shouldHandleSingleWriterWithoutActiveConnections()
     {
         BoltServerAddress address = new BoltServerAddress( "writer", 9999 );
 
@@ -82,7 +82,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleSingleReaderWithActiveConnections()
+    void shouldHandleSingleReaderWithActiveConnections()
     {
         BoltServerAddress address = new BoltServerAddress( "reader", 9999 );
         when( connectionPool.inUseConnections( address ) ).thenReturn( 42 );
@@ -91,7 +91,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleSingleWriterWithActiveConnections()
+    void shouldHandleSingleWriterWithActiveConnections()
     {
         BoltServerAddress address = new BoltServerAddress( "writer", 9999 );
         when( connectionPool.inUseConnections( address ) ).thenReturn( 24 );
@@ -100,7 +100,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleMultipleReadersWithActiveConnections()
+    void shouldHandleMultipleReadersWithActiveConnections()
     {
         BoltServerAddress address1 = new BoltServerAddress( "reader", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "reader", 2 );
@@ -114,7 +114,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleMultipleWritersWithActiveConnections()
+    void shouldHandleMultipleWritersWithActiveConnections()
     {
         BoltServerAddress address1 = new BoltServerAddress( "writer", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "writer", 2 );
@@ -131,7 +131,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldReturnDifferentReaderOnEveryInvocationWhenNoActiveConnections()
+    void shouldReturnDifferentReaderOnEveryInvocationWhenNoActiveConnections()
     {
         BoltServerAddress address1 = new BoltServerAddress( "reader", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "reader", 2 );
@@ -147,7 +147,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldReturnDifferentWriterOnEveryInvocationWhenNoActiveConnections()
+    void shouldReturnDifferentWriterOnEveryInvocationWhenNoActiveConnections()
     {
         BoltServerAddress address1 = new BoltServerAddress( "writer", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "writer", 2 );
@@ -160,7 +160,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldTraceLogWhenNoAddressSelected()
+    void shouldTraceLogWhenNoAddressSelected()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
@@ -176,7 +176,7 @@ public class LeastConnectedLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldTraceLogSelectedAddress()
+    void shouldTraceLogSelectedAddress()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -19,7 +19,7 @@
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
 import io.netty.util.concurrent.GlobalEventExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,14 +44,13 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -70,10 +69,10 @@ import static org.neo4j.driver.v1.AccessMode.WRITE;
 import static org.neo4j.driver.v1.util.TestUtil.asOrderedSet;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class LoadBalancerTest
+class LoadBalancerTest
 {
     @Test
-    public void acquireShouldUpdateRoutingTableWhenKnownRoutingTableIsStale()
+    void acquireShouldUpdateRoutingTableWhenKnownRoutingTableIsStale()
     {
         BoltServerAddress initialRouter = new BoltServerAddress( "initialRouter", 1 );
         BoltServerAddress reader1 = new BoltServerAddress( "reader-1", 2 );
@@ -104,31 +103,31 @@ public class LoadBalancerTest
     }
 
     @Test
-    public void shouldRediscoverOnReadWhenRoutingTableIsStaleForReads()
+    void shouldRediscoverOnReadWhenRoutingTableIsStaleForReads()
     {
         testRediscoveryWhenStale( READ );
     }
 
     @Test
-    public void shouldRediscoverOnWriteWhenRoutingTableIsStaleForWrites()
+    void shouldRediscoverOnWriteWhenRoutingTableIsStaleForWrites()
     {
         testRediscoveryWhenStale( WRITE );
     }
 
     @Test
-    public void shouldNotRediscoverOnReadWhenRoutingTableIsStaleForWritesButNotReads()
+    void shouldNotRediscoverOnReadWhenRoutingTableIsStaleForWritesButNotReads()
     {
         testNoRediscoveryWhenNotStale( WRITE, READ );
     }
 
     @Test
-    public void shouldNotRediscoverOnWriteWhenRoutingTableIsStaleForReadsButNotWrites()
+    void shouldNotRediscoverOnWriteWhenRoutingTableIsStaleForReadsButNotWrites()
     {
         testNoRediscoveryWhenNotStale( READ, WRITE );
     }
 
     @Test
-    public void shouldThrowWhenRediscoveryReturnsNoSuitableServers()
+    void shouldThrowWhenRediscoveryReturnsNoSuitableServers()
     {
         ConnectionPool connectionPool = newConnectionPoolMock();
         RoutingTable routingTable = mock( RoutingTable.class );
@@ -143,31 +142,15 @@ public class LoadBalancerTest
         LoadBalancer loadBalancer = new LoadBalancer( connectionPool, routingTable, rediscovery,
                 GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGING );
 
-        try
-        {
-            await( loadBalancer.acquireConnection( READ ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( SessionExpiredException.class ) );
-            assertThat( e.getMessage(), startsWith( "Failed to obtain connection towards READ server" ) );
-        }
+        SessionExpiredException error1 = assertThrows( SessionExpiredException.class, () -> await( loadBalancer.acquireConnection( READ ) ) );
+        assertThat( error1.getMessage(), startsWith( "Failed to obtain connection towards READ server" ) );
 
-        try
-        {
-            await( loadBalancer.acquireConnection( WRITE ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( SessionExpiredException.class ) );
-            assertThat( e.getMessage(), startsWith( "Failed to obtain connection towards WRITE server" ) );
-        }
+        SessionExpiredException error2 = assertThrows( SessionExpiredException.class, () -> await( loadBalancer.acquireConnection( WRITE ) ) );
+        assertThat( error2.getMessage(), startsWith( "Failed to obtain connection towards WRITE server" ) );
     }
 
     @Test
-    public void shouldSelectLeastConnectedAddress()
+    void shouldSelectLeastConnectedAddress()
     {
         ConnectionPool connectionPool = newConnectionPoolMock();
 
@@ -198,7 +181,7 @@ public class LoadBalancerTest
     }
 
     @Test
-    public void shouldRoundRobinWhenNoActiveConnections()
+    void shouldRoundRobinWhenNoActiveConnections()
     {
         ConnectionPool connectionPool = newConnectionPoolMock();
 
@@ -224,7 +207,7 @@ public class LoadBalancerTest
     }
 
     @Test
-    public void shouldTryMultipleServersAfterRediscovery()
+    void shouldTryMultipleServersAfterRediscovery()
     {
         Set<BoltServerAddress> unavailableAddresses = asOrderedSet( A );
         ConnectionPool connectionPool = newConnectionPoolMockWithFailures( unavailableAddresses );
@@ -248,7 +231,7 @@ public class LoadBalancerTest
     }
 
     @Test
-    public void shouldRemoveAddressFromRoutingTableOnConnectionFailure()
+    void shouldRemoveAddressFromRoutingTableOnConnectionFailure()
     {
         RoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
         routingTable.update( new ClusterComposition(
@@ -271,7 +254,7 @@ public class LoadBalancerTest
     }
 
     @Test
-    public void shouldRetainAllFetchedAddressesInConnectionPoolAfterFetchingOfRoutingTable()
+    void shouldRetainAllFetchedAddressesInConnectionPoolAfterFetchingOfRoutingTable()
     {
         RoutingTable routingTable = new ClusterRoutingTable( new FakeClock() );
         routingTable.update( new ClusterComposition(

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinArrayIndexTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinArrayIndexTest.java
@@ -18,14 +18,14 @@
  */
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class RoundRobinArrayIndexTest
+class RoundRobinArrayIndexTest
 {
     @Test
-    public void shouldHandleZeroLength()
+    void shouldHandleZeroLength()
     {
         RoundRobinArrayIndex roundRobinIndex = new RoundRobinArrayIndex();
 
@@ -35,7 +35,7 @@ public class RoundRobinArrayIndexTest
     }
 
     @Test
-    public void shouldReturnIndexesInRoundRobinOrder()
+    void shouldReturnIndexesInRoundRobinOrder()
     {
         RoundRobinArrayIndex roundRobinIndex = new RoundRobinArrayIndex();
 
@@ -53,7 +53,7 @@ public class RoundRobinArrayIndexTest
     }
 
     @Test
-    public void shouldHandleOverflow()
+    void shouldHandleOverflow()
     {
         int arrayLength = 10;
         RoundRobinArrayIndex roundRobinIndex = new RoundRobinArrayIndex( Integer.MAX_VALUE - 1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinLoadBalancingStrategyTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoundRobinLoadBalancingStrategyTest.java
@@ -18,14 +18,14 @@
  */
 package org.neo4j.driver.internal.cluster.loadbalancing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -35,24 +35,24 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.cluster.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
-public class RoundRobinLoadBalancingStrategyTest
+class RoundRobinLoadBalancingStrategyTest
 {
     private final RoundRobinLoadBalancingStrategy strategy = new RoundRobinLoadBalancingStrategy( DEV_NULL_LOGGING );
 
     @Test
-    public void shouldHandleEmptyReadersArray()
+    void shouldHandleEmptyReadersArray()
     {
         assertNull( strategy.selectReader( new BoltServerAddress[0] ) );
     }
 
     @Test
-    public void shouldHandleEmptyWritersArray()
+    void shouldHandleEmptyWritersArray()
     {
         assertNull( strategy.selectWriter( new BoltServerAddress[0] ) );
     }
 
     @Test
-    public void shouldHandleSingleReader()
+    void shouldHandleSingleReader()
     {
         BoltServerAddress address = new BoltServerAddress( "reader", 9999 );
 
@@ -60,7 +60,7 @@ public class RoundRobinLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldHandleSingleWriter()
+    void shouldHandleSingleWriter()
     {
         BoltServerAddress address = new BoltServerAddress( "writer", 9999 );
 
@@ -68,7 +68,7 @@ public class RoundRobinLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldReturnReadersInRoundRobinOrder()
+    void shouldReturnReadersInRoundRobinOrder()
     {
         BoltServerAddress address1 = new BoltServerAddress( "server-1", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "server-2", 2 );
@@ -89,7 +89,7 @@ public class RoundRobinLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldReturnWriterInRoundRobinOrder()
+    void shouldReturnWriterInRoundRobinOrder()
     {
         BoltServerAddress address1 = new BoltServerAddress( "server-1", 1 );
         BoltServerAddress address2 = new BoltServerAddress( "server-2", 2 );
@@ -107,7 +107,7 @@ public class RoundRobinLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldTraceLogWhenNoAddressSelected()
+    void shouldTraceLogWhenNoAddressSelected()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
@@ -123,7 +123,7 @@ public class RoundRobinLoadBalancingStrategyTest
     }
 
     @Test
-    public void shouldTraceLogSelectedAddress()
+    void shouldTraceLogSelectedAddress()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/AckFailureResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/AckFailureResponseHandlerTest.java
@@ -18,27 +18,27 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AckFailureResponseHandlerTest
+class AckFailureResponseHandlerTest
 {
     private final InboundMessageDispatcher dispatcher = mock( InboundMessageDispatcher.class );
     private final AckFailureResponseHandler handler = new AckFailureResponseHandler( dispatcher );
 
     @Test
-    public void shouldClearCurrentErrorOnSuccess()
+    void shouldClearCurrentErrorOnSuccess()
     {
         verify( dispatcher, never() ).clearCurrentError();
         handler.onSuccess( emptyMap() );
@@ -46,23 +46,16 @@ public class AckFailureResponseHandlerTest
     }
 
     @Test
-    public void shouldThrowOnFailure()
+    void shouldThrowOnFailure()
     {
         RuntimeException error = new RuntimeException( "Unable to process ACK_FAILURE" );
 
-        try
-        {
-            handler.onFailure( error );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertSame( error, e.getCause() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> handler.onFailure( error ) );
+        assertSame( error, e.getCause() );
     }
 
     @Test
-    public void shouldClearCurrentErrorWhenAckFailureMutedAndFailureReceived()
+    void shouldClearCurrentErrorWhenAckFailureMutedAndFailureReceived()
     {
         RuntimeException error = new RuntimeException( "Some error" );
         when( dispatcher.isAckFailureMuted() ).thenReturn( true );
@@ -73,15 +66,8 @@ public class AckFailureResponseHandlerTest
     }
 
     @Test
-    public void shouldThrowOnRecord()
+    void shouldThrowOnRecord()
     {
-        try
-        {
-            handler.onRecord( new Value[0] );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedOperationException ignore )
-        {
-        }
+        assertThrows( UnsupportedOperationException.class, () -> handler.onRecord( new Value[0] ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/ChannelReleasingResetResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/ChannelReleasingResetResponseHandlerTest.java
@@ -22,8 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -32,9 +32,9 @@ import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.FakeClock;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -42,19 +42,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.async.ChannelAttributes.lastUsedTimestamp;
 
-public class ChannelReleasingResetResponseHandlerTest
+class ChannelReleasingResetResponseHandlerTest
 {
     private final EmbeddedChannel channel = new EmbeddedChannel();
     private final InboundMessageDispatcher messageDispatcher = mock( InboundMessageDispatcher.class );
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldReleaseChannelOnSuccess()
+    void shouldReleaseChannelOnSuccess()
     {
         ChannelPool pool = newChannelPoolMock();
         FakeClock clock = new FakeClock();
@@ -71,7 +71,7 @@ public class ChannelReleasingResetResponseHandlerTest
     }
 
     @Test
-    public void shouldCloseAndReleaseChannelOnFailure()
+    void shouldCloseAndReleaseChannelOnFailure()
     {
         ChannelPool pool = newChannelPoolMock();
         FakeClock clock = new FakeClock();
@@ -88,7 +88,7 @@ public class ChannelReleasingResetResponseHandlerTest
     }
 
     @Test
-    public void shouldUnMuteAckFailureOnSuccess()
+    void shouldUnMuteAckFailureOnSuccess()
     {
         ChannelPool pool = newChannelPoolMock();
         ChannelReleasingResetResponseHandler handler = newHandler( pool, new FakeClock(), new CompletableFuture<>() );
@@ -99,7 +99,7 @@ public class ChannelReleasingResetResponseHandlerTest
     }
 
     @Test
-    public void shouldUnMuteAckFailureOnFailure()
+    void shouldUnMuteAckFailureOnFailure()
     {
         ChannelPool pool = newChannelPoolMock();
         ChannelReleasingResetResponseHandler handler = newHandler( pool, new FakeClock(), new CompletableFuture<>() );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PingResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PingResponseHandlerTest.java
@@ -21,23 +21,21 @@ package org.neo4j.driver.internal.handlers;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.v1.Value;
 
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
 
-public class PingResponseHandlerTest
+class PingResponseHandlerTest
 {
     @Test
-    public void shouldResolvePromiseOnSuccess()
+    void shouldResolvePromiseOnSuccess()
     {
         Promise<Boolean> promise = newPromise();
         PingResponseHandler handler = newHandler( promise );
@@ -49,7 +47,7 @@ public class PingResponseHandlerTest
     }
 
     @Test
-    public void shouldResolvePromiseOnFailure()
+    void shouldResolvePromiseOnFailure()
     {
         Promise<Boolean> promise = newPromise();
         PingResponseHandler handler = newHandler( promise );
@@ -61,19 +59,11 @@ public class PingResponseHandlerTest
     }
 
     @Test
-    public void shouldNotSupportRecordMessages()
+    void shouldNotSupportRecordMessages()
     {
         PingResponseHandler handler = newHandler( newPromise() );
 
-        try
-        {
-            handler.onRecord( new Value[0] );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( UnsupportedOperationException.class ) );
-        }
+        assertThrows( UnsupportedOperationException.class, () -> handler.onRecord( new Value[0] ) );
     }
 
     private static Promise<Boolean> newPromise()

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
@@ -44,12 +44,12 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -58,10 +58,10 @@ import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class PullAllResponseHandlerTest
+class PullAllResponseHandlerTest
 {
     @Test
-    public void shouldReturnNoFailureWhenAlreadySucceeded()
+    void shouldReturnNoFailureWhenAlreadySucceeded()
     {
         PullAllResponseHandler handler = newHandler();
         handler.onSuccess( emptyMap() );
@@ -72,7 +72,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnNoFailureWhenSucceededAfterFailureRequested()
+    void shouldReturnNoFailureWhenSucceededAfterFailureRequested()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -86,7 +86,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureWhenAlreadyFailed()
+    void shouldReturnFailureWhenAlreadyFailed()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -98,7 +98,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureWhenFailedAfterFailureRequested()
+    void shouldReturnFailureWhenFailedAfterFailureRequested()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -113,7 +113,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureWhenRequestedMultipleTimes()
+    void shouldReturnFailureWhenRequestedMultipleTimes()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -134,7 +134,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureOnlyOnceWhenFailedBeforeFailureRequested()
+    void shouldReturnFailureOnlyOnceWhenFailedBeforeFailureRequested()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -146,7 +146,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureOnlyOnceWhenFailedAfterFailureRequested()
+    void shouldReturnFailureOnlyOnceWhenFailedAfterFailureRequested()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -160,7 +160,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnSummaryWhenAlreadySucceeded()
+    void shouldReturnSummaryWhenAlreadySucceeded()
     {
         Statement statement = new Statement( "CREATE () RETURN 42" );
         PullAllResponseHandler handler = newHandler( statement );
@@ -173,7 +173,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnSummaryWhenSucceededAfterSummaryRequested()
+    void shouldReturnSummaryWhenSucceededAfterSummaryRequested()
     {
         Statement statement = new Statement( "RETURN 'Hi!" );
         PullAllResponseHandler handler = newHandler( statement );
@@ -191,26 +191,19 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnFailureWhenSummaryRequestedWhenAlreadyFailed()
+    void shouldReturnFailureWhenSummaryRequestedWhenAlreadyFailed()
     {
         PullAllResponseHandler handler = newHandler();
 
         RuntimeException failure = new RuntimeException( "Computer is burning" );
         handler.onFailure( failure );
 
-        try
-        {
-            await( handler.summaryAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( failure, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.summaryAsync() ) );
+        assertEquals( failure, e );
     }
 
     @Test
-    public void shouldReturnFailureWhenFailedAfterSummaryRequested()
+    void shouldReturnFailureWhenFailedAfterSummaryRequested()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -221,20 +214,12 @@ public class PullAllResponseHandlerTest
         handler.onFailure( failure );
 
         assertTrue( summaryFuture.isDone() );
-
-        try
-        {
-            await( summaryFuture );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( failure, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( summaryFuture ) );
+        assertEquals( failure, e );
     }
 
     @Test
-    public void shouldFailSummaryWhenRequestedMultipleTimes()
+    void shouldFailSummaryWhenRequestedMultipleTimes()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -249,29 +234,15 @@ public class PullAllResponseHandlerTest
         assertTrue( summaryFuture1.isDone() );
         assertTrue( summaryFuture2.isDone() );
 
-        try
-        {
-            await( summaryFuture1 );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( failure, e );
-        }
+        Exception e1 = assertThrows( Exception.class, () -> await( summaryFuture1 ) );
+        assertEquals( failure, e1 );
 
-        try
-        {
-            await( summaryFuture2 );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( failure, e );
-        }
+        Exception e2 = assertThrows( Exception.class, () -> await( summaryFuture2 ) );
+        assertEquals( failure, e2 );
     }
 
     @Test
-    public void shouldPropagateFailureOnlyOnceFromSummary()
+    void shouldPropagateFailureOnlyOnceFromSummary()
     {
         Statement statement = new Statement( "CREATE INDEX ON :Person(name)" );
         PullAllResponseHandler handler = newHandler( statement );
@@ -279,15 +250,8 @@ public class PullAllResponseHandlerTest
         IllegalStateException failure = new IllegalStateException( "Some state is illegal :(" );
         handler.onFailure( failure );
 
-        try
-        {
-            await( handler.summaryAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( failure, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.summaryAsync() ) );
+        assertEquals( failure, e );
 
         ResultSummary summary = await( handler.summaryAsync() );
         assertNotNull( summary );
@@ -295,7 +259,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnSummaryWhenAlreadyFailedAndFailureConsumed()
+    void shouldReturnSummaryWhenAlreadyFailedAndFailureConsumed()
     {
         Statement statement = new Statement( "CREATE ()" );
         PullAllResponseHandler handler = newHandler( statement );
@@ -311,7 +275,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekSingleAvailableRecord()
+    void shouldPeekSingleAvailableRecord()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -325,7 +289,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekFirstRecordWhenMultipleAvailable()
+    void shouldPeekFirstRecordWhenMultipleAvailable()
     {
         List<String> keys = asList( "key1", "key2", "key3" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -343,7 +307,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekRecordThatBecomesAvailableLater()
+    void shouldPeekRecordThatBecomesAvailableLater()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -361,7 +325,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekAvailableNothingAfterSuccess()
+    void shouldPeekAvailableNothingAfterSuccess()
     {
         List<String> keys = asList( "key1", "key2", "key3" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -377,7 +341,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekNothingAfterSuccess()
+    void shouldPeekNothingAfterSuccess()
     {
         PullAllResponseHandler handler = newHandler();
         handler.onSuccess( emptyMap() );
@@ -386,7 +350,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPeekWhenRequestedMultipleTimes()
+    void shouldPeekWhenRequestedMultipleTimes()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -424,26 +388,19 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPropagateNotConsumedFailureInPeek()
+    void shouldPropagateNotConsumedFailureInPeek()
     {
         PullAllResponseHandler handler = newHandler();
 
         RuntimeException failure = new RuntimeException( "Something is wrong" );
         handler.onFailure( failure );
 
-        try
-        {
-            await( handler.peekAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( failure, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.peekAsync() ) );
+        assertEquals( failure, e );
     }
 
     @Test
-    public void shouldPropagateFailureInPeekWhenItBecomesAvailable()
+    void shouldPropagateFailureInPeekWhenItBecomesAvailable()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -453,40 +410,25 @@ public class PullAllResponseHandlerTest
         RuntimeException failure = new RuntimeException( "Error" );
         handler.onFailure( failure );
 
-        try
-        {
-            await( recordFuture );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( failure, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( recordFuture ) );
+        assertEquals( failure, e );
     }
 
     @Test
-    public void shouldPropagateFailureInPeekOnlyOnce()
+    void shouldPropagateFailureInPeekOnlyOnce()
     {
         PullAllResponseHandler handler = newHandler();
 
         RuntimeException failure = new RuntimeException( "Something is wrong" );
         handler.onFailure( failure );
 
-        try
-        {
-            await( handler.peekAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( failure, e );
-        }
-
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.peekAsync() ) );
+        assertEquals( failure, e );
         assertNull( await( handler.peekAsync() ) );
     }
 
     @Test
-    public void shouldReturnSingleAvailableRecordInNextAsync()
+    void shouldReturnSingleAvailableRecordInNextAsync()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -501,7 +443,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnNoRecordsWhenNoneAvailableInNextAsync()
+    void shouldReturnNoRecordsWhenNoneAvailableInNextAsync()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
         handler.onSuccess( emptyMap() );
@@ -510,7 +452,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnNoRecordsWhenSuccessComesAfterNextAsync()
+    void shouldReturnNoRecordsWhenSuccessComesAfterNextAsync()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
 
@@ -524,7 +466,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPullAllAvailableRecordsWithNextAsync()
+    void shouldPullAllAvailableRecordsWithNextAsync()
     {
         List<String> keys = asList( "key1", "key2", "key3" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -568,7 +510,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnRecordInNextAsyncWhenItBecomesAvailableLater()
+    void shouldReturnRecordInNextAsyncWhenItBecomesAvailableLater()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -587,7 +529,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnSameRecordOnceWhenRequestedMultipleTimesInNextAsync()
+    void shouldReturnSameRecordOnceWhenRequestedMultipleTimesInNextAsync()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -615,25 +557,18 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPropagateExistingFailureInNextAsync()
+    void shouldPropagateExistingFailureInNextAsync()
     {
         PullAllResponseHandler handler = newHandler();
         RuntimeException error = new RuntimeException( "Failed to read" );
         handler.onFailure( error );
 
-        try
-        {
-            await( handler.nextAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.nextAsync() ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldPropagateFailureInNextAsyncWhenFailureMessagesArrivesLater()
+    void shouldPropagateFailureInNextAsyncWhenFailureMessagesArrivesLater()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -644,19 +579,12 @@ public class PullAllResponseHandlerTest
         handler.onFailure( error );
 
         assertTrue( recordFuture.isDone() );
-        try
-        {
-            await( recordFuture );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( recordFuture ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldDisableAutoReadWhenTooManyRecordsArrive()
+    void shouldDisableAutoReadWhenTooManyRecordsArrive()
     {
         Connection connection = connectionMock();
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ), connection );
@@ -670,7 +598,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldEnableAutoReadWhenRecordsRetrievedFromBuffer()
+    void shouldEnableAutoReadWhenRecordsRetrievedFromBuffer()
     {
         Connection connection = connectionMock();
         List<String> keys = asList( "key1", "key2" );
@@ -697,7 +625,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldNotDisableAutoReadWhenSummaryRequested()
+    void shouldNotDisableAutoReadWhenSummaryRequested()
     {
         Connection connection = connectionMock();
         List<String> keys = asList( "key1", "key2" );
@@ -733,7 +661,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldNotDisableAutoReadWhenFailureRequested()
+    void shouldNotDisableAutoReadWhenFailureRequested()
     {
         Connection connection = connectionMock();
         List<String> keys = asList( "key1", "key2" );
@@ -769,7 +697,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldEnableAutoReadOnConnectionWhenFailureRequestedButNotAvailable() throws Exception
+    void shouldEnableAutoReadOnConnectionWhenFailureRequestedButNotAvailable() throws Exception
     {
         Connection connection = connectionMock();
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ), connection );
@@ -797,7 +725,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldEnableAutoReadOnConnectionWhenSummaryRequestedButNotAvailable() throws Exception
+    void shouldEnableAutoReadOnConnectionWhenSummaryRequestedButNotAvailable() throws Exception
     {
         Connection connection = connectionMock();
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2", "key3" ), connection );
@@ -824,25 +752,18 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldPropagateFailureFromListAsync()
+    void shouldPropagateFailureFromListAsync()
     {
         PullAllResponseHandler handler = newHandler();
         RuntimeException error = new RuntimeException( "Hi!" );
         handler.onFailure( error );
 
-        try
-        {
-            await( handler.listAsync( Functions.identity() ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.listAsync( Functions.identity() ) ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldPropagateFailureAfterRecordFromListAsync()
+    void shouldPropagateFailureAfterRecordFromListAsync()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
 
@@ -851,19 +772,12 @@ public class PullAllResponseHandlerTest
         RuntimeException error = new RuntimeException( "Hi!" );
         handler.onFailure( error );
 
-        try
-        {
-            await( handler.listAsync( Functions.identity() ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.listAsync( Functions.identity() ) ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldFailListAsyncWhenTransformationFunctionThrows()
+    void shouldFailListAsyncWhenTransformationFunctionThrows()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
         handler.onRecord( values( 1, 2 ) );
@@ -881,19 +795,12 @@ public class PullAllResponseHandlerTest
             return 42;
         } );
 
-        try
-        {
-            await( stage );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( stage ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldReturnEmptyListInListAsyncAfterSuccess()
+    void shouldReturnEmptyListInListAsyncAfterSuccess()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -903,7 +810,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnEmptyListInListAsyncAfterFailure()
+    void shouldReturnEmptyListInListAsyncAfterFailure()
     {
         PullAllResponseHandler handler = newHandler();
 
@@ -916,7 +823,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnTransformedListInListAsync()
+    void shouldReturnTransformedListInListAsync()
     {
         PullAllResponseHandler handler = newHandler( singletonList( "key1" ) );
 
@@ -932,7 +839,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnNotTransformedListInListAsync()
+    void shouldReturnNotTransformedListInListAsync()
     {
         List<String> keys = asList( "key1", "key2" );
         PullAllResponseHandler handler = newHandler( keys );
@@ -957,7 +864,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeAfterSuccessWithRecords()
+    void shouldConsumeAfterSuccessWithRecords()
     {
         PullAllResponseHandler handler = newHandler( singletonList( "key1" ) );
         handler.onRecord( values( 1 ) );
@@ -970,7 +877,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeAfterSuccessWithoutRecords()
+    void shouldConsumeAfterSuccessWithoutRecords()
     {
         PullAllResponseHandler handler = newHandler();
         handler.onSuccess( emptyMap() );
@@ -981,7 +888,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeAfterFailureWithRecords()
+    void shouldConsumeAfterFailureWithRecords()
     {
         PullAllResponseHandler handler = newHandler( singletonList( "key1" ) );
         handler.onRecord( values( 1 ) );
@@ -989,41 +896,25 @@ public class PullAllResponseHandlerTest
         RuntimeException error = new RuntimeException( "Hi" );
         handler.onFailure( error );
 
-        try
-        {
-            await( handler.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
-
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.consumeAsync() ) );
+        assertEquals( error, e );
         assertNoRecordsCanBeFetched( handler );
     }
 
     @Test
-    public void shouldConsumeAfterFailureWithoutRecords()
+    void shouldConsumeAfterFailureWithoutRecords()
     {
         PullAllResponseHandler handler = newHandler();
         RuntimeException error = new RuntimeException( "Hi" );
         handler.onFailure( error );
 
-        try
-        {
-            await( handler.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
-
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.consumeAsync() ) );
+        assertEquals( error, e );
         assertNoRecordsCanBeFetched( handler );
     }
 
     @Test
-    public void shouldConsumeAfterProcessedFailureWithRecords()
+    void shouldConsumeAfterProcessedFailureWithRecords()
     {
         PullAllResponseHandler handler = newHandler( singletonList( "key1" ) );
         handler.onRecord( values( 1 ) );
@@ -1040,7 +931,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeAfterProcessedFailureWithoutRecords()
+    void shouldConsumeAfterProcessedFailureWithoutRecords()
     {
         PullAllResponseHandler handler = newHandler();
         RuntimeException error = new RuntimeException( "Hi" );
@@ -1055,7 +946,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeUntilSuccess()
+    void shouldConsumeUntilSuccess()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
         handler.onRecord( values( 1, 2 ) );
@@ -1077,7 +968,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldConsumeUntilFailure()
+    void shouldConsumeUntilFailure()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
         handler.onRecord( values( 1, 2 ) );
@@ -1095,21 +986,13 @@ public class PullAllResponseHandlerTest
 
         assertTrue( consumeFuture.isDone() );
         assertTrue( consumeFuture.isCompletedExceptionally() );
-        try
-        {
-            await( consumeFuture );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
-
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( consumeFuture ) );
+        assertEquals( error, e );
         assertNoRecordsCanBeFetched( handler );
     }
 
     @Test
-    public void shouldReturnNoRecordsWhenConsumed()
+    void shouldReturnNoRecordsWhenConsumed()
     {
         PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ) );
         handler.onRecord( values( 1, 2 ) );
@@ -1140,7 +1023,7 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReceiveSummaryAfterConsume()
+    void shouldReceiveSummaryAfterConsume()
     {
         Statement statement = new Statement( "RETURN 'Hello!'" );
         PullAllResponseHandler handler = newHandler( statement, singletonList( "key" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/ResetResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/ResetResponseHandlerTest.java
@@ -18,25 +18,25 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.v1.Values.values;
 
-public class ResetResponseHandlerTest
+class ResetResponseHandlerTest
 {
     @Test
-    public void shouldCompleteFutureOnSuccess() throws Exception
+    void shouldCompleteFutureOnSuccess() throws Exception
     {
         CompletableFuture<Void> future = new CompletableFuture<>();
         ResetResponseHandler handler = newHandler( future );
@@ -50,7 +50,7 @@ public class ResetResponseHandlerTest
     }
 
     @Test
-    public void shouldUnMuteAckFailureOnSuccess()
+    void shouldUnMuteAckFailureOnSuccess()
     {
         InboundMessageDispatcher messageDispatcher = mock( InboundMessageDispatcher.class );
         ResetResponseHandler handler = newHandler( messageDispatcher, new CompletableFuture<>() );
@@ -61,7 +61,7 @@ public class ResetResponseHandlerTest
     }
 
     @Test
-    public void shouldCompleteFutureOnFailure() throws Exception
+    void shouldCompleteFutureOnFailure() throws Exception
     {
         CompletableFuture<Void> future = new CompletableFuture<>();
         ResetResponseHandler handler = newHandler( future );
@@ -75,7 +75,7 @@ public class ResetResponseHandlerTest
     }
 
     @Test
-    public void shouldUnMuteAckFailureOnFailure()
+    void shouldUnMuteAckFailureOnFailure()
     {
         InboundMessageDispatcher messageDispatcher = mock( InboundMessageDispatcher.class );
         ResetResponseHandler handler = newHandler( messageDispatcher, new CompletableFuture<>() );
@@ -86,18 +86,11 @@ public class ResetResponseHandlerTest
     }
 
     @Test
-    public void shouldThrowWhenOnRecord()
+    void shouldThrowWhenOnRecord()
     {
         ResetResponseHandler handler = newHandler( new CompletableFuture<>() );
 
-        try
-        {
-            handler.onRecord( values( 1, 2, 3 ) );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedOperationException ignore )
-        {
-        }
+        assertThrows( UnsupportedOperationException.class, () -> handler.onRecord( values( 1, 2, 3 ) ) );
     }
 
     private static ResetResponseHandler newHandler( CompletableFuture<Void> future )

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/RunResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/RunResponseHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,18 +27,18 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.Values.values;
 
-public class RunResponseHandlerTest
+class RunResponseHandlerTest
 {
     @Test
-    public void shouldNotifyCompletionFutureOnSuccess() throws Exception
+    void shouldNotifyCompletionFutureOnSuccess() throws Exception
     {
         CompletableFuture<Void> runCompletedFuture = new CompletableFuture<>();
         RunResponseHandler handler = newHandler( runCompletedFuture );
@@ -51,7 +51,7 @@ public class RunResponseHandlerTest
     }
 
     @Test
-    public void shouldNotifyCompletionFutureOnFailure() throws Exception
+    void shouldNotifyCompletionFutureOnFailure() throws Exception
     {
         CompletableFuture<Void> runCompletedFuture = new CompletableFuture<>();
         RunResponseHandler handler = newHandler( runCompletedFuture );
@@ -64,22 +64,15 @@ public class RunResponseHandlerTest
     }
 
     @Test
-    public void shouldThrowOnRecord()
+    void shouldThrowOnRecord()
     {
         RunResponseHandler handler = newHandler();
 
-        try
-        {
-            handler.onRecord( values( "a", "b", "c" ) );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedOperationException ignore )
-        {
-        }
+        assertThrows( UnsupportedOperationException.class, () -> handler.onRecord( values( "a", "b", "c" ) ) );
     }
 
     @Test
-    public void shouldReturnNoKeysWhenFailed()
+    void shouldReturnNoKeysWhenFailed()
     {
         RunResponseHandler handler = newHandler();
 
@@ -89,7 +82,7 @@ public class RunResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnDefaultResultAvailableAfterWhenFailed()
+    void shouldReturnDefaultResultAvailableAfterWhenFailed()
     {
         RunResponseHandler handler = newHandler();
 
@@ -99,7 +92,7 @@ public class RunResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnKeysWhenSucceeded()
+    void shouldReturnKeysWhenSucceeded()
     {
         RunResponseHandler handler = newHandler();
 
@@ -110,7 +103,7 @@ public class RunResponseHandlerTest
     }
 
     @Test
-    public void shouldReturnResultAvailableAfterWhenSucceeded()
+    void shouldReturnResultAvailableAfterWhenSucceeded()
     {
         RunResponseHandler handler = newHandler();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -32,10 +32,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SessionPullAllResponseHandlerTest
+class SessionPullAllResponseHandlerTest
 {
     @Test
-    public void shouldReleaseConnectionOnSuccess()
+    void shouldReleaseConnectionOnSuccess()
     {
         Connection connection = newConnectionMock();
         SessionPullAllResponseHandler handler = newHandler( connection );
@@ -46,7 +46,7 @@ public class SessionPullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldReleaseConnectionOnFailure()
+    void shouldReleaseConnectionOnFailure()
     {
         Connection connection = newConnectionMock();
         SessionPullAllResponseHandler handler = newHandler( connection );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -37,10 +37,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TransactionPullAllResponseHandlerTest
+class TransactionPullAllResponseHandlerTest
 {
     @Test
-    public void shouldMarkTransactionAsFailedOnNonFatalFailures()
+    void shouldMarkTransactionAsFailedOnNonFatalFailures()
     {
         testErrorHandling( new ClientException( "Neo.ClientError.Cluster.NotALeader", "" ), false );
         testErrorHandling( new ClientException( "Neo.ClientError.Procedure.ProcedureCallFailed", "" ), false );
@@ -49,7 +49,7 @@ public class TransactionPullAllResponseHandlerTest
     }
 
     @Test
-    public void shouldMarkTransactionAsTerminatedOnFatalFailures()
+    void shouldMarkTransactionAsTerminatedOnFatalFailures()
     {
         testErrorHandling( new RuntimeException(), true );
         testErrorHandling( new IOException(), true );

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/ConsoleLoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/ConsoleLoggingTest.java
@@ -18,51 +18,50 @@
  */
 package org.neo4j.driver.internal.logging;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Scanner;
 import java.util.logging.Level;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import org.neo4j.driver.internal.logging.ConsoleLogging.ConsoleLogger;
 import org.neo4j.driver.v1.Logger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConsoleLoggingTest
+class ConsoleLoggingTest
 {
-
     private static ByteArrayOutputStream out = new ByteArrayOutputStream();
     private static PrintStream sysErr;
 
-    @BeforeClass
-    public static void saveSysOut()
+    @BeforeAll
+    static void saveSysOut()
     {
         sysErr = System.err;
         System.setErr( new PrintStream( out ) );
     }
 
-    @AfterClass
-    public static void restoreSysOut()
+    @AfterAll
+    static void restoreSysOut()
     {
         System.setErr( sysErr );
     }
 
-    @Before
-    public void setup()
+    @BeforeEach
+    void setup()
     {
         out.reset();
     }
 
     @Test
-    public void shouldOnlyRecordMessageOnce()
+    void shouldOnlyRecordMessageOnce()
     {
         // Given
         ConsoleLogging logging = new ConsoleLogging( Level.ALL );
@@ -81,7 +80,7 @@ public class ConsoleLoggingTest
     }
 
     @Test
-    public void shouldResetLoggerLevel()
+    void shouldResetLoggerLevel()
     {
         // Given
         String logName = ConsoleLogging.class.getName();

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/PrefixedLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/PrefixedLoggerTest.java
@@ -18,15 +18,13 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.v1.Logger;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -34,34 +32,26 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class PrefixedLoggerTest
+class PrefixedLoggerTest
 {
     private static final String PREFIX = "Output";
     private static final String MESSAGE = "Hello World!";
     private static final Exception ERROR = new Exception();
 
     @Test
-    public void shouldThrowWhenDelegateIsNull()
+    void shouldThrowWhenDelegateIsNull()
     {
-        try
-        {
-            new PrefixedLogger( null );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( NullPointerException.class ) );
-        }
+        assertThrows( NullPointerException.class, () -> new PrefixedLogger( null ) );
     }
 
     @Test
-    public void shouldAllowNullPrefix()
+    void shouldAllowNullPrefix()
     {
         assertNotNull( new PrefixedLogger( null, newLoggerMock() ) );
     }
 
     @Test
-    public void shouldDelegateIsDebugEnabled()
+    void shouldDelegateIsDebugEnabled()
     {
         Logger delegate = newLoggerMock( true, false );
 
@@ -72,7 +62,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateIsTraceEnabled()
+    void shouldDelegateIsTraceEnabled()
     {
         Logger delegate = newLoggerMock( false, true );
 
@@ -83,7 +73,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldNotDelegateDebugLogWhenDebugDisabled()
+    void shouldNotDelegateDebugLogWhenDebugDisabled()
     {
         Logger delegate = newLoggerMock();
 
@@ -94,7 +84,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldNotDelegateTraceLogWhenTraceDisabled()
+    void shouldNotDelegateTraceLogWhenTraceDisabled()
     {
         Logger delegate = newLoggerMock();
 
@@ -105,7 +95,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateErrorMessageWhenNoPrefix()
+    void shouldDelegateErrorMessageWhenNoPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -116,7 +106,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateInfoMessageWhenNoPrefix()
+    void shouldDelegateInfoMessageWhenNoPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -127,7 +117,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateWarnMessageWhenNoPrefix()
+    void shouldDelegateWarnMessageWhenNoPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -138,7 +128,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateWarnMessageWithoutErrorWhenNoPrefix()
+    void shouldDelegateWarnMessageWithoutErrorWhenNoPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -150,7 +140,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateDebugMessageWhenNoPrefix()
+    void shouldDelegateDebugMessageWhenNoPrefix()
     {
         Logger delegate = newLoggerMock( true, false );
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -161,7 +151,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateTraceMessageWhenNoPrefix()
+    void shouldDelegateTraceMessageWhenNoPrefix()
     {
         Logger delegate = newLoggerMock( false, true );
         PrefixedLogger logger = new PrefixedLogger( delegate );
@@ -172,7 +162,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateErrorMessageWithPrefix()
+    void shouldDelegateErrorMessageWithPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );
@@ -183,7 +173,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateInfoMessageWithPrefix()
+    void shouldDelegateInfoMessageWithPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );
@@ -194,7 +184,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateWarnMessageWithPrefix()
+    void shouldDelegateWarnMessageWithPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );
@@ -205,7 +195,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateWarnMessageWithErrorWithPrefix()
+    void shouldDelegateWarnMessageWithErrorWithPrefix()
     {
         Logger delegate = newLoggerMock();
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );
@@ -217,7 +207,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateDebugMessageWithPrefix()
+    void shouldDelegateDebugMessageWithPrefix()
     {
         Logger delegate = newLoggerMock( true, false );
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );
@@ -228,7 +218,7 @@ public class PrefixedLoggerTest
     }
 
     @Test
-    public void shouldDelegateTraceMessageWithPrefix()
+    void shouldDelegateTraceMessageWithPrefix()
     {
         Logger delegate = newLoggerMock( false, true );
         PrefixedLogger logger = new PrefixedLogger( PREFIX, delegate );

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggerTest.java
@@ -18,22 +18,22 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class Slf4jLoggerTest
+class Slf4jLoggerTest
 {
     private final Logger logger = mock( Logger.class );
     private final Slf4jLogger slf4jLogger = new Slf4jLogger( logger );
 
     @Test
-    public void shouldLogErrorWithMessageAndThrowable()
+    void shouldLogErrorWithMessageAndThrowable()
     {
         when( logger.isErrorEnabled() ).thenReturn( true );
         String message = "Hello";
@@ -45,7 +45,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldLogInfoWithMessageAndParams()
+    void shouldLogInfoWithMessageAndParams()
     {
         when( logger.isInfoEnabled() ).thenReturn( true );
         String message = "One %s, two %s, three %s";
@@ -57,7 +57,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldLogWarnWithMessageAndParams()
+    void shouldLogWarnWithMessageAndParams()
     {
         when( logger.isWarnEnabled() ).thenReturn( true );
         String message = "C for %s, d for %s";
@@ -69,7 +69,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldLogWarnWithMessageAndThrowable()
+    void shouldLogWarnWithMessageAndThrowable()
     {
         when( logger.isWarnEnabled() ).thenReturn( true );
         String message = "Hello";
@@ -81,7 +81,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldLogDebugWithMessageAndParams()
+    void shouldLogDebugWithMessageAndParams()
     {
         when( logger.isDebugEnabled() ).thenReturn( true );
         String message = "Hello%s%s!";
@@ -93,7 +93,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldLogTraceWithMessageAndParams()
+    void shouldLogTraceWithMessageAndParams()
     {
         when( logger.isTraceEnabled() ).thenReturn( true );
         String message = "I'll be %s!";
@@ -105,7 +105,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldCheckIfDebugIsEnabled()
+    void shouldCheckIfDebugIsEnabled()
     {
         when( logger.isDebugEnabled() ).thenReturn( false );
         assertFalse( slf4jLogger.isDebugEnabled() );
@@ -115,7 +115,7 @@ public class Slf4jLoggerTest
     }
 
     @Test
-    public void shouldCheckIfTraceIsEnabled()
+    void shouldCheckIfTraceIsEnabled()
     {
         when( logger.isTraceEnabled() ).thenReturn( false );
         assertFalse( slf4jLogger.isTraceEnabled() );

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/Slf4jLoggingTest.java
@@ -18,18 +18,18 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.v1.Logger;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class Slf4jLoggingTest
+class Slf4jLoggingTest
 {
     @Test
-    public void shouldCreateLoggers()
+    void shouldCreateLoggers()
     {
         Slf4jLogging logging = new Slf4jLogging();
 
@@ -39,7 +39,7 @@ public class Slf4jLoggingTest
     }
 
     @Test
-    public void shouldCheckIfAvailable()
+    void shouldCheckIfAvailable()
     {
         assertNull( Slf4jLogging.checkAvailability() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV2Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/PackStreamMessageFormatV2Test.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal.messaging;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -51,8 +51,8 @@ import static java.time.Month.DECEMBER;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -67,27 +67,20 @@ import static org.neo4j.driver.v1.Values.point;
 import static org.neo4j.driver.v1.Values.value;
 import static org.neo4j.driver.v1.util.TestUtil.assertByteBufContains;
 
-public class PackStreamMessageFormatV2Test
+class PackStreamMessageFormatV2Test
 {
     private final PackStreamMessageFormatV2 messageFormat = new PackStreamMessageFormatV2();
 
     @Test
-    public void shouldFailToCreateWriterWithoutByteArraySupport()
+    void shouldFailToCreateWriterWithoutByteArraySupport()
     {
         PackOutput output = mock( PackOutput.class );
 
-        try
-        {
-            messageFormat.newWriter( output, false );
-            fail( "Exception expected" );
-        }
-        catch ( IllegalArgumentException ignore )
-        {
-        }
+        assertThrows( IllegalArgumentException.class, () -> messageFormat.newWriter( output, false ) );
     }
 
     @Test
-    public void shouldWritePoint2D() throws Exception
+    void shouldWritePoint2D() throws Exception
     {
         ByteBuf buf = Unpooled.buffer();
         MessageFormat.Writer writer = newWriter( buf );
@@ -102,7 +95,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWritePoint3D() throws Exception
+    void shouldWritePoint3D() throws Exception
     {
         ByteBuf buf = Unpooled.buffer();
         MessageFormat.Writer writer = newWriter( buf );
@@ -117,7 +110,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadPoint2D() throws Exception
+    void shouldReadPoint2D() throws Exception
     {
         Point point = new InternalPoint2D( 42, 120.65, -99.2 );
 
@@ -133,7 +126,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadPoint3D() throws Exception
+    void shouldReadPoint3D() throws Exception
     {
         Point point = new InternalPoint3D( 42, 85.391, 98.8, 11.1 );
 
@@ -150,7 +143,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteDate() throws Exception
+    void shouldWriteDate() throws Exception
     {
         LocalDate date = LocalDate.ofEpochDay( 2147483650L );
         ByteBuf buf = Unpooled.buffer();
@@ -165,7 +158,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadDate() throws Exception
+    void shouldReadDate() throws Exception
     {
         LocalDate date = LocalDate.of( 2012, AUGUST, 3 );
 
@@ -179,7 +172,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteTime() throws Exception
+    void shouldWriteTime() throws Exception
     {
         OffsetTime time = OffsetTime.of( 4, 16, 20, 999, ZoneOffset.MIN );
         ByteBuf buf = Unpooled.buffer();
@@ -194,7 +187,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadTime() throws Exception
+    void shouldReadTime() throws Exception
     {
         OffsetTime time = OffsetTime.of( 23, 59, 59, 999, ZoneOffset.MAX );
 
@@ -209,7 +202,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteLocalTime() throws Exception
+    void shouldWriteLocalTime() throws Exception
     {
         LocalTime time = LocalTime.of( 12, 9, 18, 999_888 );
         ByteBuf buf = Unpooled.buffer();
@@ -224,7 +217,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadLocalTime() throws Exception
+    void shouldReadLocalTime() throws Exception
     {
         LocalTime time = LocalTime.of( 12, 25 );
 
@@ -238,7 +231,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteLocalDateTime() throws Exception
+    void shouldWriteLocalDateTime() throws Exception
     {
         LocalDateTime dateTime = LocalDateTime.of( 2049, DECEMBER, 12, 17, 25, 49, 199 );
         ByteBuf buf = Unpooled.buffer();
@@ -253,7 +246,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadLocalDateTime() throws Exception
+    void shouldReadLocalDateTime() throws Exception
     {
         LocalDateTime dateTime = LocalDateTime.of( 1999, APRIL, 3, 19, 5, 5, 100_200_300 );
 
@@ -268,7 +261,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteZonedDateTimeWithOffset() throws Exception
+    void shouldWriteZonedDateTimeWithOffset() throws Exception
     {
         ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutes( 9, 30 );
         ZonedDateTime dateTime = ZonedDateTime.of( 2000, 1, 10, 12, 2, 49, 300, zoneOffset );
@@ -287,7 +280,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadZonedDateTimeWithOffset() throws Exception
+    void shouldReadZonedDateTimeWithOffset() throws Exception
     {
         ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutes( -7, -15 );
         ZonedDateTime dateTime = ZonedDateTime.of( 1823, 1, 12, 23, 59, 59, 999_999_999, zoneOffset );
@@ -304,7 +297,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteZonedDateTimeWithZoneId() throws Exception
+    void shouldWriteZonedDateTimeWithZoneId() throws Exception
     {
         String zoneName = "Europe/Stockholm";
         byte[] zoneNameBytes = zoneName.getBytes();
@@ -332,7 +325,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadZonedDateTimeWithZoneId() throws Exception
+    void shouldReadZonedDateTimeWithZoneId() throws Exception
     {
         String zoneName = "Europe/Stockholm";
         ZonedDateTime dateTime = ZonedDateTime.of( 1823, 1, 12, 23, 59, 59, 999_999_999, ZoneId.of( zoneName ) );
@@ -349,7 +342,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldWriteDuration() throws Exception
+    void shouldWriteDuration() throws Exception
     {
         Value durationValue = Values.isoDuration( Long.MAX_VALUE - 1, Integer.MAX_VALUE - 1, Short.MAX_VALUE - 1, Byte.MAX_VALUE - 1 );
         IsoDuration duration = durationValue.asIsoDuration();
@@ -367,7 +360,7 @@ public class PackStreamMessageFormatV2Test
     }
 
     @Test
-    public void shouldReadDuration() throws Exception
+    void shouldReadDuration() throws Exception
     {
         Value durationValue = Values.isoDuration( 17, 22, 99, 15 );
         IsoDuration duration = durationValue.asIsoDuration();

--- a/driver/src/test/java/org/neo4j/driver/internal/metrics/InternalHistogramTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/metrics/InternalHistogramTest.java
@@ -18,19 +18,19 @@
  */
 package org.neo4j.driver.internal.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.metrics.spi.Histogram;
 
 import static java.lang.Math.abs;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-public class InternalHistogramTest
+class InternalHistogramTest
 {
     @Test
-    public void shouldRecordSmallValuesPrecisely() throws Throwable
+    void shouldRecordSmallValuesPrecisely()
     {
         // Given
         InternalHistogram histogram = new InternalHistogram();
@@ -48,7 +48,7 @@ public class InternalHistogramTest
     }
 
     @Test
-    public void shouldRecordBigValuesPrecisely() throws Throwable
+    void shouldRecordBigValuesPrecisely()
     {
         // Given
         InternalHistogram histogram = new InternalHistogram();
@@ -66,7 +66,7 @@ public class InternalHistogramTest
     }
 
     @Test
-    public void shouldResetOnOriginalHistogram() throws Throwable
+    void shouldResetOnOriginalHistogram()
     {
         // Given
         InternalHistogram histogram = new InternalHistogram();

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -18,34 +18,34 @@
  */
 package org.neo4j.driver.internal.net;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.neo4j.driver.internal.BoltServerAddress.DEFAULT_PORT;
 
-public class BoltServerAddressTest
+class BoltServerAddressTest
 {
     @Test
-    public void defaultPortShouldBe7687()
+    void defaultPortShouldBe7687()
     {
         assertThat( DEFAULT_PORT, equalTo( 7687 ) );
     }
 
     @Test
-    public void portShouldUseDefaultIfNotSupplied()
+    void portShouldUseDefaultIfNotSupplied()
     {
         assertThat( new BoltServerAddress( "localhost" ).port(), equalTo( BoltServerAddress.DEFAULT_PORT ) );
     }
 
     @Test
-    public void shouldAlwaysResolveAddress()
+    void shouldAlwaysResolveAddress()
     {
         BoltServerAddress boltAddress = new BoltServerAddress( "localhost" );
 
@@ -56,7 +56,7 @@ public class BoltServerAddressTest
     }
 
     @Test
-    public void shouldHaveCorrectToString()
+    void shouldHaveCorrectToString()
     {
         assertEquals( "localhost:4242", new BoltServerAddress( "localhost", 4242 ).toString() );
         assertEquals( "127.0.0.1:8888", new BoltServerAddress( "127.0.0.1", 8888 ).toString() );

--- a/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/packstream/PackStreamTest.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal.packstream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,15 +36,13 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PackStreamTest
 {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     public static Map<String, Object> asMap( Object... keysAndValues )
     {
         Map<String,Object> map = Iterables.newLinkedHashMapWithSize( keysAndValues.length / 2 );
@@ -73,7 +69,7 @@ public class PackStreamTest
         private final WritableByteChannel writable;
         private final PackStream.Packer packer;
 
-        public Machine()
+        Machine()
         {
             this.output = new ByteArrayOutputStream();
             this.writable = Channels.newChannel( this.output );
@@ -90,7 +86,7 @@ public class PackStreamTest
             return output.toByteArray();
         }
 
-        public PackStream.Packer packer()
+        PackStream.Packer packer()
         {
             return packer;
         }
@@ -103,7 +99,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackNull() throws Throwable
+    void testCanPackAndUnpackNull() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -125,7 +121,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackTrue() throws Throwable
+    void testCanPackAndUnpackTrue() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -148,7 +144,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackFalse() throws Throwable
+    void testCanPackAndUnpackFalse() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -171,7 +167,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackTinyIntegers() throws Throwable
+    void testCanPackAndUnpackTinyIntegers() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -197,7 +193,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackShortIntegers() throws Throwable
+    void testCanPackAndUnpackShortIntegers() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -225,7 +221,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackPowersOfTwoAsIntegers() throws Throwable
+    void testCanPackAndUnpackPowersOfTwoAsIntegers() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -251,7 +247,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackPowersOfTwoPlusABitAsDoubles() throws Throwable
+    void testCanPackAndUnpackPowersOfTwoPlusABitAsDoubles() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -277,7 +273,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackPowersOfTwoMinusABitAsDoubles() throws Throwable
+    void testCanPackAndUnpackPowersOfTwoMinusABitAsDoubles() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -303,7 +299,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackByteArrays() throws Throwable
+    void testCanPackAndUnpackByteArrays() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -330,7 +326,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackStrings() throws Throwable
+    void testCanPackAndUnpackStrings() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -355,7 +351,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackBytes() throws Throwable
+    void testCanPackAndUnpackBytes() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -375,7 +371,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackString() throws Throwable
+    void testCanPackAndUnpackString() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -395,7 +391,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackSpecialString() throws Throwable
+    void testCanPackAndUnpackSpecialString() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -415,7 +411,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackListOneItemAtATime() throws Throwable
+    void testCanPackAndUnpackListOneItemAtATime() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -440,7 +436,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackListOfString() throws Throwable
+    void testCanPackAndUnpackListOfString() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -462,7 +458,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackListOfSpecialStrings() throws Throwable
+    void testCanPackAndUnpackListOfSpecialStrings() throws Throwable
     {
         assertPackStringLists( 3, "Mjölnir" );
         assertPackStringLists( 126, "Mjölnir" );
@@ -471,7 +467,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackListOfStringOneByOne() throws Throwable
+    void testCanPackAndUnpackListOfStringOneByOne() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -496,7 +492,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackListOfSpecialStringOneByOne() throws Throwable
+    void testCanPackAndUnpackListOfSpecialStringOneByOne() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -521,7 +517,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackMap() throws Throwable
+    void testCanPackAndUnpackMap() throws Throwable
     {
         assertMap( 2 );
         assertMap( 126 );
@@ -530,7 +526,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackStruct() throws Throwable
+    void testCanPackAndUnpackStruct() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -564,19 +560,18 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackStructsOfDifferentSizes() throws Throwable
+    void testCanPackAndUnpackStructsOfDifferentSizes() throws Throwable
     {
         assertStruct( 2 );
         assertStruct( 126 );
         assertStruct( 2439 );
 
         //we cannot have 'too many' fields
-        exception.expect( PackStream.Overflow.class );
-        assertStruct( 65536 );
+        assertThrows( PackStream.Overflow.class, () -> assertStruct( 65536 ) );
     }
 
     @Test
-    public void testCanDoStreamingListUnpacking() throws Throwable
+    void testCanDoStreamingListUnpacking() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -607,7 +602,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanDoStreamingStructUnpacking() throws Throwable
+    void testCanDoStreamingStructUnpacking() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -644,7 +639,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanDoStreamingMapUnpacking() throws Throwable
+    void testCanDoStreamingMapUnpacking() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -675,11 +670,11 @@ public class PackStreamTest
         assertEquals( "Bob", v1 );
         assertEquals( "cat_ages", k2 );
         assertEquals( 4.3, d, 0.0001 );
-        assertEquals( true, e );
+        assertTrue( e );
     }
 
     @Test
-    public void handlesDataCrossingBufferBoundaries() throws Throwable
+    void handlesDataCrossingBufferBoundaries() throws Throwable
     {
         // Given
         Machine machine = new Machine();
@@ -706,7 +701,7 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPeekOnNextType() throws Throwable
+    void testCanPeekOnNextType() throws Throwable
     {
         // When & Then
         assertPeekType( PackType.STRING, "a string" );
@@ -718,22 +713,19 @@ public class PackStreamTest
     }
 
     @Test
-    public void shouldFailForUnknownValue() throws IOException
+    void shouldFailForUnknownValue() throws IOException
     {
         // Given
         Machine machine = new Machine();
         PackStream.Packer packer = machine.packer();
 
         // Expect
-        exception.expect( PackStream.UnPackable.class );
-
-        // When
-        packer.pack( new MyRandomClass() );
+        assertThrows( PackStream.UnPackable.class, () -> packer.pack( new MyRandomClass() ) );
     }
 
     private static class MyRandomClass{}
 
-    void assertPeekType( PackType type, Object value ) throws IOException
+    private void assertPeekType( PackType type, Object value ) throws IOException
     {
         // Given
         Machine machine = new Machine();

--- a/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.retry;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -39,10 +39,10 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -58,98 +58,50 @@ import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class ExponentialBackoffRetryLogicTest
+class ExponentialBackoffRetryLogicTest
 {
     private final ImmediateSchedulingEventExecutor eventExecutor = new ImmediateSchedulingEventExecutor();
 
     @Test
-    public void throwsForIllegalMaxRetryTime()
+    void throwsForIllegalMaxRetryTime()
     {
-        try
-        {
-            newRetryLogic( -100, 1, 1, 1, Clock.SYSTEM );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Max retry time" ) );
-        }
+        IllegalArgumentException error = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( -100, 1, 1, 1, Clock.SYSTEM ) );
+        assertThat( error.getMessage(), containsString( "Max retry time" ) );
     }
 
     @Test
-    public void throwsForIllegalInitialRetryDelay()
+    void throwsForIllegalInitialRetryDelay()
     {
-        try
-        {
-            newRetryLogic( 1, -100, 1, 1, Clock.SYSTEM );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Initial retry delay" ) );
-        }
+        IllegalArgumentException error = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( 1, -100, 1, 1, Clock.SYSTEM ) );
+        assertThat( error.getMessage(), containsString( "Initial retry delay" ) );
     }
 
     @Test
-    public void throwsForIllegalMultiplier()
+    void throwsForIllegalMultiplier()
     {
-        try
-        {
-            newRetryLogic( 1, 1, 0.42, 1, Clock.SYSTEM );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Multiplier" ) );
-        }
+        IllegalArgumentException error = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( 1, 1, 0.42, 1, Clock.SYSTEM ) );
+        assertThat( error.getMessage(), containsString( "Multiplier" ) );
     }
 
     @Test
-    public void throwsForIllegalJitterFactor()
+    void throwsForIllegalJitterFactor()
     {
-        try
-        {
-            newRetryLogic( 1, 1, 1, -0.42, Clock.SYSTEM );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Jitter" ) );
-        }
+        IllegalArgumentException error1 = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( 1, 1, 1, -0.42, Clock.SYSTEM ) );
+        assertThat( error1.getMessage(), containsString( "Jitter" ) );
 
-        try
-        {
-            newRetryLogic( 1, 1, 1, 1.42, Clock.SYSTEM );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Jitter" ) );
-        }
+        IllegalArgumentException error2 = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( 1, 1, 1, 1.42, Clock.SYSTEM ) );
+        assertThat( error2.getMessage(), containsString( "Jitter" ) );
     }
 
     @Test
-    public void throwsForIllegalClock()
+    void throwsForIllegalClock()
     {
-        try
-        {
-            newRetryLogic( 1, 1, 1, 1, null );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-            assertThat( e.getMessage(), containsString( "Clock" ) );
-        }
+        IllegalArgumentException error = assertThrows( IllegalArgumentException.class, () -> newRetryLogic( 1, 1, 1, 1, null ) );
+        assertThat( error.getMessage(), containsString( "Clock" ) );
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToMultiplier() throws Exception
+    void nextDelayCalculatedAccordingToMultiplier() throws Exception
     {
         int retries = 27;
         int initialDelay = 1;
@@ -164,7 +116,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToMultiplierAsync()
+    void nextDelayCalculatedAccordingToMultiplierAsync()
     {
         String result = "The Result";
         int retries = 14;
@@ -182,7 +134,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToJitter() throws Exception
+    void nextDelayCalculatedAccordingToJitter() throws Exception
     {
         int retries = 32;
         double jitterFactor = 0.2;
@@ -201,7 +153,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void nextDelayCalculatedAccordingToJitterAsync()
+    void nextDelayCalculatedAccordingToJitterAsync()
     {
         String result = "The Result";
         int retries = 24;
@@ -222,7 +174,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryWhenMaxRetryTimeExceeded() throws Exception
+    void doesNotRetryWhenMaxRetryTimeExceeded() throws Exception
     {
         long retryStart = Clock.SYSTEM.millis();
         int initialDelay = 100;
@@ -239,15 +191,8 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenThrow( error );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error, e );
 
         verify( clock ).sleep( initialDelay );
         verify( clock ).sleep( initialDelay * multiplier );
@@ -255,7 +200,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotRetryWhenMaxRetryTimeExceededAsync()
+    void doesNotRetryWhenMaxRetryTimeExceededAsync()
     {
         long retryStart = Clock.SYSTEM.millis();
         int initialDelay = 100;
@@ -274,15 +219,8 @@ public class ExponentialBackoffRetryLogicTest
 
         CompletionStage<Object> future = retryLogic.retryAsync( workMock );
 
-        try
-        {
-            await( future );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( future ) );
+        assertEquals( error, e );
 
         List<Long> scheduleDelays = eventExecutor.scheduleDelays();
         assertEquals( 2, scheduleDelays.size() );
@@ -293,7 +231,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void sleepsOnServiceUnavailableException() throws Exception
+    void sleepsOnServiceUnavailableException() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 42, 1, 0, clock );
@@ -309,7 +247,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnServiceUnavailableExceptionAsync()
+    void schedulesRetryOnServiceUnavailableExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -329,7 +267,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void sleepsOnSessionExpiredException() throws Exception
+    void sleepsOnSessionExpiredException() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 4242, 1, 0, clock );
@@ -345,7 +283,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnSessionExpiredExceptionAsync()
+    void schedulesRetryOnSessionExpiredExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -365,7 +303,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void sleepsOnTransientException() throws Exception
+    void sleepsOnTransientException() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 23, 1, 0, clock );
@@ -381,7 +319,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void schedulesRetryOnTransientExceptionAsync()
+    void schedulesRetryOnTransientExceptionAsync()
     {
         String result = "The Result";
         Clock clock = mock( Clock.class );
@@ -401,7 +339,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void throwsWhenUnknownError() throws Exception
+    void throwsWhenUnknownError() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 1, 1, 1, clock );
@@ -410,22 +348,15 @@ public class ExponentialBackoffRetryLogicTest
         IllegalStateException error = new IllegalStateException();
         when( workMock.get() ).thenThrow( error );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         verify( clock, never() ).sleep( anyLong() );
     }
 
     @Test
-    public void doesNotRetryOnUnknownErrorAsync()
+    void doesNotRetryOnUnknownErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -435,22 +366,15 @@ public class ExponentialBackoffRetryLogicTest
         IllegalStateException error = new IllegalStateException();
         when( workMock.get() ).thenReturn( failedFuture( error ) );
 
-        try
-        {
-            await( retryLogic.retryAsync( workMock ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( retryLogic.retryAsync( workMock ) ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         assertEquals( 0, eventExecutor.scheduleDelays().size() );
     }
 
     @Test
-    public void throwsWhenTransactionTerminatedError() throws Exception
+    void throwsWhenTransactionTerminatedError() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 13, 1, 0, clock );
@@ -459,22 +383,15 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error = new TransientException( "Neo.TransientError.Transaction.Terminated", "" );
         when( workMock.get() ).thenThrow( error ).thenReturn( null );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         verify( clock, never() ).sleep( 13 );
     }
 
     @Test
-    public void doesNotRetryOnTransactionTerminatedErrorAsync()
+    void doesNotRetryOnTransactionTerminatedErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -484,22 +401,15 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error = new TransientException( "Neo.TransientError.Transaction.Terminated", "" );
         when( workMock.get() ).thenReturn( failedFuture( error ) );
 
-        try
-        {
-            await( retryLogic.retryAsync( workMock ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( retryLogic.retryAsync( workMock ) ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         assertEquals( 0, eventExecutor.scheduleDelays().size() );
     }
 
     @Test
-    public void throwsWhenTransactionLockClientStoppedError() throws Exception
+    void throwsWhenTransactionLockClientStoppedError() throws Exception
     {
         Clock clock = mock( Clock.class );
         ExponentialBackoffRetryLogic logic = newRetryLogic( 1, 13, 1, 0, clock );
@@ -508,22 +418,15 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error = new TransientException( "Neo.TransientError.Transaction.LockClientStopped", "" );
         when( workMock.get() ).thenThrow( error ).thenReturn( null );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         verify( clock, never() ).sleep( 13 );
     }
 
     @Test
-    public void doesNotRetryOnTransactionLockClientStoppedErrorAsync()
+    void doesNotRetryOnTransactionLockClientStoppedErrorAsync()
     {
         Clock clock = mock( Clock.class );
 
@@ -533,22 +436,15 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error = new TransientException( "Neo.TransientError.Transaction.LockClientStopped", "" );
         when( workMock.get() ).thenReturn( failedFuture( error ) );
 
-        try
-        {
-            await( retryLogic.retryAsync( workMock ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( retryLogic.retryAsync( workMock ) ) );
+        assertEquals( error, e );
 
         verify( workMock ).get();
         assertEquals( 0, eventExecutor.scheduleDelays().size() );
     }
 
     @Test
-    public void throwsWhenSleepInterrupted() throws Exception
+    void throwsWhenSleepInterrupted() throws Exception
     {
         Clock clock = mock( Clock.class );
         doThrow( new InterruptedException() ).when( clock ).sleep( 1 );
@@ -559,12 +455,7 @@ public class ExponentialBackoffRetryLogicTest
 
         try
         {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalStateException.class ) );
+            IllegalStateException e = assertThrows( IllegalStateException.class, () -> logic.retry( workMock ) );
             assertThat( e.getCause(), instanceOf( InterruptedException.class ) );
         }
         finally
@@ -575,7 +466,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void collectsSuppressedErrors() throws Exception
+    void collectsSuppressedErrors() throws Exception
     {
         long maxRetryTime = 20;
         int initialDelay = 15;
@@ -591,20 +482,13 @@ public class ExponentialBackoffRetryLogicTest
         TransientException error4 = transientException();
         when( workMock.get() ).thenThrow( error1, error2, error3, error4 ).thenReturn( null );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error4, e );
-            Throwable[] suppressed = e.getSuppressed();
-            assertEquals( 3, suppressed.length );
-            assertEquals( error1, suppressed[0] );
-            assertEquals( error2, suppressed[1] );
-            assertEquals( error3, suppressed[2] );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error4, e );
+        Throwable[] suppressed = e.getSuppressed();
+        assertEquals( 3, suppressed.length );
+        assertEquals( error1, suppressed[0] );
+        assertEquals( error2, suppressed[1] );
+        assertEquals( error3, suppressed[2] );
 
         verify( workMock, times( 4 ) ).get();
 
@@ -615,7 +499,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void collectsSuppressedErrorsAsync()
+    void collectsSuppressedErrorsAsync()
     {
         String result = "The Result";
         long maxRetryTime = 20;
@@ -638,20 +522,13 @@ public class ExponentialBackoffRetryLogicTest
                 .thenReturn( failedFuture( error4 ) )
                 .thenReturn( completedFuture( result ) );
 
-        try
-        {
-            await( retryLogic.retryAsync( workMock ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error4, e );
-            Throwable[] suppressed = e.getSuppressed();
-            assertEquals( 3, suppressed.length );
-            assertEquals( error1, suppressed[0] );
-            assertEquals( error2, suppressed[1] );
-            assertEquals( error3, suppressed[2] );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( retryLogic.retryAsync( workMock ) ) );
+        assertEquals( error4, e );
+        Throwable[] suppressed = e.getSuppressed();
+        assertEquals( 3, suppressed.length );
+        assertEquals( error1, suppressed[0] );
+        assertEquals( error2, suppressed[1] );
+        assertEquals( error3, suppressed[2] );
 
         verify( workMock, times( 4 ) ).get();
 
@@ -663,7 +540,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotCollectSuppressedErrorsWhenSameErrorIsThrown() throws Exception
+    void doesNotCollectSuppressedErrorsWhenSameErrorIsThrown() throws Exception
     {
         long maxRetryTime = 20;
         int initialDelay = 15;
@@ -676,16 +553,9 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenThrow( error );
 
-        try
-        {
-            logic.retry( workMock );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-            assertEquals( 0, e.getSuppressed().length );
-        }
+        Exception e = assertThrows( Exception.class, () -> logic.retry( workMock ) );
+        assertEquals( error, e );
+        assertEquals( 0, e.getSuppressed().length );
 
         verify( workMock, times( 3 ) ).get();
 
@@ -695,7 +565,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void doesNotCollectSuppressedErrorsWhenSameErrorIsThrownAsync()
+    void doesNotCollectSuppressedErrorsWhenSameErrorIsThrownAsync()
     {
         long maxRetryTime = 20;
         int initialDelay = 15;
@@ -709,16 +579,9 @@ public class ExponentialBackoffRetryLogicTest
         SessionExpiredException error = sessionExpired();
         when( workMock.get() ).thenReturn( failedFuture( error ) );
 
-        try
-        {
-            await( retryLogic.retryAsync( workMock ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-            assertEquals( 0, e.getSuppressed().length );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( retryLogic.retryAsync( workMock ) ) );
+        assertEquals( error, e );
+        assertEquals( 0, e.getSuppressed().length );
 
         verify( workMock, times( 3 ) ).get();
 
@@ -729,7 +592,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void eachRetryIsLogged()
+    void eachRetryIsLogged()
     {
         int retries = 9;
         Clock clock = mock( Clock.class );
@@ -748,7 +611,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void eachRetryIsLoggedAsync()
+    void eachRetryIsLoggedAsync()
     {
         String result = "The Result";
         int retries = 9;
@@ -769,7 +632,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void nothingIsLoggedOnFatalFailure()
+    void nothingIsLoggedOnFatalFailure()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
@@ -777,23 +640,17 @@ public class ExponentialBackoffRetryLogicTest
         ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
                 mock( Clock.class ), logging );
 
-        try
-        {
-            logic.retry( () ->
-            {
-                throw new RuntimeException( "Fatal blocking" );
-            } );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( "Fatal blocking", e.getMessage() );
-        }
+        RuntimeException error = assertThrows( RuntimeException.class, () ->
+                logic.retry( () ->
+                {
+                    throw new RuntimeException( "Fatal blocking" );
+                } ) );
+        assertEquals( "Fatal blocking", error.getMessage() );
         verifyZeroInteractions( logger );
     }
 
     @Test
-    public void nothingIsLoggedOnFatalFailureAsync()
+    void nothingIsLoggedOnFatalFailureAsync()
     {
         Logging logging = mock( Logging.class );
         Logger logger = mock( Logger.class );
@@ -801,20 +658,15 @@ public class ExponentialBackoffRetryLogicTest
         ExponentialBackoffRetryLogic logic = new ExponentialBackoffRetryLogic( RetrySettings.DEFAULT, eventExecutor,
                 mock( Clock.class ), logging );
 
-        try
-        {
-            await( logic.retryAsync( () -> failedFuture( new RuntimeException( "Fatal async" ) ) ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( "Fatal async", e.getMessage() );
-        }
+        RuntimeException error = assertThrows( RuntimeException.class, () ->
+                await( logic.retryAsync( () -> failedFuture( new RuntimeException( "Fatal async" ) ) ) ) );
+
+        assertEquals( "Fatal async", error.getMessage() );
         verifyZeroInteractions( logger );
     }
 
     @Test
-    public void correctNumberOfRetiesAreLoggedOnFailure()
+    void correctNumberOfRetiesAreLoggedOnFailure()
     {
         Clock clock = mock( Clock.class );
         Logging logging = mock( Logging.class );
@@ -823,34 +675,28 @@ public class ExponentialBackoffRetryLogicTest
         RetrySettings settings = RetrySettings.DEFAULT;
         RetryLogic logic = new ExponentialBackoffRetryLogic( settings, eventExecutor, clock, logging );
 
-        try
-        {
-            logic.retry( new Supplier<Long>()
-            {
-                boolean invoked;
-
-                @Override
-                public Long get()
+        ServiceUnavailableException error = assertThrows( ServiceUnavailableException.class, () ->
+                logic.retry( new Supplier<Long>()
                 {
-                    // work that always fails and moves clock forward after the first failure
-                    if ( invoked )
+                    boolean invoked;
+
+                    @Override
+                    public Long get()
                     {
-                        // move clock forward to stop retries
-                        when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                        // work that always fails and moves clock forward after the first failure
+                        if ( invoked )
+                        {
+                            // move clock forward to stop retries
+                            when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                        }
+                        else
+                        {
+                            invoked = true;
+                        }
+                        throw new ServiceUnavailableException( "Error" );
                     }
-                    else
-                    {
-                        invoked = true;
-                    }
-                    throw new ServiceUnavailableException( "Error" );
-                }
-            } );
-            fail( "Exception expected" );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            assertEquals( "Error", e.getMessage() );
-        }
+                } ) );
+        assertEquals( "Error", error.getMessage() );
         verify( logger ).warn(
                 startsWith( "Transaction failed and will be retried" ),
                 any( ServiceUnavailableException.class )
@@ -858,7 +704,7 @@ public class ExponentialBackoffRetryLogicTest
     }
 
     @Test
-    public void correctNumberOfRetiesAreLoggedOnFailureAsync()
+    void correctNumberOfRetiesAreLoggedOnFailureAsync()
     {
         Clock clock = mock( Clock.class );
         Logging logging = mock( Logging.class );
@@ -867,34 +713,28 @@ public class ExponentialBackoffRetryLogicTest
         RetrySettings settings = RetrySettings.DEFAULT;
         RetryLogic logic = new ExponentialBackoffRetryLogic( settings, eventExecutor, clock, logging );
 
-        try
-        {
-            await( logic.retryAsync( new Supplier<CompletionStage<Void>>()
-            {
-                volatile boolean invoked;
-
-                @Override
-                public CompletionStage<Void> get()
+        SessionExpiredException error = assertThrows( SessionExpiredException.class, () ->
+                await( logic.retryAsync( new Supplier<CompletionStage<Void>>()
                 {
-                    // work that always returns failed future and moves clock forward after the first failure
-                    if ( invoked )
+                    volatile boolean invoked;
+
+                    @Override
+                    public CompletionStage<Void> get()
                     {
-                        // move clock forward to stop retries
-                        when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                        // work that always returns failed future and moves clock forward after the first failure
+                        if ( invoked )
+                        {
+                            // move clock forward to stop retries
+                            when( clock.millis() ).thenReturn( settings.maxRetryTimeMs() + 42 );
+                        }
+                        else
+                        {
+                            invoked = true;
+                        }
+                        return failedFuture( new SessionExpiredException( "Session no longer valid" ) );
                     }
-                    else
-                    {
-                        invoked = true;
-                    }
-                    return failedFuture( new SessionExpiredException( "Session no longer valid" ) );
-                }
-            } ) );
-            fail( "Exception expected" );
-        }
-        catch ( SessionExpiredException e )
-        {
-            assertEquals( "Session no longer valid", e.getMessage() );
-        }
+                } ) ) );
+        assertEquals( "Session no longer valid", error.getMessage() );
         verify( logger ).warn(
                 startsWith( "Async transaction failed and is scheduled to retry" ),
                 any( SessionExpiredException.class )

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalInputPositionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalInputPositionTest.java
@@ -18,15 +18,15 @@
  */
 package org.neo4j.driver.internal.summary;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class InternalInputPositionTest
+class InternalInputPositionTest
 {
     @Test
-    public void shouldBehaveAsExpected()
+    void shouldBehaveAsExpected()
     {
         // GIVEN, WHEN
         InternalInputPosition position = new InternalInputPosition( 0, 2, 1 );

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalNotificationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalNotificationTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.summary;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,18 +26,18 @@ import java.util.Map;
 import org.neo4j.driver.internal.value.IntegerValue;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.InputPosition;
 import org.neo4j.driver.v1.summary.Notification;
-import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 
-public class InternalNotificationTest
+class InternalNotificationTest
 {
     @Test
-    public void shouldHandleNotificationWithPosition()
+    void shouldHandleNotificationWithPosition()
     {
         // GIVEN
         Map<String,Value> map = new HashMap<>();
@@ -67,7 +67,7 @@ public class InternalNotificationTest
     }
 
     @Test
-    public void shouldHandleNotificationWithoutPosition()
+    void shouldHandleNotificationWithoutPosition()
     {
         // GIVEN
         Map<String,Value> map = new HashMap<>();

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalPlanTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalPlanTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.summary;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,17 +27,16 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.Plan;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.neo4j.driver.v1.Values.ofValue;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.Values.value;
-import static org.neo4j.driver.v1.Values.ofValue;
 import static org.neo4j.driver.v1.Values.values;
 
-@SuppressWarnings("unchecked")
-public class InternalPlanTest
+class InternalPlanTest
 {
     @Test
-    public void shouldConvertFromEmptyMapValue()
+    void shouldConvertFromEmptyMapValue()
     {
         // Given
         Value value = value( parameters( "operatorType", "X" ) );
@@ -48,12 +47,12 @@ public class InternalPlanTest
         // Then
         assertThat( plan.operatorType(), equalTo( "X") );
         assertThat( plan.arguments(), equalTo( parameters().asMap( ofValue()) ) );
-        assertThat( plan.identifiers(), equalTo( Collections.<String>emptyList() ) );
-        assertThat( (List<Plan>) plan.children(), equalTo( Collections.<Plan>emptyList() ) );
+        assertThat( plan.identifiers(), equalTo( Collections.emptyList() ) );
+        assertThat( plan.children(), equalTo( Collections.emptyList() ) );
     }
 
     @Test
-    public void shouldConvertFromSimpleMapValue()
+    void shouldConvertFromSimpleMapValue()
     {
         // Given
         Value value = value( parameters(
@@ -69,12 +68,12 @@ public class InternalPlanTest
         // Then
         assertThat( plan.operatorType(), equalTo( "X") );
         assertThat( plan.arguments(), equalTo( parameters( "a", 1 ).asMap( ofValue()) ) );
-        assertThat( plan.identifiers(), equalTo( Collections.<String>emptyList() ) );
-        assertThat( (List<Plan>) plan.children(), equalTo( Collections.<Plan>emptyList() ) );
+        assertThat( plan.identifiers(), equalTo( Collections.emptyList() ) );
+        assertThat( plan.children(), equalTo( Collections.emptyList() ) );
     }
 
     @Test
-    public void shouldConvertFromNestedMapValue()
+    void shouldConvertFromNestedMapValue()
     {
         // Given
         Value value = value( parameters(
@@ -94,7 +93,7 @@ public class InternalPlanTest
         // Then
         assertThat( plan.operatorType(), equalTo( "X") );
         assertThat( plan.arguments(), equalTo( parameters( "a", 1 ).asMap( ofValue() ) ) );
-        assertThat( plan.identifiers(), equalTo( Collections.<String>emptyList() ) );
+        assertThat( plan.identifiers(), equalTo( Collections.emptyList() ) );
         List<? extends Plan> children = plan.children();
         assertThat( children.size(), equalTo( 1 ) );
         assertThat( children.get( 0 ).operatorType(), equalTo( "Y" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalProfiledPlanTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalProfiledPlanTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.summary;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,21 +27,20 @@ import org.neo4j.driver.internal.value.IntegerValue;
 import org.neo4j.driver.internal.value.ListValue;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.internal.value.StringValue;
-import org.neo4j.driver.v1.summary.ProfiledPlan;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.summary.ProfiledPlan;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 
-public class InternalProfiledPlanTest
+class InternalProfiledPlanTest
 {
 
     @Test
-    public void shouldHandlePlanWithNoChildren()
+    void shouldHandlePlanWithNoChildren()
     {
         // GIVEN
         Value value = new MapValue( createPlanMap() );
@@ -59,7 +58,7 @@ public class InternalProfiledPlanTest
     }
 
     @Test
-    public void shouldHandlePlanWithChildren()
+    void shouldHandlePlanWithChildren()
     {
         // GIVEN
         Map<String,Value> planMap = createPlanMap();

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -32,18 +32,18 @@ import org.neo4j.driver.v1.exceptions.TransientException;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.ErrorUtil.isFatal;
 import static org.neo4j.driver.internal.util.ErrorUtil.newConnectionTerminatedError;
 import static org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError;
 
-public class ErrorUtilTest
+class ErrorUtilTest
 {
     @Test
-    public void shouldCreateAuthenticationException()
+    void shouldCreateAuthenticationException()
     {
         String code = "Neo.ClientError.Security.Unauthorized";
         String message = "Wrong credentials";
@@ -56,7 +56,7 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldCreateClientException()
+    void shouldCreateClientException()
     {
         String code = "Neo.ClientError.Transaction.InvalidBookmark";
         String message = "Wrong bookmark";
@@ -69,7 +69,7 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldCreateTransientException()
+    void shouldCreateTransientException()
     {
         String code = "Neo.TransientError.Transaction.DeadlockDetected";
         String message = "Deadlock occurred";
@@ -82,7 +82,7 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldCreateDatabaseException()
+    void shouldCreateDatabaseException()
     {
         String code = "Neo.DatabaseError.Transaction.TransactionLogError";
         String message = "Failed to write the transaction log";
@@ -95,7 +95,7 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldCreateDatabaseExceptionWhenErrorCodeIsWrong()
+    void shouldCreateDatabaseExceptionWhenErrorCodeIsWrong()
     {
         String code = "WrongErrorCode";
         String message = "Some really strange error";
@@ -108,13 +108,13 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldTreatNotNeo4jExceptionAsFatal()
+    void shouldTreatNotNeo4jExceptionAsFatal()
     {
         assertTrue( isFatal( new IOException( "IO failed!" ) ) );
     }
 
     @Test
-    public void shouldTreatProtocolErrorAsFatal()
+    void shouldTreatProtocolErrorAsFatal()
     {
         assertTrue( isFatal( new ClientException( "Neo.ClientError.Request.Invalid", "Illegal request" ) ) );
         assertTrue( isFatal( new ClientException( "Neo.ClientError.Request.InvalidFormat", "Wrong format" ) ) );
@@ -122,39 +122,39 @@ public class ErrorUtilTest
     }
 
     @Test
-    public void shouldTreatAuthenticationExceptionAsNonFatal()
+    void shouldTreatAuthenticationExceptionAsNonFatal()
     {
         assertFalse( isFatal( new AuthenticationException( "Neo.ClientError.Security.Unauthorized", "" ) ) );
     }
 
     @Test
-    public void shouldTreatClientExceptionAsNonFatal()
+    void shouldTreatClientExceptionAsNonFatal()
     {
         assertFalse( isFatal( new ClientException( "Neo.ClientError.Transaction.ConstraintsChanged", "" ) ) );
     }
 
     @Test
-    public void shouldTreatDatabaseExceptionAsFatal()
+    void shouldTreatDatabaseExceptionAsFatal()
     {
         assertTrue( isFatal( new ClientException( "Neo.DatabaseError.Schema.ConstraintCreationFailed", "" ) ) );
     }
 
     @Test
-    public void shouldCreateConnectionTerminatedError()
+    void shouldCreateConnectionTerminatedError()
     {
         ServiceUnavailableException error = newConnectionTerminatedError();
         assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
     }
 
     @Test
-    public void shouldCreateConnectionTerminatedErrorWithNullReason()
+    void shouldCreateConnectionTerminatedErrorWithNullReason()
     {
         ServiceUnavailableException error = newConnectionTerminatedError( null );
         assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
     }
 
     @Test
-    public void shouldCreateConnectionTerminatedErrorWithReason()
+    void shouldCreateConnectionTerminatedErrorWithReason()
     {
         String reason = "Thread interrupted";
         ServiceUnavailableException error = newConnectionTerminatedError( reason );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
@@ -24,7 +24,7 @@ import io.netty.util.concurrent.FailedFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.SucceededFuture;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
@@ -37,21 +37,21 @@ import java.util.concurrent.Executors;
 import org.neo4j.driver.internal.async.EventLoopGroupFactory;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.Matchers.blockingOperationInEventLoopError;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 import static org.neo4j.driver.v1.util.TestUtil.sleep;
 
-public class FuturesTest
+class FuturesTest
 {
     @Test
-    public void shouldConvertCanceledNettyFutureToCompletionStage() throws Exception
+    void shouldConvertCanceledNettyFutureToCompletionStage() throws Exception
     {
         DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
         promise.cancel( true );
@@ -60,19 +60,11 @@ public class FuturesTest
 
         assertTrue( future.isCancelled() );
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( CancellationException ignore )
-        {
-            // expected
-        }
+        assertThrows( CancellationException.class, future::get );
     }
 
     @Test
-    public void shouldConvertSucceededNettyFutureToCompletionStage() throws Exception
+    void shouldConvertSucceededNettyFutureToCompletionStage() throws Exception
     {
         SucceededFuture<String> nettyFuture = new SucceededFuture<>( ImmediateEventExecutor.INSTANCE, "Hello" );
 
@@ -84,7 +76,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldConvertFailedNettyFutureToCompletionStage() throws Exception
+    void shouldConvertFailedNettyFutureToCompletionStage() throws Exception
     {
         RuntimeException error = new RuntimeException( "Hello" );
         FailedFuture<Object> nettyFuture = new FailedFuture<>( ImmediateEventExecutor.INSTANCE, error );
@@ -92,19 +84,12 @@ public class FuturesTest
         CompletableFuture<Object> future = Futures.asCompletionStage( nettyFuture ).toCompletableFuture();
 
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            assertEquals( error, e.getCause() );
-        }
+        ExecutionException e = assertThrows( ExecutionException.class, future::get );
+        assertEquals( error, e.getCause() );
     }
 
     @Test
-    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureCanceled() throws Exception
+    void shouldConvertRunningNettyFutureToCompletionStageWhenFutureCanceled() throws Exception
     {
         DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
 
@@ -115,19 +100,11 @@ public class FuturesTest
 
         assertTrue( future.isCancelled() );
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( CancellationException ignore )
-        {
-            // expected
-        }
+        assertThrows( CancellationException.class, future::get );
     }
 
     @Test
-    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureSucceeded() throws Exception
+    void shouldConvertRunningNettyFutureToCompletionStageWhenFutureSucceeded() throws Exception
     {
         DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
 
@@ -142,7 +119,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldConvertRunningNettyFutureToCompletionStageWhenFutureFailed() throws Exception
+    void shouldConvertRunningNettyFutureToCompletionStageWhenFutureFailed() throws Exception
     {
         RuntimeException error = new RuntimeException( "Hello" );
         DefaultPromise<String> promise = new DefaultPromise<>( ImmediateEventExecutor.INSTANCE );
@@ -153,53 +130,32 @@ public class FuturesTest
         promise.setFailure( error );
 
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            assertEquals( error, e.getCause() );
-        }
+        ExecutionException e = assertThrows( ExecutionException.class, future::get );
+        assertEquals( error, e.getCause() );
     }
 
     @Test
-    public void shouldCreateFailedFutureWithUncheckedException() throws Exception
+    void shouldCreateFailedFutureWithUncheckedException() throws Exception
     {
         RuntimeException error = new RuntimeException( "Hello" );
         CompletableFuture<Object> future = Futures.failedFuture( error ).toCompletableFuture();
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            assertEquals( error, e.getCause() );
-        }
+        ExecutionException e = assertThrows( ExecutionException.class, future::get );
+        assertEquals( error, e.getCause() );
     }
 
     @Test
-    public void shouldCreateFailedFutureWithCheckedException() throws Exception
+    void shouldCreateFailedFutureWithCheckedException() throws Exception
     {
         IOException error = new IOException( "Hello" );
         CompletableFuture<Object> future = Futures.failedFuture( error ).toCompletableFuture();
         assertTrue( future.isCompletedExceptionally() );
-        try
-        {
-            future.get();
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            assertEquals( error, e.getCause() );
-        }
+        ExecutionException e = assertThrows( ExecutionException.class, future::get );
+        assertEquals( error, e.getCause() );
     }
 
     @Test
-    public void shouldFailBlockingGetInEventLoopThread() throws Exception
+    void shouldFailBlockingGetInEventLoopThread() throws Exception
     {
         EventLoopGroup eventExecutor = EventLoopGroupFactory.newEventLoopGroup( 1 );
         try
@@ -207,15 +163,8 @@ public class FuturesTest
             CompletableFuture<String> future = new CompletableFuture<>();
             Future<String> result = eventExecutor.submit( () -> Futures.blockingGet( future ) );
 
-            try
-            {
-                result.get();
-                fail( "Exception expected" );
-            }
-            catch ( ExecutionException e )
-            {
-                assertThat( e.getCause(), is( blockingOperationInEventLoopError() ) );
-            }
+            ExecutionException e = assertThrows( ExecutionException.class, result::get );
+            assertThat( e.getCause(), is( blockingOperationInEventLoopError() ) );
         }
         finally
         {
@@ -224,45 +173,31 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldThrowInBlockingGetWhenFutureThrowsUncheckedException()
+    void shouldThrowInBlockingGetWhenFutureThrowsUncheckedException()
     {
         RuntimeException error = new RuntimeException( "Hello" );
 
         CompletableFuture<String> future = new CompletableFuture<>();
         future.completeExceptionally( error );
 
-        try
-        {
-            Futures.blockingGet( future );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> Futures.blockingGet( future ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldThrowInBlockingGetWhenFutureThrowsCheckedException()
+    void shouldThrowInBlockingGetWhenFutureThrowsCheckedException()
     {
         IOException error = new IOException( "Hello" );
 
         CompletableFuture<String> future = new CompletableFuture<>();
         future.completeExceptionally( error );
 
-        try
-        {
-            Futures.blockingGet( future );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () -> Futures.blockingGet( future ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldReturnFromBlockingGetWhenFutureCompletes()
+    void shouldReturnFromBlockingGetWhenFutureCompletes()
     {
         CompletableFuture<String> future = new CompletableFuture<>();
         future.complete( "Hello" );
@@ -271,7 +206,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldWaitForFutureInBlockingGetEvenWhenInterrupted()
+    void shouldWaitForFutureInBlockingGetEvenWhenInterrupted()
     {
         ExecutorService executor = Executors.newSingleThreadExecutor( daemon( "InterruptThread" ) );
         try
@@ -296,7 +231,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldHandleInterruptsInBlockingGet()
+    void shouldHandleInterruptsInBlockingGet()
     {
         try
         {
@@ -314,7 +249,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldGetNowWhenFutureDone()
+    void shouldGetNowWhenFutureDone()
     {
         CompletableFuture<String> future = new CompletableFuture<>();
         future.complete( "Hello" );
@@ -323,7 +258,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldGetNowWhenFutureNotDone()
+    void shouldGetNowWhenFutureNotDone()
     {
         CompletableFuture<String> future = new CompletableFuture<>();
 
@@ -331,7 +266,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldGetCauseFromCompletionException()
+    void shouldGetCauseFromCompletionException()
     {
         RuntimeException error = new RuntimeException( "Hello" );
         CompletionException completionException = new CompletionException( error );
@@ -340,7 +275,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldReturnSameExceptionWhenItIsNotCompletionException()
+    void shouldReturnSameExceptionWhenItIsNotCompletionException()
     {
         RuntimeException error = new RuntimeException( "Hello" );
 
@@ -348,7 +283,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldWrapWithCompletionException()
+    void shouldWrapWithCompletionException()
     {
         RuntimeException error = new RuntimeException( "Hello" );
         CompletionException completionException = Futures.asCompletionException( error );
@@ -356,14 +291,14 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldKeepCompletionExceptionAsIs()
+    void shouldKeepCompletionExceptionAsIs()
     {
         CompletionException error = new CompletionException( new RuntimeException( "Hello" ) );
         assertEquals( error, Futures.asCompletionException( error ) );
     }
 
     @Test
-    public void shouldCombineTwoErrors()
+    void shouldCombineTwoErrors()
     {
         RuntimeException error1 = new RuntimeException( "Error1" );
         RuntimeException error2Cause = new RuntimeException( "Error2" );
@@ -376,7 +311,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldCombineErrorAndNull()
+    void shouldCombineErrorAndNull()
     {
         RuntimeException error1 = new RuntimeException( "Error1" );
 
@@ -386,7 +321,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldCombineNullAndError()
+    void shouldCombineNullAndError()
     {
         RuntimeException error2 = new RuntimeException( "Error2" );
 
@@ -396,7 +331,7 @@ public class FuturesTest
     }
 
     @Test
-    public void shouldCombineNullAndNullErrors()
+    void shouldCombineNullAndNullErrors()
     {
         assertNull( Futures.combineErrors( null, null ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/IterablesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/IterablesTest.java
@@ -18,59 +18,45 @@
  */
 package org.neo4j.driver.internal.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Queue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IterablesTest
+class IterablesTest
 {
     @Test
-    public void shouldCreateHashMapWithExpectedSize()
+    void shouldCreateHashMapWithExpectedSize()
     {
         assertNotNull( Iterables.newHashMapWithSize( 42 ) );
     }
 
     @Test
-    public void shouldCreateLinkedHashMapWithExpectedSize()
+    void shouldCreateLinkedHashMapWithExpectedSize()
     {
         assertNotNull( Iterables.newLinkedHashMapWithSize( 42 ) );
     }
 
     @Test
-    public void shouldThrowWhenNegativeHashMapSizeGiven()
+    void shouldThrowWhenNegativeHashMapSizeGiven()
     {
-        try
-        {
-            Iterables.newHashMapWithSize( -42 );
-            fail( "Exception expected" );
-        }
-        catch ( IllegalArgumentException ignore )
-        {
-        }
+        assertThrows( IllegalArgumentException.class, () -> Iterables.newHashMapWithSize( -42 ) );
     }
 
     @Test
-    public void shouldThrowWhenNegativeLinkedHashMapSizeGiven()
+    void shouldThrowWhenNegativeLinkedHashMapSizeGiven()
     {
-        try
-        {
-            Iterables.newLinkedHashMapWithSize( -42 );
-            fail( "Exception expected" );
-        }
-        catch ( IllegalArgumentException ignore )
-        {
-        }
+        assertThrows( IllegalArgumentException.class, () -> Iterables.newLinkedHashMapWithSize( -42 ) );
     }
 
     @Test
-    public void shouldReturnEmptyQueue()
+    void shouldReturnEmptyQueue()
     {
         Queue<Object> queue = Iterables.emptyQueue();
         assertEquals( 0, queue.size() );
@@ -78,27 +64,12 @@ public class IterablesTest
         assertNull( queue.peek() );
         assertNull( queue.poll() );
 
-        try
-        {
-            queue.add( "Hello" );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedOperationException ignore )
-        {
-        }
-
-        try
-        {
-            queue.offer( "World" );
-            fail( "Exception expected" );
-        }
-        catch ( UnsupportedOperationException ignore )
-        {
-        }
+        assertThrows( UnsupportedOperationException.class, () -> queue.add( "Hello" ) );
+        assertThrows( UnsupportedOperationException.class, () -> queue.offer( "World" ) );
     }
 
     @Test
-    public void shouldReturnSameEmptyQueue()
+    void shouldReturnSameEmptyQueue()
     {
         assertSame( Iterables.emptyQueue(), Iterables.emptyQueue() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MetadataUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MetadataUtilTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -38,10 +38,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.summary.InternalSummaryCounters.EMPTY_STATS;
@@ -56,10 +56,10 @@ import static org.neo4j.driver.v1.summary.StatementType.READ_WRITE;
 import static org.neo4j.driver.v1.summary.StatementType.SCHEMA_WRITE;
 import static org.neo4j.driver.v1.summary.StatementType.WRITE_ONLY;
 
-public class MetadataUtilTest
+class MetadataUtilTest
 {
     @Test
-    public void shouldExtractStatementKeys()
+    void shouldExtractStatementKeys()
     {
         List<String> keys = asList( "hello", " ", "world", "!" );
         List<String> extractedKeys = extractStatementKeys( singletonMap( "fields", value( keys ) ) );
@@ -67,14 +67,14 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldExtractEmptyStatementKeysWhenNoneInMetadata()
+    void shouldExtractEmptyStatementKeysWhenNoneInMetadata()
     {
         List<String> extractedKeys = extractStatementKeys( emptyMap() );
         assertEquals( emptyList(), extractedKeys );
     }
 
     @Test
-    public void shouldExtractResultAvailableAfter()
+    void shouldExtractResultAvailableAfter()
     {
         long extractedResultAvailableAfter = extractResultAvailableAfter(
                 singletonMap( "result_available_after", value( 424242 ) ) );
@@ -82,14 +82,14 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldExtractNoResultAvailableAfterWhenNoneInMetadata()
+    void shouldExtractNoResultAvailableAfterWhenNoneInMetadata()
     {
         long extractedResultAvailableAfter = extractResultAvailableAfter( emptyMap() );
         assertEquals( -1, extractedResultAvailableAfter );
     }
 
     @Test
-    public void shouldBuildResultSummaryWithStatement()
+    void shouldBuildResultSummaryWithStatement()
     {
         Statement statement = new Statement( "UNWIND range(10, 100) AS x CREATE (:Node {name: $name, x: x})",
                 singletonMap( "name", "Apa" ) );
@@ -100,7 +100,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithServerInfo()
+    void shouldBuildResultSummaryWithServerInfo()
     {
         Connection connection = connectionMock( new BoltServerAddress( "server:42" ), ServerVersion.v3_2_0 );
 
@@ -111,7 +111,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithStatementType()
+    void shouldBuildResultSummaryWithStatementType()
     {
         assertEquals( READ_ONLY, createWithStatementType( value( "r" ) ).statementType() );
         assertEquals( READ_WRITE, createWithStatementType( value( "rw" ) ).statementType() );
@@ -122,7 +122,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithCounters()
+    void shouldBuildResultSummaryWithCounters()
     {
         Value stats = parameters(
                 "nodes-created", value( 42 ),
@@ -156,14 +156,14 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithoutCounters()
+    void shouldBuildResultSummaryWithoutCounters()
     {
         ResultSummary summary = extractSummary( statement(), connectionMock(), 42, emptyMap() );
         assertEquals( EMPTY_STATS, summary.counters() );
     }
 
     @Test
-    public void shouldBuildResultSummaryWithPlan()
+    void shouldBuildResultSummaryWithPlan()
     {
         Value plan = value( parameters(
                 "operatorType", "Projection",
@@ -197,7 +197,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithoutPlan()
+    void shouldBuildResultSummaryWithoutPlan()
     {
         ResultSummary summary = extractSummary( statement(), connectionMock(), 42, emptyMap() );
         assertFalse( summary.hasPlan() );
@@ -205,7 +205,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithProfiledPlan()
+    void shouldBuildResultSummaryWithProfiledPlan()
     {
         Value profile = value( parameters(
                 "operatorType", "ProduceResult",
@@ -247,7 +247,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithoutProfiledPlan()
+    void shouldBuildResultSummaryWithoutProfiledPlan()
     {
         ResultSummary summary = extractSummary( statement(), connectionMock(), 42, emptyMap() );
         assertFalse( summary.hasProfile() );
@@ -255,7 +255,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithNotifications()
+    void shouldBuildResultSummaryWithNotifications()
     {
         Value notification1 = parameters(
                 "description", "Almost bad thing",
@@ -302,14 +302,14 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithoutNotifications()
+    void shouldBuildResultSummaryWithoutNotifications()
     {
         ResultSummary summary = extractSummary( statement(), connectionMock(), 42, emptyMap() );
         assertEquals( 0, summary.notifications().size() );
     }
 
     @Test
-    public void shouldBuildResultSummaryWithResultAvailableAfter()
+    void shouldBuildResultSummaryWithResultAvailableAfter()
     {
         int value = 42_000;
 
@@ -320,7 +320,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithResultConsumedAfter()
+    void shouldBuildResultSummaryWithResultConsumedAfter()
     {
         int value = 42_000;
         Map<String,Value> metadata = singletonMap( "result_consumed_after", value( value ) );
@@ -332,7 +332,7 @@ public class MetadataUtilTest
     }
 
     @Test
-    public void shouldBuildResultSummaryWithoutResultConsumedAfter()
+    void shouldBuildResultSummaryWithoutResultConsumedAfter()
     {
         ResultSummary summary = extractSummary( statement(), connectionMock(), 42, emptyMap() );
         assertEquals( -1, summary.resultConsumedAfter( TimeUnit.SECONDS ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/BooleanValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/BooleanValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -26,18 +26,18 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.value.BooleanValue.FALSE;
 import static org.neo4j.driver.internal.value.BooleanValue.TRUE;
 
-public class BooleanValueTest
+class BooleanValueTest
 {
-    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
+    private TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 
     @Test
-    public void testBooleanTrue() throws Exception
+    void testBooleanTrue()
     {
         // Given
         BooleanValue value = TRUE;
@@ -49,7 +49,7 @@ public class BooleanValueTest
     }
 
     @Test
-    public void testBooleanFalse() throws Exception
+    void testBooleanFalse()
     {
         // Given
         BooleanValue value = FALSE;
@@ -61,7 +61,7 @@ public class BooleanValueTest
     }
 
     @Test
-    public void testIsBoolean() throws Exception
+    void testIsBoolean()
     {
         // Given
         BooleanValue value = TRUE;
@@ -71,7 +71,7 @@ public class BooleanValueTest
     }
 
     @Test
-    public void testEquals() throws Exception
+    void testEquals()
     {
         // Given
         BooleanValue firstValue = TRUE;
@@ -82,7 +82,7 @@ public class BooleanValueTest
     }
 
     @Test
-    public void testHashCode() throws Exception
+    void testHashCode()
     {
         // Given
         BooleanValue value = TRUE;
@@ -92,21 +92,21 @@ public class BooleanValueTest
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         assertFalse( TRUE.isNull() );
         assertFalse( BooleanValue.FALSE.isNull() );
     }
 
     @Test
-    public void shouldTypeAsBoolean()
+    void shouldTypeAsBoolean()
     {
         assertThat( TRUE.typeConstructor(), equalTo( TypeConstructor.BOOLEAN ) );
         assertThat( BooleanValue.FALSE.typeConstructor(), equalTo( TypeConstructor.BOOLEAN ) );
     }
 
     @Test
-    public void shouldConvertToBooleanAndObject()
+    void shouldConvertToBooleanAndObject()
     {
         assertTrue( TRUE.asBoolean());
         assertFalse( BooleanValue.FALSE.asBoolean());

--- a/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -27,17 +27,17 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class BytesValueTest
+class BytesValueTest
 {
-    public static final byte[] TEST_BYTES = "0123".getBytes();
+    private static final byte[] TEST_BYTES = "0123".getBytes();
 
-    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
+    private TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 
     @Test
-    public void testBytesValue() throws Exception
+    void testBytesValue()
     {
         // Given
         BytesValue value = new BytesValue( TEST_BYTES );
@@ -47,7 +47,7 @@ public class BytesValueTest
     }
 
     @Test
-    public void testIsBytes() throws Exception
+    void testIsBytes()
     {
         // Given
         BytesValue value = new BytesValue( TEST_BYTES );
@@ -57,7 +57,7 @@ public class BytesValueTest
     }
 
     @Test
-    public void testEquals() throws Exception
+    void testEquals()
     {
         // Given
         BytesValue firstValue = new BytesValue( TEST_BYTES );
@@ -68,7 +68,7 @@ public class BytesValueTest
     }
 
     @Test
-    public void testHashCode() throws Exception
+    void testHashCode()
     {
         // Given
         BytesValue value = new BytesValue( TEST_BYTES );
@@ -78,21 +78,21 @@ public class BytesValueTest
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = new BytesValue( TEST_BYTES );
         assertFalse( value.isNull() );
     }
 
     @Test
-    public void shouldTypeAsString()
+    void shouldTypeAsString()
     {
         InternalValue value = new BytesValue( TEST_BYTES );
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.BYTES ) );
     }
 
     @Test
-    public void shouldHaveBytesType()
+    void shouldHaveBytesType()
     {
         InternalValue value = new BytesValue( TEST_BYTES );
         assertThat( value.type(), equalTo( InternalTypeSystem.TYPE_SYSTEM.BYTES() ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -27,13 +27,13 @@ import java.time.ZonedDateTime;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DateTimeValueTest
+class DateTimeValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         ZonedDateTime dateTime = ZonedDateTime.of( 1991, 2, 24, 12, 0, 0, 999_000, ZoneOffset.ofHours( -5 ) );
         DateTimeValue dateTimeValue = new DateTimeValue( dateTime );
@@ -41,7 +41,7 @@ public class DateTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         ZonedDateTime dateTime = ZonedDateTime.of( 2015, 8, 2, 23, 59, 59, 999_999, ZoneId.of( "Europe/Stockholm" ) );
         DateTimeValue dateTimeValue = new DateTimeValue( dateTime );
@@ -49,7 +49,7 @@ public class DateTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsZonedDateTime()
+    void shouldSupportAsZonedDateTime()
     {
         ZonedDateTime dateTime = ZonedDateTime.of( 1822, 9, 24, 9, 23, 57, 123, ZoneOffset.ofHoursMinutes( 12, 15 ) );
         DateTimeValue dateTimeValue = new DateTimeValue( dateTime );
@@ -57,18 +57,11 @@ public class DateTimeValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         ZonedDateTime dateTime = ZonedDateTime.now();
         DateTimeValue dateTimeValue = new DateTimeValue( dateTime );
 
-        try
-        {
-            dateTimeValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, dateTimeValue::asLong );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DateValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DateValueTest.java
@@ -18,20 +18,20 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DateValueTest
+class DateValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         LocalDate localDate = LocalDate.now();
         DateValue dateValue = new DateValue( localDate );
@@ -39,7 +39,7 @@ public class DateValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         LocalDate localDate = LocalDate.now();
         DateValue dateValue = new DateValue( localDate );
@@ -47,7 +47,7 @@ public class DateValueTest
     }
 
     @Test
-    public void shouldSupportAsLocalDate()
+    void shouldSupportAsLocalDate()
     {
         LocalDate localDate = LocalDate.now();
         DateValue dateValue = new DateValue( localDate );
@@ -55,18 +55,11 @@ public class DateValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         LocalDate localDate = LocalDate.now();
         DateValue dateValue = new DateValue( localDate );
 
-        try
-        {
-            dateValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, dateValue::asLong );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DurationValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DurationValueTest.java
@@ -18,20 +18,20 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.InternalIsoDuration;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 import org.neo4j.driver.v1.types.IsoDuration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DurationValueTest
+class DurationValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         IsoDuration duration = newDuration( 1, 2, 3, 4 );
         DurationValue durationValue = new DurationValue( duration );
@@ -39,7 +39,7 @@ public class DurationValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         IsoDuration duration = newDuration( 11, 22, 33, 44 );
         DurationValue durationValue = new DurationValue( duration );
@@ -47,7 +47,7 @@ public class DurationValueTest
     }
 
     @Test
-    public void shouldSupportAsOffsetTime()
+    void shouldSupportAsOffsetTime()
     {
         IsoDuration duration = newDuration( 111, 222, 333, 444 );
         DurationValue durationValue = new DurationValue( duration );
@@ -55,19 +55,12 @@ public class DurationValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         IsoDuration duration = newDuration( 1111, 2222, 3333, 4444 );
         DurationValue durationValue = new DurationValue( duration );
 
-        try
-        {
-            durationValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, durationValue::asLong );
     }
 
     private static IsoDuration newDuration( long months, long days, long seconds, int nanoseconds )

--- a/driver/src/test/java/org/neo4j/driver/internal/value/FloatValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/FloatValueTest.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -30,18 +28,16 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FloatValueTest
+class FloatValueTest
 {
-    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+    private TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 
     @Test
-    public void testZeroFloatValue() throws Exception
+    void testZeroFloatValue()
     {
         // Given
         FloatValue value = new FloatValue( 0 );
@@ -54,7 +50,7 @@ public class FloatValueTest
     }
 
     @Test
-    public void testNonZeroFloatValue() throws Exception
+    void testNonZeroFloatValue()
     {
         // Given
         FloatValue value = new FloatValue( 6.28 );
@@ -64,7 +60,7 @@ public class FloatValueTest
     }
 
     @Test
-    public void testIsFloat() throws Exception
+    void testIsFloat()
     {
         // Given
         FloatValue value = new FloatValue( 6.28 );
@@ -74,7 +70,7 @@ public class FloatValueTest
     }
 
     @Test
-    public void testEquals() throws Exception
+    void testEquals()
     {
         // Given
         FloatValue firstValue = new FloatValue( 6.28 );
@@ -85,7 +81,7 @@ public class FloatValueTest
     }
 
     @Test
-    public void testHashCode() throws Exception
+    void testHashCode()
     {
         // Given
         FloatValue value = new FloatValue( 6.28 );
@@ -95,47 +91,44 @@ public class FloatValueTest
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = new FloatValue( 6.28 );
         assertFalse( value.isNull() );
     }
 
     @Test
-    public void shouldTypeAsFloat()
+    void shouldTypeAsFloat()
     {
         InternalValue value = new FloatValue( 6.28 );
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.FLOAT ) );
     }
 
     @Test
-    public void shouldThrowIfFloatContainsDecimalWhenConverting()
+    void shouldThrowIfFloatContainsDecimalWhenConverting()
     {
         FloatValue value = new FloatValue( 1.1 );
 
-        exception.expect( LossyCoercion.class );
-        value.asInt();
+        assertThrows( LossyCoercion.class, value::asInt );
     }
 
     @Test
-    public void shouldThrowIfLargerThanIntegerMax()
+    void shouldThrowIfLargerThanIntegerMax()
     {
         FloatValue value1 = new FloatValue( Integer.MAX_VALUE );
         FloatValue value2 = new FloatValue( Integer.MAX_VALUE + 1L);
 
         assertThat(value1.asInt(), equalTo(Integer.MAX_VALUE));
-        exception.expect( LossyCoercion.class );
-        value2.asInt();
+        assertThrows( LossyCoercion.class, value2::asInt );
     }
 
     @Test
-    public void shouldThrowIfSmallerThanIntegerMin()
+    void shouldThrowIfSmallerThanIntegerMin()
     {
         FloatValue value1 = new FloatValue( Integer.MIN_VALUE );
         FloatValue value2 = new FloatValue( Integer.MIN_VALUE - 1L );
 
         assertThat(value1.asInt(), equalTo(Integer.MIN_VALUE));
-        exception.expect( LossyCoercion.class );
-        value2.asInt();
+        assertThrows( LossyCoercion.class, value2::asInt );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
@@ -18,9 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -30,18 +28,16 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class IntegerValueTest
+class IntegerValueTest
 {
-    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
+    private TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 
     @Test
-    public void testZeroIntegerValue() throws Exception
+    void testZeroIntegerValue()
     {
         // Given
         IntegerValue value = new IntegerValue( 0 );
@@ -55,7 +51,7 @@ public class IntegerValueTest
     }
 
     @Test
-    public void testNonZeroIntegerValue() throws Exception
+    void testNonZeroIntegerValue()
     {
         // Given
         IntegerValue value = new IntegerValue( 1 );
@@ -69,7 +65,7 @@ public class IntegerValueTest
     }
 
     @Test
-    public void testIsInteger() throws Exception
+    void testIsInteger()
     {
         // Given
         IntegerValue value = new IntegerValue( 1L );
@@ -79,7 +75,7 @@ public class IntegerValueTest
     }
 
     @Test
-    public void testEquals() throws Exception
+    void testEquals()
     {
         // Given
         IntegerValue firstValue = new IntegerValue( 1 );
@@ -90,7 +86,7 @@ public class IntegerValueTest
     }
 
     @Test
-    public void testHashCode() throws Exception
+    void testHashCode()
     {
         // Given
         IntegerValue value = new IntegerValue( 1L );
@@ -100,49 +96,46 @@ public class IntegerValueTest
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = new IntegerValue( 1L );
         assertFalse( value.isNull() );
     }
 
     @Test
-    public void shouldTypeAsInteger()
+    void shouldTypeAsInteger()
     {
         InternalValue value = new IntegerValue( 1L );
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.INTEGER ) );
     }
 
     @Test
-    public void shouldThrowIfLargerThanIntegerMax()
+    void shouldThrowIfLargerThanIntegerMax()
     {
         IntegerValue value1 = new IntegerValue( Integer.MAX_VALUE );
         IntegerValue value2 = new IntegerValue( Integer.MAX_VALUE + 1L);
 
         assertThat(value1.asInt(), equalTo(Integer.MAX_VALUE));
-        exception.expect( LossyCoercion.class );
-        value2.asInt();
+        assertThrows( LossyCoercion.class, value2::asInt );
     }
 
     @Test
-    public void shouldThrowIfSmallerThanIntegerMin()
+    void shouldThrowIfSmallerThanIntegerMin()
     {
         IntegerValue value1 = new IntegerValue( Integer.MIN_VALUE );
         IntegerValue value2 = new IntegerValue( Integer.MIN_VALUE - 1L );
 
         assertThat(value1.asInt(), equalTo(Integer.MIN_VALUE));
-        exception.expect( LossyCoercion.class );
-        value2.asInt();
+        assertThrows( LossyCoercion.class, value2::asInt );
     }
 
     @Test
-    public void shouldThrowIfLargerThan()
+    void shouldThrowIfLargerThan()
     {
         IntegerValue value1 = new IntegerValue( 9007199254740992L);
         IntegerValue value2 = new IntegerValue(9007199254740993L );
 
         assertThat(value1.asDouble(), equalTo(9007199254740992D));
-        exception.expect( LossyCoercion.class );
-        value2.asDouble();
+        assertThrows( LossyCoercion.class, value2::asDouble );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
@@ -18,27 +18,26 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.value;
 
-public class ListValueTest
+class ListValueTest
 {
     @Test
-    public void shouldHaveSensibleToString() throws Throwable
+    void shouldHaveSensibleToString()
     {
         ListValue listValue = listValue( value( 1 ), value( 2 ), value( 3 ) );
         assertThat( listValue.toString(), equalTo( "[1, 2, 3]" ) );
     }
 
     @Test
-    public void shouldHaveCorrectType() throws Throwable
+    void shouldHaveCorrectType()
     {
 
         ListValue listValue = listValue();

--- a/driver/src/test/java/org/neo4j/driver/internal/value/LocalDateTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/LocalDateTimeValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -28,13 +28,13 @@ import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 import static java.time.Month.AUGUST;
 import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LocalDateTimeValueTest
+class LocalDateTimeValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         LocalDateTime dateTime = LocalDateTime.of( 1991, AUGUST, 24, 12, 0, 0 );
         LocalDateTimeValue dateTimeValue = new LocalDateTimeValue( dateTime );
@@ -42,7 +42,7 @@ public class LocalDateTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         LocalDateTime dateTime = LocalDateTime.of( 2015, FEBRUARY, 2, 23, 59, 59, 999_999 );
         LocalDateTimeValue dateTimeValue = new LocalDateTimeValue( dateTime );
@@ -50,7 +50,7 @@ public class LocalDateTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsLocalDateTime()
+    void shouldSupportAsLocalDateTime()
     {
         LocalDateTime dateTime = LocalDateTime.of( 1822, JANUARY, 24, 9, 23, 57, 123 );
         LocalDateTimeValue dateTimeValue = new LocalDateTimeValue( dateTime );
@@ -58,18 +58,11 @@ public class LocalDateTimeValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         LocalDateTime dateTime = LocalDateTime.now();
         LocalDateTimeValue dateTimeValue = new LocalDateTimeValue( dateTime );
 
-        try
-        {
-            dateTimeValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, dateTimeValue::asLong );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/LocalTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/LocalTimeValueTest.java
@@ -18,20 +18,20 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LocalTimeValueTest
+class LocalTimeValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         LocalTime time = LocalTime.of( 23, 59, 59 );
         LocalTimeValue timeValue = new LocalTimeValue( time );
@@ -39,7 +39,7 @@ public class LocalTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         LocalTime time = LocalTime.of( 1, 17, 59, 999 );
         LocalTimeValue timeValue = new LocalTimeValue( time );
@@ -47,7 +47,7 @@ public class LocalTimeValueTest
     }
 
     @Test
-    public void shouldSupportAsLocalTime()
+    void shouldSupportAsLocalTime()
     {
         LocalTime time = LocalTime.of( 12, 59, 12, 999_999_999 );
         LocalTimeValue timeValue = new LocalTimeValue( time );
@@ -55,18 +55,11 @@ public class LocalTimeValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         LocalTime time = LocalTime.now();
         LocalTimeValue timeValue = new LocalTimeValue( time );
 
-        try
-        {
-            timeValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, timeValue::asLong );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/MapValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/MapValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -26,28 +26,28 @@ import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.v1.Values.value;
 
-public class MapValueTest
+class MapValueTest
 {
     @Test
-    public void shouldHaveSensibleToString() throws Throwable
+    void shouldHaveSensibleToString()
     {
         MapValue mapValue = mapValue();
         assertThat( mapValue.toString(), equalTo( "{k1: \"v1\", k2: 42}" ) );
     }
 
     @Test
-    public void shouldHaveCorrectPropertyCount() throws Throwable
+    void shouldHaveCorrectPropertyCount()
     {
         MapValue mapValue = mapValue();
         assertThat( mapValue.size(), equalTo( 2 ) );
     }
 
     @Test
-    public void shouldHaveCorrectType() throws Throwable
+    void shouldHaveCorrectType()
     {
 
         MapValue map = mapValue();
@@ -56,7 +56,7 @@ public class MapValueTest
     }
 
     @Test
-    public void shouldNotBeNull() throws Throwable
+    void shouldNotBeNull()
     {
         MapValue map = mapValue();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NodeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NodeValueTest.java
@@ -18,48 +18,48 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledNodeValue;
 
-public class NodeValueTest
+class NodeValueTest
 {
     @Test
-    public void shouldHaveSensibleToString() throws Throwable
+    void shouldHaveSensibleToString()
     {
         assertEquals( "node<1234>", emptyNodeValue().toString() );
         assertEquals( "node<1234>", filledNodeValue().toString() );
     }
 
     @Test
-    public void shouldHaveCorrectPropertyCount() throws Throwable
+    void shouldHaveCorrectPropertyCount()
     {
         assertEquals( 0, emptyNodeValue().size()) ;
         assertEquals( 1, filledNodeValue().size()) ;
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         assertFalse( emptyNodeValue().isNull() );
     }
 
     @Test
-    public void shouldHaveCorrectType() throws Throwable
+    void shouldHaveCorrectType()
     {
         assertThat( emptyNodeValue().type(), equalTo( InternalTypeSystem.TYPE_SYSTEM.NODE() ));
     }
 
     @Test
-    public void shouldTypeAsNode()
+    void shouldTypeAsNode()
     {
         InternalValue value = emptyNodeValue();
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.NODE ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -34,33 +34,33 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.Values.isoDuration;
 import static org.neo4j.driver.v1.Values.ofValue;
 import static org.neo4j.driver.v1.Values.point;
 
-public class NullValueTest
+class NullValueTest
 {
     @Test
-    public void shouldEqualItself()
+    void shouldEqualItself()
     {
         assertThat( NullValue.NULL, equalTo( NullValue.NULL ) );
     }
 
     @Test
-    public void shouldBeNull()
+    void shouldBeNull()
     {
         assertTrue( NullValue.NULL.isNull() );
     }
 
     @Test
-    public void shouldTypeAsNull()
+    void shouldTypeAsNull()
     {
         assertThat( ((InternalValue) NullValue.NULL).typeConstructor(), equalTo( TypeConstructor.NULL ) );
     }
 
     @Test
-    public void shouldReturnNativeTypesAsDefaultValue() throws Throwable
+    void shouldReturnNativeTypesAsDefaultValue()
     {
         Value value = NullValue.NULL;
         // string
@@ -94,7 +94,7 @@ public class NullValueTest
     }
 
     @Test
-    public void shouldReturnAsNull() throws Throwable
+    void shouldReturnAsNull()
     {
         assertComputeOrDefaultReturnNull( Value::asObject );
         assertComputeOrDefaultReturnNull( Value::asNumber );
@@ -122,7 +122,7 @@ public class NullValueTest
     }
 
     @Test
-    public void shouldReturnAsDefaultValue() throws Throwable
+    void shouldReturnAsDefaultValue()
     {
         assertComputeOrDefaultReturnDefault( Value::asObject, "null string" );
         assertComputeOrDefaultReturnDefault( Value::asNumber, 10 );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/PathValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/PathValueTest.java
@@ -18,37 +18,35 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
 
-public class PathValueTest
+class PathValueTest
 {
     @Test
-    public void shouldHaveSensibleToString() throws Throwable
+    void shouldHaveSensibleToString()
     {
         assertEquals("path[(42)-[43:T]->(44)]", filledPathValue().toString());
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = filledPathValue();
         assertFalse( value.isNull() );
     }
 
-
     @Test
-    public void shouldHaveCorrectType() throws Throwable
+    void shouldHaveCorrectType()
     {
-
         assertThat( filledPathValue().type(), equalTo( InternalTypeSystem.TYPE_SYSTEM.PATH() ));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/RelationshipValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/RelationshipValueTest.java
@@ -18,43 +18,43 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledRelationshipValue;
 
-public class RelationshipValueTest
+class RelationshipValueTest
 {
     @Test
-    public void shouldHaveSensibleToString() throws Throwable
+    void shouldHaveSensibleToString()
     {
         assertEquals( "relationship<1234>", emptyRelationshipValue().toString() );
         assertEquals( "relationship<1234>", filledRelationshipValue().toString() );
     }
 
     @Test
-    public void shouldHaveCorrectPropertyCount() throws Throwable
+    void shouldHaveCorrectPropertyCount()
     {
         assertEquals( 0, emptyRelationshipValue().size()) ;
         assertEquals( 1, filledRelationshipValue().size()) ;
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = emptyRelationshipValue();
         assertFalse( value.isNull() );
     }
 
     @Test
-    public void shouldTypeAsRelationship()
+    void shouldTypeAsRelationship()
     {
         InternalValue value = emptyRelationshipValue();
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.RELATIONSHIP ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -27,15 +27,15 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class StringValueTest
+class StringValueTest
 {
-    TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
+    private TypeSystem typeSystem = InternalTypeSystem.TYPE_SYSTEM;
 
     @Test
-    public void testStringValue() throws Exception
+    void testStringValue()
     {
         // Given
         StringValue value = new StringValue( "Spongebob" );
@@ -45,7 +45,7 @@ public class StringValueTest
     }
 
     @Test
-    public void testIsString() throws Exception
+    void testIsString()
     {
         // Given
         StringValue value = new StringValue( "Spongebob" );
@@ -55,7 +55,7 @@ public class StringValueTest
     }
 
     @Test
-    public void testEquals() throws Exception
+    void testEquals()
     {
         // Given
         StringValue firstValue = new StringValue( "Spongebob" );
@@ -66,7 +66,7 @@ public class StringValueTest
     }
 
     @Test
-    public void testHashCode() throws Exception
+    void testHashCode()
     {
         // Given
         StringValue value = new StringValue( "Spongebob" );
@@ -76,21 +76,21 @@ public class StringValueTest
     }
 
     @Test
-    public void shouldNotBeNull()
+    void shouldNotBeNull()
     {
         Value value = new StringValue( "Spongebob" );
         assertFalse( value.isNull() );
     }
 
     @Test
-    public void shouldTypeAsString()
+    void shouldTypeAsString()
     {
         InternalValue value = new StringValue( "Spongebob" );
         assertThat( value.typeConstructor(), equalTo( TypeConstructor.STRING ) );
     }
 
     @Test
-    public void shouldHaveStringType()
+    void shouldHaveStringType()
     {
         InternalValue value = new StringValue( "Spongebob" );
         assertThat( value.type(), equalTo( InternalTypeSystem.TYPE_SYSTEM.STRING() ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/value/TimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/TimeValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
@@ -26,13 +26,13 @@ import java.time.ZoneOffset;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TimeValueTest
+class TimeValueTest
 {
     @Test
-    public void shouldHaveCorrectType()
+    void shouldHaveCorrectType()
     {
         OffsetTime time = OffsetTime.now().withOffsetSameInstant( ZoneOffset.ofHoursMinutes( 5, 30 ) );
         TimeValue timeValue = new TimeValue( time );
@@ -40,7 +40,7 @@ public class TimeValueTest
     }
 
     @Test
-    public void shouldSupportAsObject()
+    void shouldSupportAsObject()
     {
         OffsetTime time = OffsetTime.of( 19, 0, 10, 1, ZoneOffset.ofHours( -3 ) );
         TimeValue timeValue = new TimeValue( time );
@@ -48,7 +48,7 @@ public class TimeValueTest
     }
 
     @Test
-    public void shouldSupportAsOffsetTime()
+    void shouldSupportAsOffsetTime()
     {
         OffsetTime time = OffsetTime.of( 23, 59, 59, 999_999_999, ZoneOffset.ofHoursMinutes( 2, 15 ) );
         TimeValue timeValue = new TimeValue( time );
@@ -56,18 +56,11 @@ public class TimeValueTest
     }
 
     @Test
-    public void shouldNotSupportAsLong()
+    void shouldNotSupportAsLong()
     {
         OffsetTime time = OffsetTime.now().withOffsetSameInstant( ZoneOffset.ofHours( -5 ) );
         TimeValue timeValue = new TimeValue( time );
 
-        try
-        {
-            timeValue.asLong();
-            fail( "Exception expected" );
-        }
-        catch ( Uncoercible ignore )
-        {
-        }
+        assertThrows( Uncoercible.class, timeValue::asLong );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/AuthTokensTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/AuthTokensTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.v1;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,18 +30,17 @@ import org.neo4j.driver.internal.value.StringValue;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.v1.AuthTokens.basic;
 import static org.neo4j.driver.v1.AuthTokens.custom;
 import static org.neo4j.driver.v1.Values.values;
 
-public class AuthTokensTest
+class AuthTokensTest
 {
-
     @Test
-    public void basicAuthWithoutRealm()
+    void basicAuthWithoutRealm()
     {
         InternalAuthToken basic = (InternalAuthToken) basic( "foo", "bar" );
 
@@ -54,7 +53,7 @@ public class AuthTokensTest
     }
 
     @Test
-    public void basicAuthWithRealm()
+    void basicAuthWithRealm()
     {
         InternalAuthToken basic = (InternalAuthToken) basic( "foo", "bar", "baz" );
 
@@ -68,7 +67,7 @@ public class AuthTokensTest
     }
 
     @Test
-    public void customAuthWithoutParameters()
+    void customAuthWithoutParameters()
     {
         InternalAuthToken basic = (InternalAuthToken) custom( "foo", "bar", "baz", "my_scheme" );
 
@@ -82,7 +81,7 @@ public class AuthTokensTest
     }
 
     @Test
-    public void customAuthParameters()
+    void customAuthParameters()
     {
         HashMap<String,Object> parameters = new HashMap<>();
         parameters.put( "list", asList( 1, 2, 3 ) );
@@ -102,7 +101,7 @@ public class AuthTokensTest
     }
 
     @Test
-    public void basicKerberosAuthWithRealm()
+    void basicKerberosAuthWithRealm()
     {
         InternalAuthToken token = (InternalAuthToken) AuthTokens.kerberos( "base64" );
         Map<String,Value> map = token.toMap();
@@ -114,35 +113,21 @@ public class AuthTokensTest
     }
 
     @Test
-    public void shouldNotAllowBasicAuthTokenWithNullUsername()
+    void shouldNotAllowBasicAuthTokenWithNullUsername()
     {
-        try
-        {
-            AuthTokens.basic( null, "password" );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Username can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.basic( null, "password" ) );
+        assertEquals( "Username can't be null", e.getMessage() );
     }
 
     @Test
-    public void shouldNotAllowBasicAuthTokenWithNullPassword()
+    void shouldNotAllowBasicAuthTokenWithNullPassword()
     {
-        try
-        {
-            AuthTokens.basic( "username", null );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Password can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.basic( "username", null ) );
+        assertEquals( "Password can't be null", e.getMessage() );
     }
 
     @Test
-    public void shouldAllowBasicAuthTokenWithNullRealm()
+    void shouldAllowBasicAuthTokenWithNullRealm()
     {
         AuthToken token = AuthTokens.basic( "username", "password", null );
         Map<String,Value> map = ((InternalAuthToken) token).toMap();
@@ -154,49 +139,28 @@ public class AuthTokensTest
     }
 
     @Test
-    public void shouldNotAllowKerberosAuthTokenWithNullTicket()
+    void shouldNotAllowKerberosAuthTokenWithNullTicket()
     {
-        try
-        {
-            AuthTokens.kerberos( null );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Ticket can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.kerberos( null ) );
+        assertEquals( "Ticket can't be null", e.getMessage() );
     }
 
     @Test
-    public void shouldNotAllowCustomAuthTokenWithNullPrincipal()
+    void shouldNotAllowCustomAuthTokenWithNullPrincipal()
     {
-        try
-        {
-            AuthTokens.custom( null, "credentials", "realm", "scheme" );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Principal can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.custom( null, "credentials", "realm", "scheme" ) );
+        assertEquals( "Principal can't be null", e.getMessage() );
     }
 
     @Test
-    public void shouldNotAllowCustomAuthTokenWithNullCredentials()
+    void shouldNotAllowCustomAuthTokenWithNullCredentials()
     {
-        try
-        {
-            AuthTokens.custom( "principal", null, "realm", "scheme" );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Credentials can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.custom( "principal", null, "realm", "scheme" ) );
+        assertEquals( "Credentials can't be null", e.getMessage() );
     }
 
     @Test
-    public void shouldAllowCustomAuthTokenWithNullRealm()
+    void shouldAllowCustomAuthTokenWithNullRealm()
     {
         AuthToken token = AuthTokens.custom( "principal", "credentials", null, "scheme" );
         Map<String,Value> map = ((InternalAuthToken) token).toMap();
@@ -208,16 +172,9 @@ public class AuthTokensTest
     }
 
     @Test
-    public void shouldNotAllowCustomAuthTokenWithNullScheme()
+    void shouldNotAllowCustomAuthTokenWithNullScheme()
     {
-        try
-        {
-            AuthTokens.custom( "principal", "credentials", "realm", null );
-            fail( "Exception expected" );
-        }
-        catch ( NullPointerException e )
-        {
-            assertEquals( "Scheme can't be null", e.getMessage() );
-        }
+        NullPointerException e = assertThrows( NullPointerException.class, () -> AuthTokens.custom( "principal", "credentials", "realm", null ) );
+        assertEquals( "Scheme can't be null", e.getMessage() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -18,23 +18,21 @@
  */
 package org.neo4j.driver.v1;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConfigTest
+class ConfigTest
 {
     @Test
-    public void shouldDefaultToKnownCerts()
+    void shouldDefaultToKnownCerts()
     {
         // Given
         Config config = Config.defaultConfig();
@@ -48,7 +46,7 @@ public class ConfigTest
 
     @SuppressWarnings( "deprecation" )
     @Test
-    public void shouldChangeToNewKnownCerts()
+    void shouldChangeToNewKnownCerts()
     {
         // Given
         File knownCerts = new File( "new_known_hosts" );
@@ -63,7 +61,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldChangeToTrustedCert()
+    void shouldChangeToTrustedCert()
     {
         // Given
         File trustedCert = new File( "trusted_cert" );
@@ -78,7 +76,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldSupportLivenessCheckTimeoutSetting() throws Throwable
+    void shouldSupportLivenessCheckTimeoutSetting() throws Throwable
     {
         Config config = Config.build().withConnectionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).toConfig();
 
@@ -86,7 +84,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowZeroConnectionLivenessCheckTimeout() throws Throwable
+    void shouldAllowZeroConnectionLivenessCheckTimeout() throws Throwable
     {
         Config config = Config.build().withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS ).toConfig();
 
@@ -94,7 +92,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowNegativeConnectionLivenessCheckTimeout() throws Throwable
+    void shouldAllowNegativeConnectionLivenessCheckTimeout() throws Throwable
     {
         Config config = Config.build().withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS ).toConfig();
 
@@ -102,13 +100,13 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldHaveCorrectMaxConnectionLifetime()
+    void shouldHaveCorrectMaxConnectionLifetime()
     {
         assertEquals( TimeUnit.HOURS.toMillis( 1 ), Config.defaultConfig().maxConnectionLifetimeMillis() );
     }
 
     @Test
-    public void shouldSupportMaxConnectionLifetimeSetting() throws Throwable
+    void shouldSupportMaxConnectionLifetimeSetting() throws Throwable
     {
         Config config = Config.build().withMaxConnectionLifetime( 42, TimeUnit.SECONDS ).toConfig();
 
@@ -116,7 +114,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowZeroConnectionMaxConnectionLifetime() throws Throwable
+    void shouldAllowZeroConnectionMaxConnectionLifetime() throws Throwable
     {
         Config config = Config.build().withMaxConnectionLifetime( 0, TimeUnit.SECONDS ).toConfig();
 
@@ -124,7 +122,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowNegativeConnectionMaxConnectionLifetime() throws Throwable
+    void shouldAllowNegativeConnectionMaxConnectionLifetime() throws Throwable
     {
         Config config = Config.build().withMaxConnectionLifetime( -42, TimeUnit.SECONDS ).toConfig();
 
@@ -132,7 +130,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldTurnOnLeakedSessionsLogging()
+    void shouldTurnOnLeakedSessionsLogging()
     {
         // leaked sessions logging is turned off by default
         assertFalse( Config.build().toConfig().logLeakedSessions() );
@@ -142,76 +140,52 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldHaveDefaultConnectionTimeout()
+    void shouldHaveDefaultConnectionTimeout()
     {
         Config defaultConfig = Config.defaultConfig();
         assertEquals( TimeUnit.SECONDS.toMillis( 5 ), defaultConfig.connectionTimeoutMillis() );
     }
 
     @Test
-    public void shouldRespectConfiguredConnectionTimeout()
+    void shouldRespectConfiguredConnectionTimeout()
     {
         Config config = Config.build().withConnectionTimeout( 42, TimeUnit.HOURS ).toConfig();
         assertEquals( TimeUnit.HOURS.toMillis( 42 ), config.connectionTimeoutMillis() );
     }
 
     @Test
-    public void shouldAllowConnectionTimeoutOfZero()
+    void shouldAllowConnectionTimeoutOfZero()
     {
         Config config = Config.build().withConnectionTimeout( 0, TimeUnit.SECONDS ).toConfig();
         assertEquals( 0, config.connectionTimeoutMillis() );
     }
 
     @Test
-    public void shouldThrowForNegativeConnectionTimeout()
+    void shouldThrowForNegativeConnectionTimeout()
     {
         Config.ConfigBuilder builder = Config.build();
 
-        try
-        {
-            builder.withConnectionTimeout( -42, TimeUnit.SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertThrows( IllegalArgumentException.class, () -> builder.withConnectionTimeout( -42, TimeUnit.SECONDS ) );
     }
 
     @Test
-    public void shouldThrowForTooLargeConnectionTimeout()
+    void shouldThrowForTooLargeConnectionTimeout()
     {
         Config.ConfigBuilder builder = Config.build();
 
-        try
-        {
-            builder.withConnectionTimeout( Long.MAX_VALUE - 42, TimeUnit.SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertThrows( IllegalArgumentException.class, () -> builder.withConnectionTimeout( Long.MAX_VALUE - 42, TimeUnit.SECONDS ) );
     }
 
     @Test
-    public void shouldNotAllowNegativeMaxRetryTimeMs()
+    void shouldNotAllowNegativeMaxRetryTimeMs()
     {
         Config.ConfigBuilder builder = Config.build();
 
-        try
-        {
-            builder.withMaxTransactionRetryTime( -42, TimeUnit.SECONDS );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IllegalArgumentException.class ) );
-        }
+        assertThrows( IllegalArgumentException.class, () -> builder.withMaxTransactionRetryTime( -42, TimeUnit.SECONDS ) );
     }
 
     @Test
-    public void shouldAllowZeroMaxRetryTimeMs()
+    void shouldAllowZeroMaxRetryTimeMs()
     {
         Config config = Config.build().withMaxTransactionRetryTime( 0, TimeUnit.SECONDS ).toConfig();
 
@@ -219,7 +193,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowPositiveRetryAttempts()
+    void shouldAllowPositiveRetryAttempts()
     {
         Config config = Config.build().withMaxTransactionRetryTime( 42, TimeUnit.SECONDS ).toConfig();
 
@@ -227,13 +201,13 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldHaveCorrectDefaultMaxConnectionPoolSize()
+    void shouldHaveCorrectDefaultMaxConnectionPoolSize()
     {
         assertEquals( 100, Config.defaultConfig().maxConnectionPoolSize() );
     }
 
     @Test
-    public void shouldAllowPositiveMaxConnectionPoolSize()
+    void shouldAllowPositiveMaxConnectionPoolSize()
     {
         Config config = Config.build().withMaxConnectionPoolSize( 42 ).toConfig();
 
@@ -241,7 +215,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowNegativeMaxConnectionPoolSize()
+    void shouldAllowNegativeMaxConnectionPoolSize()
     {
         Config config = Config.build().withMaxConnectionPoolSize( -42 ).toConfig();
 
@@ -249,27 +223,20 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldDisallowZeroMaxConnectionPoolSize()
+    void shouldDisallowZeroMaxConnectionPoolSize()
     {
-        try
-        {
-            Config.build().withMaxConnectionPoolSize( 0 ).toConfig();
-            fail( "Exception expected" );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            assertEquals( "Zero value is not supported", e.getMessage() );
-        }
+        IllegalArgumentException e = assertThrows( IllegalArgumentException.class, () -> Config.build().withMaxConnectionPoolSize( 0 ).toConfig() );
+        assertEquals( "Zero value is not supported", e.getMessage() );
     }
 
     @Test
-    public void shouldHaveCorrectDefaultConnectionAcquisitionTimeout()
+    void shouldHaveCorrectDefaultConnectionAcquisitionTimeout()
     {
         assertEquals( TimeUnit.SECONDS.toMillis( 60 ), Config.defaultConfig().connectionAcquisitionTimeoutMillis() );
     }
 
     @Test
-    public void shouldAllowPositiveConnectionAcquisitionTimeout()
+    void shouldAllowPositiveConnectionAcquisitionTimeout()
     {
         Config config = Config.build().withConnectionAcquisitionTimeout( 42, TimeUnit.SECONDS ).toConfig();
 
@@ -277,7 +244,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowNegativeConnectionAcquisitionTimeout()
+    void shouldAllowNegativeConnectionAcquisitionTimeout()
     {
         Config config = Config.build().withConnectionAcquisitionTimeout( -42, TimeUnit.HOURS ).toConfig();
 
@@ -285,7 +252,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldAllowConnectionAcquisitionTimeoutOfZero()
+    void shouldAllowConnectionAcquisitionTimeoutOfZero()
     {
         Config config = Config.build().withConnectionAcquisitionTimeout( 0, TimeUnit.DAYS ).toConfig();
 
@@ -293,7 +260,7 @@ public class ConfigTest
     }
 
     @Test
-    public void shouldEnableAndDisableHostnameVerificationOnTrustStrategy()
+    void shouldEnableAndDisableHostnameVerificationOnTrustStrategy()
     {
         Config.TrustStrategy trustStrategy = Config.TrustStrategy.trustAllCertificates();
         assertFalse( trustStrategy.isHostnameVerificationEnabled() );

--- a/driver/src/test/java/org/neo4j/driver/v1/StatementTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/StatementTest.java
@@ -18,19 +18,19 @@
  */
 package org.neo4j.driver.v1;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class StatementTest
+class StatementTest
 {
     @Test
-    public void shouldConstructStatementWithParameters()
+    void shouldConstructStatementWithParameters()
     {
         // given
         String text = "MATCH (n) RETURN n";
@@ -44,7 +44,7 @@ public class StatementTest
     }
 
     @Test
-    public void shouldConstructStatementWithNoParameters()
+    void shouldConstructStatementWithNoParameters()
     {
         // given
         String text = "MATCH (n) RETURN n";
@@ -58,7 +58,7 @@ public class StatementTest
     }
 
     @Test
-    public void shouldUpdateStatementText()
+    void shouldUpdateStatementText()
     {
         // when
         Statement statement =
@@ -72,7 +72,7 @@ public class StatementTest
 
 
     @Test
-    public void shouldReplaceStatementParameters()
+    void shouldReplaceStatementParameters()
     {
         // when
         String text = "MATCH (n) RETURN n";
@@ -85,7 +85,7 @@ public class StatementTest
     }
 
     @Test
-    public void shouldReplaceMapParameters()
+    void shouldReplaceMapParameters()
     {
         // when
         String text = "MATCH (n) RETURN n";
@@ -99,7 +99,7 @@ public class StatementTest
     }
 
     @Test
-    public void shouldUpdateStatementParameters()
+    void shouldUpdateStatementParameters()
     {
         // when
         String text = "MATCH (n) RETURN n";

--- a/driver/src/test/java/org/neo4j/driver/v1/types/TypeSystemTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/types/TypeSystemTest.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.v1.types;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,11 +39,11 @@ import org.neo4j.driver.v1.Value;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.internal.types.InternalTypeSystem.TYPE_SYSTEM;
 import static org.neo4j.driver.v1.Values.value;
 
-public class TypeSystemTest
+class TypeSystemTest
 {
     private final InternalNode node = new InternalNode( 42L );
     private final InternalRelationship relationship = new InternalRelationship( 42L, 42L, 43L, "T" );
@@ -61,7 +61,7 @@ public class TypeSystemTest
 
     private InternalTypeSystem typeSystem = TYPE_SYSTEM;
 
-    TypeVerifier newTypeVerifierFor( Type type )
+    private TypeVerifier newTypeVerifierFor( Type type )
     {
         HashSet<Value> allValues = new HashSet<>();
         allValues.add( integerValue );
@@ -78,7 +78,7 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldNameTypeCorrectly()
+    void shouldNameTypeCorrectly()
     {
         assertThat( TYPE_SYSTEM.ANY().name(), is( "ANY" ) );
         assertThat( TYPE_SYSTEM.BOOLEAN().name(), is( "BOOLEAN" ) );
@@ -95,7 +95,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferAnyTypeCorrectly() {
+    void shouldInferAnyTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.ANY() ) )
         {
             verifier.assertIncludes( booleanValue );
@@ -111,7 +112,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferNumberTypeCorrectly() {
+    void shouldInferNumberTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.NUMBER() ) )
         {
             verifier.assertIncludes( integerValue );
@@ -120,7 +122,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferNodesTypeCorrectly() {
+    void shouldInferNodesTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.NODE() ) )
         {
             verifier.assertIncludes( nodeValue );
@@ -128,7 +131,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferRelTypeCorrectly() {
+    void shouldInferRelTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.RELATIONSHIP() ) )
         {
             verifier.assertIncludes( relationshipValue );
@@ -136,7 +140,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferStringTypeCorrectly() {
+    void shouldInferStringTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.STRING() ) )
         {
             verifier.assertIncludes( stringValue );
@@ -144,7 +149,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferMapTypeCorrectly() {
+    void shouldInferMapTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.MAP() ) )
         {
             verifier.assertIncludes( nodeValue );
@@ -154,7 +160,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferPathTypeCorrectly() {
+    void shouldInferPathTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.PATH() ) )
         {
             verifier.assertIncludes( pathValue );
@@ -162,7 +169,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferNullCorrectly() {
+    void shouldInferNullCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.NULL() ) )
         {
             verifier.assertIncludes( nullValue );
@@ -170,7 +178,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferBooleanTypeCorrectly() {
+    void shouldInferBooleanTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.BOOLEAN() ) )
         {
             verifier.assertIncludes( booleanValue );
@@ -178,7 +187,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldIntegerTypeCorrectly() {
+    void shouldIntegerTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.INTEGER() ) )
         {
             verifier.assertIncludes( integerValue );
@@ -186,7 +196,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferFloatTypeCorrectly() {
+    void shouldInferFloatTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( TYPE_SYSTEM.FLOAT() ) )
         {
             verifier.assertIncludes( floatValue );
@@ -194,7 +205,8 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldInferListTypeCorrectly() {
+    void shouldInferListTypeCorrectly()
+    {
         try ( TypeVerifier verifier = newTypeVerifierFor( typeSystem.LIST() ) )
         {
             verifier.assertIncludes( listValue );
@@ -202,7 +214,7 @@ public class TypeSystemTest
     }
 
     @Test
-    public void shouldDetermineTypeCorrectly()
+    void shouldDetermineTypeCorrectly()
     {
         assertThat( integerValue, hasType( TYPE_SYSTEM.INTEGER() ) );
         assertThat( floatValue, hasType( TYPE_SYSTEM.FLOAT() ) );
@@ -227,7 +239,7 @@ public class TypeSystemTest
             this.values = values;
         }
 
-        public void assertIncludes( Value value )
+        void assertIncludes( Value value )
         {
             assertThat( value, hasType( type ) );
             values.remove( value );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/CertificateToolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/CertificateToolTest.java
@@ -32,7 +32,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -57,8 +57,8 @@ import javax.security.auth.x500.X500Principal;
 
 import org.neo4j.driver.internal.util.CertificateTool;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.CertificateTool.saveX509Cert;
 
 public class CertificateToolTest
@@ -69,7 +69,7 @@ public class CertificateToolTest
         Security.addProvider( new BouncyCastleProvider() );
     }
 
-    public static KeyPair generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException
+    private static KeyPair generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException
     {
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA", "BC" );
         keyPairGenerator.initialize( 2048, new SecureRandom() );
@@ -77,7 +77,7 @@ public class CertificateToolTest
         return keyPair;
     }
 
-    public static X509Certificate generateCert( X500Name issuer, X500Name subject, KeyPair issuerKeys, PublicKey
+    private static X509Certificate generateCert( X500Name issuer, X500Name subject, KeyPair issuerKeys, PublicKey
             publicKey )
             throws GeneralSecurityException, IOException, OperatorCreationException
     {
@@ -211,7 +211,7 @@ public class CertificateToolTest
     }
 
     @Test
-    public void shouldLoadMultipleCertsIntoKeyStore() throws Throwable
+    void shouldLoadMultipleCertsIntoKeyStore() throws Throwable
     {
         // Given
         File certFile = File.createTempFile( "3random", ".cer" );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/FileToolsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/FileToolsTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.v1.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,14 +27,14 @@ import java.io.PrintWriter;
 import java.util.Scanner;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class FileToolsTest
+class FileToolsTest
 {
     @Test
-    public void shouldBeAbleToCreateTemporaryDirectory() throws Throwable
+    void shouldBeAbleToCreateTemporaryDirectory() throws Throwable
     {
         // Given
         File dir = FileTools.tmpDir();
@@ -51,7 +51,7 @@ public class FileToolsTest
     }
 
     @Test
-    public void shouldAddPropertyAtBottom() throws IOException
+    void shouldAddPropertyAtBottom() throws IOException
     {
         // Given
         File propertyFile = createPropertyFile();
@@ -77,7 +77,7 @@ public class FileToolsTest
     }
 
     @Test
-    public void shouldResetPropertyAtTheSameLine() throws IOException
+    void shouldResetPropertyAtTheSameLine() throws IOException
     {
         // Given
         File propertyFile = createPropertyFile();


### PR DESCRIPTION
Examples, TCK, integration tests that use database rules and parameterized tests are left untouched.