### PR TITLE
Fail correctly when connecting to a server with an unknown server identifier

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
@@ -29,10 +29,10 @@ import org.neo4j.driver.v1.Value;
 
 import static org.neo4j.driver.internal.async.ChannelAttributes.setConnectionId;
 import static org.neo4j.driver.internal.async.ChannelAttributes.setServerVersion;
+import static org.neo4j.driver.internal.util.MetadataExtractor.extractNeo4jServerVersion;
 
 public class HelloResponseHandler implements ResponseHandler
 {
-    private static final String SERVER_METADATA_KEY = "server";
     private static final String CONNECTION_ID_METADATA_KEY = "connection_id";
 
     private final ChannelPromise connectionInitializedPromise;
@@ -49,10 +49,10 @@ public class HelloResponseHandler implements ResponseHandler
     {
         try
         {
-            ServerVersion serverVersion = ServerVersion.version( extractMetadataValue( SERVER_METADATA_KEY, metadata ) );
+            ServerVersion serverVersion = extractNeo4jServerVersion( metadata );
             setServerVersion( channel, serverVersion );
 
-            String connectionId = extractMetadataValue( CONNECTION_ID_METADATA_KEY, metadata );
+            String connectionId = extractConnectionId( metadata );
             setConnectionId( channel, connectionId );
 
             connectionInitializedPromise.setSuccess();
@@ -76,12 +76,13 @@ public class HelloResponseHandler implements ResponseHandler
         throw new UnsupportedOperationException();
     }
 
-    private static String extractMetadataValue( String key, Map<String,Value> metadata )
+    private static String extractConnectionId( Map<String,Value> metadata )
     {
-        Value value = metadata.get( key );
+        Value value = metadata.get( CONNECTION_ID_METADATA_KEY );
         if ( value == null || value.isNull() )
         {
-            throw new IllegalStateException( "Unable to extract " + key + " from a response to HELLO message. Metadata: " + metadata );
+            throw new IllegalStateException( "Unable to extract " + CONNECTION_ID_METADATA_KEY + " from a response to HELLO message. " +
+                                             "Received metadata: " + metadata );
         }
         return value.asString();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/InitResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/InitResponseHandler.java
@@ -77,7 +77,7 @@ public class InitResponseHandler implements ResponseHandler
         Value versionValue = metadata.get( "server" );
         if ( versionValue == null || versionValue.isNull() )
         {
-            return ServerVersion.v3_0_0;
+            throw new UntrustedServerException( "Server provides no product identifier" );
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -146,7 +146,7 @@ public class ServerVersion
     {
         if ( !product.equals( o.product ) )
         {
-            throw new IllegalArgumentException("Comparing different products");
+            throw new IllegalArgumentException( "Comparing different products '" + product + "' with '" + o.product + "'" );
         }
         int c = compare( major, o.major );
         if (c == 0)

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -71,34 +71,27 @@ public class ServerVersion
 
     public static ServerVersion version( String server )
     {
-        if ( server == null )
+        Matcher matcher = PATTERN.matcher( server );
+        if ( matcher.matches() )
         {
-            return v3_0_0;
+            String product = matcher.group( 1 );
+            int major = Integer.valueOf( matcher.group( 2 ) );
+            int minor = Integer.valueOf( matcher.group( 3 ) );
+            String patchString = matcher.group( 4 );
+            int patch = 0;
+            if ( patchString != null && !patchString.isEmpty() )
+            {
+                patch = Integer.valueOf( patchString );
+            }
+            return new ServerVersion( product, major, minor, patch );
+        }
+        else if ( server.equalsIgnoreCase( NEO4J_IN_DEV_VERSION_STRING ) )
+        {
+            return vInDev;
         }
         else
         {
-            Matcher matcher = PATTERN.matcher( server );
-            if ( matcher.matches() )
-            {
-                String product = matcher.group( 1 );
-                int major = Integer.valueOf( matcher.group( 2 ) );
-                int minor = Integer.valueOf( matcher.group( 3 ) );
-                String patchString = matcher.group( 4 );
-                int patch = 0;
-                if ( patchString != null && !patchString.isEmpty() )
-                {
-                    patch = Integer.valueOf( patchString );
-                }
-                return new ServerVersion( product, major, minor, patch );
-            }
-            else if ( server.equalsIgnoreCase( NEO4J_IN_DEV_VERSION_STRING ) )
-            {
-                return vInDev;
-            }
-            else
-            {
-                throw new IllegalArgumentException( "Cannot parse " + server );
-            }
+            throw new IllegalArgumentException( "Cannot parse " + server );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -29,16 +29,18 @@ import static java.lang.Integer.compare;
 
 public class ServerVersion
 {
-    public static final ServerVersion v3_5_0 = new ServerVersion( "Neo4j", 3, 5, 0 );
-    public static final ServerVersion v3_4_0 = new ServerVersion( "Neo4j", 3, 4, 0 );
-    public static final ServerVersion v3_2_0 = new ServerVersion( "Neo4j", 3, 2, 0 );
-    public static final ServerVersion v3_1_0 = new ServerVersion( "Neo4j", 3, 1, 0 );
-    public static final ServerVersion v3_0_0 = new ServerVersion( "Neo4j", 3, 0, 0 );
-    public static final ServerVersion vInDev = new ServerVersion( "Neo4j", Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
+    public static final String NEO4J_PRODUCT = "Neo4j";
+
+    public static final ServerVersion v3_5_0 = new ServerVersion( NEO4J_PRODUCT, 3, 5, 0 );
+    public static final ServerVersion v3_4_0 = new ServerVersion( NEO4J_PRODUCT, 3, 4, 0 );
+    public static final ServerVersion v3_2_0 = new ServerVersion( NEO4J_PRODUCT, 3, 2, 0 );
+    public static final ServerVersion v3_1_0 = new ServerVersion( NEO4J_PRODUCT, 3, 1, 0 );
+    public static final ServerVersion v3_0_0 = new ServerVersion( NEO4J_PRODUCT, 3, 0, 0 );
+    public static final ServerVersion vInDev = new ServerVersion( NEO4J_PRODUCT, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
 
     private static final String NEO4J_IN_DEV_VERSION_STRING = "Neo4j/dev";
     private static final Pattern PATTERN =
-            Pattern.compile( "([^/]*)/(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?" );
+            Pattern.compile( "([^/]+)/(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?" );
 
     private final String product;
     private final int major;

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -38,7 +38,7 @@ public class ServerVersion
     public static final ServerVersion v3_0_0 = new ServerVersion( NEO4J_PRODUCT, 3, 0, 0 );
     public static final ServerVersion vInDev = new ServerVersion( NEO4J_PRODUCT, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
 
-    private static final String NEO4J_IN_DEV_VERSION_STRING = "Neo4j/dev";
+    private static final String NEO4J_IN_DEV_VERSION_STRING = NEO4J_PRODUCT + "/dev";
     private static final Pattern PATTERN =
             Pattern.compile( "([^/]+)/(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?" );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.util;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,28 +29,35 @@ import static java.lang.Integer.compare;
 
 public class ServerVersion
 {
-    public static final ServerVersion v3_5_0 = new ServerVersion( 3, 5, 0 );
-    public static final ServerVersion v3_4_0 = new ServerVersion( 3, 4, 0 );
-    public static final ServerVersion v3_2_0 = new ServerVersion( 3, 2, 0 );
-    public static final ServerVersion v3_1_0 = new ServerVersion( 3, 1, 0 );
-    public static final ServerVersion v3_0_0 = new ServerVersion( 3, 0, 0 );
-    public static final ServerVersion vInDev = new ServerVersion( Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
+    public static final ServerVersion v3_5_0 = new ServerVersion( "Neo4j", 3, 5, 0 );
+    public static final ServerVersion v3_4_0 = new ServerVersion( "Neo4j", 3, 4, 0 );
+    public static final ServerVersion v3_2_0 = new ServerVersion( "Neo4j", 3, 2, 0 );
+    public static final ServerVersion v3_1_0 = new ServerVersion( "Neo4j", 3, 1, 0 );
+    public static final ServerVersion v3_0_0 = new ServerVersion( "Neo4j", 3, 0, 0 );
+    public static final ServerVersion vInDev = new ServerVersion( "Neo4j", Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
 
     private static final String NEO4J_IN_DEV_VERSION_STRING = "Neo4j/dev";
     private static final Pattern PATTERN =
-            Pattern.compile( "(Neo4j/)?(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?" );
+            Pattern.compile( "([^/]*)/(\\d+)\\.(\\d+)(?:\\.)?(\\d*)(\\.|-|\\+)?([0-9A-Za-z-.]*)?" );
 
+    private final String product;
     private final int major;
     private final int minor;
     private final int patch;
     private final String stringValue;
 
-    private ServerVersion( int major, int minor, int patch )
+    private ServerVersion( String product, int major, int minor, int patch )
     {
+        this.product = product;
         this.major = major;
         this.minor = minor;
         this.patch = patch;
-        this.stringValue = stringValue( major, minor, patch );
+        this.stringValue = stringValue( product, major, minor, patch );
+    }
+
+    public String product()
+    {
+        return product;
     }
 
     public static ServerVersion version( Driver driver )
@@ -72,6 +80,7 @@ public class ServerVersion
             Matcher matcher = PATTERN.matcher( server );
             if ( matcher.matches() )
             {
+                String product = matcher.group( 1 );
                 int major = Integer.valueOf( matcher.group( 2 ) );
                 int minor = Integer.valueOf( matcher.group( 3 ) );
                 String patchString = matcher.group( 4 );
@@ -80,7 +89,7 @@ public class ServerVersion
                 {
                     patch = Integer.valueOf( patchString );
                 }
-                return new ServerVersion( major, minor, patch );
+                return new ServerVersion( product, major, minor, patch );
             }
             else if ( server.equalsIgnoreCase( NEO4J_IN_DEV_VERSION_STRING ) )
             {
@@ -103,6 +112,8 @@ public class ServerVersion
 
         ServerVersion that = (ServerVersion) o;
 
+        if ( !product.equals( that.product ) )
+        { return false; }
         if ( major != that.major )
         { return false; }
         if ( minor != that.minor )
@@ -113,10 +124,7 @@ public class ServerVersion
     @Override
     public int hashCode()
     {
-        int result = major;
-        result = 31 * result + minor;
-        result = 31 * result + patch;
-        return result;
+        return Objects.hash(product, major, minor, patch);
     }
 
     public boolean greaterThan(ServerVersion other)
@@ -141,6 +149,10 @@ public class ServerVersion
 
     private int compareTo( ServerVersion o )
     {
+        if ( !product.equals( o.product ) )
+        {
+            throw new IllegalArgumentException("Comparing different products");
+        }
         int c = compare( major, o.major );
         if (c == 0)
         {
@@ -160,12 +172,12 @@ public class ServerVersion
         return stringValue;
     }
 
-    private static String stringValue( int major, int minor, int patch )
+    private static String stringValue( String product, int major, int minor, int patch )
     {
         if ( major == Integer.MAX_VALUE && minor == Integer.MAX_VALUE && patch == Integer.MAX_VALUE )
         {
             return NEO4J_IN_DEV_VERSION_STRING;
         }
-        return String.format( "Neo4j/%s.%s.%s", major, minor, patch );
+        return String.format( "%s/%s.%s.%s", product, major, minor, patch );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/UntrustedServerException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/UntrustedServerException.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.neo4j.driver.v1.exceptions;
 
 /**

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/UntrustedServerException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/UntrustedServerException.java
@@ -1,0 +1,12 @@
+package org.neo4j.driver.v1.exceptions;
+
+/**
+ * Thrown if the remote server cannot be verified as Neo4j.
+ */
+public class UntrustedServerException extends RuntimeException
+{
+    public UntrustedServerException(String message)
+    {
+        super(message);
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.driver.internal;
 
 import org.junit.jupiter.api.Test;
+
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.exceptions.UntrustedServerException;
@@ -30,7 +31,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.v1.Logging.none;
 
-public class TrustedServerProductTest
+class TrustedServerProductTest
 {
     private static final Config config = Config.build()
             .withoutEncryption()

--- a/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.neo4j.driver.internal;
 
 import org.junit.jupiter.api.Test;

--- a/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
@@ -1,0 +1,29 @@
+package org.neo4j.driver.internal;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.exceptions.UntrustedServerException;
+import org.neo4j.driver.v1.util.StubServer;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.v1.Logging.none;
+
+public class TrustedServerProductTest
+{
+    private static final Config config = Config.build()
+            .withoutEncryption()
+            .withLogging( none() )
+            .toConfig();
+
+    @Test
+    void shouldRejectConnectionsToNonNeo4jServers() throws Exception
+    {
+        StubServer server = StubServer.start( "untrusted_server.script", 9001 );
+        assertThrows( UntrustedServerException.class, () -> GraphDatabase.driver( "bolt://127.0.0.1:9001", config ));
+        assertThat( server.exitStatus(), equalTo( 0 ) );
+    }
+
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ChannelAttributesTest.java
@@ -149,7 +149,7 @@ class ChannelAttributesTest
     @Test
     void shouldSetAndGetServerVersion()
     {
-        ServerVersion version = version( "3.2.1" );
+        ServerVersion version = version( "Neo4j/3.2.1" );
         setServerVersion( channel, version );
         assertEquals( version, serverVersion( channel ) );
     }
@@ -157,9 +157,9 @@ class ChannelAttributesTest
     @Test
     void shouldFailToSetServerVersionTwice()
     {
-        setServerVersion( channel, version( "3.2.2" ) );
+        setServerVersion( channel, version( "Neo4j/3.2.2" ) );
 
-        assertThrows( IllegalStateException.class, () -> setServerVersion( channel, version( "3.2.3" ) ) );
+        assertThrows( IllegalStateException.class, () -> setServerVersion( channel, version( "Neo4j/3.2.3" ) ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
@@ -37,6 +37,7 @@ import org.neo4j.driver.internal.messaging.v1.MessageFormatV1;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.exceptions.UntrustedServerException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -88,7 +89,7 @@ class HelloResponseHandlerTest
         HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( null, "bolt-1" );
-        assertThrows( IllegalStateException.class, () -> handler.onSuccess( metadata ) );
+        assertThrows( UntrustedServerException.class, () -> handler.onSuccess( metadata ) );
 
         assertFalse( channelPromise.isSuccess() ); // initialization failed
         assertTrue( channel.closeFuture().isDone() ); // channel was closed
@@ -101,7 +102,7 @@ class HelloResponseHandlerTest
         HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( Values.NULL, "bolt-x" );
-        assertThrows( IllegalStateException.class, () -> handler.onSuccess( metadata ) );
+        assertThrows( UntrustedServerException.class, () -> handler.onSuccess( metadata ) );
 
         assertFalse( channelPromise.isSuccess() ); // initialization failed
         assertTrue( channel.closeFuture().isDone() ); // channel was closed

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
@@ -152,7 +152,7 @@ class HelloResponseHandlerTest
         ChannelPromise channelPromise = channel.newPromise();
         HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
-        Map<String,Value> metadata = metadata( ServerVersion.v3_0_0, Values.NULL );
+        Map<String,Value> metadata = metadata( ServerVersion.v3_2_0, Values.NULL );
         assertThrows( IllegalStateException.class, () -> handler.onSuccess( metadata ) );
 
         assertFalse( channelPromise.isSuccess() ); // initialization failed

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/InitResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/InitResponseHandlerTest.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.internal.messaging.v1.MessageFormatV1;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.exceptions.UntrustedServerException;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.startsWith;
@@ -84,16 +85,13 @@ class InitResponseHandlerTest
     }
 
     @Test
-    void shouldSetServerVersionToDefaultValueWhenUnknown()
+    void shouldFailToConnectWhenNoServerIdentifierIsProvided()
     {
         ChannelPromise channelPromise = channel.newPromise();
         InitResponseHandler handler = new InitResponseHandler( channelPromise );
 
         Map<String,Value> metadata = singletonMap( "server", Values.NULL );
-        handler.onSuccess( metadata );
-
-        assertTrue( channelPromise.isSuccess() );
-        assertEquals( ServerVersion.v3_0_0, serverVersion( channel ) );
+        assertThrows( UntrustedServerException.class, () -> handler.onSuccess( metadata ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -122,7 +122,7 @@ public class BoltProtocolV1Test
         assertEquals( 1, messageDispatcher.queuedHandlersCount() );
         assertFalse( promise.isDone() );
 
-        messageDispatcher.handleSuccessMessage( emptyMap() );
+        messageDispatcher.handleSuccessMessage( singletonMap( "server", value( "Neo4j/3.1.0" ) ) );
 
         assertTrue( promise.isDone() );
         assertTrue( promise.isSuccess() );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -51,4 +51,13 @@ class ServerVersionTest
         assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "Neo4j1.2.3" ) );
         assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "Neo4j" ) );
     }
+
+    @Test
+    void shouldFailToCompareDifferentProducts()
+    {
+        ServerVersion version1 = ServerVersion.version( "MyNeo4j/1.2.3" );
+        ServerVersion version2 = ServerVersion.version( "OtherNeo4j/1.2.4" );
+
+        assertThrows( IllegalArgumentException.class, () -> version1.greaterThanOrEqual( version2 ) );
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -35,17 +35,20 @@ class ServerVersionTest
     }
 
     @Test
-    void versionShouldThrowExceptionIfServerVersionCantBeParsed()
-    {
-        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "" ) );
-    }
-
-    @Test
     void shouldHaveCorrectToString()
     {
         assertEquals( "Neo4j/dev", ServerVersion.vInDev.toString() );
         assertEquals( "Neo4j/3.1.0", ServerVersion.v3_1_0.toString() );
         assertEquals( "Neo4j/3.2.0", ServerVersion.v3_2_0.toString() );
         assertEquals( "Neo4j/3.5.7", ServerVersion.version( "Neo4j/3.5.7" ).toString() );
+    }
+
+    @Test
+    void shouldFailToParseIllegalVersions()
+    {
+        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "" ) );
+        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "/1.2.3" ) );
+        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "Neo4j1.2.3" ) );
+        assertThrows( IllegalArgumentException.class, () -> ServerVersion.version( "Neo4j" ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -30,8 +30,6 @@ class ServerVersionTest
     @Test
     void version()
     {
-        String nullVersion = null;
-        assertThat( ServerVersion.version( nullVersion ), is( ServerVersion.v3_0_0 ) );
         assertThat( ServerVersion.version( "Neo4j/dev" ), is( ServerVersion.vInDev ) );
         assertThat( ServerVersion.version( "Neo4j/3.2.0" ), is( ServerVersion.v3_2_0 ) );
     }
@@ -46,7 +44,6 @@ class ServerVersionTest
     void shouldHaveCorrectToString()
     {
         assertEquals( "Neo4j/dev", ServerVersion.vInDev.toString() );
-        assertEquals( "Neo4j/3.0.0", ServerVersion.v3_0_0.toString() );
         assertEquals( "Neo4j/3.1.0", ServerVersion.v3_1_0.toString() );
         assertEquals( "Neo4j/3.2.0", ServerVersion.v3_2_0.toString() );
         assertEquals( "Neo4j/3.5.7", ServerVersion.version( "Neo4j/3.5.7" ).toString() );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.v1.util.Neo4jRunner;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.internal.util.Neo4jFeature.CAUSAL_CLUSTER;
+import static org.neo4j.driver.internal.util.ServerVersion.NEO4J_PRODUCT;
 import static org.neo4j.driver.v1.util.Neo4jRunner.PASSWORD;
 import static org.neo4j.driver.v1.util.Neo4jRunner.TARGET_DIR;
 import static org.neo4j.driver.v1.util.Neo4jRunner.USER;
@@ -126,7 +127,7 @@ public class ClusterExtension implements BeforeAllCallback, AfterEachCallback, A
     {
         String[] split = Neo4jRunner.NEOCTRL_ARGS.split( "\\s+" );
         String version = split[split.length - 1];
-        ServerVersion serverVersion = ServerVersion.version( "Neo4j/" + version );
+        ServerVersion serverVersion = ServerVersion.version( NEO4J_PRODUCT + "/" + version );
         assumeTrue( CAUSAL_CLUSTER.availableIn( serverVersion ), "Server version `" + version + "` does not support Casual Cluster" );
         return version;
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterExtension.java
@@ -126,7 +126,7 @@ public class ClusterExtension implements BeforeAllCallback, AfterEachCallback, A
     {
         String[] split = Neo4jRunner.NEOCTRL_ARGS.split( "\\s+" );
         String version = split[split.length - 1];
-        ServerVersion serverVersion = ServerVersion.version( version );
+        ServerVersion serverVersion = ServerVersion.version( "Neo4j/" + version );
         assumeTrue( CAUSAL_CLUSTER.availableIn( serverVersion ), "Server version `" + version + "` does not support Casual Cluster" );
         return version;
     }

--- a/driver/src/test/resources/acquire_endpoints.script
+++ b/driver/src/test/resources/acquire_endpoints.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/discover_no_writers.script
+++ b/driver/src/test/resources/discover_no_writers.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/discover_one_router.script
+++ b/driver/src/test/resources/discover_one_router.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/discover_servers.script
+++ b/driver/src/test/resources/discover_servers.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/failed_discovery.script
+++ b/driver/src/test/resources/failed_discovery.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
 S: IGNORED

--- a/driver/src/test/resources/non_discovery_server.script
+++ b/driver/src/test/resources/non_discovery_server.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
 S: IGNORED

--- a/driver/src/test/resources/rediscover_using_initial_router.script
+++ b/driver/src/test/resources/rediscover_using_initial_router.script
@@ -5,7 +5,7 @@
 !: AUTO RUN "COMMIT" {}
 !: AUTO RUN "ROLLBACK" {}
 
-C: RUN "CALL dbms.cluster.routing.getServers" {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/untrusted_server.script
+++ b/driver/src/test/resources/untrusted_server.script
@@ -1,0 +1,4 @@
+!: AUTO RESET
+
+C: INIT "neo4j-java/dev" {"scheme": "none"}
+S: SUCCESS {"server": "AgentSmith/0.0.1"}


### PR DESCRIPTION
While we currently parse the "server" string returned in the INIT metadata to extract the server version, no logic existed to validate the product part of that string. Indeed, an unexpected product name would have caused the internal regex to fail and an unhelpful error would surface. This PR raises a new `UntrustedServerException` in the case that the product string does not identify `Neo4j`.