### PR TITLE
Expose transaction timeout and metadata in the API

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -31,10 +32,6 @@ import org.neo4j.driver.v1.StatementRunner;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.types.TypeSystem;
-
-import static org.neo4j.driver.internal.util.Extract.assertParameter;
-import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
-import static org.neo4j.driver.v1.Values.value;
 
 abstract class AbstractStatementRunner implements StatementRunner
 {
@@ -103,14 +100,6 @@ abstract class AbstractStatementRunner implements StatementRunner
         {
             return Values.EmptyMap;
         }
-
-        Map<String,Value> asValues = newHashMapWithSize( map.size() );
-        for ( Map.Entry<String,Object> entry : map.entrySet() )
-        {
-            Object value = entry.getValue();
-            assertParameter( value );
-            asValues.put( entry.getKey(), value( value ) );
-        }
-        return new MapValue( asValues );
+        return new MapValue( Extract.mapOfValues( map ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ExplicitTransaction.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
@@ -78,9 +79,9 @@ public class ExplicitTransaction extends AbstractStatementRunner implements Tran
         this.resultCursors = new ResultCursorsHolder();
     }
 
-    public CompletionStage<ExplicitTransaction> beginAsync( Bookmarks initialBookmarks )
+    public CompletionStage<ExplicitTransaction> beginAsync( Bookmarks initialBookmarks, TransactionConfig config )
     {
-        return protocol.beginTransaction( connection, initialBookmarks )
+        return protocol.beginTransaction( connection, initialBookmarks, config )
                 .handle( ( ignore, beginError ) ->
                 {
                     if ( beginError != null )

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -23,6 +23,7 @@ import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Logging;
+import org.neo4j.driver.v1.TransactionConfig;
 
 import static java.lang.System.lineSeparator;
 
@@ -31,9 +32,9 @@ class LeakLoggingNetworkSession extends NetworkSession
     private final String stackTrace;
 
     LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic,
-            Logging logging )
+            TransactionConfig defaultTransactionConfig, Logging logging )
     {
-        super( connectionProvider, mode, retryLogic, logging );
+        super( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging );
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -23,7 +23,6 @@ import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Logging;
-import org.neo4j.driver.v1.TransactionConfig;
 
 import static java.lang.System.lineSeparator;
 
@@ -31,10 +30,9 @@ class LeakLoggingNetworkSession extends NetworkSession
 {
     private final String stackTrace;
 
-    LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic,
-            TransactionConfig defaultTransactionConfig, Logging logging )
+    LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic, Logging logging )
     {
-        super( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging );
+        super( connectionProvider, mode, retryLogic, logging );
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -53,7 +53,6 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     private final ConnectionProvider connectionProvider;
     private final AccessMode mode;
     private final RetryLogic retryLogic;
-    private final TransactionConfig defaultTransactionConfig;
     protected final Logger logger;
 
     private volatile Bookmarks bookmarks = Bookmarks.empty();
@@ -63,13 +62,11 @@ public class NetworkSession extends AbstractStatementRunner implements Session
 
     private final AtomicBoolean open = new AtomicBoolean( true );
 
-    public NetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic,
-            TransactionConfig defaultTransactionConfig, Logging logging )
+    public NetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic, Logging logging )
     {
         this.connectionProvider = connectionProvider;
         this.mode = mode;
         this.retryLogic = retryLogic;
-        this.defaultTransactionConfig = defaultTransactionConfig;
         this.logger = new PrefixedLogger( "[" + hashCode() + "]", logging.getLog( LOG_NAME ) );
     }
 
@@ -172,7 +169,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public Transaction beginTransaction()
     {
-        return beginTransaction( defaultTransactionConfig );
+        return beginTransaction( TransactionConfig.empty() );
     }
 
     @Override
@@ -192,7 +189,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public CompletionStage<Transaction> beginTransactionAsync()
     {
-        return beginTransactionAsync( defaultTransactionConfig );
+        return beginTransactionAsync( TransactionConfig.empty() );
     }
 
     @Override
@@ -205,7 +202,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public <T> T readTransaction( TransactionWork<T> work )
     {
-        return readTransaction( work, defaultTransactionConfig );
+        return readTransaction( work, TransactionConfig.empty() );
     }
 
     @Override
@@ -217,7 +214,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work )
     {
-        return readTransactionAsync( work, defaultTransactionConfig );
+        return readTransactionAsync( work, TransactionConfig.empty() );
     }
 
     @Override
@@ -229,7 +226,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public <T> T writeTransaction( TransactionWork<T> work )
     {
-        return writeTransaction( work, defaultTransactionConfig );
+        return writeTransaction( work, TransactionConfig.empty() );
     }
 
     @Override
@@ -241,7 +238,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
     @Override
     public <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work )
     {
-        return writeTransactionAsync( work, defaultTransactionConfig );
+        return writeTransactionAsync( work, TransactionConfig.empty() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -26,13 +26,11 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.TransactionConfig;
 
 public class SessionFactoryImpl implements SessionFactory
 {
     private final ConnectionProvider connectionProvider;
     private final RetryLogic retryLogic;
-    private final TransactionConfig defaultTransactionConfig;
     private final Logging logging;
     private final boolean leakedSessionsLoggingEnabled;
 
@@ -41,7 +39,6 @@ public class SessionFactoryImpl implements SessionFactory
         this.connectionProvider = connectionProvider;
         this.leakedSessionsLoggingEnabled = config.logLeakedSessions();
         this.retryLogic = retryLogic;
-        this.defaultTransactionConfig = config.defaultTransactionConfig();
         this.logging = config.logging();
     }
 
@@ -81,7 +78,7 @@ public class SessionFactoryImpl implements SessionFactory
             AccessMode mode, Logging logging )
     {
         return leakedSessionsLoggingEnabled
-               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging )
-               : new NetworkSession( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging );
+               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, logging )
+               : new NetworkSession( connectionProvider, mode, retryLogic, logging );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -26,11 +26,13 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.TransactionConfig;
 
 public class SessionFactoryImpl implements SessionFactory
 {
     private final ConnectionProvider connectionProvider;
     private final RetryLogic retryLogic;
+    private final TransactionConfig defaultTransactionConfig;
     private final Logging logging;
     private final boolean leakedSessionsLoggingEnabled;
 
@@ -39,6 +41,7 @@ public class SessionFactoryImpl implements SessionFactory
         this.connectionProvider = connectionProvider;
         this.leakedSessionsLoggingEnabled = config.logLeakedSessions();
         this.retryLogic = retryLogic;
+        this.defaultTransactionConfig = config.defaultTransactionConfig();
         this.logging = config.logging();
     }
 
