### PR TITLE
Support Java 8 streams as query parameters and results

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -19,7 +19,11 @@
 package org.neo4j.driver.internal;
 
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
@@ -86,6 +90,13 @@ public class InternalStatementResult implements StatementResult
             throw new NoSuchRecordException( "Cannot peek past the last record" );
         }
         return record;
+    }
+
+    @Override
+    public Stream<Record> stream()
+    {
+        Spliterator<Record> spliterator = Spliterators.spliteratorUnknownSize( this, Spliterator.IMMUTABLE | Spliterator.ORDERED );
+        return StreamSupport.stream( spliterator, false );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/v1/StatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/StatementResult.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.v1;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.summary.ResultSummary;
@@ -93,6 +94,15 @@ public interface StatementResult extends Iterator<Record>
      * @return the next record
      */
     Record peek();
+
+    /**
+     * Convert this result to a sequential {@link Stream} of records.
+     * <p>
+     * Result is exhausted when a terminal operation on the returned stream is executed.
+     *
+     * @return sequential {@link Stream} of records. Empty stream if this result has already been consumed or is empty.
+     */
+    Stream<Record> stream();
 
     /**
      * Retrieve and store the entire result stream.

--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.AsValue;
 import org.neo4j.driver.internal.InternalIsoDuration;
@@ -116,6 +117,7 @@ public abstract class Values
         if ( value instanceof Map<?,?> ) { return value( (Map<String,Object>) value ); }
         if ( value instanceof Iterable<?> ) { return value( (Iterable<Object>) value ); }
         if ( value instanceof Iterator<?> ) { return value( (Iterator<Object>) value ); }
+        if ( value instanceof Stream<?> ) { return value( (Stream<Object>) value ); }
 
         if ( value instanceof byte[] ) { return value( (byte[]) value ); }
         if ( value instanceof boolean[] ) { return value( (boolean[]) value ); }
@@ -246,7 +248,13 @@ public abstract class Values
         {
             values.add( value( val.next() ) );
         }
-        return new ListValue( values.toArray( new Value[values.size()] ) );
+        return new ListValue( values.toArray( new Value[0] ) );
+    }
+
+    public static Value value( Stream<Object> stream )
+    {
+        Value[] values = stream.map( Values::value ).toArray( Value[]::new );
+        return new ListValue( values );
     }
 
     public static Value value( final char val )

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.value.DateTimeValue;
 import org.neo4j.driver.internal.value.DateValue;
@@ -519,5 +520,37 @@ class ValuesTest
         Path path = filledPathValue().asPath();
         Value value = value( path );
         assertEquals( path, value.asPath() );
+    }
+
+    @Test
+    void shouldCreateValueFromStream()
+    {
+        Stream<String> stream = Stream.of( "foo", "bar", "baz", "qux" );
+        Value value = value( stream );
+        assertEquals( asList( "foo", "bar", "baz", "qux" ), value.asObject() );
+    }
+
+    @Test
+    void shouldFailToConvertStreamOfUnsupportedTypeToValue()
+    {
+        Stream<Object> stream = Stream.of( new Object(), new Object() );
+        ClientException e = assertThrows( ClientException.class, () -> value( stream ) );
+        assertEquals( "Unable to convert java.lang.Object to Neo4j Value.", e.getMessage() );
+    }
+
+    @Test
+    void shouldCreateValueFromStreamOfStreams()
+    {
+        Stream<Stream<String>> stream = Stream.of( Stream.of( "foo", "bar" ), Stream.of( "baz", "qux" ) );
+        Value value = value( stream );
+        assertEquals( asList( asList( "foo", "bar" ), asList( "baz", "qux" ) ), value.asObject() );
+    }
+
+    @Test
+    void shouldCreateValueFromStreamOfNulls()
+    {
+        Stream<Object> stream = Stream.of( null, null, null );
+        Value value = value( stream );
+        assertEquals( asList( null, null, null ), value.asObject() );
     }
 }


### PR DESCRIPTION
* Allow streams as query parameters. They will get converted to lists, same as iterables and iterators.
    Example:

    ```java
    Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5);
    StatementResult result = session.run("UNWIND $xs AS x RETURN x", singletonMap("xs", stream));
    ```
* Allow conversion of statement result to stream. Queries executed via blocking API return `StatementResult` which is an iterable of records. This commit adds a convenience method `StatementResult#stream()` to convert result to a stream. It should be convenient to use this method when processing of returned records is required.
    Example:

    ```java
    List<Integer> list = session.run("UNWIND range(1, 100) AS x RETURN x")
                                .stream()
                                .map(record -> record.get("x"))
                                .map(Value::asInt)
                                .collect(toList());
    ```