### PR TITLE
Ensure a single handler manages channel's auto-read

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeCompletedListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/HandshakeCompletedListener.java
@@ -56,7 +56,7 @@ public class HandshakeCompletedListener implements ChannelFutureListener
             InitMessage message = new InitMessage( userAgent, authToken );
             InitResponseHandler handler = new InitResponseHandler( connectionInitializedPromise );
 
-            messageDispatcher( channel ).queue( handler );
+            messageDispatcher( channel ).enqueue( handler );
             channel.writeAndFlush( message, channel.voidPromise() );
         }
         else

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyConnection.java
@@ -199,8 +199,8 @@ public class NettyConnection implements Connection
     private void writeMessages( Message message1, ResponseHandler handler1, Message message2, ResponseHandler handler2,
             boolean flush )
     {
-        messageDispatcher.queue( handler1 );
-        messageDispatcher.queue( handler2 );
+        messageDispatcher.enqueue( handler1 );
+        messageDispatcher.enqueue( handler2 );
 
         channel.write( message1, channel.voidPromise() );
 
@@ -216,7 +216,7 @@ public class NettyConnection implements Connection
 
     private void writeAndFlushMessage( Message message, ResponseHandler handler )
     {
-        messageDispatcher.queue( handler );
+        messageDispatcher.enqueue( handler );
         channel.writeAndFlush( message, channel.voidPromise() );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -265,11 +265,11 @@ public class InboundMessageDispatcher implements MessageHandler
     private ResponseHandler removeHandler()
     {
         ResponseHandler handler = handlers.remove();
-        if ( autoReadManagingHandler == handler )
+        if ( handler == autoReadManagingHandler )
         {
-            // handler that is being removed is the auto-read managing handler
+            // the auto-read managing handler is being removed
             // make sure this dispatcher does not hold on to a removed handler
-            autoReadManagingHandler = null;
+            updateAutoReadManagingHandler( null );
         }
         return handler;
     }
@@ -278,15 +278,20 @@ public class InboundMessageDispatcher implements MessageHandler
     {
         if ( handler instanceof AutoReadManagingResponseHandler )
         {
-            if ( autoReadManagingHandler != null )
-            {
-                // there already exists a handler that manages channel's auto-read
-                // make it stop because new managing handler is being added and there should only be a single such handler
-                autoReadManagingHandler.disableAutoReadManagement();
-                // restore the default value of auto-read
-                channel.config().setAutoRead( true );
-            }
-            autoReadManagingHandler = (AutoReadManagingResponseHandler) handler;
+            updateAutoReadManagingHandler( (AutoReadManagingResponseHandler) handler );
         }
+    }
+
+    private void updateAutoReadManagingHandler( AutoReadManagingResponseHandler newHandler )
+    {
+        if ( autoReadManagingHandler != null )
+        {
+            // there already exists a handler that manages channel's auto-read
+            // make it stop because new managing handler is being added and there should only be a single such handler
+            autoReadManagingHandler.disableAutoReadManagement();
+            // restore the default value of auto-read
+            channel.config().setAutoRead( true );
+        }
+        autoReadManagingHandler = newHandler;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -54,7 +54,7 @@ public class InboundMessageDispatcher implements MessageHandler
         this.log = new ChannelActivityLogger( channel, logging, getClass() );
     }
 
-    public void queue( ResponseHandler handler )
+    public void enqueue( ResponseHandler handler )
     {
         if ( fatalErrorOccurred )
         {
@@ -245,7 +245,7 @@ public class InboundMessageDispatcher implements MessageHandler
     {
         if ( !ackFailureMuted )
         {
-            queue( new AckFailureResponseHandler( this ) );
+            enqueue( new AckFailureResponseHandler( this ) );
             channel.writeAndFlush( ACK_FAILURE, channel.voidPromise() );
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthChecker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelHealthChecker.java
@@ -103,7 +103,7 @@ public class NettyChannelHealthChecker implements ChannelHealthChecker
     private Future<Boolean> ping( Channel channel )
     {
         Promise<Boolean> result = channel.eventLoop().newPromise();
-        messageDispatcher( channel ).queue( new PingResponseHandler( result, channel, log ) );
+        messageDispatcher( channel ).enqueue( new PingResponseHandler( result, channel, log ) );
         channel.writeAndFlush( ResetMessage.RESET, channel.voidPromise() );
         return result;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -27,8 +27,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.spi.AutoReadManagingResponseHandler;
 import org.neo4j.driver.internal.spi.Connection;
-import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.Iterables;
 import org.neo4j.driver.internal.util.MetadataUtil;
@@ -44,7 +44,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
-public abstract class PullAllResponseHandler implements ResponseHandler
+public abstract class PullAllResponseHandler implements AutoReadManagingResponseHandler
 {
     private static final Queue<Record> UNINITIALIZED_RECORDS = Iterables.emptyQueue();
 
@@ -58,6 +58,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     // initialized lazily when first record arrives
     private Queue<Record> records = UNINITIALIZED_RECORDS;
 
+    private boolean autoReadManagementEnabled = true;
     private boolean finished;
     private Throwable failure;
     private ResultSummary summary;
@@ -127,6 +128,12 @@ public abstract class PullAllResponseHandler implements ResponseHandler
             enqueueRecord( record );
             completeRecordFuture( record );
         }
+    }
+
+    @Override
+    public synchronized void disableAutoReadManagement()
+    {
+        autoReadManagementEnabled = false;
     }
 
     public synchronized CompletionStage<Record> peekAsync()
@@ -209,7 +216,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
                 // neither SUCCESS nor FAILURE message has arrived, register future to be notified when it arrives
                 // future will be completed with null on SUCCESS and completed with Throwable on FAILURE
                 // enable auto-read, otherwise we might not read SUCCESS/FAILURE if records are not consumed
-                connection.enableAutoRead();
+                enableAutoRead();
                 failureFuture = new CompletableFuture<>();
             }
             return failureFuture;
@@ -234,7 +241,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
             // more than high watermark records are already queued, tell connection to stop auto-reading from network
             // this is needed to deal with slow consumers, we do not want to buffer all records in memory if they are
             // fetched from network faster than consumed
-            connection.disableAutoRead();
+            disableAutoRead();
         }
     }
 
@@ -246,7 +253,7 @@ public abstract class PullAllResponseHandler implements ResponseHandler
         {
             // less than low watermark records are now available in the buffer, tell connection to pre-fetch more
             // and populate queue with new records from network
-            connection.enableAutoRead();
+            enableAutoRead();
         }
 
         return record;
@@ -318,5 +325,21 @@ public abstract class PullAllResponseHandler implements ResponseHandler
     {
         long resultAvailableAfter = runResponseHandler.resultAvailableAfter();
         return MetadataUtil.extractSummary( statement, connection, resultAvailableAfter, metadata );
+    }
+
+    private void enableAutoRead()
+    {
+        if ( autoReadManagementEnabled )
+        {
+            connection.enableAutoRead();
+        }
+    }
+
+    private void disableAutoRead()
+    {
+        if ( autoReadManagementEnabled )
+        {
+            connection.disableAutoRead();
+        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/AutoReadManagingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/AutoReadManagingResponseHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.spi;
+
+import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+
+/**
+ * A type of {@link ResponseHandler handler} that manages auto-read of the underlying connection using {@link Connection#enableAutoRead()} and
+ * {@link Connection#disableAutoRead()}.
+ * <p>
+ * Implementations can use auto-read management to apply network-level backpressure when receiving a stream of records.
+ * There should only be a single such handler active for a connection at one point in time. Otherwise, handlers can interfere and turn on/off auto-read
+ * racing with each other. {@link InboundMessageDispatcher} is responsible for tracking these handlers and disabling auto-read management to maintain just
+ * a single auto-read managing handler per connection.
+ */
+public interface AutoReadManagingResponseHandler extends ResponseHandler
+{
+    /**
+     * Tell this handler that it should stop changing auto-read setting for the connection.
+     */
+    void disableAutoReadManagement();
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/HandshakeCompletedListenerTest.java
@@ -94,7 +94,7 @@ public class HandshakeCompletedListenerTest
         listener.operationComplete( handshakeCompletedPromise );
         assertTrue( channel.finish() );
 
-        verify( messageDispatcher ).queue( any( InitResponseHandler.class ) );
+        verify( messageDispatcher ).enqueue( any( InitResponseHandler.class ) );
         Object outboundMessage = channel.readOutbound();
         assertThat( outboundMessage, instanceOf( InitMessage.class ) );
         InitMessage initMessage = (InitMessage) outboundMessage;

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyConnectionTest.java
@@ -521,10 +521,10 @@ public class NettyConnectionTest
         }
 
         @Override
-        public void queue( ResponseHandler handler )
+        public void enqueue( ResponseHandler handler )
         {
             queueThreadNames.add( Thread.currentThread().getName() );
-            super.queue( handler );
+            super.enqueue( handler );
         }
 
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -501,6 +502,25 @@ public class InboundMessageDispatcherTest
         dispatcher.handleSuccessMessage( emptyMap() );
 
         assertNull( dispatcher.autoReadManagingHandler() );
+    }
+
+    @Test
+    public void shouldReEnableAutoReadWhenAutoReadManagingHandlerIsRemoved()
+    {
+        Channel channel = newChannelMock();
+        InboundMessageDispatcher dispatcher = newDispatcher( channel );
+
+        AutoReadManagingResponseHandler handler = mock( AutoReadManagingResponseHandler.class );
+        dispatcher.enqueue( handler );
+        assertEquals( handler, dispatcher.autoReadManagingHandler() );
+        verify( handler, never() ).disableAutoReadManagement();
+        verify( channel.config(), never() ).setAutoRead( anyBoolean() );
+
+        dispatcher.handleSuccessMessage( emptyMap() );
+
+        assertNull( dispatcher.autoReadManagingHandler() );
+        verify( handler ).disableAutoReadManagement();
+        verify( channel.config() ).setAutoRead( anyBoolean() );
     }
 
     private static void verifyFailure( ResponseHandler handler )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
@@ -92,7 +92,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher();
 
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         Map<String,Value> metadata = new HashMap<>();
@@ -110,7 +110,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher();
 
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -128,7 +128,7 @@ public class InboundMessageDispatcherTest
         Channel channel = mock( Channel.class );
         InboundMessageDispatcher dispatcher = newDispatcher( channel );
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -143,7 +143,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher( channel );
         dispatcher.muteAckFailure();
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -159,7 +159,7 @@ public class InboundMessageDispatcherTest
 
         dispatcher.unMuteAckFailure();
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -173,7 +173,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher( channel );
         dispatcher.muteAckFailure();
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -181,7 +181,7 @@ public class InboundMessageDispatcherTest
 
         dispatcher.unMuteAckFailure();
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -193,7 +193,7 @@ public class InboundMessageDispatcherTest
     {
         InboundMessageDispatcher dispatcher = newDispatcher();
 
-        dispatcher.queue( mock( ResponseHandler.class ) );
+        dispatcher.enqueue( mock( ResponseHandler.class ) );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
@@ -208,7 +208,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher();
 
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
         assertEquals( 1, dispatcher.queuedHandlersCount() );
 
         Value[] fields1 = {new IntegerValue( 1 )};
@@ -234,9 +234,9 @@ public class InboundMessageDispatcherTest
         ResponseHandler handler2 = mock( ResponseHandler.class );
         ResponseHandler handler3 = mock( ResponseHandler.class );
 
-        dispatcher.queue( handler1 );
-        dispatcher.queue( handler2 );
-        dispatcher.queue( handler3 );
+        dispatcher.enqueue( handler1 );
+        dispatcher.enqueue( handler2 );
+        dispatcher.enqueue( handler3 );
 
         RuntimeException fatalError = new RuntimeException( "Fatal!" );
         dispatcher.handleFatalError( fatalError );
@@ -256,7 +256,7 @@ public class InboundMessageDispatcherTest
         dispatcher.handleFatalError( fatalError );
 
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
 
         verify( handler ).onFailure( fatalError );
     }
@@ -267,7 +267,7 @@ public class InboundMessageDispatcherTest
         InboundMessageDispatcher dispatcher = newDispatcher();
         ResponseHandler handler = mock( ResponseHandler.class );
 
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
         dispatcher.handleIgnoredMessage();
 
         assertEquals( 0, dispatcher.queuedHandlersCount() );
@@ -280,8 +280,8 @@ public class InboundMessageDispatcherTest
         ResponseHandler handler1 = mock( ResponseHandler.class );
         ResponseHandler handler2 = mock( ResponseHandler.class );
 
-        dispatcher.queue( handler1 );
-        dispatcher.queue( handler2 );
+        dispatcher.enqueue( handler1 );
+        dispatcher.enqueue( handler2 );
 
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
         verifyFailure( handler1 );
@@ -296,7 +296,7 @@ public class InboundMessageDispatcherTest
     {
         InboundMessageDispatcher dispatcher = newDispatcher();
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
 
         dispatcher.muteAckFailure();
         dispatcher.handleIgnoredMessage();
@@ -309,7 +309,7 @@ public class InboundMessageDispatcherTest
     {
         InboundMessageDispatcher dispatcher = newDispatcher();
         ResponseHandler handler = mock( ResponseHandler.class );
-        dispatcher.queue( handler );
+        dispatcher.enqueue( handler );
 
         dispatcher.handleIgnoredMessage();
 
@@ -323,8 +323,8 @@ public class InboundMessageDispatcherTest
         ResponseHandler handler1 = mock( ResponseHandler.class );
         ResponseHandler handler2 = mock( ResponseHandler.class );
 
-        dispatcher.queue( handler1 );
-        dispatcher.queue( handler2 );
+        dispatcher.enqueue( handler1 );
+        dispatcher.enqueue( handler2 );
         dispatcher.handleFailureMessage( FAILURE_CODE, FAILURE_MESSAGE );
         dispatcher.handleIgnoredMessage();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageHandlerTest.java
@@ -86,7 +86,7 @@ public class InboundMessageHandlerTest
     public void shouldReadSuccessMessage()
     {
         ResponseHandler responseHandler = mock( ResponseHandler.class );
-        messageDispatcher.queue( responseHandler );
+        messageDispatcher.enqueue( responseHandler );
 
         Map<String,Value> metadata = new HashMap<>();
         metadata.put( "key1", value( 1 ) );
@@ -100,7 +100,7 @@ public class InboundMessageHandlerTest
     public void shouldReadFailureMessage()
     {
         ResponseHandler responseHandler = mock( ResponseHandler.class );
-        messageDispatcher.queue( responseHandler );
+        messageDispatcher.enqueue( responseHandler );
 
         channel.writeInbound( writer.asByteBuf( new FailureMessage( "Neo.TransientError.General.ReadOnly", "Hi!" ) ) );
 
@@ -114,7 +114,7 @@ public class InboundMessageHandlerTest
     public void shouldReadRecordMessage()
     {
         ResponseHandler responseHandler = mock( ResponseHandler.class );
-        messageDispatcher.queue( responseHandler );
+        messageDispatcher.enqueue( responseHandler );
 
         Value[] fields = {value( 1 ), value( 2 ), value( 3 )};
         channel.writeInbound( writer.asByteBuf( new RecordMessage( fields ) ) );
@@ -126,7 +126,7 @@ public class InboundMessageHandlerTest
     public void shouldReadIgnoredMessage()
     {
         ResponseHandler responseHandler = mock( ResponseHandler.class );
-        messageDispatcher.queue( responseHandler );
+        messageDispatcher.enqueue( responseHandler );
 
         channel.writeInbound( writer.asByteBuf( new IgnoredMessage() ) );
         assertEquals( 0, messageDispatcher.queuedHandlersCount() );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTest.java
@@ -824,6 +824,21 @@ public class PullAllResponseHandlerTest
     }
 
     @Test
+    public void shouldNotDisableAutoReadWhenAutoReadManagementDisabled()
+    {
+        Connection connection = connectionMock();
+        PullAllResponseHandler handler = newHandler( asList( "key1", "key2" ), connection );
+        handler.disableAutoReadManagement();
+
+        for ( int i = 0; i < PullAllResponseHandler.RECORD_BUFFER_HIGH_WATERMARK + 1; i++ )
+        {
+            handler.onRecord( values( 100, 200 ) );
+        }
+
+        verify( connection, never() ).disableAutoRead();
+    }
+
+    @Test
     public void shouldPropagateFailureFromListAsync()
     {
         PullAllResponseHandler handler = newHandler();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/NestedQueriesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/NestedQueriesIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.integration;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+import java.util.List;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.StatementRunner;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.util.TestNeo4jSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class NestedQueriesIT
+{
+    private static final String OUTER_QUERY = "UNWIND range(1, 10000) AS x RETURN x";
+    private static final String INNER_QUERY = "UNWIND range(1, 10) AS y RETURN y";
+    private static final int EXPECTED_RECORDS = 10_000 * 10 + 10_000;
+
+    private final TestNeo4jSession session = new TestNeo4jSession();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( session ).around( Timeout.seconds( 120 ) );
+
+    @Test
+    public void shouldAllowNestedQueriesInTransactionConsumedAsIterators() throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            testNestedQueriesConsumedAsIterators( tx );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldAllowNestedQueriesInTransactionConsumedAsLists() throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            testNestedQueriesConsumedAsLists( tx );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldAllowNestedQueriesInTransactionConsumedAsIteratorAndList() throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            testNestedQueriesConsumedAsIteratorAndList( tx );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldAllowNestedQueriesInSessionConsumedAsIterators() throws Exception
+    {
+        testNestedQueriesConsumedAsIterators( session );
+    }
+
+    @Test
+    public void shouldAllowNestedQueriesInSessionConsumedAsLists() throws Exception
+    {
+        testNestedQueriesConsumedAsLists( session );
+    }
+
+    @Test
+    public void shouldAllowNestedQueriesInSessionConsumedAsIteratorAndList() throws Exception
+    {
+        testNestedQueriesConsumedAsIteratorAndList( session );
+    }
+
+    private void testNestedQueriesConsumedAsIterators( StatementRunner statementRunner ) throws Exception
+    {
+        int recordsSeen = 0;
+
+        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
+
+        while ( result1.hasNext() )
+        {
+            Record record1 = result1.next();
+            assertFalse( record1.get( "x" ).isNull() );
+            recordsSeen++;
+
+            StatementResult result2 = statementRunner.run( INNER_QUERY );
+            while ( result2.hasNext() )
+            {
+                Record record2 = result2.next();
+                assertFalse( record2.get( "y" ).isNull() );
+                recordsSeen++;
+            }
+        }
+
+        assertEquals( EXPECTED_RECORDS, recordsSeen );
+    }
+
+    private void testNestedQueriesConsumedAsLists( StatementRunner statementRunner ) throws Exception
+    {
+        int recordsSeen = 0;
+
+        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
+
+        List<Record> records1 = result1.list();
+        for ( Record record1 : records1 )
+        {
+            assertFalse( record1.get( "x" ).isNull() );
+            recordsSeen++;
+
+            StatementResult result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            List<Record> records2 = result2.list();
+            for ( Record record2 : records2 )
+            {
+                assertFalse( record2.get( "y" ).isNull() );
+                recordsSeen++;
+            }
+        }
+
+        assertEquals( EXPECTED_RECORDS, recordsSeen );
+    }
+
+    private void testNestedQueriesConsumedAsIteratorAndList( StatementRunner statementRunner ) throws Exception
+    {
+        int recordsSeen = 0;
+
+        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
+
+        while ( result1.hasNext() )
+        {
+            Record record1 = result1.next();
+            assertFalse( record1.get( "x" ).isNull() );
+            recordsSeen++;
+
+            StatementResult result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            List<Record> records2 = result2.list();
+            for ( Record record2 : records2 )
+            {
+                assertFalse( record2.get( "y" ).isNull() );
+                recordsSeen++;
+            }
+        }
+
+        assertEquals( EXPECTED_RECORDS, recordsSeen );
+    }
+}


### PR DESCRIPTION
`PullAllResponseHandler` is responsible for receiving a stream of records. Stream might be very large and handler tries to not fetch if fully into memory. It applies a network-level backpressure by disabling/enabling auto-read property of the underlying Netty channel. This property tells channel to not read from the network. Auto-read is disabled when number of queued records goes beyond the threshold.

Management of auto-read turned out to be problematic for nested queries within a single transaction. Nested queries result in multiple `PullAllResponseHandler`s being added to the queue of handlers. They will try to manage auto-read concurrently and can sometimes disable it completely. Callers would then be blocked and unable to proceed. This is not a problem for `Session#run()` because every such call ensures there was a logical SYNC and the previous query has completed and its result is buffered.

This PR fixes a problem by making only a single installed handler manage the channel's auto-read property. Making sure there only exists a single such handler is the responsibility of `InboundMessageDispatcher`. Auto-read is enabled when new auto-read managing handler is installed. Previous such handler is disabled.

Also renamed `InboundMessageDispatcher#queue()` to `InboundMessageDispatcher#enqueue()`.

Fixes https://github.com/neo4j/neo4j/issues/12033