### PR TITLE
Allow driver to accept and return OffsetDateTime

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/value/DateTimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/DateTimeValue.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.value;
 
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 
 import org.neo4j.driver.internal.types.InternalTypeSystem;
@@ -28,6 +29,12 @@ public class DateTimeValue extends ObjectValueAdapter<ZonedDateTime>
     public DateTimeValue( ZonedDateTime zonedDateTime )
     {
         super( zonedDateTime );
+    }
+
+    @Override
+    public OffsetDateTime asOffsetDateTime()
+    {
+        return asZonedDateTime().toOffsetDateTime();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.value;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -251,6 +252,12 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     }
 
     @Override
+    public OffsetDateTime asOffsetDateTime( OffsetDateTime defaultValue )
+    {
+        return computeOrDefault( Value::asOffsetDateTime, defaultValue );
+    }
+
+    @Override
     public ZonedDateTime asZonedDateTime( ZonedDateTime defaultValue )
     {
         return computeOrDefault( Value::asZonedDateTime, defaultValue );
@@ -326,6 +333,12 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     public LocalDateTime asLocalDateTime()
     {
         throw new Uncoercible( type().name(), "LocalDateTime" );
+    }
+
+    @Override
+    public OffsetDateTime asOffsetDateTime()
+    {
+        throw new Uncoercible( type().name(), "OffsetDateTime" );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/v1/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Value.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.v1;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -409,6 +410,12 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
     LocalDateTime asLocalDateTime();
 
     /**
+     * @return the value as a {@link java.time.OffsetDateTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    OffsetDateTime asOffsetDateTime();
+
+    /**
      * @return the value as a {@link ZonedDateTime}, if possible.
      * @throws Uncoercible if value types are incompatible.
      */
@@ -453,6 +460,13 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * @throws Uncoercible if value types are incompatible.
      */
     LocalDateTime asLocalDateTime( LocalDateTime defaultValue );
+
+    /**
+     * @param defaultValue default to this value if the value is a {@link NullValue}
+     * @return the value as a {@link OffsetDateTime}, if possible.
+     * @throws Uncoercible if value types are incompatible.
+     */
+    OffsetDateTime asOffsetDateTime( OffsetDateTime defaultValue );
 
     /**
      * @param defaultValue default to this value if the value is a {@link NullValue}

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
 import java.time.ZonedDateTime;
@@ -106,6 +107,7 @@ public abstract class Values
         if ( value instanceof OffsetTime ) { return value( (OffsetTime) value ); }
         if ( value instanceof LocalTime ) { return value( (LocalTime) value ); }
         if ( value instanceof LocalDateTime ) { return value( (LocalDateTime) value ); }
+        if ( value instanceof OffsetDateTime ) { return value( (OffsetDateTime) value ); }
         if ( value instanceof ZonedDateTime ) { return value( (ZonedDateTime) value ); }
         if ( value instanceof IsoDuration ) { return value( (IsoDuration) value ); }
         if ( value instanceof Period ) { return value( (Period) value ); }
@@ -307,6 +309,11 @@ public abstract class Values
     public static Value value( LocalDateTime localDateTime )
     {
         return new LocalDateTimeValue( localDateTime );
+    }
+
+    public static Value value( OffsetDateTime offsetDateTime )
+    {
+        return new DateTimeValue( offsetDateTime.toZonedDateTime() );
     }
 
     public static Value value( ZonedDateTime zonedDateTime )
@@ -611,6 +618,16 @@ public abstract class Values
     public static Function<Value,LocalDateTime> ofLocalDateTime()
     {
         return Value::asLocalDateTime;
+    }
+
+    /**
+     * Converts values to {@link OffsetDateTime}.
+     *
+     * @return a function that returns {@link Value#asOffsetDateTime()} of a {@link Value}
+     */
+    public static Function<Value,OffsetDateTime> ofOffsetDateTime()
+    {
+        return Value::asOffsetDateTime;
     }
 
     /**

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
 import java.time.ZonedDateTime;
@@ -373,6 +374,18 @@ class ValuesTest
 
         assertThat( value, instanceOf( LocalDateTimeValue.class ) );
         assertEquals( localDateTime, value.asObject() );
+    }
+
+    @Test
+    void shouldCreateDateTimeValueFromOffsetDateTime()
+    {
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        Value value = value( offsetDateTime );
+
+        assertThat( value, instanceOf( DateTimeValue.class ) );
+        assertEquals( offsetDateTime, value.asOffsetDateTime() );
+        assertEquals( offsetDateTime.toZonedDateTime(), value.asZonedDateTime() );
+        assertEquals( offsetDateTime.toZonedDateTime(), value.asObject() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
@@ -57,6 +57,18 @@ class DateTimeValueTest
     }
 
     @Test
+    void shouldSupportAsOffsetDateTime()
+    {
+        ZonedDateTime dateTimeWithOffset = ZonedDateTime.of( 2019, 1, 2, 3, 14, 22, 100, ZoneOffset.ofHours( -5 ) );
+        DateTimeValue dateTimeValue1 = new DateTimeValue( dateTimeWithOffset );
+        assertEquals( dateTimeWithOffset.toOffsetDateTime(), dateTimeValue1.asOffsetDateTime() );
+
+        ZonedDateTime dateTimeWithZoneId = ZonedDateTime.of( 2000, 11, 8, 5, 57, 59, 1, ZoneId.of( "Europe/Stockholm" ) );
+        DateTimeValue dateTimeValue2 = new DateTimeValue( dateTimeWithZoneId );
+        assertEquals( dateTimeWithZoneId.toOffsetDateTime(), dateTimeValue2.asOffsetDateTime() );
+    }
+
+    @Test
     void shouldNotSupportAsLong()
     {
         ZonedDateTime dateTime = ZonedDateTime.now();

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 
@@ -88,6 +89,7 @@ class NullValueTest
         assertAsWithDefaultValueReturnDefault( value::asOffsetTime, OffsetTime.now() );
         assertAsWithDefaultValueReturnDefault( value::asLocalTime, LocalTime.now() );
         assertAsWithDefaultValueReturnDefault( value::asLocalDateTime, LocalDateTime.now() );
+        assertAsWithDefaultValueReturnDefault( value::asOffsetDateTime, OffsetDateTime.now() );
         assertAsWithDefaultValueReturnDefault( value::asZonedDateTime, ZonedDateTime.now() );
         assertAsWithDefaultValueReturnDefault( value::asIsoDuration,
                 isoDuration( 1, 2, 3, 4 ).asIsoDuration() );
@@ -117,6 +119,7 @@ class NullValueTest
         assertComputeOrDefaultReturnNull( Value::asOffsetTime );
         assertComputeOrDefaultReturnNull( Value::asLocalTime );
         assertComputeOrDefaultReturnNull( Value::asLocalDateTime );
+        assertComputeOrDefaultReturnNull( Value::asOffsetTime );
         assertComputeOrDefaultReturnNull( Value::asZonedDateTime );
         assertComputeOrDefaultReturnNull( Value::asIsoDuration );
     }
@@ -128,18 +131,18 @@ class NullValueTest
         assertComputeOrDefaultReturnDefault( Value::asNumber, 10 );
     }
 
-    private <T> void assertComputeOrDefaultReturnDefault( Function<Value,T> f, T defaultAndExpectedValue )
+    private static <T> void assertComputeOrDefaultReturnDefault( Function<Value,T> f, T defaultAndExpectedValue )
     {
         Value value = NullValue.NULL;
         assertThat( value.computeOrDefault( f, defaultAndExpectedValue ), equalTo( defaultAndExpectedValue ) );
     }
 
-    private <T> void assertComputeOrDefaultReturnNull( Function<Value,T> f )
+    private static <T> void assertComputeOrDefaultReturnNull( Function<Value,T> f )
     {
         assertComputeOrDefaultReturnDefault( f, null );
     }
 
-    private <T> void assertAsWithDefaultValueReturnDefault( Function<T,T> map, T defaultValue )
+    private static <T> void assertAsWithDefaultValueReturnDefault( Function<T,T> map, T defaultValue )
     {
         assertThat( map.apply( defaultValue ), equalTo( defaultValue ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TemporalTypesIT.java
@@ -29,7 +29,10 @@ import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.v1.Record;
@@ -42,15 +45,21 @@ import org.neo4j.driver.v1.util.TemporalUtil;
 
 import static java.time.Month.MARCH;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.internal.util.Neo4jFeature.TEMPORAL_TYPES;
 import static org.neo4j.driver.v1.Values.isoDuration;
+import static org.neo4j.driver.v1.Values.ofOffsetDateTime;
 import static org.neo4j.driver.v1.Values.parameters;
 
 @EnabledOnNeo4jWith( TEMPORAL_TYPES )
 class TemporalTypesIT
 {
     private static final int RANDOM_VALUES_TO_TEST = 1_000;
+
+    private static final int RANDOM_LISTS_TO_TEST = 100;
+    private static final int MIN_LIST_SIZE = 100;
+    private static final int MAX_LIST_SIZE = 1_000;
 
     @RegisterExtension
     static final SessionExtension session = new SessionExtension();
@@ -82,6 +91,12 @@ class TemporalTypesIT
     }
 
     @Test
+    void shouldSendAndReceiveListsWithRandomDates()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomLocalDate );
+    }
+
+    @Test
     void shouldSendTime()
     {
         testSendValue( OffsetTime.now(), Value::asOffsetTime );
@@ -105,6 +120,12 @@ class TemporalTypesIT
     void shouldSendAndReceiveRandomTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomOffsetTime, Value::asOffsetTime );
+    }
+
+    @Test
+    void shouldSendAndReceiveListsWithRandomTimes()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomOffsetTime );
     }
 
     @Test
@@ -134,6 +155,12 @@ class TemporalTypesIT
     }
 
     @Test
+    void shouldSendAndReceiveListsWithRandomLocalTimes()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomLocalTime );
+    }
+
+    @Test
     void shouldSendLocalDateTime()
     {
         testSendValue( LocalDateTime.now(), Value::asLocalDateTime );
@@ -157,6 +184,12 @@ class TemporalTypesIT
     void shouldSendAndReceiveRandomLocalDateTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomLocalDateTime, Value::asLocalDateTime );
+    }
+
+    @Test
+    void shouldSendAndReceiveListsWithRandomLocalDateTimes()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomLocalDateTime );
     }
 
     @Test
@@ -189,6 +222,12 @@ class TemporalTypesIT
     }
 
     @Test
+    void shouldSendAndReceiveListsWithRandomDateTimeWithZoneOffsets()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomZonedDateTimeWithOffset );
+    }
+
+    @Test
     void shouldSendDateTimeRepresentedWithOffsetDateTime()
     {
         testSendValue( OffsetDateTime.of( 1851, 9, 29, 1, 29, 42, 987, ZoneOffset.ofHours( -8 ) ), Value::asOffsetDateTime );
@@ -212,6 +251,12 @@ class TemporalTypesIT
     void shouldSendAndReceiveRandomDateTimeRepresentedWithOffsetDateTime()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomOffsetDateTime, Value::asOffsetDateTime );
+    }
+
+    @Test
+    void shouldSendAndReceiveListsWithRandomDateTimeRepresentedWithOffsetDateTimes()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomOffsetDateTime, value -> value.asList( ofOffsetDateTime() ) );
     }
 
     @Test
@@ -244,6 +289,12 @@ class TemporalTypesIT
     }
 
     @Test
+    void shouldSendAndReceiveListsWithRandomDateTimeWithZoneIds()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomZonedDateTimeWithZoneId );
+    }
+
+    @Test
     void shouldSendDuration()
     {
         testSendValue( newDuration( 8, 12, 90, 8 ), Value::asIsoDuration );
@@ -267,6 +318,12 @@ class TemporalTypesIT
     void shouldSendAndReceiveRandomDuration()
     {
         testSendAndReceiveRandomValues( TemporalUtil::randomDuration, Value::asIsoDuration );
+    }
+
+    @Test
+    void shouldSendAndReceiveListsWithRandomDurations()
+    {
+        testSendAndReceiveRandomLists( TemporalUtil::randomDuration );
     }
 
     @Test
@@ -302,11 +359,29 @@ class TemporalTypesIT
         testDurationToString( -40, -2_123_456_789, "P0M0DT-42.123456789S" );
     }
 
-    private static <T> void testSendAndReceiveRandomValues( Supplier<T> supplier, Function<Value,T> converter )
+    private static <T> void testSendAndReceiveRandomValues( Supplier<T> valueSupplier, Function<Value,T> converter )
     {
         for ( int i = 0; i < RANDOM_VALUES_TO_TEST; i++ )
         {
-            testSendAndReceiveValue( supplier.get(), converter );
+            testSendAndReceiveValue( valueSupplier.get(), converter );
+        }
+    }
+
+    private static <T> void testSendAndReceiveRandomLists( Supplier<T> valueSupplier )
+    {
+        testSendAndReceiveRandomLists( valueSupplier::get, Value::asList );
+    }
+
+    private static <T> void testSendAndReceiveRandomLists( Supplier<T> valueSupplier, Function<Value,List<T>> converter )
+    {
+        for ( int i = 0; i < RANDOM_LISTS_TO_TEST; i++ )
+        {
+            int listSize = ThreadLocalRandom.current().nextInt( MIN_LIST_SIZE, MAX_LIST_SIZE );
+            List<T> list = Stream.generate( valueSupplier )
+                    .limit( listSize )
+                    .collect( toList() );
+
+            testSendAndReceiveValue( list, converter );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TemporalUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TemporalUtil.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.v1.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -67,6 +68,11 @@ public final class TemporalUtil
     {
         return LocalDateTime.of( random( YEAR ), random( MONTH_OF_YEAR ), random( DAY_OF_MONTH ), random( HOUR_OF_DAY ),
                 random( MINUTE_OF_HOUR ), random( SECOND_OF_MINUTE ), random( NANO_OF_SECOND ) );
+    }
+
+    public static OffsetDateTime randomOffsetDateTime()
+    {
+        return randomZonedDateTimeWithOffset().toOffsetDateTime();
     }
 
     public static ZonedDateTime randomZonedDateTimeWithOffset()


### PR DESCRIPTION
Which is another variant of representing `DateTime` with zone offset Cypher type. Before this change, driver could only represent such `DateTime` values with `ZonedDateTime`. It is now possible to pass `OffsetDateTime` as a query parameter and convert the returned value to it.

Also added ITs for lists of temporal types.