### PR TITLE
Configurable server address resolver

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/DnsResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/DnsResolver.java
@@ -20,42 +20,40 @@ package org.neo4j.driver.internal.cluster;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.net.ServerAddress;
+import org.neo4j.driver.v1.net.ServerAddressResolver;
 
-public class DnsResolver implements HostNameResolver
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toSet;
+
+public class DnsResolver implements ServerAddressResolver
 {
     private final Logger logger;
 
-    public DnsResolver( Logger logger )
+    public DnsResolver( Logging logging )
     {
-        this.logger = logger;
+        this.logger = logging.getLog( DnsResolver.class.getSimpleName() );
     }
 
     @Override
-    public Set<BoltServerAddress> resolve( BoltServerAddress initialRouter )
+    public Set<ServerAddress> resolve( ServerAddress initialRouter )
     {
-        Set<BoltServerAddress> addresses = new HashSet<>();
         try
         {
-            InetAddress[] ipAddresses = InetAddress.getAllByName( initialRouter.host() );
-
-            for ( InetAddress ipAddress : ipAddresses )
-            {
-                addresses.add( new BoltServerAddress( ipAddress.getHostAddress(), initialRouter.port() ) );
-            }
-
-            return addresses;
+            return Stream.of( InetAddress.getAllByName( initialRouter.host() ) )
+                    .map( address -> new BoltServerAddress( address.getHostAddress(), initialRouter.port() ) )
+                    .collect( toSet() );
         }
         catch ( UnknownHostException e )
         {
-            logger.error( "Failed to resolve URI `" + initialRouter + "` to IPs due to error: " + e.getMessage(), e );
-
-            addresses.add( initialRouter );
-            return addresses;
+            logger.error( "Failed to resolve address `" + initialRouter + "` to IPs due to error: " + e.getMessage(), e );
+            return singleton( initialRouter );
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.net;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+
+/**
+ * Represents a host and port. Host can either be an IP address or a DNS name.
+ * Both IPv4 and IPv6 hosts are supported.
+ */
+public interface ServerAddress
+{
+    /**
+     * Retrieve the host portion of this {@link ServerAddress}.
+     *
+     * @return the host, never {@code null}.
+     */
+    String host();
+
+    /**
+     * Retrieve the port portion of this {@link ServerAddress}.
+     *
+     * @return the port, always in range [0, 65535].
+     */
+    int port();
+
+    /**
+     * Create a new address with the given host and port.
+     *
+     * @param host the host portion. Should not be {@code null}.
+     * @param port the port portion. Should be in range [0, 65535].
+     * @return new server address with the specified host and port.
+     */
+    static ServerAddress of( String host, int port )
+    {
+        return new BoltServerAddress( host, port );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddressResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddressResolver.java
@@ -16,13 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.cluster;
+package org.neo4j.driver.v1.net;
 
 import java.util.Set;
 
-import org.neo4j.driver.internal.BoltServerAddress;
-
-public interface HostNameResolver
+/**
+ * A resolver function used by the routing driver to resolve the initial address used to create the driver.
+ */
+@FunctionalInterface
+public interface ServerAddressResolver
 {
-    Set<BoltServerAddress> resolve( BoltServerAddress initialRouter );
+    /**
+     * Resolve the given address to a set of other addresses.
+     * Exceptions thrown by this method will be logged and driver will continue using the original address.
+     *
+     * @param address the address to resolve.
+     * @return new set of addresses.
+     */
+    Set<ServerAddress> resolve( ServerAddress address );
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/DnsResolverTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/DnsResolverTest.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.v1.Logger;
+import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.net.ServerAddress;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -34,33 +36,33 @@ import static org.mockito.Mockito.verify;
 
 class DnsResolverTest
 {
-    private DnsResolver resolver = new DnsResolver( mock( Logger.class ) );
+    private DnsResolver resolver = new DnsResolver( Logging.none() );
 
     @Test
     void shouldResolveDNSToIPs()
     {
-        Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "google.com", 80 ) );
+        Set<ServerAddress> resolve = resolver.resolve( new BoltServerAddress( "google.com", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
     void shouldResolveLocalhostIPDNSToIPs()
     {
-        Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "127.0.0.1", 80 ) );
+        Set<ServerAddress> resolve = resolver.resolve( new BoltServerAddress( "127.0.0.1", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
     void shouldResolveLocalhostDNSToIPs()
     {
-        Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "localhost", 80 ) );
+        Set<ServerAddress> resolve = resolver.resolve( new BoltServerAddress( "localhost", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
     @Test
     void shouldResolveIPv6LocalhostDNSToIPs()
     {
-        Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "[::1]", 80 ) );
+        Set<ServerAddress> resolve = resolver.resolve( new BoltServerAddress( "[::1]", 80 ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }
 
@@ -68,8 +70,8 @@ class DnsResolverTest
     void shouldExceptionAndGiveDefaultValue()
     {
         Logger logger = mock( Logger.class );
-        DnsResolver resolver = new DnsResolver( logger );
-        Set<BoltServerAddress> resolve = resolver.resolve( new BoltServerAddress( "[/]", 80 ) );
+        DnsResolver resolver = new DnsResolver( name -> logger );
+        Set<ServerAddress> resolve = resolver.resolve( new BoltServerAddress( "[/]", 80 ) );
         verify( logger ).error( any( String.class ), any( UnknownHostException.class ) );
         assertThat( resolve.size(), greaterThanOrEqualTo( 1 ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -23,11 +23,16 @@ import org.junit.jupiter.api.Test;
 import java.net.SocketAddress;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.v1.net.ServerAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.BoltServerAddress.DEFAULT_PORT;
 
 class BoltServerAddressTest
@@ -60,5 +65,54 @@ class BoltServerAddressTest
     {
         assertEquals( "localhost:4242", new BoltServerAddress( "localhost", 4242 ).toString() );
         assertEquals( "127.0.0.1:8888", new BoltServerAddress( "127.0.0.1", 8888 ).toString() );
+    }
+
+    @Test
+    void shouldVerifyHost()
+    {
+        assertThrows( NullPointerException.class, () -> new BoltServerAddress( null, 0 ) );
+    }
+
+    @Test
+    void shouldVerifyPort()
+    {
+        assertThrows( IllegalArgumentException.class, () -> new BoltServerAddress( "localhost", -1 ) );
+        assertThrows( IllegalArgumentException.class, () -> new BoltServerAddress( "localhost", -42 ) );
+        assertThrows( IllegalArgumentException.class, () -> new BoltServerAddress( "localhost", 65_536 ) );
+        assertThrows( IllegalArgumentException.class, () -> new BoltServerAddress( "localhost", 99_999 ) );
+    }
+
+    @Test
+    void shouldCreateBoltServerAddressFromServerAddress()
+    {
+        BoltServerAddress address1 = new BoltServerAddress( "my.server.com", 8899 );
+        assertSame( address1, BoltServerAddress.from( address1 ) );
+
+        BoltServerAddress address2 = new BoltServerAddress( "db.neo4j.com" );
+        assertSame( address2, BoltServerAddress.from( address2 ) );
+
+        ServerAddress address3 = mock( ServerAddress.class );
+        when( address3.host() ).thenReturn( "graph.database.com" );
+        when( address3.port() ).thenReturn( 20600 );
+        assertEquals( new BoltServerAddress( "graph.database.com", 20600 ), BoltServerAddress.from( address3 ) );
+    }
+
+    @Test
+    void shouldFailToCreateBoltServerAddressFromInvalidServerAddress()
+    {
+        ServerAddress address1 = mock( ServerAddress.class );
+        when( address1.host() ).thenReturn( null );
+        when( address1.port() ).thenReturn( 8888 );
+        assertThrows( NullPointerException.class, () -> BoltServerAddress.from( address1 ) );
+
+        ServerAddress address2 = mock( ServerAddress.class );
+        when( address2.host() ).thenReturn( "neo4j.host.com" );
+        when( address2.port() ).thenReturn( -1 );
+        assertThrows( IllegalArgumentException.class, () -> BoltServerAddress.from( address2 ) );
+
+        ServerAddress address3 = mock( ServerAddress.class );
+        when( address3.host() ).thenReturn( "my.database.org" );
+        when( address3.port() ).thenReturn( 99_000 );
+        assertThrows( IllegalArgumentException.class, () -> BoltServerAddress.from( address3 ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -23,11 +23,14 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.driver.v1.net.ServerAddressResolver;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class ConfigTest
 {
@@ -270,5 +273,20 @@ class ConfigTest
 
         assertSame( trustStrategy, trustStrategy.withoutHostnameVerification() );
         assertFalse( trustStrategy.isHostnameVerificationEnabled() );
+    }
+
+    @Test
+    void shouldAllowToConfigureResolver()
+    {
+        ServerAddressResolver resolver = mock( ServerAddressResolver.class );
+        Config config = Config.build().withResolver( resolver ).toConfig();
+
+        assertEquals( resolver, config.resolver() );
+    }
+
+    @Test
+    void shouldNotAllowNullResolver()
+    {
+        assertThrows( NullPointerException.class, () -> Config.build().withResolver( null ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/net/ServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/net/ServerAddressTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.net;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServerAddressTest
+{
+    @Test
+    void shouldCreateAddress()
+    {
+        ServerAddress address = ServerAddress.of( "my.database.com", 8897 );
+        assertEquals( "my.database.com", address.host() );
+        assertEquals( 8897, address.port() );
+    }
+
+    @Test
+    void shouldFailToCreateAddressWithInvalidHost()
+    {
+        assertThrows( NullPointerException.class, () -> ServerAddress.of( null, 9999 ) );
+    }
+
+    @Test
+    void shouldFailToCreateAddressWithInvalidPort()
+    {
+        assertThrows( IllegalArgumentException.class, () -> ServerAddress.of( "hello.graphs.com", -42 ) );
+        assertThrows( IllegalArgumentException.class, () -> ServerAddress.of( "hello.graphs.com", 66_000 ) );
+    }
+}


### PR DESCRIPTION
This PR makes it possible to configure a resolver function used by the routing driver. Such function is used during the initial discovery and when all known routers have failed. Driver already had an internal facility like this which performed a DNS lookup for the hostname of the initial address. This remains the default. Users are now able to provide a custom resolver in the config.