@@ -78,7 +81,7 @@ public class SessionFactoryImpl implements SessionFactory
             AccessMode mode, Logging logging )
     {
         return leakedSessionsLoggingEnabled
-               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, logging )
-               : new NetworkSession( connectionProvider, mode, retryLogic, logging );
+               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging )
+               : new NetworkSession( connectionProvider, mode, retryLogic, defaultTransactionConfig, logging );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -22,12 +22,14 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.internal.Bookmarks;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResultCursor;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static org.neo4j.driver.internal.util.ServerVersion.v3_2_0;
@@ -60,7 +62,7 @@ public class RoutingProcedureRunner
     CompletionStage<List<Record>> runProcedure( Connection connection, Statement procedure )
     {
         return connection.protocol()
-                .runInAutoCommitTransaction( connection, procedure, true )
+                .runInAutoCommitTransaction( connection, procedure, Bookmarks.empty(), TransactionConfig.empty(), true )
                 .thenCompose( StatementResultCursor::listAsync );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
@@ -62,9 +63,10 @@ public interface BoltProtocol
      *
      * @param connection the connection to use.
      * @param bookmarks the bookmarks. Never null, should be {@link Bookmarks#empty()} when absent.
+     * @param config the transaction configuration. Never null, should be {@link TransactionConfig#empty()} when absent.
      * @return a completion stage completed when transaction is started or completed exceptionally when there was a failure.
      */
-    CompletionStage<Void> beginTransaction( Connection connection, Bookmarks bookmarks );
+    CompletionStage<Void> beginTransaction( Connection connection, Bookmarks bookmarks, TransactionConfig config );
 
     /**
      * Commit the explicit transaction.
@@ -87,12 +89,15 @@ public interface BoltProtocol
      *
      * @param connection the network connection to use.
      * @param statement the cypher to execute.
+     * @param bookmarks the bookmarks. Never null, should be {@link Bookmarks#empty()} when absent.
+     * @param config the transaction config for the implicitly started auto-commit transaction.
      * @param waitForRunResponse {@code true} for async query execution and {@code false} for blocking query
      * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have statement
      * keys populated.
      * @return stage with cursor.
      */
-    CompletionStage<InternalStatementResultCursor> runInAutoCommitTransaction( Connection connection, Statement statement, boolean waitForRunResponse );
+    CompletionStage<InternalStatementResultCursor> runInAutoCommitTransaction( Connection connection, Statement statement,
+            Bookmarks bookmarks, TransactionConfig config, boolean waitForRunResponse );
 
     /**
      * Execute the given statement in a running explicit transaction, i.e. {@link Transaction#run(Statement)}.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -23,11 +23,17 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 
 public class BeginMessage extends TransactionStartingMessage
 {
     public static final byte SIGNATURE = 0x11;
+
+    public BeginMessage( Bookmarks bookmarks, TransactionConfig config )
+    {
+        this( bookmarks, config.timeout(), config.metadata() );
+    }
 
     public BeginMessage( Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 
 public class RunWithMetadataMessage extends TransactionStartingMessage
@@ -31,6 +32,11 @@ public class RunWithMetadataMessage extends TransactionStartingMessage
 
     private final String statement;
     private final Map<String,Value> parameters;
+
+    public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, TransactionConfig config )
+    {
+        this( statement, parameters, bookmarks, config.timeout(), config.metadata() );
+    }
 
     public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionStartingMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionStartingMessage.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.util.Iterables;
 import org.neo4j.driver.v1.Value;
 
+import static java.util.Collections.emptyMap;
 import static org.neo4j.driver.v1.Values.value;
 
 abstract class TransactionStartingMessage implements Message
@@ -48,19 +49,26 @@ abstract class TransactionStartingMessage implements Message
 
     private static Map<String,Value> buildMetadata( Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata )
     {
+        boolean bookmarksPresent = bookmarks != null && !bookmarks.isEmpty();
+        boolean txTimeoutPresent = txTimeout != null;
+        boolean txMetadataPresent = txMetadata != null && !txMetadata.isEmpty();
+
+        if ( !bookmarksPresent && !txTimeoutPresent && !txMetadataPresent )
+        {
+            return emptyMap();
+        }
+
         Map<String,Value> result = Iterables.newHashMapWithSize( 3 );
 
-        if ( bookmarks != null && !bookmarks.isEmpty() )
+        if ( bookmarksPresent )
         {
             result.put( BOOKMARKS_METADATA_KEY, value( bookmarks.values() ) );
         }
-
-        if ( txTimeout != null )
+        if ( txTimeoutPresent )
         {
             result.put( TX_TIMEOUT_METADATA_KEY, value( txTimeout.toMillis() ) );
         }
-
-        if ( txMetadata != null && !txMetadata.isEmpty() )
+        if ( txMetadataPresent )
         {
             result.put( TX_METADATA_METADATA_KEY, value( txMetadata ) );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Extract.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Extract.java
@@ -43,6 +43,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
+import static org.neo4j.driver.v1.Values.value;
 
 /**
  * Utility class for extracting data.
@@ -83,18 +85,6 @@ public final class Extract
                     result.add( mapFunction.apply( value ) );
                 }
                 return unmodifiableList( result );
-        }
-    }
-
-    public static Map<String, Value> map( Map<String, Value> data )
-    {
-        if ( data.isEmpty() )
-        {
-            return emptyMap();
-        }
-        else
-        {
-            return unmodifiableMap( data );
         }
     }
 
@@ -196,6 +186,23 @@ public final class Extract
                 return unmodifiableList( list );
             }
         }
+    }
+
+    public static Map<String,Value> mapOfValues( Map<String,Object> map )
+    {
+        if ( map == null || map.isEmpty() )
+        {
+            return emptyMap();
+        }
+
+        Map<String,Value> result = newHashMapWithSize( map.size() );
+        for ( Map.Entry<String,Object> entry : map.entrySet() )
+        {
+            Object value = entry.getValue();
+            assertParameter( value );
+            result.put( entry.getKey(), value( value ) );
+        }
+        return result;
     }
 
     public static void assertParameter( Object value )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Preconditions.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Preconditions.java
@@ -25,6 +25,21 @@ public final class Preconditions
     }
 
     /**
+     * Assert that given expression is true.
+     *
+     * @param expression the value to check.
+     * @param message the message.
+     * @throws IllegalArgumentException if given value is {@code false}.
+     */
+    public static void checkArgument( boolean expression, String message )
+    {
+        if ( !expression )
+        {
+            throw new IllegalArgumentException( message );
+        }
+    }
+
+    /**
      * Assert that given argument is of expected type.
      *
      * @param argument the object to check.

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -28,6 +28,7 @@ import static java.lang.Integer.compare;
 
 public class ServerVersion
 {
+    public static final ServerVersion v3_5_0 = new ServerVersion( 3, 5, 0 );
     public static final ServerVersion v3_4_0 = new ServerVersion( 3, 4, 0 );
     public static final ServerVersion v3_2_0 = new ServerVersion( 3, 2, 0 );
     public static final ServerVersion v3_1_0 = new ServerVersion( 3, 1, 0 );

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -92,7 +92,6 @@ public class Config
 
     private final LoadBalancingStrategy loadBalancingStrategy;
     private final ServerAddressResolver resolver;
-    private final TransactionConfig defaultTransactionConfig;
 
     private Config( ConfigBuilder builder)
     {
@@ -112,7 +111,6 @@ public class Config
         this.retrySettings = builder.retrySettings;
         this.loadBalancingStrategy = builder.loadBalancingStrategy;
         this.resolver = builder.resolver;
-        this.defaultTransactionConfig = builder.defaultTransactionConfig;
     }
 
     /**
@@ -243,11 +241,6 @@ public class Config
         return resolver;
     }
 
-    public TransactionConfig defaultTransactionConfig()
-    {
-        return defaultTransactionConfig;
-    }
-
     /**
      * Return a {@link ConfigBuilder} instance
      * @return a {@link ConfigBuilder} instance
@@ -294,7 +287,6 @@ public class Config
         private int connectionTimeoutMillis = (int) TimeUnit.SECONDS.toMillis( 5 );
         private RetrySettings retrySettings = RetrySettings.DEFAULT;
         private ServerAddressResolver resolver;
-        private TransactionConfig defaultTransactionConfig = TransactionConfig.empty();
 
         private ConfigBuilder() {}
 
@@ -751,12 +743,6 @@ public class Config
         public ConfigBuilder withResolver( ServerAddressResolver resolver )
         {
             this.resolver = Objects.requireNonNull( resolver, "resolver" );
-            return this;
-        }
-
-        public ConfigBuilder withDefaultTransactionConfig( TransactionConfig defaultTransactionConfig )
-        {
-            this.defaultTransactionConfig = Objects.requireNonNull( defaultTransactionConfig, "defaultTransactionConfig" );
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -92,6 +92,7 @@ public class Config
 
     private final LoadBalancingStrategy loadBalancingStrategy;
     private final ServerAddressResolver resolver;
+    private final TransactionConfig defaultTransactionConfig;
 
     private Config( ConfigBuilder builder)
     {
@@ -111,6 +112,7 @@ public class Config
         this.retrySettings = builder.retrySettings;
         this.loadBalancingStrategy = builder.loadBalancingStrategy;
         this.resolver = builder.resolver;
+        this.defaultTransactionConfig = builder.defaultTransactionConfig;
     }
 
     /**
@@ -241,6 +243,11 @@ public class Config
         return resolver;
     }
 
+    public TransactionConfig defaultTransactionConfig()
+    {
+        return defaultTransactionConfig;
+    }
+
     /**
      * Return a {@link ConfigBuilder} instance
      * @return a {@link ConfigBuilder} instance
@@ -287,6 +294,7 @@ public class Config
         private int connectionTimeoutMillis = (int) TimeUnit.SECONDS.toMillis( 5 );
         private RetrySettings retrySettings = RetrySettings.DEFAULT;
         private ServerAddressResolver resolver;
+        private TransactionConfig defaultTransactionConfig = TransactionConfig.empty();
 
         private ConfigBuilder() {}
 
@@ -743,6 +751,12 @@ public class Config
         public ConfigBuilder withResolver( ServerAddressResolver resolver )
         {
             this.resolver = Objects.requireNonNull( resolver, "resolver" );
+            return this;
+        }
+
+        public ConfigBuilder withDefaultTransactionConfig( TransactionConfig defaultTransactionConfig )
+        {
+            this.defaultTransactionConfig = Objects.requireNonNull( defaultTransactionConfig, "defaultTransactionConfig" );
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/v1/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Session.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.v1;
 
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
@@ -77,6 +78,8 @@ public interface Session extends Resource, StatementRunner
      */
     Transaction beginTransaction();
 
+    Transaction beginTransaction( TransactionConfig config );
+
     /**
      * Begin a new <em>explicit {@linkplain Transaction transaction}</em>,
      * requiring that the server hosting is at least as up-to-date as the
@@ -112,6 +115,8 @@ public interface Session extends Resource, StatementRunner
      */
     CompletionStage<Transaction> beginTransactionAsync();
 
+    CompletionStage<Transaction> beginTransactionAsync( TransactionConfig config );
+
     /**
      * Execute given unit of work in a  {@link AccessMode#READ read} transaction.
      * <p>
@@ -126,6 +131,8 @@ public interface Session extends Resource, StatementRunner
      * @return a result as returned by the given unit of work.
      */
     <T> T readTransaction( TransactionWork<T> work );
+
+    <T> T readTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
      * Execute given unit of asynchronous work in a  {@link AccessMode#READ read} asynchronous transaction.
@@ -150,6 +157,8 @@ public interface Session extends Resource, StatementRunner
      */
     <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work );
 
+    <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config );
+
     /**
      * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction.
      * <p>
@@ -164,6 +173,8 @@ public interface Session extends Resource, StatementRunner
      * @return a result as returned by the given unit of work.
      */
     <T> T writeTransaction( TransactionWork<T> work );
+
+    <T> T writeTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
      * Execute given unit of asynchronous work in a  {@link AccessMode#WRITE write} asynchronous transaction.
@@ -187,6 +198,20 @@ public interface Session extends Resource, StatementRunner
      * unit of work. Stage can be completed exceptionally if given work or commit fails.
      */
     <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work );
+
+    <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config );
+
+    StatementResult run( String statement, TransactionConfig config );
+
+    StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config );
+
+    StatementResult run( Statement statement, TransactionConfig config );
+
+    CompletionStage<StatementResultCursor> runAsync( String statement, TransactionConfig config );
+
+    CompletionStage<StatementResultCursor> runAsync( String statement, Map<String,Object> parameters, TransactionConfig config );
+
+    CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed

