### PR TITLE
Keep bookmark returned after auto-commit tx

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BookmarksHolder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BookmarksHolder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+public interface BookmarksHolder
+{
+    Bookmarks getBookmarks();
+
+    void setBookmarks( Bookmarks bookmarks );
+
+    BookmarksHolder NO_OP = new BookmarksHolder()
+    {
+        @Override
+        public Bookmarks getBookmarks()
+        {
+            return Bookmarks.empty();
+        }
+
+        @Override
+        public void setBookmarks( Bookmarks bookmarks )
+        {
+        }
+    };
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -46,7 +46,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
-public class NetworkSession extends AbstractStatementRunner implements Session
+public class NetworkSession extends AbstractStatementRunner implements Session, BookmarksHolder
 {
     private static final String LOG_NAME = "Session";
 
@@ -247,7 +247,14 @@ public class NetworkSession extends AbstractStatementRunner implements Session
         return transactionAsync( AccessMode.WRITE, work, config );
     }
 
-    void setBookmarks( Bookmarks bookmarks )
+    @Override
+    public Bookmarks getBookmarks()
+    {
+        return bookmarks;
+    }
+
+    @Override
+    public void setBookmarks( Bookmarks bookmarks )
     {
         if ( bookmarks != null && !bookmarks.isEmpty() )
         {
@@ -439,7 +446,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session
         CompletionStage<InternalStatementResultCursor> newResultCursorStage = ensureNoOpenTxBeforeRunningQuery()
                 .thenCompose( ignore -> acquireConnection( mode ) )
                 .thenCompose( connection ->
-                        connection.protocol().runInAutoCommitTransaction( connection, statement, bookmarks, config, waitForRunResponse ) );
+                        connection.protocol().runInAutoCommitTransaction( connection, statement, this, config, waitForRunResponse ) );
 
         resultCursorStage = newResultCursorStage.exceptionally( error -> null );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.ServerVersion;
@@ -62,7 +62,7 @@ public class RoutingProcedureRunner
     CompletionStage<List<Record>> runProcedure( Connection connection, Statement procedure )
     {
         return connection.protocol()
-                .runInAutoCommitTransaction( connection, procedure, Bookmarks.empty(), TransactionConfig.empty(), true )
+                .runInAutoCommitTransaction( connection, procedure, BookmarksHolder.NO_OP, TransactionConfig.empty(), true )
                 .thenCompose( StatementResultCursor::listAsync );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -53,7 +53,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
 
     private final Statement statement;
     private final RunResponseHandler runResponseHandler;
-    private final MetadataExtractor metadataExtractor;
+    protected final MetadataExtractor metadataExtractor;
     protected final Connection connection;
 
     // initialized lazily when first record arrives
@@ -81,13 +81,13 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         finished = true;
         summary = extractResultSummary( metadata );
 
-        afterSuccess();
+        afterSuccess( metadata );
 
         completeRecordFuture( null );
         completeFailureFuture( null );
     }
 
-    protected abstract void afterSuccess();
+    protected abstract void afterSuccess( Map<String,Value> metadata );
 
     @Override
     public synchronized void onFailure( Throwable error )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandler.java
@@ -18,22 +18,32 @@
  */
 package org.neo4j.driver.internal.handlers;
 
+import java.util.Map;
+
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.MetadataExtractor;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
+
+import static java.util.Objects.requireNonNull;
 
 public class SessionPullAllResponseHandler extends PullAllResponseHandler
 {
+    private final BookmarksHolder bookmarksHolder;
+
     public SessionPullAllResponseHandler( Statement statement, RunResponseHandler runResponseHandler,
-            Connection connection, MetadataExtractor metadataExtractor )
+            Connection connection, BookmarksHolder bookmarksHolder, MetadataExtractor metadataExtractor )
     {
         super( statement, runResponseHandler, connection, metadataExtractor );
+        this.bookmarksHolder = requireNonNull( bookmarksHolder );
     }
 
     @Override
-    protected void afterSuccess()
+    protected void afterSuccess( Map<String,Value> metadata )
     {
         releaseConnection();
+        bookmarksHolder.setBookmarks( metadataExtractor.extractBookmarks( metadata ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullAllResponseHandler.java
@@ -18,10 +18,13 @@
  */
 package org.neo4j.driver.internal.handlers;
 
+import java.util.Map;
+
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.MetadataExtractor;
 import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,7 +40,7 @@ public class TransactionPullAllResponseHandler extends PullAllResponseHandler
     }
 
     @Override
-    protected void afterSuccess()
+    protected void afterSuccess( Map<String,Value> metadata )
     {
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.messaging.v1.BoltProtocolV1;
@@ -89,7 +90,7 @@ public interface BoltProtocol
      *
      * @param connection the network connection to use.
      * @param statement the cypher to execute.
-     * @param bookmarks the bookmarks. Never null, should be {@link Bookmarks#empty()} when absent.
+     * @param bookmarksHolder the bookmarksHolder that keeps track of the current bookmark and can be updated with a new bookmark.
      * @param config the transaction config for the implicitly started auto-commit transaction.
      * @param waitForRunResponse {@code true} for async query execution and {@code false} for blocking query
      * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have statement
@@ -97,7 +98,7 @@ public interface BoltProtocol
      * @return stage with cursor.
      */
     CompletionStage<InternalStatementResultCursor> runInAutoCommitTransaction( Connection connection, Statement statement,
-            Bookmarks bookmarks, TransactionConfig config, boolean waitForRunResponse );
+            BookmarksHolder bookmarksHolder, TransactionConfig config, boolean waitForRunResponse );
 
     /**
      * Execute the given statement in a running explicit transaction, i.e. {@link Transaction#run(Statement)}.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
@@ -142,7 +143,7 @@ public class BoltProtocolV1 implements BoltProtocol
 
     @Override
     public CompletionStage<InternalStatementResultCursor> runInAutoCommitTransaction( Connection connection, Statement statement,
-            Bookmarks bookmarks, TransactionConfig config, boolean waitForRunResponse )
+            BookmarksHolder bookmarksHolder, TransactionConfig config, boolean waitForRunResponse )
     {
         // bookmarks are ignored for auto-commit transactions in this version of the protocol
 
@@ -193,7 +194,7 @@ public class BoltProtocolV1 implements BoltProtocol
         {
             return new TransactionPullAllResponseHandler( statement, runHandler, connection, tx, METADATA_EXTRACTOR );
         }
-        return new SessionPullAllResponseHandler( statement, runHandler, connection, METADATA_EXTRACTOR );
+        return new SessionPullAllResponseHandler( statement, runHandler, connection, BookmarksHolder.NO_OP, METADATA_EXTRACTOR );
     }
 
     private static <T> CompletionStage<T> txConfigNotSupported()

--- a/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.internal.Bookmarks;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.summary.InternalNotification;
 import org.neo4j.driver.internal.summary.InternalPlan;
@@ -40,6 +41,7 @@ import org.neo4j.driver.v1.summary.ServerInfo;
 import org.neo4j.driver.v1.summary.StatementType;
 
 import static java.util.Collections.emptyList;
+import static org.neo4j.driver.internal.types.InternalTypeSystem.TYPE_SYSTEM;
 
 public class MetadataExtractor
 {
@@ -87,6 +89,16 @@ public class MetadataExtractor
         return new InternalResultSummary( statement, serverInfo, extractStatementType( metadata ),
                 extractCounters( metadata ), extractPlan( metadata ), extractProfiledPlan( metadata ),
                 extractNotifications( metadata ), resultAvailableAfter, extractResultConsumedAfter( metadata, resultConsumedAfterMetadataKey ) );
+    }
+
+    public Bookmarks extractBookmarks( Map<String,Value> metadata )
+    {
+        Value bookmarkValue = metadata.get( "bookmark" );
+        if ( bookmarkValue != null && !bookmarkValue.isNull() && bookmarkValue.hasType( TYPE_SYSTEM.STRING() ) )
+        {
+            return Bookmarks.from( bookmarkValue.asString() );
+        }
+        return Bookmarks.empty();
     }
 
     private static StatementType extractStatementType( Map<String,Value> metadata )

--- a/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExplicitTransactionTest.java
@@ -202,40 +202,6 @@ class ExplicitTransactionTest
     }
 
     @Test
-    void shouldHaveEmptyBookmarkInitially()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-        assertTrue( tx.bookmark().isEmpty() );
-    }
-
-    @Test
-    void shouldNotKeepInitialBookmark()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock(), Bookmarks.from( "Dog" ) );
-        assertTrue( tx.bookmark().isEmpty() );
-    }
-
-    @Test
-    void shouldNotOverwriteBookmarkWithNull()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-        tx.setBookmarks( Bookmarks.from( "Cat" ) );
-        assertEquals( "Cat", tx.bookmark().maxBookmarkAsString() );
-        tx.setBookmarks( null );
-        assertEquals( "Cat", tx.bookmark().maxBookmarkAsString() );
-    }
-
-    @Test
-    void shouldNotOverwriteBookmarkWithEmptyBookmark()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-        tx.setBookmarks( Bookmarks.from( "Cat" ) );
-        assertEquals( "Cat", tx.bookmark().maxBookmarkAsString() );
-        tx.setBookmarks( Bookmarks.empty() );
-        assertEquals( "Cat", tx.bookmark().maxBookmarkAsString() );
-    }
-
-    @Test
     void shouldReleaseConnectionWhenBeginFails()
     {
         RuntimeException error = new RuntimeException( "Wrong bookmark!" );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
@@ -356,7 +356,8 @@ class InternalStatementResultTest
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( ServerVersion.v3_2_0 );
-        PullAllResponseHandler pullAllHandler = new SessionPullAllResponseHandler( statement, runHandler, connection, METADATA_EXTRACTOR );
+        PullAllResponseHandler pullAllHandler =
+                new SessionPullAllResponseHandler( statement, runHandler, connection, BookmarksHolder.NO_OP, METADATA_EXTRACTOR );
 
         for ( int i = 1; i <= numberOfRecords; i++ )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/NetworkSessionTest.java
@@ -652,6 +652,37 @@ class NetworkSessionTest
         assertNotNull( session.beginTransaction() );
     }
 
+    @Test
+    void shouldAllowToGetAndSetBookmarks()
+    {
+        NetworkSession session = newSession( connectionProvider, READ );
+        assertEquals( Bookmarks.empty(), session.getBookmarks() );
+
+        session.setBookmarks( null );
+        assertEquals( Bookmarks.empty(), session.getBookmarks() );
+
+        session.setBookmarks( Bookmarks.empty() );
+        assertEquals( Bookmarks.empty(), session.getBookmarks() );
+
+        Bookmarks bookmarks1 = Bookmarks.from( "neo4j:bookmark:v1:tx1" );
+        session.setBookmarks( bookmarks1 );
+        assertEquals( bookmarks1, session.getBookmarks() );
+
+        session.setBookmarks( null );
+        assertEquals( bookmarks1, session.getBookmarks() );
+
+        session.setBookmarks( Bookmarks.empty() );
+        assertEquals( bookmarks1, session.getBookmarks() );
+
+        Bookmarks bookmarks2 = Bookmarks.from( "neo4j:bookmark:v1:tx2" );
+        session.setBookmarks( bookmarks2 );
+        assertEquals( bookmarks2, session.getBookmarks() );
+
+        Bookmarks bookmarks3 = Bookmarks.from( "neo4j:bookmark:v1:tx42" );
+        session.setBookmarks( bookmarks3 );
+        assertEquals( bookmarks3, session.getBookmarks() );
+    }
+
     private void testConnectionAcquisition( AccessMode sessionMode, AccessMode transactionMode )
     {
         NetworkSession session = newSession( connectionProvider, sessionMode );

--- a/driver/src/test/java/org/neo4j/driver/internal/SimpleBookmarksHolder.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SimpleBookmarksHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+public class SimpleBookmarksHolder implements BookmarksHolder
+{
+    private volatile Bookmarks bookmarks;
+
+    public SimpleBookmarksHolder( Bookmarks bookmarks )
+    {
+        this.bookmarks = bookmarks;
+    }
+
+    @Override
+    public Bookmarks getBookmarks()
+    {
+        return bookmarks;
+    }
+
+    @Override
+    public void setBookmarks( Bookmarks bookmarks )
+    {
+        this.bookmarks = bookmarks;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -1096,7 +1097,7 @@ class PullAllResponseHandlerTest
         }
 
         @Override
-        protected void afterSuccess()
+        protected void afterSuccess( Map<String,Value> metadata )
         {
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullAllResponseHandlerTest.java
@@ -23,15 +23,19 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Statement;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.messaging.v1.BoltProtocolV1.METADATA_EXTRACTOR;
+import static org.neo4j.driver.v1.Values.value;
 
 class SessionPullAllResponseHandlerTest
 {
@@ -57,10 +61,27 @@ class SessionPullAllResponseHandlerTest
         verify( connection ).release();
     }
 
+    @Test
+    void shouldUpdateBookmarksOnSuccess()
+    {
+        String bookmarkValue = "neo4j:bookmark:v1:tx42";
+        BookmarksHolder bookmarksHolder = mock( BookmarksHolder.class );
+        SessionPullAllResponseHandler handler = newHandler( newConnectionMock(), bookmarksHolder );
+
+        handler.onSuccess( singletonMap( "bookmark", value( bookmarkValue ) ) );
+
+        verify( bookmarksHolder ).setBookmarks( Bookmarks.from( bookmarkValue ) );
+    }
+
     private static SessionPullAllResponseHandler newHandler( Connection connection )
     {
+        return newHandler( connection, BookmarksHolder.NO_OP );
+    }
+
+    private static SessionPullAllResponseHandler newHandler( Connection connection, BookmarksHolder bookmarksHolder )
+    {
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
-        return new SessionPullAllResponseHandler( new Statement( "RETURN 1" ), runHandler, connection, METADATA_EXTRACTOR );
+        return new SessionPullAllResponseHandler( new Statement( "RETURN 1" ), runHandler, connection, bookmarksHolder, METADATA_EXTRACTOR );
     }
 
     private static Connection newConnectionMock()

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.async.ChannelAttributes;
@@ -270,7 +271,7 @@ public class BoltProtocolV1Test
                 .build();
 
         CompletionStage<InternalStatementResultCursor> cursorFuture = protocol.runInAutoCommitTransaction( connectionMock(), new Statement( "RETURN 1" ),
-                Bookmarks.empty(), config, true );
+                BookmarksHolder.NO_OP, config, true );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursorFuture ) );
         assertThat( e.getMessage(), startsWith( "Driver is connected to the database that does not support transaction configuration" ) );
@@ -294,7 +295,7 @@ public class BoltProtocolV1Test
         if ( autoCommitTx )
         {
 
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), TransactionConfig.empty(), false );
+            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, BookmarksHolder.NO_OP, TransactionConfig.empty(), false );
         }
         else
         {
@@ -314,7 +315,7 @@ public class BoltProtocolV1Test
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( session )
         {
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, Bookmarks.empty(), TransactionConfig.empty(), true );
+            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, BookmarksHolder.NO_OP, TransactionConfig.empty(), true );
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
+import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.request.BeginMessage;
@@ -45,6 +46,7 @@ import org.neo4j.driver.internal.messaging.request.RunMessage;
 import org.neo4j.driver.internal.messaging.v2.BoltProtocolV2;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
@@ -191,6 +193,8 @@ public final class TestUtil
     public static Connection connectionMock()
     {
         Connection connection = mock( Connection.class );
+        when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
+        when( connection.serverVersion() ).thenReturn( ServerVersion.vInDev );
         when( connection.protocol() ).thenReturn( DEFAULT_TEST_PROTOCOL );
         setupSuccessfulPullAll( connection, "COMMIT" );
         setupSuccessfulPullAll( connection, "ROLLBACK" );


### PR DESCRIPTION
Auto-commit transactions return bookmarks in Bolt V3. They were previously unused. This PR makes driver extract such bookmarks and expose them via `Session#lastBookmark()`. It then possible for explicit and auto-commit transactions within the same session to be chained with bookmarks.