### PR TITLE
Add ability to create graph drivers fromUri with a builder

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -86,6 +86,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/driver/src/main/java/org/neo4j/driver/v1/GraphDatabaseDriverCreator.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/GraphDatabaseDriverCreator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1;
+
+import java.net.URI;
+import java.util.Collection;
+
+/**
+ * Helps in creating {@link Driver drivers}.
+ *
+ * @see Driver
+ * @see #createDriver()
+ * @since 1.7
+ */
+public class GraphDatabaseDriverCreator {
+
+    private final Collection<URI> uris;
+    private final AuthToken authToken;
+    private final Config config;
+
+    GraphDatabaseDriverCreator(Collection<URI> uris) {
+        this(uris, AuthTokens.none(), Config.defaultConfig());
+    }
+
+    GraphDatabaseDriverCreator(Collection<URI> uris, AuthToken authToken, Config config) {
+        this.uris = uris;
+        this.authToken = authToken;
+        this.config = config;
+    }
+
+    /**
+     * <p>Override default {@link AuthToken auth token}.</p>
+     *
+     * Existing instance of the {@link GraphDatabaseDriverCreator driver creator} is cloned.
+     * Mutation of this class is not supported.
+     *
+     * @see AuthTokens#none()
+     * @param authToken {@link AuthToken token} to be used for authentication
+     * @return new instance of {@link GraphDatabaseDriverCreator this class}
+     */
+    public GraphDatabaseDriverCreator withToken(AuthToken authToken) {
+        return new GraphDatabaseDriverCreator(this.uris, authToken, this.config);
+    }
+
+    /**
+     * <p>Override default {@link Config config}.</p>
+     *
+     * Existing instance of the {@link GraphDatabaseDriverCreator driver creator} is cloned.
+     * Mutation of this class is not supported.
+     *
+     * @see Config#defaultConfig()
+     * @param config {@link Config config} to be used for the driver connection
+     * @return new instance of {@link GraphDatabaseDriverCreator this class}
+     */
+    public GraphDatabaseDriverCreator withConfig(Config config) {
+        return new GraphDatabaseDriverCreator(this.uris, this.authToken, config);
+    }
+
+    /**
+     * <p>Create an instance of a driver with the current settings</p>
+     *
+     * <p>If a single URI was provided, {@link GraphDatabase#driver(URI, AuthToken, Config)} is invoked.</p>
+     * <p>If a collection of URIs were provided, {@link GraphDatabase#routingDriver(Iterable, AuthToken, Config)} will be invoked</p>
+     *
+     * @see GraphDatabase#driver(URI, AuthToken, Config)
+     * @see GraphDatabase#routingDriver(Iterable, AuthToken, Config)
+     * @return new instance of {@link GraphDatabaseDriverCreator this class}
+     */
+    public Driver createDriver() {
+        if (uris.size() > 1) {
+            return GraphDatabase.routingDriver(uris, authToken, config);
+        } else {
+            return GraphDatabase.driver(uris.iterator().next(), authToken, config);
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Matchers.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Matchers.java
@@ -18,26 +18,24 @@
  */
 package org.neo4j.driver.internal.util;
 
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.DirectConnectionProvider;
-import org.neo4j.driver.internal.InternalDriver;
-import org.neo4j.driver.internal.SessionFactory;
-import org.neo4j.driver.internal.SessionFactoryImpl;
+import org.neo4j.driver.internal.*;
 import org.neo4j.driver.internal.cluster.AddressSet;
 import org.neo4j.driver.internal.cluster.RoutingTable;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabaseDriverCreator;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 import static org.neo4j.driver.internal.util.Neo4jFeature.STATEMENT_RESULT_TIMINGS;
 
 public final class Matchers
@@ -160,6 +158,19 @@ public final class Matchers
             public void describeTo( Description description )
             {
                 description.appendText( "cluster 'bolt+routing://' driver " );
+            }
+        };
+    }
+
+    public static Matcher<GraphDatabaseDriverCreator> isEqualTo(GraphDatabaseDriverCreator expectedValue) {
+        return new BaseMatcher<GraphDatabaseDriverCreator>() {
+            @Override
+            public boolean matches(Object actualValue) {
+                return reflectionEquals(actualValue, expectedValue, false, null, true);
+            }
+
+            @Override
+            public void describeTo(Description description) {
             }
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,12 @@
         <version>1.2.3</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.8.1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Allows consumers to keep a single code path to instantiate the driver for causal clusters and single node deployments.

1. If a protocol is specified, it is always used.
2. If only one URI is passed and no protocol is specified, the driver defaults to the bolt protocol.
3. If multiple URIs are passed and no protocol is specified, the driver uses the bolt+routing protocol.