--- a/driver/src/main/java/org/neo4j/driver/v1/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Session.java
@@ -78,6 +78,18 @@ public interface Session extends Resource, StatementRunner
      */
     Transaction beginTransaction();
 
+    /**
+     * Begin a new <em>explicit {@linkplain Transaction transaction}</em> with the specified {@link TransactionConfig configuration}.
+     * At most one transaction may exist in a session at any point in time. To
+     * maintain multiple concurrent transactions, use multiple concurrent
+     * sessions.
+     * <p>
+     * This operation works the same way as {@link #beginTransactionAsync(TransactionConfig)} but blocks until
+     * transaction is actually started.
+     *
+     * @param config configuration for the new transaction.
+     * @return a new {@link Transaction}
+     */
     Transaction beginTransaction( TransactionConfig config );
 
     /**
@@ -115,6 +127,26 @@ public interface Session extends Resource, StatementRunner
      */
     CompletionStage<Transaction> beginTransactionAsync();
 
+    /**
+     * Begin a new <em>explicit {@linkplain Transaction transaction}</em> with the specified {@link TransactionConfig configuration}.
+     * At most one transaction may exist in a session at any point in time. To
+     * maintain multiple concurrent transactions, use multiple concurrent
+     * sessions.
+     * <p>
+     * This operation is asynchronous and returns a {@link CompletionStage}. This stage is completed with a new
+     * {@link Transaction} object when begin operation is successful. It is completed exceptionally if
+     * transaction can't be started.
+     * <p>
+     * Returned stage can be completed by an IO thread which should never block. Otherwise IO operations on this and
+     * potentially other network connections might deadlock. Please do not chain blocking operations like
+     * {@link #run(String)} on the returned stage. Driver will throw {@link IllegalStateException} when blocking API
+     * call is executed in IO thread. Consider using asynchronous calls throughout the chain or offloading blocking
+     * operation to a different {@link Executor}. This can be done using methods with "Async" suffix like
+     * {@link CompletionStage#thenApplyAsync(Function)} or {@link CompletionStage#thenApplyAsync(Function, Executor)}.
+     *
+     * @param config configuration for the new transaction.
+     * @return a {@link CompletionStage completion stage} that represents the asynchronous begin of a transaction.
+     */
     CompletionStage<Transaction> beginTransactionAsync( TransactionConfig config );
 
     /**
@@ -132,6 +164,20 @@ public interface Session extends Resource, StatementRunner
      */
     <T> T readTransaction( TransactionWork<T> work );
 
+    /**
+     * Execute given unit of work in a  {@link AccessMode#READ read} transaction with the specified {@link TransactionConfig configuration}.
+     * <p>
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
+     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * <p>
+     * This operation works the same way as {@link #readTransactionAsync(TransactionWork)} but blocks until given
+     * blocking unit of work is completed.
+     *
+     * @param work the {@link TransactionWork} to be applied to a new read transaction.
+     * @param config configuration for all transactions started to execute the unit of work.
+     * @param <T> the return type of the given unit of work.
+     * @return a result as returned by the given unit of work.
+     */
     <T> T readTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
@@ -157,6 +203,29 @@ public interface Session extends Resource, StatementRunner
      */
     <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work );
 
+    /**
+     * Execute given unit of asynchronous work in a  {@link AccessMode#READ read} asynchronous transaction with
+     * the specified {@link TransactionConfig configuration}.
+     * <p>
+     * Transaction will automatically be committed unless given unit of work fails or
+     * {@link Transaction#commitAsync() async transaction commit} fails. It will also not be committed if explicitly
+     * rolled back via {@link Transaction#rollbackAsync()}.
+     * <p>
+     * Returned stage and given {@link TransactionWork} can be completed/executed by an IO thread which should never
+     * block. Otherwise IO operations on this and potentially other network connections might deadlock. Please do not
+     * chain blocking operations like {@link #run(String)} on the returned stage and do not use them inside the
+     * {@link TransactionWork}. Driver will throw {@link IllegalStateException} when blocking API
+     * call is executed in IO thread. Consider using asynchronous calls throughout the chain or offloading blocking
+     * operation to a different {@link Executor}. This can be done using methods with "Async" suffix like
+     * {@link CompletionStage#thenApplyAsync(Function)} or {@link CompletionStage#thenApplyAsync(Function, Executor)}.
+     *
+     * @param work the {@link TransactionWork} to be applied to a new read transaction. Operation executed by the
+     * given work must be asynchronous.
+     * @param config configuration for all transactions started to execute the unit of work.
+     * @param <T> the return type of the given unit of work.
+     * @return a {@link CompletionStage completion stage} completed with the same result as returned by the given
+     * unit of work. Stage can be completed exceptionally if given work or commit fails.
+     */
     <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config );
 
     /**
@@ -174,6 +243,20 @@ public interface Session extends Resource, StatementRunner
      */
     <T> T writeTransaction( TransactionWork<T> work );
 
+    /**
+     * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction with the specified {@link TransactionConfig configuration}.
+     * <p>
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
+     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * <p>
+     * This operation works the same way as {@link #writeTransactionAsync(TransactionWork)} but blocks until given
+     * blocking unit of work is completed.
+     *
+     * @param work the {@link TransactionWork} to be applied to a new write transaction.
+     * @param config configuration for all transactions started to execute the unit of work.
+     * @param <T> the return type of the given unit of work.
+     * @return a result as returned by the given unit of work.
+     */
     <T> T writeTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
@@ -199,18 +282,184 @@ public interface Session extends Resource, StatementRunner
      */
     <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work );
 
+    /**
+     * Execute given unit of asynchronous work in a  {@link AccessMode#WRITE write} asynchronous transaction with
+     * the specified {@link TransactionConfig configuration}.
+     * <p>
+     * Transaction will automatically be committed unless given unit of work fails or
+     * {@link Transaction#commitAsync() async transaction commit} fails. It will also not be committed if explicitly
+     * rolled back via {@link Transaction#rollbackAsync()}.
+     * <p>
+     * Returned stage and given {@link TransactionWork} can be completed/executed by an IO thread which should never
+     * block. Otherwise IO operations on this and potentially other network connections might deadlock. Please do not
+     * chain blocking operations like {@link #run(String)} on the returned stage and do not use them inside the
+     * {@link TransactionWork}. Driver will throw {@link IllegalStateException} when blocking API
+     * call is executed in IO thread. Consider using asynchronous calls throughout the chain or offloading blocking
+     * operation to a different {@link Executor}. This can be done using methods with "Async" suffix like
+     * {@link CompletionStage#thenApplyAsync(Function)} or {@link CompletionStage#thenApplyAsync(Function, Executor)}.
+     *
+     * @param work the {@link TransactionWork} to be applied to a new write transaction. Operation executed by the
+     * given work must be asynchronous.
+     * @param config configuration for all transactions started to execute the unit of work.
+     * @param <T> the return type of the given unit of work.
+     * @return a {@link CompletionStage completion stage} completed with the same result as returned by the given
+     * unit of work. Stage can be completed exceptionally if given work or commit fails.
+     */
     <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config );
 
+    /**
+     * Run a statement in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a result stream.
+     *
+     * @param statement text of a Neo4j statement.
+     * @param config configuration for the new transaction.
+     * @return a stream of result values and associated metadata.
+     */
     StatementResult run( String statement, TransactionConfig config );
 
+    /**
+     * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * <p>
+     * This method takes a set of parameters that will be injected into the
+     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * dangerous cypher injection attacks and improves database performance as
+     * Neo4j can re-use query plans more often.
+     * <p>
+     * This version of run takes a {@link Map} of parameters. The values in the map
+     * must be values that can be converted to Neo4j types. See {@link Values#parameters(Object...)} for
+     * a list of allowed types.
+     *
+     * <h2>Example</h2>
+     * <pre>
+     * {@code
+     * Map<String, Object> metadata = new HashMap<>();
+     * metadata.put("type", "update name");
+     *
+     * TransactionConfig config = TransactionConfig.builder()
+     *                 .withTimeout(Duration.ofSeconds(3))
+     *                 .withMetadata(metadata)
+     *                 .build();
+     *
+     * Map<String, Object> parameters = new HashMap<>();
+     * parameters.put("myNameParam", "Bob");
+     *
+     * StatementResult cursor = session.run("MATCH (n) WHERE n.name = {myNameParam} RETURN (n)", parameters, config);
+     * }
+     * </pre>
+     *
+     * @param statement text of a Neo4j statement.
+     * @param parameters input data for the statement.
+     * @param config configuration for the new transaction.
+     * @return a stream of result values and associated metadata.
+     */
     StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config );
 
