### PR TITLE
Use composite cumulator for message decoding

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/MessageDecoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/MessageDecoder.java
@@ -26,7 +26,14 @@ import java.util.List;
 
 public class MessageDecoder extends ByteToMessageDecoder
 {
+    private static final Cumulator DEFAULT_CUMULATOR = determineDefaultCumulator();
+
     private boolean readMessageBoundary;
+
+    public MessageDecoder()
+    {
+        setCumulator( DEFAULT_CUMULATOR );
+    }
 
     @Override
     public void channelRead( ChannelHandlerContext ctx, Object msg ) throws Exception
@@ -59,5 +66,15 @@ public class MessageDecoder extends ByteToMessageDecoder
 
             readMessageBoundary = false;
         }
+    }
+
+    private static Cumulator determineDefaultCumulator()
+    {
+        String value = System.getProperty( "messageDecoderCumulator", "" );
+        if ( "merge".equals( value ) )
+        {
+            return MERGE_CUMULATOR;
+        }
+        return COMPOSITE_CUMULATOR;
     }
 }


### PR DESCRIPTION
`MessageDecoder` is responsible for assembling full Bolt messages. It accumulates bytes until an empty chunk is received. Empty chunk signals a message boundary. It used to copy all received chunks into a larger buffer every time. This resulted in an increased memory usage when receiving large results.

This PR makes `MessageDecoder` store all received chunks in a composite buffer. No buffer copying is done. It is achieved by using a different non-default byte buffer cumulator. System property "messageDecoderCumulator" can be used to make decoder use the default copying/merging cumulator "-DmessageDecoderCumulator=merge".