### PR TITLE
Migrate parameterized and integration tests to JUnit 5

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.rauschig</groupId>
       <artifactId>jarchivelib</artifactId>
     </dependency>

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverIT.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
-import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Record;
@@ -42,9 +42,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.util.Matchers.directDriverWithAddress;
+import static org.neo4j.driver.internal.util.Neo4jFeature.CONNECTOR_LISTEN_ADDRESS_CONFIGURATION;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
@@ -79,10 +79,9 @@ class DirectDriverIT
     }
 
     @Test
+    @EnabledOnNeo4jWith( CONNECTOR_LISTEN_ADDRESS_CONFIGURATION )
     void shouldAllowIPv6Address()
     {
-        assumeTrue( supportsListenAddressConfiguration( neo4j ) );
-
         // Given
         URI uri = URI.create( "bolt://[::1]" );
         BoltServerAddress address = new BoltServerAddress( uri );
@@ -183,18 +182,5 @@ class DirectDriverIT
             // Then
             assertThat( result.single().get( 0 ).asInt(), CoreMatchers.equalTo( 1 ) );
         }
-    }
-
-    /**
-     * Check if running test neo4j instance supports {@value org.neo4j.driver.v1.util.Neo4jSettings#LISTEN_ADDR}
-     * configuration option. Only 3.1+ versions support it.
-     *
-     * @param neo4j the test neo4j instance to check.
-     * @return {@code true} if given test neo4j supports config option, {@code false} otherwise.
-     */
-    private static boolean supportsListenAddressConfiguration( DatabaseExtension neo4j )
-    {
-        ServerVersion version = ServerVersion.version( neo4j.driver() );
-        return version.greaterThanOrEqual( ServerVersion.v3_1_0 );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverIT.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -31,6 +32,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.util.DatabaseExtension;
 import org.neo4j.driver.v1.util.StubServer;
@@ -44,6 +46,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.util.Matchers.directDriverWithAddress;
 import static org.neo4j.driver.v1.Values.parameters;
+import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 import static org.neo4j.driver.v1.util.StubServer.INSECURE_CONFIG;
 
 class DirectDriverIT
@@ -164,6 +167,21 @@ class DirectDriverIT
         finally
         {
             assertEquals( 0, server.exitStatus() );
+        }
+    }
+
+    @Test
+    void shouldConnectIPv6Uri()
+    {
+        // Given
+        try ( Driver driver = GraphDatabase.driver( "bolt://[::1]:7687", DEFAULT_AUTH_TOKEN );
+              Session session = driver.session() )
+        {
+            // When
+            StatementResult result = session.run( "RETURN 1" );
+
+            // Then
+            assertThat( result.single().get( 0 ).asInt(), CoreMatchers.equalTo( 1 ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Session;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
@@ -33,11 +33,11 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressParsingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressParsingTest.java
@@ -18,101 +18,93 @@
  */
 package org.neo4j.driver.internal.net;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.internal.BoltServerAddress.DEFAULT_PORT;
 
-@RunWith( Parameterized.class )
-public class BoltServerAddressParsingTest
+class BoltServerAddressParsingTest
 {
-    @Parameter
-    public String address;
-    @Parameter( 1 )
-    public String expectedHost;
-    @Parameter( 2 )
-    public int expectedPort;
-
-    @Parameters( name = "{0}" )
-    public static Object[][] addressesToParse()
+    private static Stream<Arguments> addressesToParse()
     {
-        return new Object[][]{
+        return Stream.of(
                 // Hostname
-                {"localhost", "localhost", DEFAULT_PORT},
-                {"localhost:9193", "localhost", 9193},
-                {"neo4j.com", "neo4j.com", DEFAULT_PORT},
-                {"royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
-                {"royal-server.com.uk:4546", "royal-server.com.uk", 4546},
+                Arguments.of( "localhost", "localhost", DEFAULT_PORT ),
+                Arguments.of( "localhost:9193", "localhost", 9193 ),
+                Arguments.of( "neo4j.com", "neo4j.com", DEFAULT_PORT ),
+                Arguments.of( "royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT ),
+                Arguments.of( "royal-server.com.uk:4546", "royal-server.com.uk", 4546 ),
 
                 // Hostname with scheme
-                {"bolt://localhost", "localhost", DEFAULT_PORT},
-                {"bolt+routing://localhost", "localhost", DEFAULT_PORT},
-                {"bolt://localhost:9193", "localhost", 9193},
-                {"bolt+routing://localhost:9193", "localhost", 9193},
-                {"bolt://neo4j.com", "neo4j.com", DEFAULT_PORT},
-                {"bolt+routing://neo4j.com", "neo4j.com", DEFAULT_PORT},
-                {"bolt://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
-                {"bolt+routing://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT},
-                {"bolt://royal-server.com.uk:4546", "royal-server.com.uk", 4546},
-                {"bolt+routing://royal-server.com.uk:4546", "royal-server.com.uk", 4546},
+                Arguments.of( "bolt://localhost", "localhost", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://localhost", "localhost", DEFAULT_PORT ),
+                Arguments.of( "bolt://localhost:9193", "localhost", 9193 ),
+                Arguments.of( "bolt+routing://localhost:9193", "localhost", 9193 ),
+                Arguments.of( "bolt://neo4j.com", "neo4j.com", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://neo4j.com", "neo4j.com", DEFAULT_PORT ),
+                Arguments.of( "bolt://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://royal-server.com.uk", "royal-server.com.uk", DEFAULT_PORT ),
+                Arguments.of( "bolt://royal-server.com.uk:4546", "royal-server.com.uk", 4546 ),
+                Arguments.of( "bolt+routing://royal-server.com.uk:4546", "royal-server.com.uk", 4546 ),
 
                 // IPv4
-                {"127.0.0.1", "127.0.0.1", DEFAULT_PORT},
-                {"8.8.8.8:8080", "8.8.8.8", 8080},
-                {"0.0.0.0", "0.0.0.0", DEFAULT_PORT},
-                {"192.0.2.235:4329", "192.0.2.235", 4329},
-                {"172.31.255.255:255", "172.31.255.255", 255},
+                Arguments.of( "127.0.0.1", "127.0.0.1", DEFAULT_PORT ),
+                Arguments.of( "8.8.8.8:8080", "8.8.8.8", 8080 ),
+                Arguments.of( "0.0.0.0", "0.0.0.0", DEFAULT_PORT ),
+                Arguments.of( "192.0.2.235:4329", "192.0.2.235", 4329 ),
+                Arguments.of( "172.31.255.255:255", "172.31.255.255", 255 ),
 
                 // IPv4 with scheme
-                {"bolt://198.51.100.0", "198.51.100.0", DEFAULT_PORT},
-                {"bolt://65.21.10.12:5656", "65.21.10.12", 5656},
-                {"bolt+routing://12.0.0.5", "12.0.0.5", DEFAULT_PORT},
-                {"bolt+routing://155.55.20.6:9191", "155.55.20.6", 9191},
+                Arguments.of( "bolt://198.51.100.0", "198.51.100.0", DEFAULT_PORT ),
+                Arguments.of( "bolt://65.21.10.12:5656", "65.21.10.12", 5656 ),
+                Arguments.of( "bolt+routing://12.0.0.5", "12.0.0.5", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://155.55.20.6:9191", "155.55.20.6", 9191 ),
 
                 // IPv6
-                {"::1", "[::1]", DEFAULT_PORT},
-                {"ff02::2:ff00:0", "[ff02::2:ff00:0]", DEFAULT_PORT},
-                {"[1afc:0:a33:85a3::ff2f]", "[1afc:0:a33:85a3::ff2f]", DEFAULT_PORT},
-                {"[::1]:1515", "[::1]", 1515},
-                {"[ff0a::101]:8989", "[ff0a::101]", 8989},
+                Arguments.of( "::1", "[::1]", DEFAULT_PORT ),
+                Arguments.of( "ff02::2:ff00:0", "[ff02::2:ff00:0]", DEFAULT_PORT ),
+                Arguments.of( "[1afc:0:a33:85a3::ff2f]", "[1afc:0:a33:85a3::ff2f]", DEFAULT_PORT ),
+                Arguments.of( "[::1]:1515", "[::1]", 1515 ),
+                Arguments.of( "[ff0a::101]:8989", "[ff0a::101]", 8989 ),
 
                 // IPv6 with scheme
-                {"bolt://[::1]", "[::1]", DEFAULT_PORT},
-                {"bolt+routing://[::1]", "[::1]", DEFAULT_PORT},
-                {"bolt://[ff02::d]", "[ff02::d]", DEFAULT_PORT},
-                {"bolt+routing://[fe80::b279:2f]", "[fe80::b279:2f]", DEFAULT_PORT},
-                {"bolt://[::1]:8687", "[::1]", 8687},
-                {"bolt+routing://[::1]:1212", "[::1]", 1212},
-                {"bolt://[ff02::d]:9090", "[ff02::d]", 9090},
-                {"bolt+routing://[fe80::b279:2f]:7878", "[fe80::b279:2f]", 7878},
+                Arguments.of( "bolt://[::1]", "[::1]", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://[::1]", "[::1]", DEFAULT_PORT ),
+                Arguments.of( "bolt://[ff02::d]", "[ff02::d]", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://[fe80::b279:2f]", "[fe80::b279:2f]", DEFAULT_PORT ),
+                Arguments.of( "bolt://[::1]:8687", "[::1]", 8687 ),
+                Arguments.of( "bolt+routing://[::1]:1212", "[::1]", 1212 ),
+                Arguments.of( "bolt://[ff02::d]:9090", "[ff02::d]", 9090 ),
+                Arguments.of( "bolt+routing://[fe80::b279:2f]:7878", "[fe80::b279:2f]", 7878 ),
 
                 // IPv6 with zone id
-                {"::1%eth0", "[::1%eth0]", DEFAULT_PORT},
-                {"ff02::2:ff00:0%12", "[ff02::2:ff00:0%12]", DEFAULT_PORT},
-                {"[1afc:0:a33:85a3::ff2f%eth1]", "[1afc:0:a33:85a3::ff2f%eth1]", DEFAULT_PORT},
-                {"[::1%eth0]:3030", "[::1%eth0]", 3030},
-                {"[ff0a::101%8]:4040", "[ff0a::101%8]", 4040},
+                Arguments.of( "::1%eth0", "[::1%eth0]", DEFAULT_PORT ),
+                Arguments.of( "ff02::2:ff00:0%12", "[ff02::2:ff00:0%12]", DEFAULT_PORT ),
+                Arguments.of( "[1afc:0:a33:85a3::ff2f%eth1]", "[1afc:0:a33:85a3::ff2f%eth1]", DEFAULT_PORT ),
+                Arguments.of( "[::1%eth0]:3030", "[::1%eth0]", 3030 ),
+                Arguments.of( "[ff0a::101%8]:4040", "[ff0a::101%8]", 4040 ),
 
                 // IPv6 with scheme and zone id
-                {"bolt://[::1%eth5]", "[::1%eth5]", DEFAULT_PORT},
-                {"bolt+routing://[::1%12]", "[::1%12]", DEFAULT_PORT},
-                {"bolt://[ff02::d%3]", "[ff02::d%3]", DEFAULT_PORT},
-                {"bolt+routing://[fe80::b279:2f%eth0]", "[fe80::b279:2f%eth0]", DEFAULT_PORT},
-                {"bolt://[::1%eth3]:8687", "[::1%eth3]", 8687},
-                {"bolt+routing://[::1%2]:1212", "[::1%2]", 1212},
-                {"bolt://[ff02::d%3]:9090", "[ff02::d%3]", 9090},
-                {"bolt+routing://[fe80::b279:2f%eth1]:7878", "[fe80::b279:2f%eth1]", 7878},
-        };
+                Arguments.of( "bolt://[::1%eth5]", "[::1%eth5]", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://[::1%12]", "[::1%12]", DEFAULT_PORT ),
+                Arguments.of( "bolt://[ff02::d%3]", "[ff02::d%3]", DEFAULT_PORT ),
+                Arguments.of( "bolt+routing://[fe80::b279:2f%eth0]", "[fe80::b279:2f%eth0]", DEFAULT_PORT ),
+                Arguments.of( "bolt://[::1%eth3]:8687", "[::1%eth3]", 8687 ),
+                Arguments.of( "bolt+routing://[::1%2]:1212", "[::1%2]", 1212 ),
+                Arguments.of( "bolt://[ff02::d%3]:9090", "[ff02::d%3]", 9090 ),
+                Arguments.of( "bolt+routing://[fe80::b279:2f%eth1]:7878", "[fe80::b279:2f%eth1]", 7878 )
+        );
     }
 
-    @Test
-    public void shouldParseAddress()
+    @ParameterizedTest
+    @MethodSource( "addressesToParse" )
+    void shouldParseAddress( String address, String expectedHost, int expectedPort )
     {
         BoltServerAddress parsed = new BoltServerAddress( address );
         assertEquals( expectedHost, parsed.host() );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DisabledOnNeo4jWith.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DisabledOnNeo4jWith.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target( {ElementType.TYPE, ElementType.METHOD} )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+@ExtendWith( Neo4jWithFeatureCondition.class )
+public @interface DisabledOnNeo4jWith
+{
+    Neo4jFeature value();
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/EnabledOnNeo4jWith.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/EnabledOnNeo4jWith.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target( {ElementType.TYPE, ElementType.METHOD} )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+@ExtendWith( Neo4jWithFeatureCondition.class )
+public @interface EnabledOnNeo4jWith
+{
+    Neo4jFeature value();
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Matchers.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Matchers.java
@@ -38,7 +38,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.STATEMENT_RESULT_TIMINGS;
 
 public final class Matchers
 {
@@ -171,9 +171,8 @@ public final class Matchers
             @Override
             protected boolean matchesSafely( ResultSummary summary )
             {
-                // resultAvailableAfter and resultConsumedAfter are only returned by 3.1.0+ databases
                 ServerVersion serverVersion = ServerVersion.version( summary.server().version() );
-                if ( serverVersion.greaterThanOrEqual( v3_1_0 ) )
+                if ( STATEMENT_RESULT_TIMINGS.availableIn( serverVersion ) )
                 {
                     return summary.resultAvailableAfter( TimeUnit.MILLISECONDS ) >= 0L &&
                            summary.resultConsumedAfter( TimeUnit.MILLISECONDS ) >= 0L;

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.ServerVersion.v3_2_0;
+import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
+
+public enum Neo4jFeature
+{
+    BOOKMARKS( v3_1_0 ),
+    CAUSAL_CLUSTER( v3_1_0 ),
+    SPATIAL_TYPES( v3_4_0 ),
+    TEMPORAL_TYPES( v3_4_0 ),
+    TRANSACTION_TERMINATION_AWARE_LOCKS( v3_1_0 ),
+    BYTE_ARRAYS( v3_2_0 ),
+    READ_ON_FOLLOWERS_BY_DEFAULT( v3_2_0 ),
+    STATEMENT_RESULT_TIMINGS( v3_1_0 ),
+    LIST_QUERIES_PROCEDURE( v3_1_0 ),
+    CONNECTOR_LISTEN_ADDRESS_CONFIGURATION( v3_1_0 );
+
+    private final ServerVersion availableFromVersion;
+
+    Neo4jFeature( ServerVersion availableFromVersion )
+    {
+        this.availableFromVersion = requireNonNull( availableFromVersion );
+    }
+
+    public boolean availableIn( ServerVersion version )
+    {
+        return version.greaterThanOrEqual( availableFromVersion );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.util.Neo4jRunner;
+import org.neo4j.driver.v1.util.Neo4jSettings;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+public class Neo4jWithFeatureCondition implements ExecutionCondition
+{
+    private static final ConditionEvaluationResult ENABLED_NOT_ANNOTATED = enabled( "Neither @EnabledOnNeo4jWith nor @DisabledOnNeo4jWith is present" );
+    private static final ConditionEvaluationResult ENABLED_UNKNOWN_DB_VERSION = enabled( "Shared neo4j is not running, unable to check version" );
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition( ExtensionContext context )
+    {
+        Optional<AnnotatedElement> elementOptional = context.getElement();
+        if ( elementOptional.isPresent() )
+        {
+            AnnotatedElement element = elementOptional.get();
+
+            EnabledOnNeo4jWith enabledAnnotation = element.getAnnotation( EnabledOnNeo4jWith.class );
+            if ( enabledAnnotation != null )
+            {
+                return checkFeatureAvailability( enabledAnnotation.value(), false );
+            }
+
+            DisabledOnNeo4jWith disabledAnnotation = element.getAnnotation( DisabledOnNeo4jWith.class );
+            if ( disabledAnnotation != null )
+            {
+                return checkFeatureAvailability( disabledAnnotation.value(), true );
+            }
+        }
+        return ENABLED_NOT_ANNOTATED;
+    }
+
+    private static ConditionEvaluationResult checkFeatureAvailability( Neo4jFeature feature, boolean negated )
+    {
+        Driver driver = getSharedNeo4jDriver();
+        if ( driver != null )
+        {
+            ServerVersion version = ServerVersion.version( driver );
+            return createResult( version, feature, negated );
+        }
+        return ENABLED_UNKNOWN_DB_VERSION;
+    }
+
+    private static ConditionEvaluationResult createResult( ServerVersion version, Neo4jFeature feature, boolean negated )
+    {
+        if ( feature.availableIn( version ) )
+        {
+            return negated
+                   ? disabled( "Disabled on neo4j " + version + " because it does not support support " + feature )
+                   : enabled( "Enabled on neo4j " + version + " because it supports " + feature );
+        }
+        else
+        {
+            return negated
+                   ? enabled( "Enabled on neo4j " + version + " because it does not support " + feature )
+                   : disabled( "Disabled on neo4j " + version + " because it does not support support " + feature );
+        }
+    }
+
+    private static Driver getSharedNeo4jDriver()
+    {
+        try
+        {
+            Neo4jRunner runner = Neo4jRunner.getOrCreateGlobalRunner();
+            // ensure database is running with default credentials
+            runner.ensureRunning( Neo4jSettings.TEST_SETTINGS );
+            return runner.driver();
+        }
+        catch ( Throwable t )
+        {
+            System.err.println( "Failed to check database version in the test execution condition" );
+            t.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -18,17 +18,17 @@
  */
 package org.neo4j.driver.internal.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ServerVersionTest
+class ServerVersionTest
 {
     @Test
-    public void version() throws Exception
+    void version()
     {
         String nullVersion = null;
         assertThat( ServerVersion.version( nullVersion ), is( ServerVersion.v3_0_0 ) );
@@ -36,15 +36,14 @@ public class ServerVersionTest
         assertThat( ServerVersion.version( "Neo4j/3.2.0" ), is( ServerVersion.v3_2_0 ) );
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void versionShouldThrowExceptionIfServerVersionCantBeParsed() throws Exception
+    @Test
+    void versionShouldThrowExceptionIfServerVersionCantBeParsed()
     {
-        ServerVersion.version( "" );
-        fail( "Should have failed to parse version" );
+        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "" ) );
     }
 
     @Test
-    public void shouldHaveCorrectToString()
+    void shouldHaveCorrectToString()
     {
         assertEquals( "Neo4j/dev", ServerVersion.vInDev.toString() );
         assertEquals( "Neo4j/3.0.0", ServerVersion.v3_0_0.toString() );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
@@ -18,10 +18,9 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashSet;
 
@@ -34,44 +33,40 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.TransientException;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
 import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 
-public class BookmarkIT
+class BookmarkIT
 {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-    @Rule
-    public TestNeo4jSession sessionRule = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension sessionRule = new SessionExtension();
 
     private Driver driver;
     private Session session;
 
-    @Before
-    public void assumeBookmarkSupport()
+    @BeforeEach
+    void assumeBookmarkSupport()
     {
         driver = sessionRule.driver();
         session = sessionRule;
 
         ServerVersion serverVersion = ServerVersion.version( driver );
-        assumeTrue( "Server version `" + serverVersion + "` does not support bookmark",
-                serverVersion.greaterThanOrEqual( v3_1_0 ) );
+        assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ), "Server version `" + serverVersion + "` does not support bookmark" );
     }
 
     @Test
-    public void shouldConnectIPv6Uri()
+    void shouldConnectIPv6Uri()
     {
         // Given
         try(Driver driver =  GraphDatabase.driver( "bolt://[::1]:7687", DEFAULT_AUTH_TOKEN );
@@ -86,7 +81,7 @@ public class BookmarkIT
     }
 
     @Test
-    public void shouldReceiveBookmarkOnSuccessfulCommit() throws Throwable
+    void shouldReceiveBookmarkOnSuccessfulCommit() throws Throwable
     {
         // Given
         assertNull( session.lastBookmark() );
@@ -100,43 +95,28 @@ public class BookmarkIT
     }
 
     @Test
-    public void shouldThrowForInvalidBookmark()
+    void shouldThrowForInvalidBookmark()
     {
         String invalidBookmark = "hi, this is an invalid bookmark";
 
-        try (Session session = driver.session( invalidBookmark )) {
-            try
-            {
-                session.beginTransaction();
-                fail( "Exception expected" );
-            }
-            catch ( Exception e )
-            {
-                assertThat( e, instanceOf( ClientException.class ) );
-            }
+        try ( Session session = driver.session( invalidBookmark ) )
+        {
+            assertThrows( ClientException.class, session::beginTransaction );
         }
     }
 
     @SuppressWarnings( "deprecation" )
     @Test
-    public void shouldThrowForUnreachableBookmark()
+    void shouldThrowForUnreachableBookmark()
     {
         createNodeInTx( session );
 
-        try
-        {
-            session.beginTransaction( session.lastBookmark() + 42 );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( TransientException.class ) );
-            assertThat( e.getMessage(), startsWith( "Database not up to the requested version" ) );
-        }
+        TransientException e = assertThrows( TransientException.class, () -> session.beginTransaction( session.lastBookmark() + 42 ) );
+        assertThat( e.getMessage(), startsWith( "Database not up to the requested version" ) );
     }
 
     @Test
-    public void bookmarkRemainsAfterRolledBackTx()
+    void bookmarkRemainsAfterRolledBackTx()
     {
         assertNull( session.lastBookmark() );
 
@@ -155,7 +135,7 @@ public class BookmarkIT
     }
 
     @Test
-    public void bookmarkRemainsAfterTxFailure()
+    void bookmarkRemainsAfterTxFailure()
     {
         assertNull( session.lastBookmark() );
 
@@ -167,21 +147,13 @@ public class BookmarkIT
         Transaction tx = session.beginTransaction();
         tx.run( "RETURN" );
         tx.success();
-        try
-        {
-            tx.close();
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-        }
 
+        assertThrows( ClientException.class, tx::close );
         assertEquals( bookmark, session.lastBookmark() );
     }
 
     @Test
-    public void bookmarkRemainsAfterSuccessfulSessionRun()
+    void bookmarkRemainsAfterSuccessfulSessionRun()
     {
         assertNull( session.lastBookmark() );
 
@@ -196,7 +168,7 @@ public class BookmarkIT
     }
 
     @Test
-    public void bookmarkRemainsAfterFailedSessionRun()
+    void bookmarkRemainsAfterFailedSessionRun()
     {
         assertNull( session.lastBookmark() );
 
@@ -205,21 +177,12 @@ public class BookmarkIT
         String bookmark = session.lastBookmark();
         assertNotNull( bookmark );
 
-        try
-        {
-            session.run( "RETURN" ).consume();
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-        }
-
+        assertThrows( ClientException.class, () -> session.run( "RETURN" ).consume() );
         assertEquals( bookmark, session.lastBookmark() );
     }
 
     @Test
-    public void bookmarkIsUpdatedOnEveryCommittedTx()
+    void bookmarkIsUpdatedOnEveryCommittedTx()
     {
         assertNull( session.lastBookmark() );
 
@@ -239,7 +202,7 @@ public class BookmarkIT
     }
 
     @Test
-    public void createSessionWithInitialBookmark()
+    void createSessionWithInitialBookmark()
     {
         String bookmark = "TheBookmark";
         try ( Session session = driver.session( bookmark ) )
@@ -249,7 +212,7 @@ public class BookmarkIT
     }
 
     @Test
-    public void createSessionWithAccessModeAndInitialBookmark()
+    void createSessionWithAccessModeAndInitialBookmark()
     {
         String bookmark = "TheBookmark";
         try ( Session session = driver.session( AccessMode.WRITE, bookmark ) )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
@@ -27,16 +27,13 @@ import java.util.HashSet;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.util.SessionExtension;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
-import static org.neo4j.driver.v1.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 
 class BookmarkIT
 {
@@ -63,21 +59,6 @@ class BookmarkIT
 
         ServerVersion serverVersion = ServerVersion.version( driver );
         assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ), "Server version `" + serverVersion + "` does not support bookmark" );
-    }
-
-    @Test
-    void shouldConnectIPv6Uri()
-    {
-        // Given
-        try(Driver driver =  GraphDatabase.driver( "bolt://[::1]:7687", DEFAULT_AUTH_TOKEN );
-            Session session = driver.session() )
-        {
-            // When
-            StatementResult result = session.run( "RETURN 1" );
-
-            // Then
-            assertThat( result.single().get( 0 ).asInt(), equalTo( 1 ) );
-        }
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/BookmarkIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashSet;
 
-import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
@@ -40,9 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOOKMARKS;
 
+@EnabledOnNeo4jWith( BOOKMARKS )
 class BookmarkIT
 {
     @RegisterExtension
@@ -56,9 +56,6 @@ class BookmarkIT
     {
         driver = sessionRule.driver();
         session = sessionRule;
-
-        ServerVersion serverVersion = ServerVersion.version( driver );
-        assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ), "Server version `" + serverVersion + "` does not support bookmark" );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/EntityTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/EntityTypeIT.java
@@ -18,25 +18,25 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class EntityTypeIT
+class EntityTypeIT
 {
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
     @Test
-    public void shouldReturnIdentitiesOfNodes() throws Throwable
+    void shouldReturnIdentitiesOfNodes()
     {
         // When
         StatementResult cursor = session.run( "CREATE (n) RETURN n" );
@@ -47,7 +47,7 @@ public class EntityTypeIT
     }
 
     @Test
-    public void shouldReturnIdentitiesOfRelationships() throws Throwable
+    void shouldReturnIdentitiesOfRelationships()
     {
         // When
         StatementResult cursor = session.run( "CREATE ()-[r:T]->() RETURN r" );
@@ -60,7 +60,7 @@ public class EntityTypeIT
     }
 
     @Test
-    public void shouldReturnIdentitiesOfPaths() throws Throwable
+    void shouldReturnIdentitiesOfPaths()
     {
         // When
         StatementResult cursor = session.run( "CREATE p=()-[r:T]->() RETURN p" );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/LoadCSVIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/LoadCSVIT.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 
@@ -27,21 +27,21 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 import org.neo4j.driver.v1.util.Neo4jSettings;
-import org.neo4j.driver.v1.util.TestNeo4j;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class LoadCSVIT
+class LoadCSVIT
 {
-    @Rule
-    public TestNeo4j neo4j = new TestNeo4j( Neo4jSettings.TEST_SETTINGS.without( Neo4jSettings.IMPORT_DIR ) );
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension( Neo4jSettings.TEST_SETTINGS.without( Neo4jSettings.IMPORT_DIR ) );
 
     @Test
-    public void shouldLoadCSV() throws Throwable
+    void shouldLoadCSV() throws Throwable
     {
         try( Driver driver =  GraphDatabase.driver( neo4j.uri(), neo4j.authToken() );
             Session session = driver.session() )
@@ -76,24 +76,14 @@ public class LoadCSVIT
         return neo4j.putTmpFile( "iris", ".csv", IRIS_DATA ).toExternalForm();
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
-    private static void consume( StatementResult result )
-    {
-        while ( result.hasNext() )
-        {
-            // be happy
-        }
-    }
-
-
-    public static String[] IRIS_CLASS_NAMES =
+    private static String[] IRIS_CLASS_NAMES =
         new String[] {
             "Iris-setosa",
             "Iris-versicolor",
             "Iris-virginica"
         };
 
-    public static String IRIS_DATA =
+    private static String IRIS_DATA =
         "sepal_length,sepal_width,petal_length,petal_width,class_name\n" +
         "5.1,3.5,1.4,0.2,Iris-setosa\n" +
         "4.9,3.0,1.4,0.2,Iris-setosa\n" +

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
@@ -27,7 +27,7 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,13 +36,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LoggingIT
+class LoggingIT
 {
-    @Rule
-    public TestNeo4j neo4j = new TestNeo4j();
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
 
     @Test
-    public void logShouldRecordDebugAndTraceInfo() throws Exception
+    void logShouldRecordDebugAndTraceInfo()
     {
         // Given
         Logging logging = mock( Logging.class );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ParametersIT.java
@@ -18,9 +18,8 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -35,7 +34,7 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.util.Collections.singletonMap;
@@ -44,10 +43,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
@@ -55,18 +55,15 @@ import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
 import static org.neo4j.driver.v1.Values.ofValue;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class ParametersIT
+class ParametersIT
 {
     private static final int LONG_VALUE_SIZE = 1_000_000;
 
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
     @Test
-    public void shouldBeAbleToSetAndReturnBooleanProperty()
+    void shouldBeAbleToSetAndReturnBooleanProperty()
     {
         // When
         StatementResult result = session.run(
@@ -82,7 +79,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnByteProperty()
+    void shouldBeAbleToSetAndReturnByteProperty()
     {
         // When
         StatementResult result = session.run(
@@ -98,7 +95,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnShortProperty()
+    void shouldBeAbleToSetAndReturnShortProperty()
     {
         // When
         StatementResult result = session.run(
@@ -114,7 +111,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnIntegerProperty()
+    void shouldBeAbleToSetAndReturnIntegerProperty()
     {
         // When
         StatementResult result = session.run(
@@ -131,7 +128,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnLongProperty()
+    void shouldBeAbleToSetAndReturnLongProperty()
     {
         // When
         StatementResult result = session.run(
@@ -148,7 +145,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnDoubleProperty()
+    void shouldBeAbleToSetAndReturnDoubleProperty()
     {
         // When
         StatementResult result = session.run(
@@ -164,7 +161,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnBytesProperty()
+    void shouldBeAbleToSetAndReturnBytesProperty()
     {
         assumeTrue( supportsBytes() );
 
@@ -178,7 +175,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldThrowExceptionWhenServerDoesNotSupportBytes()
+    void shouldThrowExceptionWhenServerDoesNotSupportBytes()
     {
         assumeFalse( supportsBytes() );
 
@@ -186,21 +183,16 @@ public class ParametersIT
         byte[] byteArray = "hello, world".getBytes();
 
         // When
-        try
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () ->
         {
-            StatementResult result = session.run(
-                    "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", byteArray ) );
+            StatementResult result = session.run( "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", byteArray ) );
             result.single();
-            fail( "Should not be able to pack bytes" );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            assertThat( e.getCause().getMessage(), containsString( "Packing bytes is not supported" ) );
-        }
+        } );
+        assertThat( e.getCause().getMessage(), containsString( "Packing bytes is not supported" ) );
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnStringProperty()
+    void shouldBeAbleToSetAndReturnStringProperty()
     {
         testStringProperty( "" );
         testStringProperty( "π≈3.14" );
@@ -209,7 +201,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnBooleanArrayProperty()
+    void shouldBeAbleToSetAndReturnBooleanArrayProperty()
     {
         // When
         boolean[] arrayValue = new boolean[]{true, true, true};
@@ -232,7 +224,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnIntegerArrayProperty()
+    void shouldBeAbleToSetAndReturnIntegerArrayProperty()
     {
         // When
         int[] arrayValue = new int[]{42, 42, 42};
@@ -255,7 +247,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnDoubleArrayProperty()
+    void shouldBeAbleToSetAndReturnDoubleArrayProperty()
     {
         // When
         double[] arrayValue = new double[]{6.28, 6.28, 6.28};
@@ -277,7 +269,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnStringArrayProperty()
+    void shouldBeAbleToSetAndReturnStringArrayProperty()
     {
         testStringArrayContaining( "cat" );
         testStringArrayContaining( "Mjölnir" );
@@ -305,7 +297,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldHandleLargeString() throws Throwable
+    void shouldHandleLargeString()
     {
         // Given
         char[] bigStr = new char[1024 * 10];
@@ -327,7 +319,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnBooleanPropertyWithinMap()
+    void shouldBeAbleToSetAndReturnBooleanPropertyWithinMap()
     {
         // When
         StatementResult result = session.run(
@@ -345,7 +337,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnIntegerPropertyWithinMap()
+    void shouldBeAbleToSetAndReturnIntegerPropertyWithinMap()
     {
         // When
         StatementResult result = session.run(
@@ -363,7 +355,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnDoublePropertyWithinMap()
+    void shouldBeAbleToSetAndReturnDoublePropertyWithinMap()
     {
         // When
         StatementResult result = session.run(
@@ -381,7 +373,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldBeAbleToSetAndReturnStringPropertyWithinMap()
+    void shouldBeAbleToSetAndReturnStringPropertyWithinMap()
     {
         // When
         StatementResult result = session.run(
@@ -398,29 +390,21 @@ public class ParametersIT
     }
 
     @Test
-    public void settingInvalidParameterTypeShouldThrowHelpfulError() throws Throwable
+    void settingInvalidParameterTypeShouldThrowHelpfulError()
     {
-        // Expect
-        exception.expect( ClientException.class );
-        exception.expectMessage( "Unable to convert java.lang.Object to Neo4j Value." );
-
-        // When
-        session.run( "anything", parameters( "k", new Object() ) );
+        ClientException e = assertThrows( ClientException.class, () -> session.run( "anything", parameters( "k", new Object() ) ) );
+        assertEquals( "Unable to convert java.lang.Object to Neo4j Value.", e.getMessage() );
     }
 
     @Test
-    public void settingInvalidParameterTypeDirectlyShouldThrowHelpfulError() throws Throwable
+    void settingInvalidParameterTypeDirectlyShouldThrowHelpfulError()
     {
-        // Expect
-        exception.expect( ClientException.class );
-        exception.expectMessage( "The parameters should be provided as Map type. Unsupported parameters type: NODE" );
-
-        // When
-        session.run( "anything", emptyNodeValue() );
+        ClientException e = assertThrows( ClientException.class, () -> session.run( "anything", emptyNodeValue() ) );
+        assertEquals( "The parameters should be provided as Map type. Unsupported parameters type: NODE", e.getMessage() );
     }
 
     @Test
-    public void shouldNotBePossibleToUseNodeAsParameterInMapValue()
+    void shouldNotBePossibleToUseNodeAsParameterInMapValue()
     {
         // GIVEN
         Value node = emptyNodeValue();
@@ -433,7 +417,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldNotBePossibleToUseRelationshipAsParameterViaMapValue()
+    void shouldNotBePossibleToUseRelationshipAsParameterViaMapValue()
     {
         // GIVEN
         Value relationship = emptyRelationshipValue();
@@ -446,7 +430,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldNotBePossibleToUsePathAsParameterViaMapValue()
+    void shouldNotBePossibleToUsePathAsParameterViaMapValue()
     {
         // GIVEN
         Value path = filledPathValue();
@@ -459,14 +443,14 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldSendAndReceiveLongString()
+    void shouldSendAndReceiveLongString()
     {
         String string = TestUtil.randomString( LONG_VALUE_SIZE );
         testSendAndReceiveValue( string );
     }
 
     @Test
-    public void shouldSendAndReceiveLongListOfLongs()
+    void shouldSendAndReceiveLongListOfLongs()
     {
         List<Long> longs = ThreadLocalRandom.current()
                 .longs( LONG_VALUE_SIZE )
@@ -477,7 +461,7 @@ public class ParametersIT
     }
 
     @Test
-    public void shouldSendAndReceiveLongArrayOfBytes()
+    void shouldSendAndReceiveLongArrayOfBytes()
     {
         assumeTrue( supportsBytes() );
 
@@ -529,21 +513,10 @@ public class ParametersIT
 
     private void expectIOExceptionWithMessage( Value value, String message )
     {
-        try
-        {
-            session.run( "RETURN {a}", value ).consume();
-            fail( "Expecting a ServiceUnavailableException" );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            Throwable cause = e.getCause();
-            assertThat( cause, instanceOf( IOException.class ) );
-            assertThat( cause.getMessage(), equalTo( message ) );
-        }
-        catch ( Exception e )
-        {
-            fail( "Expecting a ServiceUnavailableException but got " + e );
-        }
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> session.run( "RETURN {a}", value ).consume() );
+        Throwable cause = e.getCause();
+        assertThat( cause, instanceOf( IOException.class ) );
+        assertThat( cause.getMessage(), equalTo( message ) );
     }
 
     private void testSendAndReceiveValue( Object value )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ParametersIT.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
@@ -46,9 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.version;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BYTE_ARRAYS;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
@@ -161,10 +160,9 @@ class ParametersIT
     }
 
     @Test
+    @EnabledOnNeo4jWith( BYTE_ARRAYS )
     void shouldBeAbleToSetAndReturnBytesProperty()
     {
-        assumeTrue( supportsBytes() );
-
         testBytesProperty( new byte[0] );
         for ( int i = 0; i < 16; i++ )
         {
@@ -175,10 +173,9 @@ class ParametersIT
     }
 
     @Test
+    @DisabledOnNeo4jWith( BYTE_ARRAYS )
     void shouldThrowExceptionWhenServerDoesNotSupportBytes()
     {
-        assumeFalse( supportsBytes() );
-
         // Given
         byte[] byteArray = "hello, world".getBytes();
 
@@ -461,10 +458,9 @@ class ParametersIT
     }
 
     @Test
+    @EnabledOnNeo4jWith( BYTE_ARRAYS )
     void shouldSendAndReceiveLongArrayOfBytes()
     {
-        assumeTrue( supportsBytes() );
-
         byte[] bytes = new byte[LONG_VALUE_SIZE];
         ThreadLocalRandom.current().nextBytes( bytes );
 
@@ -473,10 +469,7 @@ class ParametersIT
 
     private void testBytesProperty( byte[] array )
     {
-        assumeTrue( supportsBytes() );
-
-        StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", array ) );
+        StatementResult result = session.run( "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", array ) );
 
         for ( Record record : result.list() )
         {
@@ -497,11 +490,6 @@ class ParametersIT
             assertThat( value.hasType( session.typeSystem().STRING() ), equalTo( true ) );
             assertThat( value.asString(), equalTo( string ) );
         }
-    }
-
-    private boolean supportsBytes()
-    {
-        return version( session.driver() ).greaterThanOrEqual( ServerVersion.v3_2_0 );
     }
 
     private static byte[] randomByteArray( int length )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ScalarTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ScalarTypeIT.java
@@ -18,57 +18,49 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.value.ListValue;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.parameters;
 
-@RunWith(Parameterized.class)
-public class ScalarTypeIT
+class ScalarTypeIT
 {
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
-    @Parameterized.Parameter(0)
-    public String statement;
-
-    @Parameterized.Parameter(1)
-    public Value expectedValue;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> typesToTest()
+    static Stream<Arguments> typesToTest()
     {
-        return Arrays.asList(
-                new Object[]{"RETURN 1 as v", Values.value( 1L )},
-                new Object[]{"RETURN 1.1 as v", Values.value( 1.1d )},
-                new Object[]{"RETURN 'hello' as v", Values.value( "hello" )},
-                new Object[]{"RETURN true as v", Values.value( true )},
-                new Object[]{"RETURN false as v", Values.value( false )},
-                new Object[]{"RETURN [1,2,3] as v", new ListValue( Values.value( 1 ), Values.value( 2 ), Values.value( 3 ) )},
-                new Object[]{"RETURN ['hello'] as v", new ListValue( Values.value( "hello" ) )},
-                new Object[]{"RETURN [] as v", new ListValue()},
-                new Object[]{"RETURN {k:'hello'} as v", parameters( "k", Values.value( "hello" ) )},
-                new Object[]{"RETURN {} as v", new MapValue( Collections.<String, Value>emptyMap() )}
+        return Stream.of(
+                Arguments.of( "RETURN 1 as v", Values.value( 1L ) ),
+                Arguments.of( "RETURN 1.1 as v", Values.value( 1.1d ) ),
+                Arguments.of( "RETURN 'hello' as v", Values.value( "hello" ) ),
+                Arguments.of( "RETURN true as v", Values.value( true ) ),
+                Arguments.of( "RETURN false as v", Values.value( false ) ),
+                Arguments.of( "RETURN [1,2,3] as v", new ListValue( Values.value( 1 ), Values.value( 2 ), Values.value( 3 ) ) ),
+                Arguments.of( "RETURN ['hello'] as v", new ListValue( Values.value( "hello" ) ) ),
+                Arguments.of( "RETURN [] as v", new ListValue() ),
+                Arguments.of( "RETURN {k:'hello'} as v", parameters( "k", Values.value( "hello" ) ) ),
+                Arguments.of( "RETURN {} as v", new MapValue( Collections.<String,Value>emptyMap() ) )
         );
     }
 
-    @Test
-    public void shouldHandleType() throws Throwable
+    @ParameterizedTest
+    @MethodSource( "typesToTest" )
+    void shouldHandleType( String statement, Value expectedValue )
     {
         // When
         StatementResult cursor = session.run( statement );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
@@ -36,8 +36,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.driver.internal.async.EventLoopGroupFactory;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.Futures;
-import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Statement;
@@ -72,14 +72,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 import static org.neo4j.driver.internal.util.Matchers.blockingOperationInEventLoopError;
 import static org.neo4j.driver.internal.util.Matchers.containsResultAvailableAfterAndResultConsumedAfter;
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOOKMARKS;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 import static org.neo4j.driver.v1.util.TestUtil.awaitAll;
@@ -596,11 +595,9 @@ class SessionAsyncIT
     }
 
     @Test
+    @EnabledOnNeo4jWith( BOOKMARKS )
     void shouldRunAfterBeginTxFailureOnBookmark()
     {
-        ServerVersion version = neo4j.version();
-        assumeTrue( version.greaterThanOrEqual( v3_1_0 ), "Server " + version + " does not support bookmark" );
-
         session = neo4j.driver().session( "Illegal Bookmark" );
 
         assertThrows( ClientException.class, () -> await( session.beginTransactionAsync() ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionResetIT.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
@@ -77,8 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.TRANSACTION_TERMINATION_AWARE_LOCKS;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 import static org.neo4j.driver.v1.util.Neo4jRunner.HOME_DIR;
@@ -90,6 +89,7 @@ import static org.neo4j.driver.v1.util.TestUtil.awaitAllFutures;
 import static org.neo4j.driver.v1.util.TestUtil.awaitCondition;
 
 @SuppressWarnings( "deprecation" )
+@EnabledOnNeo4jWith( TRANSACTION_TERMINATION_AWARE_LOCKS )
 class SessionResetIT
 {
     private static final int CSV_FILE_SIZE = 10_000;
@@ -116,7 +116,6 @@ class SessionResetIT
     @BeforeEach
     void setUp()
     {
-        assumeTrue( neo4j.version().greaterThanOrEqual( v3_1_0 ) );
         executor = Executors.newCachedThreadPool( daemon( getClass().getSimpleName() + "-thread" ) );
     }
 
@@ -416,9 +415,6 @@ class SessionResetIT
     @Test
     void resetShouldStopQueryWaitingForALock() throws Exception
     {
-        // 3.1+ neo4j supports termination of queries that wait for a lock
-        assumeServerIs31OrLater();
-
         testResetOfQueryWaitingForLock( new NodeIdUpdater()
         {
             @Override
@@ -439,9 +435,6 @@ class SessionResetIT
     @Test
     void resetShouldStopTransactionWaitingForALock() throws Exception
     {
-        // 3.1+ neo4j supports termination of queries that wait for a lock
-        assumeServerIs31OrLater();
-
         testResetOfQueryWaitingForLock( new NodeIdUpdater()
         {
             @Override
@@ -463,9 +456,6 @@ class SessionResetIT
     @Test
     void resetShouldStopWriteTransactionWaitingForALock() throws Exception
     {
-        // 3.1+ neo4j supports termination of queries that wait for a lock
-        assumeServerIs31OrLater();
-
         AtomicInteger invocationsOfWork = new AtomicInteger();
 
         testResetOfQueryWaitingForLock( new NodeIdUpdater()
@@ -838,12 +828,6 @@ class SessionResetIT
         {
             throw new UncheckedIOException( e );
         }
-    }
-
-    private void assumeServerIs31OrLater()
-    {
-        ServerVersion serverVersion = ServerVersion.version( neo4j.driver() );
-        assumeTrue( serverVersion.greaterThanOrEqual( v3_1_0 ), "Ignored on `" + serverVersion + "`" );
     }
 
     private abstract class NodeIdUpdater

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SpatialTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SpatialTypesIT.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -30,33 +30,33 @@ import java.util.stream.Stream;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.types.Point;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
 import static org.neo4j.driver.v1.Values.ofPoint;
 import static org.neo4j.driver.v1.Values.point;
 
-public class SpatialTypesIT
+class SpatialTypesIT
 {
     private static final int WGS_84_CRS_CODE = 4326;
     private static final int CARTESIAN_CRS_CODE = 7203;
     private static final double DELTA = 0.00001;
 
-    @Rule
-    public final TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         assumeTrue( session.version().greaterThanOrEqual( v3_4_0 ) );
     }
 
     @Test
-    public void shouldReceivePoint()
+    void shouldReceivePoint()
     {
         Record record = session.run( "RETURN point({x: 39.111748, y:-76.775635})" ).single();
 
@@ -68,7 +68,7 @@ public class SpatialTypesIT
     }
 
     @Test
-    public void shouldSendPoint()
+    void shouldSendPoint()
     {
         Value pointValue = point( WGS_84_CRS_CODE, 38.8719, 77.0563 );
         Record record1 = session.run( "CREATE (n:Node {location: $point}) RETURN 42", singletonMap( "point", pointValue ) ).single();
@@ -84,13 +84,13 @@ public class SpatialTypesIT
     }
 
     @Test
-    public void shouldSendAndReceivePoint()
+    void shouldSendAndReceivePoint()
     {
         testPointSendAndReceive( point( CARTESIAN_CRS_CODE, 40.7624, 73.9738 ) );
     }
 
     @Test
-    public void shouldSendAndReceiveRandom2DPoints()
+    void shouldSendAndReceiveRandom2DPoints()
     {
         Stream<Value> randomPoints = ThreadLocalRandom.current()
                 .ints( 1_000, 0, 2 )
@@ -102,7 +102,7 @@ public class SpatialTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveRandom2DPointArrays()
+    void shouldSendAndReceiveRandom2DPointArrays()
     {
         Stream<List<Value>> randomPointLists = ThreadLocalRandom.current()
                 .ints( 1_000, 0, 2 )
@@ -150,8 +150,8 @@ public class SpatialTypesIT
     private static void assertPoints2DEqual( Point expected, Point actual )
     {
         String message = "Expected: " + expected + " but was: " + actual;
-        assertEquals( message, expected.srid(), actual.srid() );
-        assertEquals( message, expected.x(), actual.x(), DELTA );
-        assertEquals( message, expected.y(), actual.y(), DELTA );
+        assertEquals( expected.srid(), actual.srid(), message );
+        assertEquals( expected.x(), actual.x(), DELTA, message );
+        assertEquals( expected.y(), actual.y(), DELTA, message );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SpatialTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SpatialTypesIT.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -27,6 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.types.Point;
@@ -35,11 +35,11 @@ import org.neo4j.driver.v1.util.SessionExtension;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.SPATIAL_TYPES;
 import static org.neo4j.driver.v1.Values.ofPoint;
 import static org.neo4j.driver.v1.Values.point;
 
+@EnabledOnNeo4jWith( SPATIAL_TYPES )
 class SpatialTypesIT
 {
     private static final int WGS_84_CRS_CODE = 4326;
@@ -48,12 +48,6 @@ class SpatialTypesIT
 
     @RegisterExtension
     static final SessionExtension session = new SessionExtension();
-
-    @BeforeEach
-    void setUp()
-    {
-        assumeTrue( session.version().greaterThanOrEqual( v3_4_0 ) );
-    }
 
     @Test
     void shouldReceivePoint()

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/StatementIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/StatementIT.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -30,20 +30,20 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class StatementIT
+class StatementIT
 {
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
     @Test
-    public void shouldRunWithResult() throws Throwable
+    void shouldRunWithResult()
     {
         // When I execute a statement that yields a result
         List<Record> result = session.run( "UNWIND [1,2,3] AS k RETURN k" ).list();
@@ -67,7 +67,7 @@ public class StatementIT
     }
 
     @Test
-    public void shouldRunWithParameters() throws Throwable
+    void shouldRunWithParameters()
     {
         // When
         session.run( "CREATE (n:FirstNode {name:{name}})", parameters( "name", "Steven" ) );
@@ -77,7 +77,7 @@ public class StatementIT
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldRunWithNullValuesAsParameters() throws Throwable
+    void shouldRunWithNullValuesAsParameters()
     {
         // Given
         Value params = null;
@@ -90,7 +90,7 @@ public class StatementIT
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldRunWithNullRecordAsParameters() throws Throwable
+    void shouldRunWithNullRecordAsParameters()
     {
         // Given
         Record params = null;
@@ -103,7 +103,7 @@ public class StatementIT
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldRunWithNullMapAsParameters() throws Throwable
+    void shouldRunWithNullMapAsParameters()
     {
         // Given
         Map<String, Object> params = null;
@@ -115,7 +115,7 @@ public class StatementIT
     }
 
     @Test
-    public void shouldRunWithCollectionAsParameter() throws Throwable
+    void shouldRunWithCollectionAsParameter()
     {
         // When
         session.run( "RETURN {param}", parameters( "param", Collections.singleton( "FOO" ) ) );
@@ -124,7 +124,7 @@ public class StatementIT
     }
 
     @Test
-    public void shouldRunWithIteratorAsParameter() throws Throwable
+    void shouldRunWithIteratorAsParameter()
     {
         Iterator<String> values = asList( "FOO", "BAR", "BAZ" ).iterator();
         // When
@@ -134,7 +134,7 @@ public class StatementIT
     }
 
     @Test
-    public void shouldRun() throws Throwable
+    void shouldRun()
     {
         // When
         session.run( "CREATE (n:FirstNode)" );
@@ -143,7 +143,7 @@ public class StatementIT
     }
 
     @Test
-    public void shouldRunParameterizedWithResult() throws Throwable
+    void shouldRunParameterizedWithResult()
     {
         // When
         List<Record> result =
@@ -155,7 +155,7 @@ public class StatementIT
 
     @SuppressWarnings({"StatementWithEmptyBody", "ConstantConditions"})
     @Test
-    public void shouldRunSimpleStatement() throws Throwable
+    void shouldRunSimpleStatement()
     {
         // When I run a simple write statement
         session.run( "CREATE (a {name:'Adam'})" );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
@@ -43,8 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
-import static org.neo4j.driver.internal.util.ServerVersion.version;
+import static org.neo4j.driver.internal.util.Neo4jFeature.STATEMENT_RESULT_TIMINGS;
 
 class SummaryIT
 {
@@ -85,7 +85,8 @@ class SummaryIT
         ResultSummary summary = session.run( "UNWIND range(1,1000) AS n RETURN n AS number" ).consume();
 
         // Then
-        if ( version( summary.server().version() ).greaterThanOrEqual( v3_1_0 ) )
+        ServerVersion serverVersion = ServerVersion.version( summary.server().version() );
+        if ( STATEMENT_RESULT_TIMINGS.availableIn( serverVersion ) )
         {
             assertThat( summary.resultAvailableAfter( TimeUnit.MILLISECONDS ), greaterThan( 0L ) );
             assertThat( summary.resultConsumedAfter( TimeUnit.MILLISECONDS ), greaterThan( 0L ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SummaryIT.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -32,27 +32,27 @@ import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
+import org.neo4j.driver.v1.util.SessionExtension;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 
-public class SummaryIT
+class SummaryIT
 {
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
     @Test
-    public void shouldContainBasicMetadata() throws Throwable
+    void shouldContainBasicMetadata()
     {
         // Given
         Value statementParameters = Values.parameters( "limit", 10 );
@@ -79,7 +79,7 @@ public class SummaryIT
     }
 
     @Test
-    public void shouldContainTimeInformation()
+    void shouldContainTimeInformation()
     {
         // Given
         ResultSummary summary = session.run( "UNWIND range(1,1000) AS n RETURN n AS number" ).consume();
@@ -99,7 +99,7 @@ public class SummaryIT
     }
 
     @Test
-    public void shouldContainCorrectStatistics() throws Throwable
+    void shouldContainCorrectStatistics()
     {
         assertThat( session.run( "CREATE (n)" ).consume().counters().nodesCreated(), equalTo( 1 ) );
         assertThat( session.run( "MATCH (n) DELETE (n)" ).consume().counters().nodesDeleted(), equalTo( 1 ) );
@@ -122,7 +122,7 @@ public class SummaryIT
     }
 
     @Test
-    public void shouldContainCorrectStatementType() throws Throwable
+    void shouldContainCorrectStatementType()
     {
         assertThat( session.run("MATCH (n) RETURN 1").consume().statementType(), equalTo( StatementType.READ_ONLY ));
         assertThat( session.run("CREATE (n)").consume().statementType(), equalTo( StatementType.WRITE_ONLY ));
@@ -131,7 +131,7 @@ public class SummaryIT
     }
 
     @Test
-    public void shouldContainCorrectPlan() throws Throwable
+    void shouldContainCorrectPlan()
     {
         // When
         Plan plan = session.run( "EXPLAIN MATCH (n) RETURN 1" ).consume().plan();
@@ -143,14 +143,14 @@ public class SummaryIT
     }
 
     @Test
-    public void shouldContainProfile() throws Throwable
+    void shouldContainProfile()
     {
         // When
         ResultSummary summary = session.run( "PROFILE RETURN 1" ).consume();
 
         // Then
-        assertEquals( true, summary.hasProfile() );
-        assertEquals( true, summary.hasPlan() ); // Profile is a superset of plan, so plan should be available as well if profile is available
+        assertTrue( summary.hasProfile() );
+        assertTrue( summary.hasPlan() ); // Profile is a superset of plan, so plan should be available as well if profile is available
         assertEquals( summary.plan(), summary.profile() );
 
         ProfiledPlan profile = summary.profile();
@@ -161,13 +161,13 @@ public class SummaryIT
 
 
     @Test
-    public void shouldContainNotifications() throws Throwable
+    void shouldContainNotifications()
     {
         // When
         ResultSummary summary = session.run( "EXPLAIN MATCH (n), (m) RETURN n, m" ).consume();
 
         // Then
-        assertEquals( true, summary.hasPlan() );
+        assertTrue( summary.hasPlan() );
         List<Notification> notifications = summary.notifications();
         assertNotNull( notifications );
         assertThat( notifications.size(), equalTo( 1 ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,38 +36,38 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.types.IsoDuration;
 import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.SessionExtension;
 import org.neo4j.driver.v1.util.TemporalUtil;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
 
 import static java.time.Month.MARCH;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
 import static org.neo4j.driver.v1.Values.isoDuration;
 import static org.neo4j.driver.v1.Values.parameters;
 
-public class TemporalTypesIT
+class TemporalTypesIT
 {
     private static final int RANDOM_VALUES_TO_TEST = 1_000;
 
-    @Rule
-    public final TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         assumeTrue( session.version().greaterThanOrEqual( v3_4_0 ) );
     }
 
     @Test
-    public void shouldSendDate()
+    void shouldSendDate()
     {
         testSendValue( LocalDate.now(), Value::asLocalDate );
     }
 
     @Test
-    public void shouldReceiveDate()
+    void shouldReceiveDate()
     {
         testReceiveValue( "RETURN date({year: 1995, month: 12, day: 4})",
                 LocalDate.of( 1995, 12, 4 ),
@@ -75,25 +75,25 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveDate()
+    void shouldSendAndReceiveDate()
     {
         testSendAndReceiveValue( LocalDate.now(), Value::asLocalDate );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomDate()
+    void shouldSendAndReceiveRandomDate()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomLocalDate, Value::asLocalDate );
     }
 
     @Test
-    public void shouldSendTime()
+    void shouldSendTime()
     {
         testSendValue( OffsetTime.now(), Value::asOffsetTime );
     }
 
     @Test
-    public void shouldReceiveTime()
+    void shouldReceiveTime()
     {
         testReceiveValue( "RETURN time({hour: 23, minute: 19, second: 55, timezone:'-07:00'})",
                 OffsetTime.of( 23, 19, 55, 0, ZoneOffset.ofHours( -7 ) ),
@@ -101,25 +101,25 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveTime()
+    void shouldSendAndReceiveTime()
     {
         testSendAndReceiveValue( OffsetTime.now(), Value::asOffsetTime );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomTime()
+    void shouldSendAndReceiveRandomTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomOffsetTime, Value::asOffsetTime );
     }
 
     @Test
-    public void shouldSendLocalTime()
+    void shouldSendLocalTime()
     {
         testSendValue( LocalTime.now(), Value::asLocalTime );
     }
 
     @Test
-    public void shouldReceiveLocalTime()
+    void shouldReceiveLocalTime()
     {
         testReceiveValue( "RETURN localtime({hour: 22, minute: 59, second: 10, nanosecond: 999999})",
                 LocalTime.of( 22, 59, 10, 999_999 ),
@@ -127,25 +127,25 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveLocalTime()
+    void shouldSendAndReceiveLocalTime()
     {
         testSendAndReceiveValue( LocalTime.now(), Value::asLocalTime );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomLocalTime()
+    void shouldSendAndReceiveRandomLocalTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomLocalTime, Value::asLocalTime );
     }
 
     @Test
-    public void shouldSendLocalDateTime()
+    void shouldSendLocalDateTime()
     {
         testSendValue( LocalDateTime.now(), Value::asLocalDateTime );
     }
 
     @Test
-    public void shouldReceiveLocalDateTime()
+    void shouldReceiveLocalDateTime()
     {
         testReceiveValue( "RETURN localdatetime({year: 1899, month: 3, day: 20, hour: 12, minute: 17, second: 13, nanosecond: 999})",
                 LocalDateTime.of( 1899, MARCH, 20, 12, 17, 13, 999 ),
@@ -153,26 +153,26 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveLocalDateTime()
+    void shouldSendAndReceiveLocalDateTime()
     {
         testSendAndReceiveValue( LocalDateTime.now(), Value::asLocalDateTime );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomLocalDateTime()
+    void shouldSendAndReceiveRandomLocalDateTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomLocalDateTime, Value::asLocalDateTime );
     }
 
     @Test
-    public void shouldSendDateTimeWithZoneOffset()
+    void shouldSendDateTimeWithZoneOffset()
     {
         ZoneOffset offset = ZoneOffset.ofHoursMinutes( -4, -15 );
         testSendValue( ZonedDateTime.of( 1845, 3, 25, 19, 15, 45, 22, offset ), Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldReceiveDateTimeWithZoneOffset()
+    void shouldReceiveDateTimeWithZoneOffset()
     {
         ZoneOffset offset = ZoneOffset.ofHoursMinutes( 3, 30 );
         testReceiveValue( "RETURN datetime({year:1984, month:10, day:11, hour:21, minute:30, second:34, timezone:'+03:30'})",
@@ -181,27 +181,27 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveDateTimeWithZoneOffset()
+    void shouldSendAndReceiveDateTimeWithZoneOffset()
     {
         ZoneOffset offset = ZoneOffset.ofHoursMinutes( -7, -15 );
         testSendAndReceiveValue( ZonedDateTime.of( 2017, 3, 9, 11, 12, 13, 14, offset ), Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomDateTimeWithZoneOffset()
+    void shouldSendAndReceiveRandomDateTimeWithZoneOffset()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomZonedDateTimeWithOffset, Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldSendDateTimeWithZoneId()
+    void shouldSendDateTimeWithZoneId()
     {
         ZoneId zoneId = ZoneId.of( "Europe/Stockholm" );
         testSendValue( ZonedDateTime.of( 2049, 9, 11, 19, 10, 40, 20, zoneId ), Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldReceiveDateTimeWithZoneId()
+    void shouldReceiveDateTimeWithZoneId()
     {
         ZoneId zoneId = ZoneId.of( "Europe/London" );
         testReceiveValue( "RETURN datetime({year:2000, month:1, day:1, hour:9, minute:5, second:1, timezone:'Europe/London'})",
@@ -210,26 +210,26 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveDateTimeWithZoneId()
+    void shouldSendAndReceiveDateTimeWithZoneId()
     {
         ZoneId zoneId = ZoneId.of( "Europe/Stockholm" );
         testSendAndReceiveValue( ZonedDateTime.of( 2099, 12, 29, 12, 59, 59, 59, zoneId ), Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomDateTimeWithZoneId()
+    void shouldSendAndReceiveRandomDateTimeWithZoneId()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomZonedDateTimeWithZoneId, Value::asZonedDateTime );
     }
 
     @Test
-    public void shouldSendDuration()
+    void shouldSendDuration()
     {
         testSendValue( newDuration( 8, 12, 90, 8 ), Value::asIsoDuration );
     }
 
     @Test
-    public void shouldReceiveDuration()
+    void shouldReceiveDuration()
     {
         testReceiveValue( "RETURN duration({months: 13, days: 40, seconds: 12, nanoseconds: 999})",
                 newDuration( 13, 40, 12, 999 ),
@@ -237,19 +237,19 @@ public class TemporalTypesIT
     }
 
     @Test
-    public void shouldSendAndReceiveDuration()
+    void shouldSendAndReceiveDuration()
     {
         testSendAndReceiveValue( newDuration( 7, 7, 88, 999_999 ), Value::asIsoDuration );
     }
 
     @Test
-    public void shouldSendAndReceiveRandomDuration()
+    void shouldSendAndReceiveRandomDuration()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomDuration, Value::asIsoDuration );
     }
 
     @Test
-    public void shouldFormatDurationToString()
+    void shouldFormatDurationToString()
     {
         testDurationToString( 1, 0, "P0M0DT1S" );
         testDurationToString( -1, 0, "P0M0DT-1S" );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.driver.v1.integration;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -31,6 +30,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.function.Supplier;
 
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
@@ -42,23 +42,17 @@ import org.neo4j.driver.v1.util.TemporalUtil;
 import static java.time.Month.MARCH;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.TEMPORAL_TYPES;
 import static org.neo4j.driver.v1.Values.isoDuration;
 import static org.neo4j.driver.v1.Values.parameters;
 
+@EnabledOnNeo4jWith( TEMPORAL_TYPES )
 class TemporalTypesIT
 {
     private static final int RANDOM_VALUES_TO_TEST = 1_000;
 
     @RegisterExtension
     static final SessionExtension session = new SessionExtension();
-
-    @BeforeEach
-    void setUp()
-    {
-        assumeTrue( session.version().greaterThanOrEqual( v3_4_0 ) );
-    }
 
     @Test
     void shouldSendDate()

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -21,12 +21,10 @@ package org.neo4j.driver.v1.integration;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.concurrent.Future;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,23 +57,22 @@ import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
 import org.neo4j.driver.v1.types.Node;
-import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.internal.util.Matchers.blockingOperationInEventLoopError;
@@ -85,29 +82,27 @@ import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class TransactionAsyncIT
+class TransactionAsyncIT
 {
-    private final TestNeo4j neo4j = new TestNeo4j();
-
-    @Rule
-    public final RuleChain ruleChain = RuleChain.outerRule( Timeout.seconds( 180 ) ).around( neo4j );
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
 
     private Session session;
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         session = neo4j.driver().session();
     }
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         session.closeAsync();
     }
 
     @Test
-    public void shouldBePossibleToCommitEmptyTx()
+    void shouldBePossibleToCommitEmptyTx()
     {
         String bookmarkBefore = session.lastBookmark();
 
@@ -125,7 +120,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRollbackEmptyTx()
+    void shouldBePossibleToRollbackEmptyTx()
     {
         String bookmarkBefore = session.lastBookmark();
 
@@ -137,7 +132,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunSingleStatementAndCommit()
+    void shouldBePossibleToRunSingleStatementAndCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -155,7 +150,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunSingleStatementAndRollback()
+    void shouldBePossibleToRunSingleStatementAndRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -172,7 +167,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunMultipleStatementsAndCommit()
+    void shouldBePossibleToRunMultipleStatementsAndCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -191,7 +186,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunMultipleStatementsAndCommitWithoutWaiting()
+    void shouldBePossibleToRunMultipleStatementsAndCommitWithoutWaiting()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -205,7 +200,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunMultipleStatementsAndRollback()
+    void shouldBePossibleToRunMultipleStatementsAndRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -221,7 +216,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunMultipleStatementsAndRollbackWithoutWaiting()
+    void shouldBePossibleToRunMultipleStatementsAndRollbackWithoutWaiting()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -234,53 +229,32 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToCommitAfterSingleWrongStatement()
+    void shouldFailToCommitAfterSingleWrongStatement()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-        }
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( cursor.consumeAsync() ) );
+        assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
+
+        assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
     }
 
     @Test
-    public void shouldAllowRollbackAfterSingleWrongStatement()
+    void shouldAllowRollbackAfterSingleWrongStatement()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
-        try
-        {
-            await( cursor.nextAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-        }
 
+        Exception e = assertThrows( Exception.class, () -> await( cursor.nextAsync() ) );
+        assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
         assertThat( await( tx.rollbackAsync() ), is( nullValue() ) );
     }
 
     @Test
-    public void shouldFailToCommitAfterCoupleCorrectAndSingleWrongStatement()
+    void shouldFailToCommitAfterCoupleCorrectAndSingleWrongStatement()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -295,29 +269,15 @@ public class TransactionAsyncIT
         assertEquals( 42, record2.get( 0 ).asInt() );
 
         StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
-        try
-        {
-            await( cursor3.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-        }
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-        }
+        Exception e = assertThrows( Exception.class, () -> await( cursor3.consumeAsync() ) );
+        assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
+
+        assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
     }
 
     @Test
-    public void shouldAllowRollbackAfterCoupleCorrectAndSingleWrongStatement()
+    void shouldAllowRollbackAfterCoupleCorrectAndSingleWrongStatement()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -332,68 +292,39 @@ public class TransactionAsyncIT
         assertEquals( 42, record2.get( 0 ).asInt() );
 
         StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
-        try
-        {
-            await( cursor3.summaryAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-        }
 
+        Exception e = assertThrows( Exception.class, () -> await( cursor3.summaryAsync() ) );
+        assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
         assertThat( await( tx.rollbackAsync() ), is( nullValue() ) );
     }
 
     @Test
-    public void shouldNotAllowNewStatementsAfterAnIncorrectStatement()
+    void shouldNotAllowNewStatementsAfterAnIncorrectStatement()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
-        try
-        {
-            await( cursor.nextAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-        }
 
-        try
-        {
-            tx.runAsync( "CREATE ()" );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-            assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
-        }
+        Exception e1 = assertThrows( Exception.class, () -> await( cursor.nextAsync() ) );
+        assertThat( e1, is( syntaxError( "Unexpected end of input" ) ) );
+
+        ClientException e2 = assertThrows( ClientException.class, () -> tx.runAsync( "CREATE ()" ) );
+        assertThat( e2.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
     }
 
     @Test
-    public void shouldFailBoBeginTxWithInvalidBookmark()
+    void shouldFailBoBeginTxWithInvalidBookmark()
     {
         assumeDatabaseSupportsBookmarks();
 
         Session session = neo4j.driver().session( "InvalidBookmark" );
 
-        try
-        {
-            await( session.beginTransactionAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-            assertThat( e.getMessage(), containsString( "InvalidBookmark" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( session.beginTransactionAsync() ) );
+        assertThat( e.getMessage(), containsString( "InvalidBookmark" ) );
     }
 
     @Test
-    public void shouldBePossibleToCommitWhenCommitted()
+    void shouldBePossibleToCommitWhenCommitted()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
@@ -406,7 +337,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRollbackWhenRolledBack()
+    void shouldBePossibleToRollbackWhenRolledBack()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
@@ -419,47 +350,31 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToCommitWhenRolledBack()
+    void shouldFailToCommitWhenRolledBack()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
         assertNull( await( tx.rollbackAsync() ) );
 
-        try
-        {
-            // should not be possible to commit after rollback
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-            assertThat( e.getMessage(), containsString( "transaction has been rolled back" ) );
-        }
+        // should not be possible to commit after rollback
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.getMessage(), containsString( "transaction has been rolled back" ) );
     }
 
     @Test
-    public void shouldFailToRollbackWhenCommitted()
+    void shouldFailToRollbackWhenCommitted()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
         assertNull( await( tx.commitAsync() ) );
 
-        try
-        {
-            // should not be possible to rollback after commit
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-            assertThat( e.getMessage(), containsString( "transaction has been committed" ) );
-        }
+        // should not be possible to rollback after commit
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.getMessage(), containsString( "transaction has been committed" ) );
     }
 
     @Test
-    public void shouldExposeStatementKeysForColumnsWithAliases()
+    void shouldExposeStatementKeysForColumnsWithAliases()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN 1 AS one, 2 AS two, 3 AS three, 4 AS five" ) );
@@ -468,7 +383,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldExposeStatementKeysForColumnsWithoutAliases()
+    void shouldExposeStatementKeysForColumnsWithoutAliases()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN 1, 2, 3, 5" ) );
@@ -477,7 +392,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldExposeResultSummaryForSimpleQuery()
+    void shouldExposeResultSummaryForSimpleQuery()
     {
         String query = "CREATE (p1:Person {name: $name1})-[:KNOWS]->(p2:Person {name: $name2}) RETURN p1, p2";
         Value params = parameters( "name1", "Bob", "name2", "John" );
@@ -501,7 +416,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldExposeResultSummaryForExplainQuery()
+    void shouldExposeResultSummaryForExplainQuery()
     {
         String query = "EXPLAIN MATCH (n) RETURN n";
 
@@ -525,7 +440,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldExposeResultSummaryForProfileQuery()
+    void shouldExposeResultSummaryForProfileQuery()
     {
         String query = "PROFILE MERGE (n {name: $name}) " +
                        "ON CREATE SET n.created = timestamp() " +
@@ -555,7 +470,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldPeekRecordFromCursor()
+    void shouldPeekRecordFromCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
@@ -579,52 +494,48 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldForEachWithEmptyCursor()
+    void shouldForEachWithEmptyCursor()
     {
         testForEach( "MATCH (n:SomeReallyStrangeLabel) RETURN n", 0 );
     }
 
     @Test
-    public void shouldForEachWithNonEmptyCursor()
+    void shouldForEachWithNonEmptyCursor()
     {
         testForEach( "UNWIND range(1, 12555) AS x CREATE (n:Node {id: x}) RETURN n", 12555 );
     }
 
     @Test
-    public void shouldFailForEachWhenActionFails()
+    void shouldFailForEachWhenActionFails()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hi!'" ) );
         RuntimeException error = new RuntimeException();
 
-        try
+        RuntimeException e = assertThrows( RuntimeException.class, () ->
         {
             await( cursor.forEachAsync( record ->
             {
                 throw error;
             } ) );
-            fail( "Exception expected" );
-        }
-        catch ( RuntimeException e )
-        {
-            assertEquals( error, e );
-        }
+        } );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldConvertToListWithEmptyCursor()
+    void shouldConvertToListWithEmptyCursor()
     {
         testList( "CREATE (:Person)-[:KNOWS]->(:Person)", Collections.emptyList() );
     }
 
     @Test
-    public void shouldConvertToListWithNonEmptyCursor()
+    void shouldConvertToListWithNonEmptyCursor()
     {
         testList( "UNWIND [1, '1', 2, '2', 3, '3'] AS x RETURN x", Arrays.asList( 1L, "1", 2L, "2", 3L, "3" ) );
     }
 
     @Test
-    public void shouldConvertToTransformedListWithEmptyCursor()
+    void shouldConvertToTransformedListWithEmptyCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "CREATE ()" ) );
@@ -633,7 +544,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldConvertToTransformedListWithNonEmptyCursor()
+    void shouldConvertToTransformedListWithNonEmptyCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
@@ -642,28 +553,22 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailWhenListTransformationFunctionFails()
+    void shouldFailWhenListTransformationFunctionFails()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hello'" ) );
         IOException error = new IOException( "World" );
 
-        try
-        {
-            await( cursor.listAsync( record ->
-            {
-                throw new CompletionException( error );
-            } ) );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertEquals( error, e );
-        }
+        Exception e = assertThrows( Exception.class, () ->
+                await( cursor.listAsync( record ->
+                {
+                    throw new CompletionException( error );
+                } ) ) );
+        assertEquals( error, e );
     }
 
     @Test
-    public void shouldFailToCommitWhenServerIsRestarted()
+    void shouldFailToCommitWhenServerIsRestarted()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -671,53 +576,31 @@ public class TransactionAsyncIT
 
         neo4j.killDb();
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( Throwable t )
-        {
-            assertThat( t, instanceOf( ServiceUnavailableException.class ) );
-        }
+        assertThrows( ServiceUnavailableException.class, () -> await( tx.commitAsync() ) );
     }
 
     @Test
-    public void shouldFailSingleWithEmptyCursor()
+    void shouldFailSingleWithEmptyCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "MATCH (n:NoSuchLabel) RETURN n" ) );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( NoSuchRecordException e )
-        {
-            assertThat( e.getMessage(), containsString( "result is empty" ) );
-        }
+        NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), containsString( "result is empty" ) );
     }
 
     @Test
-    public void shouldFailSingleWithMultiRecordCursor()
+    void shouldFailSingleWithMultiRecordCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b'] AS x RETURN x" ) );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( NoSuchRecordException e )
-        {
-            assertThat( e.getMessage(), startsWith( "Expected a result with a single record" ) );
-        }
+        NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), startsWith( "Expected a result with a single record" ) );
     }
 
     @Test
-    public void shouldReturnSingleWithSingleRecordCursor()
+    void shouldReturnSingleWithSingleRecordCursor()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hello!'" ) );
@@ -728,53 +611,39 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldPropagateFailureFromFirstRecordInSingleAsync()
+    void shouldPropagateFailureFromFirstRecordInSingleAsync()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND [0] AS x RETURN 10 / x" ) );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "/ by zero" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
     }
 
     @Test
-    public void shouldNotPropagateFailureFromSecondRecordInSingleAsync()
+    void shouldNotPropagateFailureFromSecondRecordInSingleAsync()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 10 / x" ) );
 
-        try
-        {
-            await( cursor.singleAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "/ by zero" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.singleAsync() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
     }
 
     @Test
-    public void shouldConsumeEmptyCursor()
+    void shouldConsumeEmptyCursor()
     {
         testConsume( "MATCH (n:NoSuchLabel) RETURN n" );
     }
 
     @Test
-    public void shouldConsumeNonEmptyCursor()
+    void shouldConsumeNonEmptyCursor()
     {
         testConsume( "RETURN 42" );
     }
 
     @Test
-    public void shouldDoNothingWhenCommittedSecondTime()
+    void shouldDoNothingWhenCommittedSecondTime()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -785,44 +654,30 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToCommitAfterRollback()
+    void shouldFailToCommitAfterRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         assertNull( await( tx.rollbackAsync() ) );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Can't commit, transaction has been rolled back", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertEquals( "Can't commit, transaction has been rolled back", e.getMessage() );
         assertFalse( tx.isOpen() );
     }
 
     @Test
-    public void shouldFailToCommitAfterTermination()
+    void shouldFailToCommitAfterTermination()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         ((ExplicitTransaction) tx).markTerminated();
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Can't commit, transaction has been terminated", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertEquals( "Can't commit, transaction has been terminated", e.getMessage() );
     }
 
     @Test
-    public void shouldDoNothingWhenRolledBackSecondTime()
+    void shouldDoNothingWhenRolledBackSecondTime()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -833,26 +688,19 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToRollbackAfterCommit()
+    void shouldFailToRollbackAfterCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         assertNull( await( tx.commitAsync() ) );
 
-        try
-        {
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Can't rollback, transaction has been committed", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertEquals( "Can't rollback, transaction has been committed", e.getMessage() );
         assertFalse( tx.isOpen() );
     }
 
     @Test
-    public void shouldRollbackAfterTermination()
+    void shouldRollbackAfterTermination()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -863,7 +711,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToRunQueryAfterCommit()
+    void shouldFailToRunQueryAfterCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE (:MyLabel)" );
@@ -871,19 +719,12 @@ public class TransactionAsyncIT
 
         assertEquals( 1, session.run( "MATCH (n:MyLabel) RETURN count(n)" ).single().get( 0 ).asInt() );
 
-        try
-        {
-            await( tx.runAsync( "CREATE (:MyOtherLabel)" ) );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Cannot run more statements in this transaction, it has been committed", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
+        assertEquals( "Cannot run more statements in this transaction, it has been committed", e.getMessage() );
     }
 
     @Test
-    public void shouldFailToRunQueryAfterRollback()
+    void shouldFailToRunQueryAfterRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE (:MyLabel)" );
@@ -891,55 +732,34 @@ public class TransactionAsyncIT
 
         assertEquals( 0, session.run( "MATCH (n:MyLabel) RETURN count(n)" ).single().get( 0 ).asInt() );
 
-        try
-        {
-            await( tx.runAsync( "CREATE (:MyOtherLabel)" ) );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Cannot run more statements in this transaction, it has been rolled back", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
+        assertEquals( "Cannot run more statements in this transaction, it has been rolled back", e.getMessage() );
     }
 
     @Test
-    public void shouldFailToRunQueryWhenMarkedForFailure()
+    void shouldFailToRunQueryWhenMarkedForFailure()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE (:MyLabel)" );
         tx.failure();
 
-        try
-        {
-            await( tx.runAsync( "CREATE (:MyOtherLabel)" ) );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
+        assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
     }
 
     @Test
-    public void shouldFailToRunQueryWhenTerminated()
+    void shouldFailToRunQueryWhenTerminated()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE (:MyLabel)" );
         ((ExplicitTransaction) tx).markTerminated();
 
-        try
-        {
-            await( tx.runAsync( "CREATE (:MyOtherLabel)" ) );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Cannot run more statements in this transaction, it has been terminated", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
+        assertEquals( "Cannot run more statements in this transaction, it has been terminated", e.getMessage() );
     }
 
     @Test
-    public void shouldAllowQueriesWhenMarkedForSuccess()
+    void shouldAllowQueriesWhenMarkedForSuccess()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE (:MyLabel)" );
@@ -953,7 +773,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldUpdateSessionBookmarkAfterCommit()
+    void shouldUpdateSessionBookmarkAfterCommit()
     {
         assumeDatabaseSupportsBookmarks();
 
@@ -970,7 +790,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldFailToCommitWhenQueriesFailAndErrorNotConsumed() throws InterruptedException
+    void shouldFailToCommitWhenQueriesFailAndErrorNotConsumed() throws InterruptedException
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
@@ -979,290 +799,169 @@ public class TransactionAsyncIT
         tx.runAsync( "RETURN 10 / 0" );
         tx.runAsync( "CREATE (:TestNode)" );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "/ by zero", e.getMessage() );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertEquals( "/ by zero", e.getMessage() );
     }
 
     @Test
-    public void shouldPropagateRunFailureFromCommit()
+    void shouldPropagateRunFailureFromCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         tx.runAsync( "RETURN ILLEGAL" );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "ILLEGAL" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.getMessage(), containsString( "ILLEGAL" ) );
     }
 
     @Test
-    public void shouldPropagateBlockedRunFailureFromCommit()
+    void shouldPropagateBlockedRunFailureFromCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         await( tx.runAsync( "RETURN 42 / 0" ) );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "/ by zero" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
     }
 
     @Test
-    public void shouldPropagateRunFailureFromRollback()
+    void shouldPropagateRunFailureFromRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         tx.runAsync( "RETURN ILLEGAL" );
 
-        try
-        {
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "ILLEGAL" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.getMessage(), containsString( "ILLEGAL" ) );
     }
 
     @Test
-    public void shouldPropagateBlockedRunFailureFromRollback()
+    void shouldPropagateBlockedRunFailureFromRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         await( tx.runAsync( "RETURN 42 / 0" ) );
 
-        try
-        {
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "/ by zero" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
     }
 
     @Test
-    public void shouldPropagatePullAllFailureFromCommit()
+    void shouldPropagatePullAllFailureFromCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "TypeError" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.code(), containsString( "TypeError" ) );
     }
 
     @Test
-    public void shouldPropagateBlockedPullAllFailureFromCommit()
+    void shouldPropagateBlockedPullAllFailureFromCommit()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         await( tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" ) );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "TypeError" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.code(), containsString( "TypeError" ) );
     }
 
     @Test
-    public void shouldPropagatePullAllFailureFromRollback()
+    void shouldPropagatePullAllFailureFromRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" );
 
-        try
-        {
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "TypeError" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.code(), containsString( "TypeError" ) );
     }
 
     @Test
-    public void shouldPropagateBlockedPullAllFailureFromRollback()
+    void shouldPropagateBlockedPullAllFailureFromRollback()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         await( tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" ) );
 
-        try
-        {
-            await( tx.rollbackAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "TypeError" ) );
-        }
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.code(), containsString( "TypeError" ) );
     }
 
     @Test
-    public void shouldFailToCommitWhenRunFailureIsConsumed()
+    void shouldFailToCommitWhenRunFailureIsConsumed()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "SyntaxError" ) );
-        }
+        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
+        assertThat( e1.code(), containsString( "SyntaxError" ) );
 
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), startsWith( "Transaction rolled back" ) );
-        }
+        ClientException e2 = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e2.getMessage(), startsWith( "Transaction rolled back" ) );
     }
 
     @Test
-    public void shouldFailToCommitWhenPullAllFailureIsConsumed()
+    void shouldFailToCommitWhenPullAllFailureIsConsumed()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync(
                 "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" ) );
 
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "TypeError" ) );
-        }
-        try
-        {
-            await( tx.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), startsWith( "Transaction rolled back" ) );
-        }
+        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
+        assertThat( e1.code(), containsString( "TypeError" ) );
+
+        ClientException e2 = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e2.getMessage(), startsWith( "Transaction rolled back" ) );
     }
 
     @Test
-    public void shouldRollbackWhenRunFailureIsConsumed()
+    void shouldRollbackWhenRunFailureIsConsumed()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "SyntaxError" ) );
-        }
-
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
+        assertThat( e.code(), containsString( "SyntaxError" ) );
         assertNull( await( tx.rollbackAsync() ) );
     }
 
     @Test
-    public void shouldRollbackWhenPullAllFailureIsConsumed()
+    void shouldRollbackWhenPullAllFailureIsConsumed()
     {
         Transaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 5 / x" ) );
 
-        try
-        {
-            await( cursor.consumeAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.getMessage(), containsString( "/ by zero" ) );
-        }
-
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
         assertNull( await( tx.rollbackAsync() ) );
     }
 
     @Test
-    public void shouldPropagateFailureFromSummary()
+    void shouldPropagateFailureFromSummary()
     {
         Transaction tx = await( session.beginTransactionAsync() );
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        try
-        {
-            await( cursor.summaryAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertThat( e.code(), containsString( "SyntaxError" ) );
-        }
-
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        assertThat( e.code(), containsString( "SyntaxError" ) );
         assertNotNull( await( cursor.summaryAsync() ) );
     }
 
     @Test
-    public void shouldFailToExecuteBlockingRunChainedWithAsyncTransaction()
+    void shouldFailToExecuteBlockingRunChainedWithAsyncTransaction()
     {
         CompletionStage<Void> result = session.beginTransactionAsync()
                 .thenApply( tx ->
                 {
                     if ( EventLoopGroupFactory.isEventLoopThread( Thread.currentThread() ) )
                     {
-                        try
-                        {
-                            tx.run( "CREATE ()" );
-                            fail( "Exception expected" );
-                        }
-                        catch ( IllegalStateException e )
-                        {
-                            assertThat( e, is( blockingOperationInEventLoopError() ) );
-                        }
+                        IllegalStateException e = assertThrows( IllegalStateException.class, () -> tx.run( "CREATE ()" ) );
+                        assertThat( e, is( blockingOperationInEventLoopError() ) );
                     }
                     return null;
                 } );
@@ -1271,7 +970,7 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldAllowUsingBlockingApiInCommonPoolWhenChaining()
+    void shouldAllowUsingBlockingApiInCommonPoolWhenChaining()
     {
         CompletionStage<Transaction> txStage = session.beginTransactionAsync()
                 // move execution to ForkJoinPool.commonPool()
@@ -1293,21 +992,14 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldBePossibleToRunMoreTransactionsAfterOneIsTerminated()
+    void shouldBePossibleToRunMoreTransactionsAfterOneIsTerminated()
     {
         Transaction tx1 = await( session.beginTransactionAsync() );
         ((ExplicitTransaction) tx1).markTerminated();
 
-        try
-        {
-            // commit should fail, make session forget about this transaction and release the connection to the pool
-            await( tx1.commitAsync() );
-            fail( "Exception expected" );
-        }
-        catch ( ClientException e )
-        {
-            assertEquals( "Can't commit, transaction has been terminated", e.getMessage() );
-        }
+        // commit should fail, make session forget about this transaction and release the connection to the pool
+        ClientException e = assertThrows( ClientException.class, () -> await( tx1.commitAsync() ) );
+        assertEquals( "Can't commit, transaction has been terminated", e.getMessage() );
 
         await( session.beginTransactionAsync()
                 .thenCompose( tx -> tx.runAsync( "CREATE (:Node {id: 42})" )
@@ -1319,13 +1011,13 @@ public class TransactionAsyncIT
     }
 
     @Test
-    public void shouldPropagateCommitFailureAfterFatalError()
+    void shouldPropagateCommitFailureAfterFatalError()
     {
         testCommitAndRollbackFailurePropagation( true );
     }
 
     @Test
-    public void shouldPropagateRollbackFailureAfterFatalError()
+    void shouldPropagateRollbackFailureAfterFatalError()
     {
         testCommitAndRollbackFailurePropagation( false );
     }
@@ -1404,22 +1096,14 @@ public class TransactionAsyncIT
                 CompletionStage<Void> commitOrRollback = commit ? tx.commitAsync() : tx.rollbackAsync();
 
                 // commit/rollback should fail and propagate the network error
-                try
-                {
-                    await( commitOrRollback );
-                    fail( "Exception expected" );
-                }
-                catch ( ServiceUnavailableException e )
-                {
-                    assertEquals( ioError, e.getCause() );
-                }
+                ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> await( commitOrRollback ) );
+                assertEquals( ioError, e.getCause() );
             }
         }
     }
 
     private void assumeDatabaseSupportsBookmarks()
     {
-        assumeTrue( "Neo4j " + neo4j.version() + " does not support bookmarks",
-                neo4j.version().greaterThanOrEqual( v3_1_0 ) );
+        assumeTrue( neo4j.version().greaterThanOrEqual( v3_1_0 ), "Neo4j " + neo4j.version() + " does not support bookmarks" );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
@@ -19,9 +19,8 @@
 package org.neo4j.driver.v1.integration;
 
 import io.netty.channel.Channel;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Map;
 
@@ -40,30 +39,28 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.TransientException;
+import org.neo4j.driver.v1.util.SessionExtension;
 import org.neo4j.driver.v1.util.StubServer;
-import org.neo4j.driver.v1.util.TestNeo4jSession;
 import org.neo4j.driver.v1.util.TestUtil;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.retry.RetrySettings.DEFAULT;
 
-public class TransactionIT
+class TransactionIT
 {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-    @Rule
-    public TestNeo4jSession session = new TestNeo4jSession();
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
 
     @Test
-    public void shouldRunAndCommit() throws Throwable
+    void shouldRunAndCommit()
     {
         // When
         try ( Transaction tx = session.beginTransaction() )
@@ -80,7 +77,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldRunAndRollbackByDefault() throws Throwable
+    void shouldRunAndRollbackByDefault()
     {
         // When
         try ( Transaction tx = session.beginTransaction() )
@@ -96,7 +93,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldRetrieveResults() throws Throwable
+    void shouldRetrieveResults()
     {
         // Given
         session.run( "CREATE (n {name:'Steve Brook'})" );
@@ -112,20 +109,15 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldNotAllowSessionLevelStatementsWhenThereIsATransaction() throws Throwable
+    void shouldNotAllowSessionLevelStatementsWhenThereIsATransaction()
     {
-        // Given
         session.beginTransaction();
 
-        // Expect
-        exception.expect( ClientException.class );
-
-        // When
-        session.run( "anything" );
+        assertThrows( ClientException.class, () -> session.run( "anything" ) );
     }
 
     @Test
-    public void shouldBeClosedAfterRollback() throws Throwable
+    void shouldBeClosedAfterRollback()
     {
         // When
         Transaction tx = session.beginTransaction();
@@ -136,7 +128,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldBeClosedAfterCommit() throws Throwable
+    void shouldBeClosedAfterCommit()
     {
         // When
         Transaction tx = session.beginTransaction();
@@ -148,7 +140,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldBeOpenBeforeCommit() throws Throwable
+    void shouldBeOpenBeforeCommit()
     {
         // When
         Transaction tx = session.beginTransaction();
@@ -158,7 +150,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldHandleNullParametersGracefully()
+    void shouldHandleNullParametersGracefully()
     {
         // When
         session.run( "match (n) return count(n)", (Value) null );
@@ -170,7 +162,7 @@ public class TransactionIT
 
     //See GH #146
     @Test
-    public void shouldHandleFailureAfterClosingTransaction()
+    void shouldHandleFailureAfterClosingTransaction()
     {
         // GIVEN a successful query in a transaction
         Transaction tx = session.beginTransaction();
@@ -179,16 +171,13 @@ public class TransactionIT
         tx.success();
         tx.close();
 
-        // EXPECT
-        exception.expect( ClientException.class );
-
-        //WHEN running a malformed query in the original session
-        session.run( "CREAT (n) RETURN n" ).consume();
+        // WHEN when running a malformed query in the original session
+        assertThrows( ClientException.class, () -> session.run( "CREAT (n) RETURN n" ).consume() );
     }
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldHandleNullRecordParameters() throws Throwable
+    void shouldHandleNullRecordParameters()
     {
         // When
         try ( Transaction tx = session.beginTransaction() )
@@ -203,7 +192,7 @@ public class TransactionIT
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldHandleNullValueParameters() throws Throwable
+    void shouldHandleNullValueParameters()
     {
         // When
         try ( Transaction tx = session.beginTransaction() )
@@ -218,7 +207,7 @@ public class TransactionIT
 
     @SuppressWarnings( "ConstantConditions" )
     @Test
-    public void shouldHandleNullMapParameters() throws Throwable
+    void shouldHandleNullMapParameters()
     {
         // When
         try ( Transaction tx = session.beginTransaction() )
@@ -232,82 +221,59 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldRollBackTxIfErrorWithoutConsume() throws Throwable
+    void shouldRollBackTxIfErrorWithoutConsume()
     {
         // Given
         Transaction tx = session.beginTransaction();
         tx.run( "invalid" ); // send run, pull_all
         tx.success();
-        try
+
+        assertThrows( ClientException.class, tx::close );
+
+        try ( Transaction anotherTx = session.beginTransaction() )
         {
-            tx.close();
-            fail("should fail tx in tx.close()");
-        } // When send run_commit, and pull_all
-
-        // Then error and should also send ack_fail, roll_back and pull_all
-        catch ( ClientException e )
-        {
-            try ( Transaction anotherTx = session.beginTransaction() )
-            {
-                StatementResult cursor = anotherTx.run( "RETURN 1" );
-                int val = cursor.single().get( "1" ).asInt();
-
-
-                assertThat( val, equalTo( 1 ) );
-            }
+            StatementResult cursor = anotherTx.run( "RETURN 1" );
+            int val = cursor.single().get( "1" ).asInt();
+            assertThat( val, equalTo( 1 ) );
         }
     }
 
     @Test
-    public void shouldRollBackTxIfErrorWithConsume() throws Throwable
+    void shouldRollBackTxIfErrorWithConsume()
     {
-
-        // Given
-        try ( Transaction tx = session.beginTransaction() )
-        {
-            StatementResult result = tx.run( "invalid" );
-            tx.success();
-
-            // When
-            result.consume(); // run, pull_all
-            fail( "Should fail tx due to syntax error" );
-        } // ack_fail, roll_back, pull_all
-        // Then
-        catch ( ClientException e )
+        assertThrows( ClientException.class, () ->
         {
             try ( Transaction tx = session.beginTransaction() )
             {
-                StatementResult cursor = tx.run( "RETURN 1" );
-                int val = cursor.single().get( "1" ).asInt();
-
-                assertThat( val, equalTo( 1 ) );
+                StatementResult result = tx.run( "invalid" );
+                tx.success();
+                result.consume();
             }
+        } );
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            StatementResult cursor = tx.run( "RETURN 1" );
+            int val = cursor.single().get( "1" ).asInt();
+            assertThat( val, equalTo( 1 ) );
         }
     }
 
     @Test
-    public void shouldPropagateFailureFromSummary()
+    void shouldPropagateFailureFromSummary()
     {
         try ( Transaction tx = session.beginTransaction() )
         {
             StatementResult result = tx.run( "RETURN Wrong" );
 
-            try
-            {
-                result.summary();
-                fail( "Exception expected" );
-            }
-            catch ( ClientException e )
-            {
-                assertThat( e.code(), containsString( "SyntaxError" ) );
-            }
-
+            ClientException e = assertThrows( ClientException.class, result::summary );
+            assertThat( e.code(), containsString( "SyntaxError" ) );
             assertNotNull( result.summary() );
         }
     }
 
     @Test
-    public void shouldBeResponsiveToThreadInterruptWhenWaitingForResult() throws Exception
+    void shouldBeResponsiveToThreadInterruptWhenWaitingForResult()
     {
         try ( Session otherSession = session.driver().session() )
         {
@@ -324,11 +290,8 @@ public class TransactionIT
 
             try
             {
-                tx2.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Stormbreaker'" ).consume();
-                fail( "Exception expected" );
-            }
-            catch ( ServiceUnavailableException e )
-            {
+                ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class,
+                        () -> tx2.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Stormbreaker'" ).consume() );
                 assertThat( e.getMessage(), containsString( "Connection to the database terminated" ) );
                 assertThat( e.getMessage(), containsString( "Thread interrupted while waiting for result to arrive" ) );
             }
@@ -341,7 +304,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldBeResponsiveToThreadInterruptWhenWaitingForCommit() throws Exception
+    void shouldBeResponsiveToThreadInterruptWhenWaitingForCommit()
     {
         try ( Session otherSession = session.driver().session() )
         {
@@ -361,13 +324,7 @@ public class TransactionIT
 
             try
             {
-                tx2.close();
-                fail( "Exception expected" );
-            }
-            catch ( ServiceUnavailableException e )
-            {
-                assertEquals( e.getMessage(),
-                        "Connection to the database terminated. Thread interrupted while closing the transaction" );
+                assertThrows( ServiceUnavailableException.class, tx2::close );
             }
             finally
             {
@@ -378,25 +335,25 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldThrowWhenConnectionKilledDuringTransaction()
+    void shouldThrowWhenConnectionKilledDuringTransaction()
     {
         testFailWhenConnectionKilledDuringTransaction( false );
     }
 
     @Test
-    public void shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess()
+    void shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess()
     {
         testFailWhenConnectionKilledDuringTransaction( true );
     }
 
     @Test
-    public void shouldThrowCommitError() throws Exception
+    void shouldThrowCommitError() throws Exception
     {
         testTxCloseErrorPropagation( "commit_error.script", true, "Unable to commit" );
     }
 
     @Test
-    public void shouldThrowRollbackError() throws Exception
+    void shouldThrowRollbackError() throws Exception
     {
         testTxCloseErrorPropagation( "rollback_error.script", false, "Unable to rollback" );
     }
@@ -409,29 +366,29 @@ public class TransactionIT
 
         try ( Driver driver = factory.newInstance( session.uri(), session.authToken(), instance, DEFAULT, config ) )
         {
-            try ( Session session = driver.session();
-                  Transaction tx = session.beginTransaction() )
+            ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () ->
             {
-                tx.run( "CREATE (:MyNode {id: 1})" ).consume();
-
-                if ( markForSuccess )
+                try ( Session session = driver.session();
+                      Transaction tx = session.beginTransaction() )
                 {
-                    tx.success();
-                }
+                    tx.run( "CREATE (:MyNode {id: 1})" ).consume();
 
-                // kill all network channels
-                for ( Channel channel : factory.channels() )
-                {
-                    channel.close().syncUninterruptibly();
-                }
+                    if ( markForSuccess )
+                    {
+                        tx.success();
+                    }
 
-                tx.run( "CREATE (:MyNode {id: 1})" ).consume();
-                fail( "Exception expected" );
-            }
-            catch ( ServiceUnavailableException e )
-            {
-                assertThat( e.getMessage(), containsString( "Connection to the database terminated" ) );
-            }
+                    // kill all network channels
+                    for ( Channel channel: factory.channels() )
+                    {
+                        channel.close().syncUninterruptibly();
+                    }
+
+                    tx.run( "CREATE (:MyNode {id: 1})" ).consume();
+                }
+            } );
+
+            assertThat( e.getMessage(), containsString( "Connection to the database terminated" ) );
         }
 
         assertEquals( 0, session.run( "MATCH (n:MyNode {id: 1}) RETURN count(n)" ).single().get( 0 ).asInt() );
@@ -460,16 +417,9 @@ public class TransactionIT
                     tx.failure();
                 }
 
-                try
-                {
-                    tx.close();
-                    fail( "Exception expected" );
-                }
-                catch ( TransientException e )
-                {
-                    assertEquals( "Neo.TransientError.General.DatabaseUnavailable", e.code() );
-                    assertEquals( expectedErrorMessage, e.getMessage() );
-                }
+                TransientException e = assertThrows( TransientException.class, tx::close );
+                assertEquals( "Neo.TransientError.General.DatabaseUnavailable", e.code() );
+                assertEquals( expectedErrorMessage, e.getMessage() );
             }
         }
         finally

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -19,9 +19,9 @@
 package org.neo4j.driver.v1.stress;
 
 import io.netty.util.internal.ConcurrentSet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
@@ -69,13 +69,13 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.metrics.spi.Metrics.DRIVER_METRICS_ENABLED_KEY;
 
-public abstract class AbstractStressTestBase<C extends AbstractContext>
+abstract class AbstractStressTestBase<C extends AbstractContext>
 {
     private static final int THREAD_COUNT = Integer.getInteger( "threadCount", 8 );
     private static final int ASYNC_BATCH_SIZE = Integer.getInteger( "asyncBatchSize", 10 );
@@ -90,8 +90,8 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
 
     InternalDriver driver;
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         System.setProperty( DRIVER_METRICS_ENABLED_KEY, "true" );
         logging = new LoggerNameTrackingLogging();
@@ -109,8 +109,8 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
         executor = Executors.newCachedThreadPool( threadFactory );
     }
 
-    @After
-    public void tearDown()
+    @AfterEach
+    void tearDown()
     {
         System.out.println( driver.metrics() );
         executor.shutdownNow();
@@ -122,26 +122,26 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
     }
 
     @Test
-    public void blockingApiStressTest() throws Throwable
+    void blockingApiStressTest() throws Throwable
     {
         runStressTest( this::launchBlockingWorkerThreads );
     }
 
     @Test
-    public void asyncApiStressTest() throws Throwable
+    void asyncApiStressTest() throws Throwable
     {
         runStressTest( this::launchAsyncWorkerThreads );
     }
 
     @Test
-    public void blockingApiBigDataTest()
+    void blockingApiBigDataTest()
     {
         String bookmark = createNodesBlocking( bigDataTestBatchCount(), BIG_DATA_TEST_BATCH_SIZE, driver );
         readNodesBlocking( driver, bookmark, BIG_DATA_TEST_NODE_COUNT );
     }
 
     @Test
-    public void asyncApiBigDataTest() throws Throwable
+    void asyncApiBigDataTest() throws Throwable
     {
         String bookmark = createNodesAsync( bigDataTestBatchCount(), BIG_DATA_TEST_BATCH_SIZE, driver );
         readNodesAsync( driver, bookmark, BIG_DATA_TEST_NODE_COUNT );
@@ -366,7 +366,7 @@ public abstract class AbstractStressTestBase<C extends AbstractContext>
             assertEquals( 1, records.size() );
             Record record = records.get( 0 );
             long actualCount = record.get( "nodesCount" ).asLong();
-            assertEquals( "Unexpected number of nodes in the database", expectedCount, actualCount );
+            assertEquals( expectedCount, actualCount, "Unexpected number of nodes in the database" );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncFailingQuery.java
@@ -27,8 +27,8 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResultCursor;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 
 public class AsyncFailingQuery<C extends AbstractContext> extends AbstractAsyncQuery<C>

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncFailingQueryInTx.java
@@ -28,8 +28,8 @@ import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.Transaction;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 
 public class AsyncFailingQueryInTx<C extends AbstractContext> extends AbstractAsyncQuery<C>

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncReadQuery.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.types.Node;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AsyncReadQuery<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncReadQueryInTx.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.types.Node;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AsyncReadQueryInTx<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWriteQuery.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResultCursor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AsyncWriteQuery<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWriteQueryInTx.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AsyncWriteQueryInTx<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWrongQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWrongQuery.java
@@ -30,9 +30,9 @@ import org.neo4j.driver.v1.exceptions.Neo4jException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class AsyncWrongQuery<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWrongQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AsyncWrongQueryInTx.java
@@ -31,9 +31,9 @@ import org.neo4j.driver.v1.exceptions.Neo4jException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class AsyncWrongQueryInTx<C extends AbstractContext> extends AbstractAsyncQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingFailingQuery.java
@@ -24,8 +24,8 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 
 public class BlockingFailingQuery<C extends AbstractContext> extends AbstractBlockingQuery<C>
@@ -41,15 +41,8 @@ public class BlockingFailingQuery<C extends AbstractContext> extends AbstractBlo
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
             StatementResult result = session.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
-            try
-            {
-                result.consume();
-                fail( "Exception expected" );
-            }
-            catch ( Exception e )
-            {
-                assertThat( e, is( arithmeticError() ) );
-            }
+            Exception e = assertThrows( Exception.class, result::consume );
+            assertThat( e, is( arithmeticError() ) );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingFailingQueryInTx.java
@@ -25,8 +25,8 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 
 public class BlockingFailingQueryInTx<C extends AbstractContext> extends AbstractBlockingQuery<C>
@@ -45,15 +45,8 @@ public class BlockingFailingQueryInTx<C extends AbstractContext> extends Abstrac
             {
                 StatementResult result = tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
 
-                try
-                {
-                    result.consume();
-                    fail( "Exception expected" );
-                }
-                catch ( Exception e )
-                {
-                    assertThat( e, is( arithmeticError() ) );
-                }
+                Exception e = assertThrows( Exception.class, result::consume );
+                assertThat( e, is( arithmeticError() ) );
             }
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingReadQuery.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.types.Node;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.neo4j.driver.internal.util.Iterables.single;
 
 public class BlockingReadQuery<C extends AbstractContext> extends AbstractBlockingQuery<C>

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingReadQueryInTx.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.types.Node;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.neo4j.driver.internal.util.Iterables.single;
 
 public class BlockingReadQueryInTx<C extends AbstractContext> extends AbstractBlockingQuery<C>

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQuery.java
@@ -23,7 +23,7 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BlockingWriteQuery<C extends AbstractContext> extends AbstractBlockingQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQueryInTx.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BlockingWriteQueryInTx<C extends AbstractContext> extends AbstractBlockingQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQueryUsingReadSession.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWriteQueryUsingReadSession.java
@@ -18,17 +18,17 @@
  */
 package org.neo4j.driver.v1.stress;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BlockingWriteQueryUsingReadSession<C extends AbstractContext> extends AbstractBlockingQuery<C>
 {
@@ -40,20 +40,16 @@ public class BlockingWriteQueryUsingReadSession<C extends AbstractContext> exten
     @Override
     public void execute( C context )
     {
-        StatementResult result = null;
-        try
+        AtomicReference<StatementResult> resultRef = new AtomicReference<>();
+        assertThrows( ClientException.class, () ->
         {
             try ( Session session = newSession( AccessMode.READ, context ) )
             {
-                result = session.run( "CREATE ()" );
+                StatementResult result = session.run( "CREATE ()" );
+                resultRef.set( result );
             }
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( ClientException.class ) );
-            assertNotNull( result );
-            assertEquals( 0, result.summary().counters().nodesCreated() );
-        }
+        } );
+        assertNotNull( resultRef.get() );
+        assertEquals( 0, resultRef.get().summary().counters().nodesCreated() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWrongQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWrongQuery.java
@@ -23,8 +23,8 @@ import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
 
 public class BlockingWrongQuery<C extends AbstractContext> extends AbstractBlockingQuery<C>
@@ -39,15 +39,8 @@ public class BlockingWrongQuery<C extends AbstractContext> extends AbstractBlock
     {
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
-            try
-            {
-                session.run( "RETURN" ).consume();
-                fail( "Exception expected" );
-            }
-            catch ( Exception e )
-            {
-                assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-            }
+            Exception e = assertThrows( Exception.class, () -> session.run( "RETURN" ).consume() );
+            assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWrongQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/BlockingWrongQueryInTx.java
@@ -24,8 +24,8 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
 
 public class BlockingWrongQueryInTx<C extends AbstractContext> extends AbstractBlockingQuery<C>
@@ -42,15 +42,8 @@ public class BlockingWrongQueryInTx<C extends AbstractContext> extends AbstractB
         {
             try ( Transaction tx = beginTransaction( session, context ) )
             {
-                try
-                {
-                    tx.run( "RETURN" ).consume();
-                    fail( "Exception expected" );
-                }
-                catch ( Exception e )
-                {
-                    assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
-                }
+                Exception e = assertThrows( Exception.class, () -> tx.run( "RETURN" ).consume() );
+                assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
             }
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.neo4j.driver.internal.util.Neo4jFeature.READ_ON_FOLLOWERS_BY_DEFAULT;
 import static org.neo4j.driver.v1.util.cc.ClusterMember.SIMPLE_SCHEME;
 
 class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringStressIT.Context>
@@ -105,7 +106,8 @@ class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringSt
         ClusterAddresses clusterAddresses = fetchClusterAddresses( driver );
 
         // before 3.2.0 only read replicas serve reads
-        boolean readsOnFollowersEnabled = ServerVersion.version( driver ).greaterThanOrEqual( ServerVersion.v3_2_0 );
+        ServerVersion version = ServerVersion.version( driver );
+        boolean readsOnFollowersEnabled = READ_ON_FOLLOWERS_BY_DEFAULT.availableIn( version );
 
         if ( readsOnFollowersEnabled )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.driver.v1.stress;
 
-import org.junit.AfterClass;
-import org.junit.Rule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -41,26 +40,19 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.cc.ClusterMemberRole;
-import org.neo4j.driver.v1.util.cc.ClusterRule;
-import org.neo4j.driver.v1.util.cc.LocalOrRemoteClusterRule;
+import org.neo4j.driver.v1.util.cc.LocalOrRemoteClusterExtension;
 
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.neo4j.driver.v1.util.cc.ClusterMember.SIMPLE_SCHEME;
 
-public class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringStressIT.Context>
+class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringStressIT.Context>
 {
-    @Rule
-    public final LocalOrRemoteClusterRule clusterRule = new LocalOrRemoteClusterRule();
-
-    @AfterClass
-    public static void stopSharedCluster()
-    {
-        ClusterRule.stopSharedCluster();
-    }
+    @RegisterExtension
+    static final LocalOrRemoteClusterExtension clusterRule = new LocalOrRemoteClusterExtension();
 
     @Override
     URI databaseUri()

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/FailedAuth.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/FailedAuth.java
@@ -26,9 +26,8 @@ import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.exceptions.SecurityException;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.v1.AuthTokens.basic;
 
 public class FailedAuth<C extends AbstractContext> implements BlockingCommand<C>
@@ -47,15 +46,8 @@ public class FailedAuth<C extends AbstractContext> implements BlockingCommand<C>
     {
         Config config = Config.build().withLogging( logging ).toConfig();
 
-        try
-        {
-            GraphDatabase.driver( clusterUri, basic( "wrongUsername", "wrongPassword" ), config );
-            fail( "Exception expected" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( SecurityException.class ) );
-            assertThat( e.getMessage(), containsString( "authentication failure" ) );
-        }
+        SecurityException e = assertThrows( SecurityException.class,
+                () -> GraphDatabase.driver( clusterUri, basic( "wrongUsername", "wrongPassword" ), config ) );
+        assertThat( e.getMessage(), containsString( "authentication failure" ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
@@ -18,15 +18,12 @@
  */
 package org.neo4j.driver.v1.stress;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -39,41 +36,17 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.GraphDatabase.driver;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 
-public class SessionPoolingStressIT
+class SessionPoolingStressIT
 {
-    @Rule
-    public final TestNeo4j neo4j = new TestNeo4j();
-
-    @Rule
-    public final TestWatcher testWatcher = new TestWatcher()
-    {
-        @Override
-        protected void failed( Throwable e, Description description )
-        {
-            super.failed( e, description );
-
-            StringBuilder sb = new StringBuilder();
-            Map<Thread,StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
-            for ( Map.Entry<Thread,StackTraceElement[]> entry : allStackTraces.entrySet() )
-            {
-                Thread thread = entry.getKey();
-                sb.append( thread ).append( " -- " ).append( thread.getState() ).append( System.lineSeparator() );
-                for ( StackTraceElement element : entry.getValue() )
-                {
-                    sb.append( "    " ).append( element ).append( System.lineSeparator() );
-                }
-            }
-
-            System.out.println( sb.toString() );
-        }
-    };
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
 
     private static final int N_THREADS = 50;
     private static final int TEST_TIME = 10000;
@@ -84,14 +57,14 @@ public class SessionPoolingStressIT
     private Driver driver;
     private ExecutorService executor;
 
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    void setUp()
     {
         executor = Executors.newFixedThreadPool( N_THREADS, daemon( getClass().getSimpleName() + "-thread-" ) );
     }
 
-    @After
-    public void tearDown() throws Exception
+    @AfterEach
+    void tearDown()
     {
         if ( executor != null )
         {
@@ -105,7 +78,7 @@ public class SessionPoolingStressIT
     }
 
     @Test
-    public void shouldWorkFine() throws Throwable
+    void shouldWorkFine() throws Throwable
     {
         Config config = Config.build()
                 .withoutEncryption()

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/SingleInstanceStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/SingleInstanceStressIT.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.v1.stress;
 
-import org.junit.Rule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
 import java.util.Collections;
@@ -27,16 +27,16 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.summary.ResultSummary;
-import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStressIT.Context>
+class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStressIT.Context>
 {
-    @Rule
-    public final TestNeo4j neo4j = new TestNeo4j();
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
 
     @Override
     URI databaseUri()

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverComplianceIT.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 
 import java.nio.file.Files;
 
-import org.neo4j.driver.v1.util.TestNeo4j;
+import org.neo4j.driver.v1.tck.tck.util.DatabaseRule;
 
 /**
  * The base class to run all cucumber tests
@@ -36,7 +36,7 @@ import org.neo4j.driver.v1.util.TestNeo4j;
 public class DriverComplianceIT
 {
     @ClassRule
-    public static TestNeo4j neo4j = new TestNeo4j();
+    public static final DatabaseRule neo4j = new DatabaseRule();
 
     @AfterClass
     public static void tearDownClass() throws Exception

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/tck/util/DatabaseRule.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/tck/util/DatabaseRule.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.tck.tck.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import org.neo4j.driver.v1.util.DatabaseExtension;
+
+public class DatabaseRule extends DatabaseExtension implements TestRule
+{
+    @Override
+    public Statement apply( Statement base, Description description )
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                DatabaseRule.this.beforeEach( null );
+                base.evaluate();
+            }
+        };
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/util/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/DatabaseExtension.java
@@ -18,9 +18,8 @@
  */
 package org.neo4j.driver.v1.util;
 
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,36 +41,29 @@ import static org.neo4j.driver.v1.util.Neo4jRunner.getOrCreateGlobalRunner;
 import static org.neo4j.driver.v1.util.Neo4jSettings.DEFAULT_TLS_CERT_PATH;
 import static org.neo4j.driver.v1.util.Neo4jSettings.DEFAULT_TLS_KEY_PATH;
 
-public class TestNeo4j implements TestRule
+public class DatabaseExtension implements BeforeEachCallback
 {
-    public static final String TEST_RESOURCE_FOLDER_PATH = "src/test/resources";
+    static final String TEST_RESOURCE_FOLDER_PATH = "src/test/resources";
+
     private final Neo4jSettings settings;
     private Neo4jRunner runner;
 
-    public TestNeo4j()
+    public DatabaseExtension()
     {
         this( Neo4jSettings.TEST_SETTINGS );
     }
 
-    public TestNeo4j( Neo4jSettings settings )
+    public DatabaseExtension( Neo4jSettings settings )
     {
         this.settings = settings;
     }
 
     @Override
-    public Statement apply( final Statement base, final Description description )
+    public void beforeEach( ExtensionContext context ) throws Exception
     {
-        return new Statement()
-        {
-            @Override
-            public void evaluate() throws Throwable
-            {
-                runner = getOrCreateGlobalRunner();
-                runner.ensureRunning( settings );
-                TestUtil.cleanDb( driver() );
-                base.evaluate();
-            }
-        };
+        runner = getOrCreateGlobalRunner();
+        runner.ensureRunning( settings );
+        TestUtil.cleanDb( driver() );
     }
 
     public Driver driver()

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.v1.GraphDatabase;
 import static java.lang.System.getProperty;
 import static java.util.Arrays.asList;
 import static java.util.logging.Level.INFO;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.v1.AuthTokens.basic;
 import static org.neo4j.driver.v1.Logging.console;
 import static org.neo4j.driver.v1.util.FileTools.moveFile;
@@ -76,7 +76,7 @@ public class Neo4jRunner
     /** Global runner controlling a single server, used to avoid having to restart the server between tests */
     public static synchronized Neo4jRunner getOrCreateGlobalRunner() throws IOException
     {
-        assumeTrue( "BoltKit support unavailable", boltKitAvailable() );
+        assumeTrue( boltKitAvailable(), "BoltKit support unavailable" );
         if ( globalInstance == null )
         {
             globalInstance = new Neo4jRunner();

--- a/driver/src/test/java/org/neo4j/driver/v1/util/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/SessionExtension.java
@@ -18,8 +18,9 @@
  */
 package org.neo4j.driver.v1.util;
 
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
@@ -35,39 +36,26 @@ import org.neo4j.driver.v1.types.TypeSystem;
 
 /**
  * A little utility for integration testing, this provides tests with a session they can work with.
- * If you want more direct control, have a look at {@link TestNeo4j} instead.
+ * If you want more direct control, have a look at {@link DatabaseExtension} instead.
  */
-public class TestNeo4jSession extends TestNeo4j implements Session
+public class SessionExtension extends DatabaseExtension implements Session, BeforeEachCallback, AfterEachCallback
 {
     private Session realSession;
 
-    public TestNeo4jSession()
+    @Override
+    public void beforeEach( ExtensionContext context ) throws Exception
     {
-        super();
+        super.beforeEach( context );
+        realSession = driver().session();
     }
 
     @Override
-    public Statement apply( final Statement base, Description description )
+    public void afterEach( ExtensionContext context )
     {
-        return super.apply( new Statement()
+        if ( realSession != null )
         {
-            @Override
-            public void evaluate() throws Throwable
-            {
-                try
-                {
-                    realSession = driver().session();
-                    base.evaluate();
-                }
-                finally
-                {
-                    if ( realSession != null )
-                    {
-                        realSession.close();
-                    }
-                }
-            }
-        }, description );
+            realSession.close();
+        }
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
@@ -35,8 +35,8 @@ import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 
 public class StubServer
@@ -53,7 +53,7 @@ public class StubServer
 
     private static final String BOLT_STUB_COMMAND = "boltstub";
 
-    private Process process = null;
+    private Process process;
 
     private StubServer( String script, int port ) throws IOException, InterruptedException
     {
@@ -95,7 +95,7 @@ public class StubServer
 
     private static String resource( String fileName )
     {
-        File resource = new File( TestNeo4j.TEST_RESOURCE_FOLDER_PATH, fileName );
+        File resource = new File( DatabaseExtension.TEST_RESOURCE_FOLDER_PATH, fileName );
         if ( !resource.exists() )
         {
             fail( fileName + " does not exists" );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -52,7 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
+import static org.neo4j.driver.internal.util.Neo4jFeature.LIST_QUERIES_PROCEDURE;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
 
 public final class TestUtil
@@ -219,8 +219,7 @@ public final class TestUtil
 
     public static List<String> activeQueryNames( Driver driver )
     {
-        // procedure dbms.listQueries() is only supported starting from 3.1
-        assumeTrue( version( driver ).greaterThanOrEqual( v3_1_0 ) );
+        assumeTrue( LIST_QUERIES_PROCEDURE.availableIn( version( driver ) ) );
 
         try ( Session session = driver.session() )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -44,10 +44,10 @@ import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -125,12 +125,12 @@ public final class TestUtil
             {
                 expectedReadableBytes += bytesCount( value );
             }
-            assertEquals( "Unexpected number of bytes", expectedReadableBytes, buf.readableBytes() );
+            assertEquals( expectedReadableBytes, buf.readableBytes(), "Unexpected number of bytes" );
             for ( Number expectedValue : values )
             {
                 Number actualValue = read( buf, expectedValue.getClass() );
                 String valueType = actualValue.getClass().getSimpleName();
-                assertEquals( valueType + " values not equal", expectedValue, actualValue );
+                assertEquals( expectedValue, actualValue, valueType + " values not equal" );
             }
         }
         finally

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.util.Neo4jRunner;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.neo4j.driver.internal.util.Neo4jFeature.CAUSAL_CLUSTER;
 import static org.neo4j.driver.v1.util.Neo4jRunner.PASSWORD;
 import static org.neo4j.driver.v1.util.Neo4jRunner.TARGET_DIR;
 import static org.neo4j.driver.v1.util.Neo4jRunner.USER;
@@ -125,9 +126,8 @@ public class ClusterExtension implements BeforeAllCallback, AfterEachCallback, A
     {
         String[] split = Neo4jRunner.NEOCTRL_ARGS.split( "\\s+" );
         String version = split[split.length - 1];
-        // if the server version is older than 3.1 series, then ignore the tests
-        assumeTrue( ServerVersion.version( version ).greaterThanOrEqual( ServerVersion.v3_1_0 ),
-                "Server version `" + version + "` does not support Casual Cluster" );
+        ServerVersion serverVersion = ServerVersion.version( version );
+        assumeTrue( CAUSAL_CLUSTER.availableIn( serverVersion ), "Server version `" + version + "` does not support Casual Cluster" );
         return version;
     }
 

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.docs.driver;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,13 +32,11 @@ import java.util.UUID;
 
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
+import org.neo4j.driver.v1.util.DatabaseExtension;
 import org.neo4j.driver.v1.util.StdIOCapture;
-import org.neo4j.driver.v1.util.TestNeo4j;
 import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -49,18 +47,18 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.Neo4jRunner.PASSWORD;
 import static org.neo4j.driver.v1.util.Neo4jRunner.USER;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 
-public class ExamplesIT
+class ExamplesIT
 {
-    @ClassRule
-    public static TestNeo4j neo4j = new TestNeo4j();
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
 
     private String uri;
 
@@ -68,14 +66,7 @@ public class ExamplesIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            return session.readTransaction( new TransactionWork<Integer>()
-            {
-                @Override
-                public Integer execute( Transaction tx )
-                {
-                    return tx.run( statement, parameters ).single().get( 0 ).asInt();
-                }
-            } );
+            return session.readTransaction( tx -> tx.run( statement, parameters ).single().get( 0 ).asInt() );
         }
     }
 
@@ -88,14 +79,10 @@ public class ExamplesIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            session.writeTransaction( new TransactionWork<Object>()
+            session.writeTransaction( tx ->
             {
-                @Override
-                public Object execute( Transaction tx )
-                {
-                    tx.run( statement, parameters );
-                    return null;
-                }
+                tx.run( statement, parameters );
+                return null;
             } );
         }
     }
@@ -115,15 +102,15 @@ public class ExamplesIT
         return readInt( "MATCH (a:Company {name: $name}) RETURN count(a)", parameters( "name", name ) );
     }
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         uri = neo4j.uri().toString();
         TestUtil.cleanDb( neo4j.driver() );
     }
 
     @Test
-    public void testShouldRunAutocommitTransactionExample() throws Exception
+    void testShouldRunAutocommitTransactionExample() throws Exception
     {
         // Given
         try ( AutocommitTransactionExample example = new AutocommitTransactionExample( uri, USER, PASSWORD ) )
@@ -137,7 +124,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunAsyncAutocommitTransactionExample() throws Exception
+    void testShouldRunAsyncAutocommitTransactionExample() throws Exception
     {
         try ( AsyncAutocommitTransactionExample example = new AsyncAutocommitTransactionExample( uri, USER, PASSWORD ) )
         {
@@ -156,7 +143,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigConnectionPoolExample() throws Exception
+    void testShouldRunConfigConnectionPoolExample() throws Exception
     {
         // Given
         try ( ConfigConnectionPoolExample example = new ConfigConnectionPoolExample( uri, USER, PASSWORD ) )
@@ -167,7 +154,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigLoadBalancingStrategyExample() throws Exception
+    void testShouldRunConfigLoadBalancingStrategyExample() throws Exception
     {
         // Given
         try ( ConfigLoadBalancingStrategyExample example =
@@ -179,7 +166,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunBasicAuthExample() throws Exception
+    void testShouldRunBasicAuthExample() throws Exception
     {
         // Given
         try ( BasicAuthExample example = new BasicAuthExample( uri, USER, PASSWORD ) )
@@ -190,7 +177,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigConnectionTimeoutExample() throws Exception
+    void testShouldRunConfigConnectionTimeoutExample() throws Exception
     {
         // Given
         try ( ConfigConnectionTimeoutExample example = new ConfigConnectionTimeoutExample( uri, USER, PASSWORD ) )
@@ -201,7 +188,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigMaxRetryTimeExample() throws Exception
+    void testShouldRunConfigMaxRetryTimeExample() throws Exception
     {
         // Given
         try ( ConfigMaxRetryTimeExample example = new ConfigMaxRetryTimeExample( uri, USER, PASSWORD ) )
@@ -212,7 +199,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigTrustExample() throws Exception
+    void testShouldRunConfigTrustExample() throws Exception
     {
         // Given
         try ( ConfigTrustExample example = new ConfigTrustExample( uri, USER, PASSWORD ) )
@@ -223,7 +210,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunConfigUnencryptedExample() throws Exception
+    void testShouldRunConfigUnencryptedExample() throws Exception
     {
         // Given
         try ( ConfigUnencryptedExample example = new ConfigUnencryptedExample( uri, USER, PASSWORD ) )
@@ -234,7 +221,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunCypherErrorExample() throws Exception
+    void testShouldRunCypherErrorExample() throws Exception
     {
         // Given
         try ( CypherErrorExample example = new CypherErrorExample( uri, USER, PASSWORD ) )
@@ -255,7 +242,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunDriverLifecycleExample() throws Exception
+    void testShouldRunDriverLifecycleExample() throws Exception
     {
         // Given
         try ( DriverLifecycleExample example = new DriverLifecycleExample( uri, USER, PASSWORD ) )
@@ -266,7 +253,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunHelloWorld() throws Exception
+    void testShouldRunHelloWorld() throws Exception
     {
         // Given
         try ( HelloWorldExample greeter = new HelloWorldExample( uri, USER, PASSWORD ) )
@@ -286,7 +273,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunReadWriteTransactionExample() throws Exception
+    void testShouldRunReadWriteTransactionExample() throws Exception
     {
         // Given
         try ( ReadWriteTransactionExample example = new ReadWriteTransactionExample( uri, USER, PASSWORD ) )
@@ -300,7 +287,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunResultConsumeExample() throws Exception
+    void testShouldRunResultConsumeExample() throws Exception
     {
         // Given
         write( "CREATE (a:Person {name: 'Alice'})" );
@@ -316,7 +303,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunResultRetainExample() throws Exception
+    void testShouldRunResultRetainExample() throws Exception
     {
         // Given
         write( "CREATE (a:Person {name: 'Alice'})" );
@@ -334,7 +321,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunServiceUnavailableExample() throws Exception
+    void testShouldRunServiceUnavailableExample() throws Exception
     {
         // Given
         try ( ServiceUnavailableExample example = new ServiceUnavailableExample( uri, USER, PASSWORD ) )
@@ -355,7 +342,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunSessionExample() throws Exception
+    void testShouldRunSessionExample() throws Exception
     {
         // Given
         try ( SessionExample example = new SessionExample( uri, USER, PASSWORD ) )
@@ -370,7 +357,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunTransactionFunctionExample() throws Exception
+    void testShouldRunTransactionFunctionExample() throws Exception
     {
         // Given
         try ( TransactionFunctionExample example = new TransactionFunctionExample( uri, USER, PASSWORD ) )
@@ -384,7 +371,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testShouldRunAsyncTransactionFunctionExample() throws Exception
+    void testShouldRunAsyncTransactionFunctionExample() throws Exception
     {
         try ( AsyncTransactionFunctionExample example = new AsyncTransactionFunctionExample( uri, USER, PASSWORD ) )
         {
@@ -411,7 +398,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testPassBookmarksExample() throws Exception
+    void testPassBookmarksExample() throws Exception
     {
         try ( PassBookmarkExample example = new PassBookmarkExample( uri, USER, PASSWORD ) )
         {
@@ -439,7 +426,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testAsyncExplicitTransactionExample() throws Exception
+    void testAsyncExplicitTransactionExample() throws Exception
     {
         try ( AsyncExplicitTransactionExample example = new AsyncExplicitTransactionExample( uri, USER, PASSWORD ) )
         {
@@ -463,7 +450,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testSlf4jLogging() throws Exception
+    void testSlf4jLogging() throws Exception
     {
         // log file is defined in logback-test.xml configuration file
         Path logFile = Paths.get( "target", "test.log" );
@@ -484,7 +471,7 @@ public class ExamplesIT
     }
 
     @Test
-    public void testHostnameVerificationExample()
+    void testHostnameVerificationExample()
     {
         if ( neo4j.version().lessThanOrEqual( ServerVersion.v3_2_0 ) )
         {

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <rootDir>${project.basedir}</rootDir>
+    <surefire.and.failsafe.version>2.22.0</surefire.and.failsafe.version>
     <!-- JUnit 4 is required for TCK tests that use Cucumber, see https://github.com/cucumber/cucumber-jvm/issues/1149 -->
     <junit4.version>4.12</junit4.version>
     <junit5.version>5.2.0</junit5.version>
@@ -95,6 +96,12 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit5.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
         <version>${junit5.version}</version>
         <scope>test</scope>
       </dependency>
@@ -336,7 +343,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>${surefire.and.failsafe.version}</version>
         <configuration>
           <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
         </configuration>
@@ -361,7 +368,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>${surefire.and.failsafe.version}</version>
         <configuration>
           <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
         </configuration>


### PR DESCRIPTION
Also introduced two annotations `@EnabledOnNeo4jWith` and `@DisabledOnNeo4jWith` to allow nicer execution of tests that require presence/absence of a particular neo4j feature. They can be applied to both method and class. Example:

```java
@EnabledOnNeo4jWith( BOOKMARKS )
class BookmarkIT {

  @Test
  @EnabledOnNeo4jWith( SPATIAL_TYPES )
  void shouldReceivePoint() {
    ...
  }

  @Test
  @DisabledOnNeo4jWith( BYTE_ARRAYS )
  void shouldThrowExceptionWhenServerDoesNotSupportBytes() {
    ...
  }
}
```

**Not ready for merge:** need to verify test count and execution time first.