+    /**
+     * Run a statement in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * <h2>Example</h2>
+     * <pre>
+     * {@code
+     * Map<String, Object> metadata = new HashMap<>();
+     * metadata.put("type", "update name");
+     *
+     * TransactionConfig config = TransactionConfig.builder()
+     *                 .withTimeout(Duration.ofSeconds(3))
+     *                 .withMetadata(metadata)
+     *                 .build();
+     *
+     * Statement statement = new Statement("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
+     * StatementResult cursor = session.run(statement.withParameters(Values.parameters("myNameParam", "Bob")));
+     * }
+     * </pre>
+     *
+     * @param statement a Neo4j statement.
+     * @param config configuration for the new transaction.
+     * @return a stream of result values and associated metadata.
+     */
     StatementResult run( Statement statement, TransactionConfig config );
 
+    /**
+     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * {@link CompletionStage} with a result cursor.
+     * <p>
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link StatementRunner} for
+     * more information.
+     *
+     * @param statement text of a Neo4j statement.
+     * @param config configuration for the new transaction.
+     * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
+     * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
+     */
     CompletionStage<StatementResultCursor> runAsync( String statement, TransactionConfig config );
 
+    /**
+     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * {@link CompletionStage} with a result cursor.
+     * <p>
+     * This method takes a set of parameters that will be injected into the
+     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * dangerous cypher injection attacks and improves database performance as
+     * Neo4j can re-use query plans more often.
+     * <p>
+     * This version of runAsync takes a {@link Map} of parameters. The values in the map
+     * must be values that can be converted to Neo4j types. See {@link Values#parameters(Object...)} for
+     * a list of allowed types.
+     * <h2>Example</h2>
+     * <pre>
+     * {@code
+     * Map<String, Object> metadata = new HashMap<>();
+     * metadata.put("type", "update name");
+     *
+     * TransactionConfig config = TransactionConfig.builder()
+     *                 .withTimeout(Duration.ofSeconds(3))
+     *                 .withMetadata(metadata)
+     *                 .build();
+     *
+     * Map<String, Object> parameters = new HashMap<String, Object>();
+     * parameters.put("myNameParam", "Bob");
+     *
+     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(
+     *             "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
+     *             parameters,
+     *             config);
+     * }
+     * </pre>
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link StatementRunner} for
+     * more information.
+     *
+     * @param statement text of a Neo4j statement.
+     * @param parameters input data for the statement.
+     * @param config configuration for the new transaction.
+     * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
+     * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
+     */
     CompletionStage<StatementResultCursor> runAsync( String statement, Map<String,Object> parameters, TransactionConfig config );
 
