### PR TITLE
Improve stacktraces for errors from blocking API

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.driver.internal.util;
 
-import io.netty.util.internal.PlatformDependent;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -121,7 +119,7 @@ public final class Futures
                 }
                 catch ( ExecutionException e )
                 {
-                    PlatformDependent.throwException( e.getCause() );
+                    ErrorUtil.rethrowAsyncException( e );
                 }
             }
         }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -45,9 +44,11 @@ import org.neo4j.driver.v1.util.SessionExtension;
 import org.neo4j.driver.v1.util.StubServer;
 import org.neo4j.driver.v1.util.TestUtil;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -368,7 +369,7 @@ class TransactionIT
         try ( Transaction tx = session.beginTransaction() )
         {
             List<Integer> xs = tx.run( "UNWIND [1,2,3] AS x CREATE (:Node) RETURN x" ).list( record -> record.get( 0 ).asInt() );
-            assertEquals( Arrays.asList( 1, 2, 3 ), xs );
+            assertEquals( asList( 1, 2, 3 ), xs );
 
             ClientException error1 = assertThrows( ClientException.class, () -> tx.run( "RETURN unknown" ).consume() );
             assertThat( error1.code(), containsString( "SyntaxError" ) );
@@ -404,7 +405,7 @@ class TransactionIT
         } );
 
         assertThat( error.code(), containsString( "SyntaxError" ) );
-        assertEquals( 1, error.getSuppressed().length );
+        assertThat( error.getSuppressed().length, greaterThanOrEqualTo( 1 ) );
         Throwable suppressed = error.getSuppressed()[0];
         assertThat( suppressed, instanceOf( ClientException.class ) );
         assertThat( suppressed.getMessage(), startsWith( "Transaction can't be committed" ) );


### PR DESCRIPTION
Blocking API works on top of async API and simply blocks on the returned futures. Exceptions can thus contain stacktraces unrelated to the user's code because they originate from driver worker threads. Such exceptions make it hard for users of the driver to determine what has caused the error.

This PR makes exceptions thrown from blocking API calls contain stacktraces of the current thread. Original async stacktrace is attached in a dummy suppressed exception.

Stacktrace before:

```
Exception in thread "main" org.neo4j.driver.v1.exceptions.ClientException: / by zero
	at org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError(ErrorUtil.java:67)
	at org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher.handleFailureMessage(InboundMessageDispatcher.java:105)
	at org.neo4j.driver.internal.messaging.v1.MessageReaderV1.unpackFailureMessage(MessageReaderV1.java:83)
	at org.neo4j.driver.internal.messaging.v1.MessageReaderV1.read(MessageReaderV1.java:59)
	at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:83)
	at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:35)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	... <more netty stacktrace elements>
```

Stacktrace after:

```
Exception in thread "main" org.neo4j.driver.v1.exceptions.ClientException: / by zero
	at org.neo4j.driver.internal.util.Futures.blockingGet(Futures.java:122)
	at org.neo4j.driver.internal.InternalStatementResult.blockingGet(InternalStatementResult.java:134)
	at org.neo4j.driver.internal.InternalStatementResult.consume(InternalStatementResult.java:117)
	at MyApp.main(MyApp.java:12)
	Suppressed: org.neo4j.driver.internal.util.ErrorUtil$InternalExceptionCause
		at org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError(ErrorUtil.java:67)
		at org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher.handleFailureMessage(InboundMessageDispatcher.java:105)
		at org.neo4j.driver.internal.messaging.v1.MessageReaderV1.unpackFailureMessage(MessageReaderV1.java:83)
		at org.neo4j.driver.internal.messaging.v1.MessageReaderV1.read(MessageReaderV1.java:59)
		at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:83)
		at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:35)
		at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
                ... <more netty stacktrace elements>
```