### PR TITLE
Fail discovery when custom resolver fails

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -227,7 +227,7 @@ class RediscoveryTest
     }
 
     @Test
-    void shouldUseInitialRouterAddressAsIsWhenResolverFails()
+    void shouldPropagateFailureWhenResolverFails()
     {
         ClusterComposition expectedComposition = new ClusterComposition( 42,
                 asOrderedSet( A, B ), asOrderedSet( A, B ), asOrderedSet( A, B ) );
@@ -242,9 +242,9 @@ class RediscoveryTest
         Rediscovery rediscovery = newRediscovery( A, compositionProvider, resolver );
         RoutingTable table = routingTableMock();
 
-        ClusterComposition actualComposition = await( rediscovery.lookupClusterComposition( table, pool ) );
+        RuntimeException error = assertThrows( RuntimeException.class, () -> await( rediscovery.lookupClusterComposition( table, pool ) ) );
+        assertEquals( "Resolver fails!", error.getMessage() );
 
-        assertEquals( expectedComposition, actualComposition );
         verify( resolver ).resolve( A );
         verify( table, never() ).forget( any() );
     }

--- a/driver/src/test/resources/get_routing_table.script
+++ b/driver/src/test/resources/get_routing_table.script
@@ -15,3 +15,4 @@ S: SUCCESS {"fields": ["name"]}
    RECORD ["Bob"]
    RECORD ["Eve"]
    SUCCESS {}
+S: <EXIT>


### PR DESCRIPTION
It is better to surface the resolution error instead of silently using the address as-is. Also added stub server tests for custom address resolver.