+    /**
+     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * {@link CompletionStage} with a result cursor.
+     * <h2>Example</h2>
+     * <pre>
+     * {@code
+     * Map<String, Object> metadata = new HashMap<>();
+     * metadata.put("type", "update name");
+     *
+     * TransactionConfig config = TransactionConfig.builder()
+     *                 .withTimeout(Duration.ofSeconds(3))
+     *                 .withMetadata(metadata)
+     *                 .build();
+     *
+     * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
+     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(statement, config);
+     * }
+     * </pre>
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link StatementRunner} for
+     * more information.
+     *
+     * @param statement a Neo4j statement.
+     * @param config configuration for the new transaction.
+     * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
+     * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
+     */
     CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config );
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementRunner.java
@@ -290,19 +290,9 @@ public interface StatementRunner
     /**
      * Run a statement asynchronously and return a {@link CompletionStage} with a
      * result cursor.
-     * <p>
-     * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
-     * dangerous cypher injection attacks and improves database performance as
-     * Neo4j can re-use query plans more often.
-     * <p>
-     * This version of runAsync takes a {@link Map} of parameters. The values in the map
-     * must be values that can be converted to Neo4j types. See {@link Values#parameters(Object...)} for
-     * a list of allowed types.
      * <h2>Example</h2>
      * <pre>
      * {@code
-     *
      * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
      * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(statement);
      * }

--- a/driver/src/main/java/org/neo4j/driver/v1/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/TransactionConfig.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+import org.neo4j.driver.internal.util.Extract;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
+
+public class TransactionConfig
+{
+    private static final TransactionConfig EMPTY = builder().build();
+
+    private final Duration timeout;
+    private final Map<String,Value> metadata;
+
+    private TransactionConfig( Builder builder )
+    {
+        this.timeout = builder.timeout;
+        this.metadata = unmodifiableMap( builder.metadata );
+    }
+
+    public static TransactionConfig empty()
+    {
+        return EMPTY;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public Duration timeout()
+    {
+        return timeout;
+    }
+
+    public Map<String,Value> metadata()
+    {
+        return metadata;
+    }
+
+    public boolean isEmpty()
+    {
+        return timeout == null && (metadata == null || metadata.isEmpty());
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        TransactionConfig that = (TransactionConfig) o;
+        return Objects.equals( timeout, that.timeout ) &&
+               Objects.equals( metadata, that.metadata );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( timeout, metadata );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TransactionConfig{" +
+               "timeout=" + timeout +
+               ", metadata=" + metadata +
+               '}';
+    }
+
+    public static class Builder
+    {
+        private Duration timeout;
+        private Map<String,Value> metadata = emptyMap();
+
+        private Builder()
+        {
+        }
+
+        public Builder withTimeout( Duration timeout )
+        {
+            requireNonNull( timeout, "Transaction timeout should not be null" );
+            checkArgument( !timeout.isZero(), "Transaction timeout should not be zero" );
+            checkArgument( !timeout.isNegative(), "Transaction timeout should not be negative" );
+
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder withMetadata( Map<String,Object> metadata )
+        {
+            requireNonNull( metadata, "Transaction metadata should not be null" );
+
+            this.metadata = Extract.mapOfValues( metadata );
+            return this;
+        }
+
+        public TransactionConfig build()
+        {
+            return new TransactionConfig( this );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
@@ -83,21 +83,6 @@ class ExtractTest
     }
 
     @Test
-    void testMapShouldNotBeModifiable()
-    {
-        // GIVEN
-        Map<String,Value> map = new HashMap<>();
-        map.put( "k1", value( "foo" ) );
-        map.put( "k2", value( 42 ) );
-
-        // WHEN
-        Map<String,Value> valueMap = Extract.map( map );
-
-        // THEN
-        assertThrows( UnsupportedOperationException.class, () -> valueMap.put( "foo", value( "bar" ) ) );
-    }
-
-    @Test
     void testMapValues()
     {
         // GIVEN

--- a/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,16 +32,19 @@ import java.util.Map;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.util.Iterables;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.util.Pair;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.v1.Values.value;
@@ -77,7 +81,7 @@ class ExtractTest
     @Test
     void testMapOverList()
     {
-        List<Integer> mapped = Extract.list( new Value[]{value( 42 ), value( 43 )}, integerExtractor() );
+        List<Integer> mapped = Extract.list( new Value[]{value( 42 ), value( 43 )}, Value::asInt );
 
         assertThat( mapped, equalTo( Arrays.asList( 42, 43 ) ) );
     }
@@ -91,7 +95,7 @@ class ExtractTest
         map.put( "k2", value( 42 ) );
 
         // WHEN
-        Map<String,Integer> mappedMap = Extract.map( map, integerExtractor() );
+        Map<String,Integer> mappedMap = Extract.map( map, Value::asInt );
 
         // THEN
         Collection<Integer> values = mappedMap.values();
@@ -108,7 +112,7 @@ class ExtractTest
         map.put( "k1", value( 42 ) );
 
         // WHEN
-        Map<String,Integer> mappedMap = Extract.map( map, integerExtractor() );
+        Map<String,Integer> mappedMap = Extract.map( map, Value::asInt );
 
         // THEN
         Collection<Integer> values = mappedMap.values();
@@ -126,7 +130,7 @@ class ExtractTest
         InternalNode node = new InternalNode( 42L, Collections.singletonList( "L" ), props );
 
         // WHEN
-        Iterable<Pair<String, Integer>> properties = Extract.properties( node, integerExtractor() );
+        Iterable<Pair<String,Integer>> properties = Extract.properties( node, Value::asInt );
 
         // THEN
         Iterator<Pair<String, Integer>> iterator = properties.iterator();
@@ -141,24 +145,43 @@ class ExtractTest
         // GIVEN
         InternalRecord record = new InternalRecord( Arrays.asList( "k1" ), new Value[]{value( 42 )} );
         // WHEN
-        List<Pair<String, Integer>> fields = Extract.fields( record, integerExtractor() );
+        List<Pair<String,Integer>> fields = Extract.fields( record, Value::asInt );
 
 
         // THEN
         assertThat( fields, equalTo( Collections.singletonList( InternalPair.of( "k1", 42 ) ) ) );
     }
 
-    private Function<Value,Integer> integerExtractor()
+    @Test
+    void shouldExtractMapOfValuesFromNullOrEmptyMap()
     {
-        return new Function<Value,Integer>()
-        {
-
-            @Override
-            public Integer apply( Value value )
-            {
-                return value.asInt();
-            }
-        };
+        assertEquals( emptyMap(), Extract.mapOfValues( null ) );
+        assertEquals( emptyMap(), Extract.mapOfValues( emptyMap() ) );
     }
 
+    @Test
+    void shouldExtractMapOfValues()
+    {
+        Map<String,Object> map = new HashMap<>();
+        map.put( "key1", "value1" );
+        map.put( "key2", 42L );
+        map.put( "key3", LocalDate.now() );
+        map.put( "key4", new byte[]{1, 2, 3} );
+
+        Map<String,Value> mapOfValues = Extract.mapOfValues( map );
+
+        assertEquals( 4, map.size() );
+        assertEquals( value( "value1" ), mapOfValues.get( "key1" ) );
+        assertEquals( value( 42L ), mapOfValues.get( "key2" ) );
+        assertEquals( value( LocalDate.now() ), mapOfValues.get( "key3" ) );
+        assertEquals( value( new byte[]{1, 2, 3} ), mapOfValues.get( "key4" ) );
+    }
+
+    @Test
+    void shouldFailToExtractMapOfValuesFromUnsupportedValues()
+    {
+        assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalNode( 1 ) ) ) );
+        assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalRelationship( 1, 1, 1, "HI" ) ) ) );
+        assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalPath( new InternalNode( 1 ) ) ) ) );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -31,7 +31,6 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -95,8 +94,7 @@ class LeakLoggingNetworkSessionTest
 
     private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
-        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ,
-                new FixedRetryLogic( 0 ), TransactionConfig.empty(), logging );
+        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ, new FixedRetryLogic( 0 ), logging );
     }
 
     private static ConnectionProvider connectionProviderMock( boolean openConnection )

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Logger;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.util.TestUtil;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -95,7 +96,7 @@ class LeakLoggingNetworkSessionTest
     private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
         return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ,
-                new FixedRetryLogic( 0 ), logging );
+                new FixedRetryLogic( 0 ), TransactionConfig.empty(), logging );
     }
 
     private static ConnectionProvider connectionProviderMock( boolean openConnection )

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -362,7 +363,7 @@ class NetworkSessionTest
     {
         NetworkSession session = newSession( connectionProvider, READ );
         session.setBookmarks( Bookmarks.from( "X" ) );
-        session.beginTransaction( null );
+        session.beginTransaction( (String) null );
         assertThat( session.lastBookmark(), equalTo( "X" ) );
     }
 
@@ -824,7 +825,7 @@ class NetworkSessionTest
     private static NetworkSession newSession( ConnectionProvider connectionProvider, AccessMode mode,
             RetryLogic retryLogic, Bookmarks bookmarks )
     {
-        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic, DEV_NULL_LOGGING );
+        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic, TransactionConfig.empty(), DEV_NULL_LOGGING );
         session.setBookmarks( bookmarks );
         return session;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -39,7 +39,6 @@ import org.neo4j.driver.internal.util.Supplier;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -825,7 +824,7 @@ class NetworkSessionTest
     private static NetworkSession newSession( ConnectionProvider connectionProvider, AccessMode mode,
             RetryLogic retryLogic, Bookmarks bookmarks )
     {
-        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic, TransactionConfig.empty(), DEV_NULL_LOGGING );
+        NetworkSession session = new NetworkSession( connectionProvider, mode, retryLogic, DEV_NULL_LOGGING );
         session.setBookmarks( bookmarks );
         return session;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -52,6 +52,7 @@ import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 
 import static java.util.Collections.emptyMap;
@@ -145,7 +146,7 @@ public class BoltProtocolV1Test
     {
         Connection connection = connectionMock();
 
-        CompletionStage<Void> stage = protocol.beginTransaction( connection, Bookmarks.empty() );
+        CompletionStage<Void> stage = protocol.beginTransaction( connection, Bookmarks.empty(), TransactionConfig.empty() );
 
         verify( connection ).write(
                 new RunMessage( "BEGIN" ), NoOpResponseHandler.INSTANCE,
@@ -160,7 +161,7 @@ public class BoltProtocolV1Test
         Connection connection = connectionMock();
         Bookmarks bookmarks = Bookmarks.from( "neo4j:bookmark:v1:tx100" );
 
-        CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmarks );
+        CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmarks, TransactionConfig.empty() );
 
         verify( connection ).writeAndFlush(
                 eq( new RunMessage( "BEGIN", bookmarks.asBeginTransactionParameters() ) ), eq( NoOpResponseHandler.INSTANCE ),
@@ -260,7 +261,7 @@ public class BoltProtocolV1Test
         if ( autoCommitTx )
         {
 
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, false );
+            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), TransactionConfig.empty(), false );
         }
         else
         {
@@ -280,7 +281,7 @@ public class BoltProtocolV1Test
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( session )
         {
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, true );
+            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), TransactionConfig.empty(), true );
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging.v1;
+package org.neo4j.driver.internal.messaging.v3;
 
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -44,52 +44,52 @@ import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.SessionPullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.TransactionPullAllResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
-import org.neo4j.driver.internal.messaging.MessageFormat;
-import org.neo4j.driver.internal.messaging.request.InitMessage;
+import org.neo4j.driver.internal.messaging.request.BeginMessage;
+import org.neo4j.driver.internal.messaging.request.CommitMessage;
+import org.neo4j.driver.internal.messaging.request.HelloMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
-import org.neo4j.driver.internal.messaging.request.RunMessage;
+import org.neo4j.driver.internal.messaging.request.RollbackMessage;
+import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
-import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.neo4j.driver.internal.util.Futures.blockingGet;
+import static org.neo4j.driver.internal.util.ServerVersion.v3_5_0;
 import static org.neo4j.driver.v1.Values.value;
-import static org.neo4j.driver.v1.util.TestUtil.DEFAULT_TEST_PROTOCOL;
 import static org.neo4j.driver.v1.util.TestUtil.await;
 import static org.neo4j.driver.v1.util.TestUtil.connectionMock;
 
-public class BoltProtocolV1Test
+class BoltProtocolV3Test
 {
     private static final String QUERY = "RETURN $x";
     private static final Map<String,Value> PARAMS = singletonMap( "x", value( 42 ) );
     private static final Statement STATEMENT = new Statement( QUERY, value( PARAMS ) );
 
-    private final BoltProtocol protocol = createProtocol();
+    private final BoltProtocol protocol = BoltProtocolV3.INSTANCE;
     private final EmbeddedChannel channel = new EmbeddedChannel();
     private final InboundMessageDispatcher messageDispatcher = new InboundMessageDispatcher( channel, Logging.none() );
+
+    private final TransactionConfig txConfig = TransactionConfig.builder()
+            .withTimeout( Duration.ofSeconds( 12 ) )
+            .withMetadata( singletonMap( "key", value( 42 ) ) )
+            .build();
 
     @BeforeEach
     void beforeEach()
@@ -106,7 +106,7 @@ public class BoltProtocolV1Test
     @Test
     void shouldCreateMessageFormat()
     {
-        assertThat( protocol.createMessageFormat(), instanceOf( expectedMessageFormatType() ) );
+        assertThat( protocol.createMessageFormat(), instanceOf( MessageFormatV3.class ) );
     }
 
     @Test
@@ -114,14 +114,14 @@ public class BoltProtocolV1Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/5.3", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/0.0.1", dummyAuthToken(), promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
-        assertThat( channel.outboundMessages().poll(), instanceOf( InitMessage.class ) );
+        assertThat( channel.outboundMessages().poll(), instanceOf( HelloMessage.class ) );
         assertEquals( 1, messageDispatcher.queuedHandlersCount() );
         assertFalse( promise.isDone() );
 
-        messageDispatcher.handleSuccessMessage( emptyMap() );
+        messageDispatcher.handleSuccessMessage( singletonMap( "server", value( v3_5_0.toString() ) ) );
 
         assertTrue( promise.isDone() );
         assertTrue( promise.isSuccess() );
@@ -132,14 +132,14 @@ public class BoltProtocolV1Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/3.1", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/2.2.1", dummyAuthToken(), promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
-        assertThat( channel.outboundMessages().poll(), instanceOf( InitMessage.class ) );
+        assertThat( channel.outboundMessages().poll(), instanceOf( HelloMessage.class ) );
         assertEquals( 1, messageDispatcher.queuedHandlersCount() );
         assertFalse( promise.isDone() );
 
-        messageDispatcher.handleFailureMessage( "Neo.TransientError.General.DatabaseUnavailable", "Oh no!" );
+        messageDispatcher.handleFailureMessage( "Neo.TransientError.General.DatabaseUnavailable", "Error!" );
 
         assertTrue( promise.isDone() );
         assertFalse( promise.isSuccess() );
@@ -152,11 +152,8 @@ public class BoltProtocolV1Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, Bookmarks.empty(), TransactionConfig.empty() );
 
-        verify( connection ).write(
-                new RunMessage( "BEGIN" ), NoOpResponseHandler.INSTANCE,
-                PullAllMessage.PULL_ALL, NoOpResponseHandler.INSTANCE );
-
-        assertNull( blockingGet( stage ) );
+        verify( connection ).write( new BeginMessage( Bookmarks.empty(), TransactionConfig.empty() ), NoOpResponseHandler.INSTANCE );
+        assertNull( await( stage ) );
     }
 
     @Test
@@ -167,34 +164,42 @@ public class BoltProtocolV1Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmarks, TransactionConfig.empty() );
 
-        verify( connection ).writeAndFlush(
-                eq( new RunMessage( "BEGIN", bookmarks.asBeginTransactionParameters() ) ), eq( NoOpResponseHandler.INSTANCE ),
-                eq( PullAllMessage.PULL_ALL ), any( BeginTxResponseHandler.class ) );
+        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmarks, TransactionConfig.empty() ) ), any( BeginTxResponseHandler.class ) );
+        assertNull( await( stage ) );
+    }
 
-        assertNull( Futures.blockingGet( stage ) );
+    @Test
+    void shouldBeginTransactionWithConfig()
+    {
+        Connection connection = connectionMock();
+
+        CompletionStage<Void> stage = protocol.beginTransaction( connection, Bookmarks.empty(), txConfig );
+
+        verify( connection ).write( new BeginMessage( Bookmarks.empty(), txConfig ), NoOpResponseHandler.INSTANCE );
+        assertNull( await( stage ) );
+    }
+
+    @Test
+    void shouldBeginTransactionWithBookmarksAndConfig()
+    {
+        Connection connection = connectionMock();
+        Bookmarks bookmarks = Bookmarks.from( "neo4j:bookmark:v1:tx4242" );
+
+        CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmarks, txConfig );
+
+        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmarks, txConfig ) ), any( BeginTxResponseHandler.class ) );
+        assertNull( await( stage ) );
     }
 
     @Test
     void shouldCommitTransaction()
     {
-        String bookmarkString = "neo4j:bookmark:v1:tx1909";
+        Connection connection = connectionMock();
 
-        Connection connection = mock( Connection.class );
-        when( connection.protocol() ).thenReturn( DEFAULT_TEST_PROTOCOL );
-        doAnswer( invocation ->
-        {
-            ResponseHandler commitHandler = invocation.getArgument( 3 );
-            commitHandler.onSuccess( singletonMap( "bookmark", value( bookmarkString ) ) );
-            return null;
-        } ).when( connection ).writeAndFlush( eq( new RunMessage( "COMMIT" ) ), any(), any(), any() );
+        CompletionStage<Void> stage = protocol.commitTransaction( connection, mock( ExplicitTransaction.class ) );
 
-        CompletionStage<Bookmarks> stage = protocol.commitTransaction( connection );
-
-        verify( connection ).writeAndFlush(
-                eq( new RunMessage( "COMMIT" ) ), eq( NoOpResponseHandler.INSTANCE ),
-                eq( PullAllMessage.PULL_ALL ), any( CommitTxResponseHandler.class ) );
-
-        assertEquals( Bookmarks.from( bookmarkString ), await( stage ) );
+        verify( connection ).writeAndFlush( eq( CommitMessage.COMMIT ), any( CommitTxResponseHandler.class ) );
+        assertNull( await( stage ) );
     }
 
     @Test
@@ -204,89 +209,59 @@ public class BoltProtocolV1Test
 
         CompletionStage<Void> stage = protocol.rollbackTransaction( connection );
 
-        verify( connection ).writeAndFlush(
-                eq( new RunMessage( "ROLLBACK" ) ), eq( NoOpResponseHandler.INSTANCE ),
-                eq( PullAllMessage.PULL_ALL ), any( RollbackTxResponseHandler.class ) );
-
-        assertNull( Futures.blockingGet( stage ) );
+        verify( connection ).writeAndFlush( eq( RollbackMessage.ROLLBACK ), any( RollbackTxResponseHandler.class ) );
+        assertNull( await( stage ) );
     }
 
     @Test
     void shouldRunInAutoCommitTransactionWithoutWaitingForRunResponse() throws Exception
     {
-        testRunWithoutWaitingForRunResponse( true );
+        testRunWithoutWaitingForRunResponse( true, TransactionConfig.empty() );
+    }
+
+    @Test
+    void shouldRunInAutoCommitWithConfigTransactionWithoutWaitingForRunResponse() throws Exception
+    {
+        testRunWithoutWaitingForRunResponse( true, txConfig );
     }
 
     @Test
     void shouldRunInAutoCommitTransactionAndWaitForSuccessRunResponse() throws Exception
     {
-        testRunWithWaitingForResponse( true, true );
+        testRunWithWaitingForResponse( true, true, TransactionConfig.empty() );
+    }
+
+    @Test
+    void shouldRunInAutoCommitWithConfigTransactionAndWaitForSuccessRunResponse() throws Exception
+    {
+        testRunWithWaitingForResponse( true, true, TransactionConfig.empty() );
     }
 
     @Test
     void shouldRunInAutoCommitTransactionAndWaitForFailureRunResponse() throws Exception
     {
-        testRunWithWaitingForResponse( false, true );
+        testRunWithWaitingForResponse( false, true, TransactionConfig.empty() );
     }
 
     @Test
     void shouldRunInTransactionWithoutWaitingForRunResponse() throws Exception
     {
-        testRunWithoutWaitingForRunResponse( false );
+        testRunWithoutWaitingForRunResponse( false, TransactionConfig.empty() );
     }
 
     @Test
     void shouldRunInTransactionAndWaitForSuccessRunResponse() throws Exception
     {
-        testRunWithWaitingForResponse( true, false );
+        testRunWithWaitingForResponse( true, false, TransactionConfig.empty() );
     }
 
     @Test
     void shouldRunInTransactionAndWaitForFailureRunResponse() throws Exception
     {
-        testRunWithWaitingForResponse( false, false );
+        testRunWithWaitingForResponse( false, false, TransactionConfig.empty() );
     }
 
-    @Test
-    void shouldNotSupportTransactionConfigInBeginTransaction()
-    {
-        TransactionConfig config = TransactionConfig.builder()
-                .withTimeout( Duration.ofSeconds( 5 ) )
-                .withMetadata( singletonMap( "key", "value" ) )
-                .build();
-
-        CompletionStage<Void> txStage = protocol.beginTransaction( connectionMock(), Bookmarks.empty(), config );
-
-        ClientException e = assertThrows( ClientException.class, () -> await( txStage ) );
-        assertThat( e.getMessage(), startsWith( "Driver is connected to the database that does not support transaction configuration" ) );
-    }
-
-    @Test
-    void shouldNotSupportTransactionConfigForAutoCommitTransactions()
-    {
-        TransactionConfig config = TransactionConfig.builder()
-                .withTimeout( Duration.ofSeconds( 42 ) )
-                .withMetadata( singletonMap( "hello", "world" ) )
-                .build();
-
-        CompletionStage<InternalStatementResultCursor> cursorFuture = protocol.runInAutoCommitTransaction( connectionMock(), new Statement( "RETURN 1" ),
-                Bookmarks.empty(), config, true );
-
-        ClientException e = assertThrows( ClientException.class, () -> await( cursorFuture ) );
-        assertThat( e.getMessage(), startsWith( "Driver is connected to the database that does not support transaction configuration" ) );
-    }
-
-    protected BoltProtocol createProtocol()
-    {
-        return BoltProtocolV1.INSTANCE;
-    }
-
-    protected Class<? extends MessageFormat> expectedMessageFormatType()
-    {
-        return MessageFormatV1.class;
-    }
-
-    private void testRunWithoutWaitingForRunResponse( boolean autoCommitTx ) throws Exception
+    private void testRunWithoutWaitingForRunResponse( boolean autoCommitTx, TransactionConfig config ) throws Exception
     {
         Connection connection = mock( Connection.class );
 
@@ -294,7 +269,7 @@ public class BoltProtocolV1Test
         if ( autoCommitTx )
         {
 
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), TransactionConfig.empty(), false );
+            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), config, false );
         }
         else
         {
@@ -304,10 +279,10 @@ public class BoltProtocolV1Test
 
         assertTrue( cursorFuture.isDone() );
         assertNotNull( cursorFuture.get() );
-        verifyRunInvoked( connection, autoCommitTx );
+        verifyRunInvoked( connection, autoCommitTx, config );
     }
 
-    private void testRunWithWaitingForResponse( boolean success, boolean session ) throws Exception
+    private void testRunWithWaitingForResponse( boolean success, boolean session, TransactionConfig config ) throws Exception
     {
         Connection connection = mock( Connection.class );
 
@@ -323,7 +298,7 @@ public class BoltProtocolV1Test
         CompletableFuture<InternalStatementResultCursor> cursorFuture = cursorStage.toCompletableFuture();
 
         assertFalse( cursorFuture.isDone() );
-        ResponseHandler runResponseHandler = verifyRunInvoked( connection, session );
+        ResponseHandler runResponseHandler = verifyRunInvoked( connection, session, config );
 
         if ( success )
         {
@@ -338,12 +313,14 @@ public class BoltProtocolV1Test
         assertNotNull( cursorFuture.get() );
     }
 
-    private static ResponseHandler verifyRunInvoked( Connection connection, boolean session )
+    private static ResponseHandler verifyRunInvoked( Connection connection, boolean session, TransactionConfig config )
     {
         ArgumentCaptor<ResponseHandler> runHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
         ArgumentCaptor<ResponseHandler> pullAllHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
 
-        verify( connection ).writeAndFlush( eq( new RunMessage( QUERY, PARAMS ) ), runHandlerCaptor.capture(),
+        RunWithMetadataMessage expectedMessage = new RunWithMetadataMessage( QUERY, PARAMS, Bookmarks.empty(), config );
+
+        verify( connection ).writeAndFlush( eq( expectedMessage ), runHandlerCaptor.capture(),
                 eq( PullAllMessage.PULL_ALL ), pullAllHandlerCaptor.capture() );
 
         assertThat( runHandlerCaptor.getValue(), instanceOf( RunResponseHandler.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_2_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
+import static org.neo4j.driver.internal.util.ServerVersion.v3_5_0;
 
 public enum Neo4jFeature
 {
@@ -34,7 +35,8 @@ public enum Neo4jFeature
     READ_ON_FOLLOWERS_BY_DEFAULT( v3_2_0 ),
     STATEMENT_RESULT_TIMINGS( v3_1_0 ),
     LIST_QUERIES_PROCEDURE( v3_1_0 ),
-    CONNECTOR_LISTEN_ADDRESS_CONFIGURATION( v3_1_0 );
+    CONNECTOR_LISTEN_ADDRESS_CONFIGURATION( v3_1_0 ),
+    BOLT_V3( v3_5_0 );
 
     private final ServerVersion availableFromVersion;
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/PreconditionsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/PreconditionsTest.java
@@ -20,6 +20,8 @@ package org.neo4j.driver.internal.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +32,16 @@ import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
 
 class PreconditionsTest
 {
+    @Test
+    void shouldCheckBooleanArgument()
+    {
+        assertDoesNotThrow( () -> checkArgument( true, "" ) );
+        assertDoesNotThrow( () -> checkArgument( !Duration.ofSeconds( 1 ).isZero(), "" ) );
+
+        assertThrows( IllegalArgumentException.class, () -> checkArgument( false, "" ) );
+        assertThrows( IllegalArgumentException.class, () -> checkArgument( Period.ofDays( 2 ).isNegative(), "" ) );
+    }
+
     @Test
     void shouldCheckArgumentType()
     {

--- a/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
@@ -105,6 +105,6 @@ class ParametersTest
     {
         ConnectionProvider provider = mock( ConnectionProvider.class );
         RetryLogic retryLogic = mock( RetryLogic.class );
-        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING );
+        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, TransactionConfig.empty(), DEV_NULL_LOGGING );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
@@ -105,6 +105,6 @@ class ParametersTest
     {
         ConnectionProvider provider = mock( ConnectionProvider.class );
         RetryLogic retryLogic = mock( RetryLogic.class );
-        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, TransactionConfig.empty(), DEV_NULL_LOGGING );
+        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/TransactionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/TransactionConfigTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.driver.internal.InternalNode;
+import org.neo4j.driver.internal.InternalPath;
+import org.neo4j.driver.internal.InternalRelationship;
+import org.neo4j.driver.v1.exceptions.ClientException;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.v1.Values.value;
+
+class TransactionConfigTest
+{
+    @Test
+    void emptyConfigShouldHaveNoTimeout()
+    {
+        assertNull( TransactionConfig.empty().timeout() );
+    }
+
+    @Test
+    void emptyConfigShouldHaveNoMetadata()
+    {
+        assertEquals( emptyMap(), TransactionConfig.empty().metadata() );
+    }
+
+    @Test
+    void shouldDisallowNullTimeout()
+    {
+        assertThrows( NullPointerException.class, () -> TransactionConfig.builder().withTimeout( null ) );
+    }
+
+    @Test
+    void shouldDisallowZeroTimeout()
+    {
+        assertThrows( IllegalArgumentException.class, () -> TransactionConfig.builder().withTimeout( Duration.ZERO ) );
+    }
+
+    @Test
+    void shouldDisallowNegativeTimeout()
+    {
+        assertThrows( IllegalArgumentException.class, () -> TransactionConfig.builder().withTimeout( Duration.ofSeconds( -1 ) ) );
+    }
+
+    @Test
+    void shouldDisallowNullMetadata()
+    {
+        assertThrows( NullPointerException.class, () -> TransactionConfig.builder().withMetadata( null ) );
+    }
+
+    @Test
+    void shouldDisallowMetadataWithIllegalValues()
+    {
+        assertThrows( ClientException.class,
+                () -> TransactionConfig.builder().withMetadata( singletonMap( "key", new InternalNode( 1 ) ) ) );
+
+        assertThrows( ClientException.class,
+                () -> TransactionConfig.builder().withMetadata( singletonMap( "key", new InternalRelationship( 1, 1, 1, "" ) ) ) );
+
+        assertThrows( ClientException.class,
+                () -> TransactionConfig.builder().withMetadata( singletonMap( "key", new InternalPath( new InternalNode( 1 ) ) ) ) );
+    }
+
+    @Test
+    void shouldHaveTimeout()
+    {
+        TransactionConfig config = TransactionConfig.builder()
+                .withTimeout( Duration.ofSeconds( 3 ) )
+                .build();
+
+        assertEquals( Duration.ofSeconds( 3 ), config.timeout() );
+    }
+
+    @Test
+    void shouldHaveMetadata()
+    {
+        Map<String,Object> map = new HashMap<>();
+        map.put( "key1", "value1" );
+        map.put( "key2", true );
+        map.put( "key3", 42 );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( map )
+                .build();
+
+        Map<String,Value> metadata = config.metadata();
+
+        assertEquals( 3, metadata.size() );
+        assertEquals( value( "value1" ), metadata.get( "key1" ) );
+        assertEquals( value( true ), metadata.get( "key2" ) );
+        assertEquals( value( 42 ), metadata.get( "key3" ) );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
+import org.neo4j.driver.v1.exceptions.TransientException;
+import org.neo4j.driver.v1.util.SessionExtension;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
+
+@EnabledOnNeo4jWith( BOLT_V3 )
+class SessionBoltV3IT
+{
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
+
+    @Test
+    void shouldSetTransactionMetadata()
+    {
+        Map<String,Object> metadata = new HashMap<>();
+        metadata.put( "a", "hello world" );
+        metadata.put( "b", LocalDate.now() );
+        metadata.put( "c", asList( true, false, true ) );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( metadata )
+                .build();
+
+        // call listTransactions procedure that should list itself with the specified metadata
+        StatementResult result = session.run( "CALL dbms.listTransactions()", config );
+        Map<String,Object> receivedMetadata = result.single().get( "metaData" ).asMap();
+
+        assertEquals( metadata, receivedMetadata );
+    }
+
+    @Test
+    void shouldSetTransactionTimeout()
+    {
+        // create a dummy node
+        session.run( "CREATE (:Node)" ).consume();
+
+        try ( Session otherSession = session.driver().session() )
+        {
+            try ( Transaction otherTx = otherSession.beginTransaction() )
+            {
+                // lock dummy node but keep the transaction open
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
+
+                TransactionConfig config = TransactionConfig.builder()
+                        .withTimeout( ofSeconds( 1 ) )
+                        .build();
+
+                // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
+                TransientException error = assertThrows( TransientException.class,
+                        () -> session.run( "MATCH (n:Node) SET n.prop = 2", config ).consume() );
+
+                assertThat( error.getMessage(), containsString( "terminated" ) );
+            }
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
@@ -24,13 +24,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.exceptions.TransientException;
+import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.SessionExtension;
 
 import static java.time.Duration.ofSeconds;
@@ -40,6 +43,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
+import static org.neo4j.driver.v1.util.TestUtil.await;
 
 @EnabledOnNeo4jWith( BOLT_V3 )
 class SessionBoltV3IT
@@ -67,6 +71,25 @@ class SessionBoltV3IT
     }
 
     @Test
+    void shouldSetTransactionMetadataAsync()
+    {
+        Map<String,Object> metadata = new HashMap<>();
+        metadata.put( "key1", "value1" );
+        metadata.put( "key2", 42L );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( metadata )
+                .build();
+
+        // call listTransactions procedure that should list itself with the specified metadata
+        CompletionStage<Map<String,Object>> metadataFuture = session.runAsync( "CALL dbms.listTransactions()", config )
+                .thenCompose( StatementResultCursor::singleAsync )
+                .thenApply( record -> record.get( "metaData" ).asMap() );
+
+        assertEquals( metadata, await( metadataFuture ) );
+    }
+
+    @Test
     void shouldSetTransactionTimeout()
     {
         // create a dummy node
@@ -91,4 +114,99 @@ class SessionBoltV3IT
             }
         }
     }
+
+    @Test
+    void shouldSetTransactionTimeoutAsync()
+    {
+        // create a dummy node
+        session.run( "CREATE (:Node)" ).consume();
+
+        try ( Session otherSession = session.driver().session() )
+        {
+            try ( Transaction otherTx = otherSession.beginTransaction() )
+            {
+                // lock dummy node but keep the transaction open
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
+
+                TransactionConfig config = TransactionConfig.builder()
+                        .withTimeout( ofSeconds( 1 ) )
+                        .build();
+
+                // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
+                CompletionStage<ResultSummary> resultFuture = session.runAsync( "MATCH (n:Node) SET n.prop = 2", config )
+                        .thenCompose( StatementResultCursor::consumeAsync );
+
+                TransientException error = assertThrows( TransientException.class, () -> await( resultFuture ) );
+
+                assertThat( error.getMessage(), containsString( "terminated" ) );
+            }
+        }
+    }
+
+    @Test
+    void shouldSetTransactionMetadataWithReadTransactionFunction()
+    {
+        testTransactionMetadataWithTransactionFunctions( true );
+    }
+
+    @Test
+    void shouldSetTransactionMetadataWithWriteTransactionFunction()
+    {
+        testTransactionMetadataWithTransactionFunctions( false );
+    }
+
+    @Test
+    void shouldSetTransactionMetadataWithAsyncReadTransactionFunction()
+    {
+        testTransactionMetadataWithAsyncTransactionFunctions( true );
+    }
+
+    @Test
+    void shouldSetTransactionMetadataWithAsyncWriteTransactionFunction()
+    {
+        testTransactionMetadataWithAsyncTransactionFunctions( false );
+    }
+
+    private static void testTransactionMetadataWithTransactionFunctions( boolean read )
+    {
+        Map<String,Object> metadata = new HashMap<>();
+        metadata.put( "foo", "bar" );
+        metadata.put( "baz", true );
+        metadata.put( "qux", 12345L );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( metadata )
+                .build();
+
+        // call listTransactions procedure that should list itself with the specified metadata
+        StatementResult result = read ? session.readTransaction( tx -> tx.run( "CALL dbms.listTransactions()" ), config )
+                                      : session.writeTransaction( tx -> tx.run( "CALL dbms.listTransactions()" ), config );
+
+        Map<String,Object> receivedMetadata = result.single().get( "metaData" ).asMap();
+
+        assertEquals( metadata, receivedMetadata );
+    }
+
+    private static void testTransactionMetadataWithAsyncTransactionFunctions( boolean read )
+    {
+        Map<String,Object> metadata = new HashMap<>();
+        metadata.put( "foo", "bar" );
+        metadata.put( "baz", true );
+        metadata.put( "qux", 12345L );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( metadata )
+                .build();
+
+        // call listTransactions procedure that should list itself with the specified metadata
+        CompletionStage<StatementResultCursor> cursorFuture =
+                read ? session.readTransactionAsync( tx -> tx.runAsync( "CALL dbms.listTransactions()" ), config )
+                     : session.writeTransactionAsync( tx -> tx.runAsync( "CALL dbms.listTransactions()" ), config );
+
+        CompletionStage<Map<String,Object>> metadataFuture = cursorFuture.thenCompose( StatementResultCursor::singleAsync )
+                .thenApply( record -> record.get( "metaData" ).asMap() );
+
+        assertEquals( metadata, await( metadataFuture ) );
+    }
+
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionBoltV3IT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.SessionExtension;
 
-import static java.time.Duration.ofSeconds;
+import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -103,7 +103,7 @@ class SessionBoltV3IT
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofSeconds( 1 ) )
+                        .withTimeout( ofMillis( 1 ) )
                         .build();
 
                 // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
@@ -129,7 +129,7 @@ class SessionBoltV3IT
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofSeconds( 1 ) )
+                        .withTimeout( ofMillis( 1 ) )
                         .build();
 
                 // run a query in an auto-commit transaction with timeout and try to update the locked dummy node

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionBoltV3IT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.TransientException;
+import org.neo4j.driver.v1.util.SessionExtension;
+
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
+
+@EnabledOnNeo4jWith( BOLT_V3 )
+class TransactionBoltV3IT
+{
+    @RegisterExtension
+    static final SessionExtension session = new SessionExtension();
+
+    @Test
+    void shouldSetTransactionMetadata()
+    {
+        Map<String,Object> metadata = new HashMap<>();
+        metadata.put( "key1", "value1" );
+        metadata.put( "key2", 42L );
+        metadata.put( "key3", false );
+
+        TransactionConfig config = TransactionConfig.builder()
+                .withMetadata( metadata )
+                .build();
+
+        try ( Transaction tx = session.beginTransaction( config ) )
+        {
+            tx.run( "RETURN 1" ).consume();
+
+            try ( Session otherSession = session.driver().session() )
+            {
+                StatementResult result = otherSession.run( "CALL dbms.listTransactions()" );
+
+                Map<String,Object> receivedMetadata = result.list()
+                        .stream()
+                        .map( record -> record.get( "metaData" ) )
+                        .map( Value::asMap )
+                        .filter( map -> !map.isEmpty() )
+                        .findFirst()
+                        .orElseThrow( IllegalStateException::new );
+
+                assertEquals( metadata, receivedMetadata );
+            }
+        }
+    }
+
+    @Test
+    void shouldSetTransactionTimeout()
+    {
+        // create a dummy node
+        session.run( "CREATE (:Node)" ).consume();
+
+        try ( Session otherSession = session.driver().session() )
+        {
+            try ( Transaction otherTx = otherSession.beginTransaction() )
+            {
+                // lock dummy node but keep the transaction open
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
+
+                TransactionConfig config = TransactionConfig.builder()
+                        .withTimeout( ofSeconds( 1 ) )
+                        .build();
+
+                // start a new transaction with timeout and try to update the locked dummy node
+                TransientException error = assertThrows( TransientException.class, () ->
+                {
+                    try ( Transaction tx = session.beginTransaction( config ) )
+                    {
+                        tx.run( "MATCH (n:Node) SET n.prop = 2" );
+                        tx.success();
+                    }
+                } );
+
+                assertThat( error.getMessage(), containsString( "terminated" ) );
+            }
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionBoltV3IT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.TransientException;
 import org.neo4j.driver.v1.util.SessionExtension;
 
-import static java.time.Duration.ofSeconds;
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,7 +111,7 @@ class TransactionBoltV3IT
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofSeconds( 1 ) )
+                        .withTimeout( ofMillis( 1 ) )
                         .build();
 
                 // start a new transaction with timeout and try to update the locked dummy node
@@ -143,7 +143,7 @@ class TransactionBoltV3IT
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofSeconds( 1 ) )
+                        .withTimeout( ofMillis( 1 ) )
                         .build();
 
                 // start a new transaction with timeout and try to update the locked dummy node

--- a/driver/src/test/java/org/neo4j/driver/v1/util/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/SessionExtension.java
@@ -27,9 +27,11 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.StatementResultCursor;
 import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.types.TypeSystem;
@@ -88,6 +90,12 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
         return realSession.beginTransaction();
     }
 
+    @Override
+    public Transaction beginTransaction( TransactionConfig config )
+    {
+        return realSession.beginTransaction( config );
+    }
+
     @Deprecated
     @Override
     public Transaction beginTransaction( String bookmark )
@@ -102,9 +110,21 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     }
 
     @Override
+    public CompletionStage<Transaction> beginTransactionAsync( TransactionConfig config )
+    {
+        return realSession.beginTransactionAsync( config );
+    }
+
+    @Override
     public <T> T readTransaction( TransactionWork<T> work )
     {
         return realSession.readTransaction( work );
+    }
+
+    @Override
+    public <T> T readTransaction( TransactionWork<T> work, TransactionConfig config )
+    {
+        return realSession.readTransaction( work, config );
     }
 
     @Override
@@ -114,15 +134,33 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     }
 
     @Override
+    public <T> CompletionStage<T> readTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config )
+    {
+        return realSession.readTransactionAsync( work, config );
+    }
+
+    @Override
     public <T> T writeTransaction( TransactionWork<T> work )
     {
         return realSession.writeTransaction( work );
     }
 
     @Override
+    public <T> T writeTransaction( TransactionWork<T> work, TransactionConfig config )
+    {
+        return realSession.writeTransaction( work, config );
+    }
+
+    @Override
     public <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work )
     {
         return realSession.writeTransactionAsync( work );
+    }
+
+    @Override
+    public <T> CompletionStage<T> writeTransactionAsync( TransactionWork<CompletionStage<T>> work, TransactionConfig config )
+    {
+        return realSession.writeTransactionAsync( work, config );
     }
 
     @Override
@@ -190,6 +228,42 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     public CompletionStage<StatementResultCursor> runAsync( org.neo4j.driver.v1.Statement statement )
     {
         return realSession.runAsync( statement );
+    }
+
+    @Override
+    public StatementResult run( String statement, TransactionConfig config )
+    {
+        return realSession.run( statement, config );
+    }
+
+    @Override
+    public StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config )
+    {
+        return realSession.run( statement, parameters, config );
+    }
+
+    @Override
+    public StatementResult run( Statement statement, TransactionConfig config )
+    {
+        return realSession.run( statement, config );
+    }
+
+    @Override
+    public CompletionStage<StatementResultCursor> runAsync( String statement, TransactionConfig config )
+    {
+        return realSession.runAsync( statement, config );
+    }
+
+    @Override
+    public CompletionStage<StatementResultCursor> runAsync( String statement, Map<String,Object> parameters, TransactionConfig config )
+    {
+        return realSession.runAsync( statement, parameters, config );
+    }
+
+    @Override
+    public CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config )
+    {
+        return realSession.runAsync( statement, config );
     }
 
     @Override


### PR DESCRIPTION
This is the first draft of the API to allow transaction timeout and/or metadata be set for explicit and auto-commit transactions. Both settings can be specified in a `TransactionConfig` object which can be created like this:

```
TransactionConfig config = TransactionConfig.builder()
            .withTimeout(Duration.ofSeconds(5))
            .withMetadata(Collections.singletonMap("key", "value"))
            .build();
```

Explicit transactions can take config like this:

```
Transaction tx = session.beginTransaction(config);
```

and auto-commit transactions accept it in various overloads of `Session#run()` and `Session#runAsync()`:

```
session.run("CREATE ()", config);

session.runAsync("RETURN $x", Collections.singletonMap("x", 1) config);
```

Transaction functions accept config like this:

```
session.readTransaction(tx -> {...}, config);

session.writeTransactionAsync(tx -> {...}, config);
```