### PR TITLE
More conventional config builder method names

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Config.java
@@ -242,10 +242,23 @@ public class Config
     }
 
     /**
-     * Return a {@link ConfigBuilder} instance
-     * @return a {@link ConfigBuilder} instance
+     * Start building a {@link Config} object using a newly created builder.
+     * <p>
+     * <b>Please use {@link #builder()} method instead.</b>
+     *
+     * @return a new {@link ConfigBuilder} instance.
      */
     public static ConfigBuilder build()
+    {
+        return builder();
+    }
+
+    /**
+     * Start building a {@link Config} object using a newly created builder.
+     *
+     * @return a new {@link ConfigBuilder} instance.
+     */
+    public static ConfigBuilder builder()
     {
         return new ConfigBuilder();
     }
@@ -255,7 +268,7 @@ public class Config
      */
     public static Config defaultConfig()
     {
-        return Config.build().toConfig();
+        return Config.builder().build();
     }
 
     RoutingSettings routingSettings()
@@ -748,9 +761,22 @@ public class Config
 
         /**
          * Create a config instance from this builder.
-         * @return a {@link Config} instance
+         * <p>
+         * <b>Please use {@link #build()} method instead.</b>
+         *
+         * @return a new {@link Config} instance.
          */
         public Config toConfig()
+        {
+            return build();
+        }
+
+        /**
+         * Create a config instance from this builder.
+         *
+         * @return a new {@link Config} instance.
+         */
+        public Config build()
         {
             return new Config( this );
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -115,9 +115,10 @@ class DirectDriverBoltKitTest
         Logger logger = mock( Logger.class );
         when( logger.isDebugEnabled() ).thenReturn( true );
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( ignore -> logger )
-                .withoutEncryption().toConfig();
+                .withoutEncryption()
+                .build();
 
         try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", config );
               Session session = driver.session() )
@@ -149,7 +150,7 @@ class DirectDriverBoltKitTest
         try
         {
             URI uri = URI.create( "bolt://localhost:9001" );
-            Config config = Config.build().withLogging( DEV_NULL_LOGGING ).withoutEncryption().toConfig();
+            Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).withoutEncryption().build();
             ChannelTrackingDriverFactory driverFactory = new ChannelTrackingDriverFactory( 1, Clock.SYSTEM );
 
             try ( Driver driver = driverFactory.newInstance( uri, AuthTokens.none(), RoutingSettings.DEFAULT, RetrySettings.DEFAULT, config ) )

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -113,7 +113,7 @@ class DriverFactoryTest
     @MethodSource( "testUris" )
     void usesLeakLoggingSessionFactoryWhenConfigured( String uri )
     {
-        Config config = Config.build().withLeakedSessionsLogging().toConfig();
+        Config config = Config.builder().withLeakedSessionsLogging().build();
         SessionFactoryCapturingDriverFactory factory = new SessionFactoryCapturingDriverFactory();
 
         createDriver( uri, factory, config );

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
@@ -68,10 +68,10 @@ import static org.neo4j.driver.v1.Logging.none;
 
 class RoutingDriverBoltKitTest
 {
-    private static final Config config = Config.build()
+    private static final Config config = Config.builder()
             .withoutEncryption()
             .withLogging( none() )
-            .toConfig();
+            .build();
 
     @Test
     void shouldHandleAcquireReadSession() throws IOException, InterruptedException, StubServer.ForceKilled
@@ -984,11 +984,11 @@ class RoutingDriverBoltKitTest
         ServerAddressResolver resolver = mock( ServerAddressResolver.class );
         when( resolver.resolve( any( ServerAddress.class ) ) ).thenThrow( new RuntimeException( "Resolution failure!" ) );
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( none() )
                 .withoutEncryption()
                 .withResolver( resolver )
-                .toConfig();
+                .build();
 
         RuntimeException error = assertThrows( RuntimeException.class, () -> GraphDatabase.driver( "bolt+routing://my.server.com:9001", config ) );
         assertEquals( "Resolution failure!", error.getMessage() );
@@ -1021,11 +1021,11 @@ class RoutingDriverBoltKitTest
             throw new AssertionError();
         };
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( none() )
                 .withoutEncryption()
                 .withResolver( resolver )
-                .toConfig();
+                .build();
 
         try ( Driver driver = GraphDatabase.driver( "bolt+routing://127.0.0.1:9001", config ) )
         {
@@ -1056,10 +1056,10 @@ class RoutingDriverBoltKitTest
         StubServer router = StubServer.start( "acquire_endpoints.script", 9001 );
         StubServer readServer = StubServer.start( "read_server.script", 9005 );
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withoutEncryption()
                 .withLogging( none() )
-                .toConfig();
+                .build();
 
         try ( Driver driver = GraphDatabase.driver( "bolt+routing://127.0.0.1:9001", config ) )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -36,7 +36,7 @@ class SessionFactoryImplTest
     @Test
     void createsNetworkSessions()
     {
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).build();
         SessionFactory factory = newSessionFactory( config );
 
         Session readSession = factory.newInstance( AccessMode.READ, null );
@@ -49,7 +49,7 @@ class SessionFactoryImplTest
     @Test
     void createsLeakLoggingNetworkSessions()
     {
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).withLeakedSessionsLogging().toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).withLeakedSessionsLogging().build();
         SessionFactory factory = newSessionFactory( config );
 
         Session readSession = factory.newInstance( AccessMode.READ, null );

--- a/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/TrustedServerProductTest.java
@@ -33,10 +33,10 @@ import static org.neo4j.driver.v1.Logging.none;
 
 class TrustedServerProductTest
 {
-    private static final Config config = Config.build()
+    private static final Config config = Config.builder()
             .withoutEncryption()
             .withLogging( none() )
-            .toConfig();
+            .build();
 
     @Test
     void shouldRejectConnectionsToNonNeo4jServers() throws Exception

--- a/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ConfigTest.java
@@ -53,7 +53,7 @@ class ConfigTest
     {
         // Given
         File knownCerts = new File( "new_known_hosts" );
-        Config config = Config.build().withTrustStrategy( Config.TrustStrategy.trustOnFirstUse( knownCerts ) ).toConfig();
+        Config config = Config.builder().withTrustStrategy( Config.TrustStrategy.trustOnFirstUse( knownCerts ) ).build();
 
         // When
         Config.TrustStrategy authConfig = config.trustStrategy();
@@ -68,7 +68,7 @@ class ConfigTest
     {
         // Given
         File trustedCert = new File( "trusted_cert" );
-        Config config = Config.build().withTrustStrategy( Config.TrustStrategy.trustCustomCertificateSignedBy( trustedCert ) ).toConfig();
+        Config config = Config.builder().withTrustStrategy( Config.TrustStrategy.trustCustomCertificateSignedBy( trustedCert ) ).build();
 
         // When
         Config.TrustStrategy authConfig = config.trustStrategy();
@@ -81,7 +81,7 @@ class ConfigTest
     @Test
     void shouldSupportLivenessCheckTimeoutSetting() throws Throwable
     {
-        Config config = Config.build().withConnectionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withConnectionLivenessCheckTimeout( 42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.idleTimeBeforeConnectionTest() );
     }
@@ -89,7 +89,7 @@ class ConfigTest
     @Test
     void shouldAllowZeroConnectionLivenessCheckTimeout() throws Throwable
     {
-        Config config = Config.build().withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withConnectionLivenessCheckTimeout( 0, TimeUnit.SECONDS ).build();
 
         assertEquals( 0, config.idleTimeBeforeConnectionTest() );
     }
@@ -97,7 +97,7 @@ class ConfigTest
     @Test
     void shouldAllowNegativeConnectionLivenessCheckTimeout() throws Throwable
     {
-        Config config = Config.build().withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withConnectionLivenessCheckTimeout( -42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( -42 ), config.idleTimeBeforeConnectionTest() );
     }
@@ -111,7 +111,7 @@ class ConfigTest
     @Test
     void shouldSupportMaxConnectionLifetimeSetting() throws Throwable
     {
-        Config config = Config.build().withMaxConnectionLifetime( 42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withMaxConnectionLifetime( 42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.maxConnectionLifetimeMillis() );
     }
@@ -119,7 +119,7 @@ class ConfigTest
     @Test
     void shouldAllowZeroConnectionMaxConnectionLifetime() throws Throwable
     {
-        Config config = Config.build().withMaxConnectionLifetime( 0, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withMaxConnectionLifetime( 0, TimeUnit.SECONDS ).build();
 
         assertEquals( 0, config.maxConnectionLifetimeMillis() );
     }
@@ -127,7 +127,7 @@ class ConfigTest
     @Test
     void shouldAllowNegativeConnectionMaxConnectionLifetime() throws Throwable
     {
-        Config config = Config.build().withMaxConnectionLifetime( -42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withMaxConnectionLifetime( -42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( -42 ), config.maxConnectionLifetimeMillis() );
     }
@@ -136,10 +136,10 @@ class ConfigTest
     void shouldTurnOnLeakedSessionsLogging()
     {
         // leaked sessions logging is turned off by default
-        assertFalse( Config.build().toConfig().logLeakedSessions() );
+        assertFalse( Config.builder().build().logLeakedSessions() );
 
         // it can be turned on using config
-        assertTrue( Config.build().withLeakedSessionsLogging().toConfig().logLeakedSessions() );
+        assertTrue( Config.builder().withLeakedSessionsLogging().build().logLeakedSessions() );
     }
 
     @Test
@@ -152,21 +152,21 @@ class ConfigTest
     @Test
     void shouldRespectConfiguredConnectionTimeout()
     {
-        Config config = Config.build().withConnectionTimeout( 42, TimeUnit.HOURS ).toConfig();
+        Config config = Config.builder().withConnectionTimeout( 42, TimeUnit.HOURS ).build();
         assertEquals( TimeUnit.HOURS.toMillis( 42 ), config.connectionTimeoutMillis() );
     }
 
     @Test
     void shouldAllowConnectionTimeoutOfZero()
     {
-        Config config = Config.build().withConnectionTimeout( 0, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withConnectionTimeout( 0, TimeUnit.SECONDS ).build();
         assertEquals( 0, config.connectionTimeoutMillis() );
     }
 
     @Test
     void shouldThrowForNegativeConnectionTimeout()
     {
-        Config.ConfigBuilder builder = Config.build();
+        Config.ConfigBuilder builder = Config.builder();
 
         assertThrows( IllegalArgumentException.class, () -> builder.withConnectionTimeout( -42, TimeUnit.SECONDS ) );
     }
@@ -174,7 +174,7 @@ class ConfigTest
     @Test
     void shouldThrowForTooLargeConnectionTimeout()
     {
-        Config.ConfigBuilder builder = Config.build();
+        Config.ConfigBuilder builder = Config.builder();
 
         assertThrows( IllegalArgumentException.class, () -> builder.withConnectionTimeout( Long.MAX_VALUE - 42, TimeUnit.SECONDS ) );
     }
@@ -182,7 +182,7 @@ class ConfigTest
     @Test
     void shouldNotAllowNegativeMaxRetryTimeMs()
     {
-        Config.ConfigBuilder builder = Config.build();
+        Config.ConfigBuilder builder = Config.builder();
 
         assertThrows( IllegalArgumentException.class, () -> builder.withMaxTransactionRetryTime( -42, TimeUnit.SECONDS ) );
     }
@@ -190,7 +190,7 @@ class ConfigTest
     @Test
     void shouldAllowZeroMaxRetryTimeMs()
     {
-        Config config = Config.build().withMaxTransactionRetryTime( 0, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withMaxTransactionRetryTime( 0, TimeUnit.SECONDS ).build();
 
         assertEquals( 0, config.retrySettings().maxRetryTimeMs() );
     }
@@ -198,7 +198,7 @@ class ConfigTest
     @Test
     void shouldAllowPositiveRetryAttempts()
     {
-        Config config = Config.build().withMaxTransactionRetryTime( 42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withMaxTransactionRetryTime( 42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.retrySettings().maxRetryTimeMs() );
     }
@@ -212,7 +212,7 @@ class ConfigTest
     @Test
     void shouldAllowPositiveMaxConnectionPoolSize()
     {
-        Config config = Config.build().withMaxConnectionPoolSize( 42 ).toConfig();
+        Config config = Config.builder().withMaxConnectionPoolSize( 42 ).build();
 
         assertEquals( 42, config.maxConnectionPoolSize() );
     }
@@ -220,7 +220,7 @@ class ConfigTest
     @Test
     void shouldAllowNegativeMaxConnectionPoolSize()
     {
-        Config config = Config.build().withMaxConnectionPoolSize( -42 ).toConfig();
+        Config config = Config.builder().withMaxConnectionPoolSize( -42 ).build();
 
         assertEquals( Integer.MAX_VALUE, config.maxConnectionPoolSize() );
     }
@@ -228,7 +228,7 @@ class ConfigTest
     @Test
     void shouldDisallowZeroMaxConnectionPoolSize()
     {
-        IllegalArgumentException e = assertThrows( IllegalArgumentException.class, () -> Config.build().withMaxConnectionPoolSize( 0 ).toConfig() );
+        IllegalArgumentException e = assertThrows( IllegalArgumentException.class, () -> Config.builder().withMaxConnectionPoolSize( 0 ).build() );
         assertEquals( "Zero value is not supported", e.getMessage() );
     }
 
@@ -241,7 +241,7 @@ class ConfigTest
     @Test
     void shouldAllowPositiveConnectionAcquisitionTimeout()
     {
-        Config config = Config.build().withConnectionAcquisitionTimeout( 42, TimeUnit.SECONDS ).toConfig();
+        Config config = Config.builder().withConnectionAcquisitionTimeout( 42, TimeUnit.SECONDS ).build();
 
         assertEquals( TimeUnit.SECONDS.toMillis( 42 ), config.connectionAcquisitionTimeoutMillis() );
     }
@@ -249,7 +249,7 @@ class ConfigTest
     @Test
     void shouldAllowNegativeConnectionAcquisitionTimeout()
     {
-        Config config = Config.build().withConnectionAcquisitionTimeout( -42, TimeUnit.HOURS ).toConfig();
+        Config config = Config.builder().withConnectionAcquisitionTimeout( -42, TimeUnit.HOURS ).build();
 
         assertEquals( -1, config.connectionAcquisitionTimeoutMillis() );
     }
@@ -257,7 +257,7 @@ class ConfigTest
     @Test
     void shouldAllowConnectionAcquisitionTimeoutOfZero()
     {
-        Config config = Config.build().withConnectionAcquisitionTimeout( 0, TimeUnit.DAYS ).toConfig();
+        Config config = Config.builder().withConnectionAcquisitionTimeout( 0, TimeUnit.DAYS ).build();
 
         assertEquals( 0, config.connectionAcquisitionTimeoutMillis() );
     }
@@ -279,7 +279,7 @@ class ConfigTest
     void shouldAllowToConfigureResolver()
     {
         ServerAddressResolver resolver = mock( ServerAddressResolver.class );
-        Config config = Config.build().withResolver( resolver ).toConfig();
+        Config config = Config.builder().withResolver( resolver ).build();
 
         assertEquals( resolver, config.resolver() );
     }
@@ -287,6 +287,6 @@ class ConfigTest
     @Test
     void shouldNotAllowNullResolver()
     {
-        assertThrows( NullPointerException.class, () -> Config.build().withResolver( null ) );
+        assertThrows( NullPointerException.class, () -> Config.builder().withResolver( null ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/GraphDatabaseTest.java
@@ -93,10 +93,10 @@ class GraphDatabaseTest
     {
         URI uri = URI.create( "bolt+routing://127.0.0.1:9001" );
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withEncryption()
                 .withTrustStrategy( trustOnFirstUse( new File( "./known_hosts" ) ) )
-                .toConfig();
+                .build();
 
         assertThrows( IllegalArgumentException.class, () -> GraphDatabase.driver( uri, config ) );
     }
@@ -117,10 +117,10 @@ class GraphDatabaseTest
         Logger logger = mock( Logger.class );
         when( logging.getLog( anyString() ) ).thenReturn( logger );
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withoutEncryption()
                 .withLogging( logging )
-                .toConfig();
+                .build();
 
         List<URI> routingUris = asList(
                 URI.create( "bolt+routing://localhost:9001" ),
@@ -185,7 +185,7 @@ class GraphDatabaseTest
 
     private static Config createConfig( boolean encrypted, int timeoutMillis )
     {
-        Config.ConfigBuilder configBuilder = Config.build()
+        Config.ConfigBuilder configBuilder = Config.builder()
                 .withConnectionTimeout( timeoutMillis, MILLISECONDS )
                 .withLogging( DEV_NULL_LOGGING );
 
@@ -198,6 +198,6 @@ class GraphDatabaseTest
             configBuilder.withoutEncryption();
         }
 
-        return configBuilder.toConfig();
+        return configBuilder.build();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -236,10 +236,10 @@ class CausalClusteringIT
         int concurrentSessionsCount = 9;
         int livenessCheckTimeoutMinutes = 2;
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, MINUTES )
                 .withLogging( DEV_NULL_LOGGING )
-                .toConfig();
+                .build();
 
         FakeClock clock = new FakeClock();
         ChannelTrackingDriverFactory driverFactory = new ChannelTrackingDriverFactory( clock );
@@ -524,11 +524,11 @@ class CausalClusteringIT
         Cluster cluster = clusterRule.getCluster();
         ClusterMember leader = cluster.leader();
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withMaxConnectionPoolSize( 2 )
                 .withConnectionAcquisitionTimeout( 42, MILLISECONDS )
                 .withLogging( DEV_NULL_LOGGING )
-                .toConfig();
+                .build();
 
         try ( Driver driver = createDriver( leader.getRoutingUri(), config ) )
         {
@@ -662,10 +662,10 @@ class CausalClusteringIT
         AtomicBoolean stop = new AtomicBoolean();
         executor = newExecutor();
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( DEV_NULL_LOGGING )
                 .withMaxTransactionRetryTime( testRunTimeMs, MILLISECONDS )
-                .toConfig();
+                .build();
 
         try ( Driver driver = driverFactory.newInstance( cluster.leader().getRoutingUri(), clusterRule.getDefaultAuthToken(),
                 defaultRoutingSettings(), RetrySettings.DEFAULT, config ) )
@@ -1023,7 +1023,7 @@ class CausalClusteringIT
 
     private static Config configWithoutLogging()
     {
-        return Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        return Config.builder().withLogging( DEV_NULL_LOGGING ).build();
     }
 
     private static ExecutorService newExecutor()

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionPoolIT.java
@@ -100,7 +100,7 @@ class ConnectionPoolIT
         ChannelTrackingDriverFactory driverFactory = new ChannelTrackingDriverFactory( clock );
 
         int maxConnLifetimeHours = 3;
-        Config config = Config.build().withMaxConnectionLifetime( maxConnLifetimeHours, TimeUnit.HOURS ).toConfig();
+        Config config = Config.builder().withMaxConnectionLifetime( maxConnLifetimeHours, TimeUnit.HOURS ).build();
         RoutingSettings routingSettings = new RoutingSettings( 1, 1 );
         driver = driverFactory.newInstance( neo4j.uri(), neo4j.authToken(), routingSettings, DEFAULT, config );
 
@@ -139,10 +139,10 @@ class ConnectionPoolIT
     void shouldRespectMaxConnectionPoolSize()
     {
         int maxPoolSize = 3;
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withMaxConnectionPoolSize( maxPoolSize )
                 .withConnectionAcquisitionTimeout( 542, TimeUnit.MILLISECONDS )
-                .toConfig();
+                .build();
 
         driver = new DriverFactoryWithOneEventLoopThread().newInstance( neo4j.uri(), neo4j.authToken(), config );
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -174,7 +174,7 @@ class CredentialsIT
 
     private void testDriverFailureOnWrongCredentials( String uri )
     {
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).build();
         AuthToken authToken = AuthTokens.basic( "neo4j", "wrongSecret" );
 
         assertThrows( AuthenticationException.class, () -> GraphDatabase.driver( uri, authToken, config ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/EncryptionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/EncryptionIT.java
@@ -141,11 +141,11 @@ class EncryptionIT
 
     private static Config configWithEncryption()
     {
-        return Config.build().withEncryption().toConfig();
+        return Config.builder().withEncryption().build();
     }
 
     private static Config configWithoutEncryption()
     {
-        return Config.build().withoutEncryption().toConfig();
+        return Config.builder().withoutEncryption().build();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ErrorIT.java
@@ -177,7 +177,7 @@ class ErrorIT
         //the http server needs some time to start up
         Thread.sleep( 2000 );
 
-        Config config = Config.build().withoutEncryption().toConfig();
+        Config config = Config.builder().withoutEncryption().build();
 
         ClientException e = assertThrows( ClientException.class, () -> GraphDatabase.driver( "bolt://localhost:" + session.httpPort(), config ) );
         assertEquals( "Server responded HTTP. Make sure you are not trying to connect to the http endpoint " +
@@ -261,7 +261,7 @@ class ErrorIT
         AuthToken authToken = session.authToken();
         RoutingSettings routingSettings = new RoutingSettings( 1, 1 );
         RetrySettings retrySettings = RetrySettings.DEFAULT;
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).build();
         Throwable queryError = null;
 
         try ( Driver driver = driverFactory.newInstance( uri, authToken, routingSettings, retrySettings, config );

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/LoggingIT.java
@@ -54,8 +54,11 @@ class LoggingIT
         when( logger.isDebugEnabled() ).thenReturn( true );
         when( logger.isTraceEnabled() ).thenReturn( true );
 
-        try ( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(),
-                Config.build().withLogging( logging ).toConfig() ) )
+        Config config = Config.builder()
+                .withLogging( logging )
+                .build();
+
+        try ( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(), config ) )
         {
             // When
             try ( Session session = driver.session() )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ServerKilledIT.java
@@ -59,17 +59,17 @@ class ServerKilledIT
     private static Stream<Arguments> data()
     {
         return Stream.of(
-                Arguments.of( "plaintext", Config.build().withoutEncryption() ),
-                Arguments.of( "tls encrypted", Config.build().withEncryption() )
+                Arguments.of( "plaintext", Config.builder().withoutEncryption() ),
+                Arguments.of( "tls encrypted", Config.builder().withEncryption() )
         );
     }
 
     @ParameterizedTest
     @MethodSource( "data" )
-    void shouldRecoverFromServerRestart( String name, Config.ConfigBuilder config )
+    void shouldRecoverFromServerRestart( String name, Config.ConfigBuilder configBuilder )
     {
         // Given config with sessionLivenessCheckTimeout not set, i.e. turned off
-        try ( Driver driver = GraphDatabase.driver( neo4j.uri(), DEFAULT_AUTH_TOKEN, config.toConfig() ) )
+        try ( Driver driver = GraphDatabase.driver( neo4j.uri(), DEFAULT_AUTH_TOKEN, configBuilder.build() ) )
         {
             acquireAndReleaseConnections( 4, driver );
 
@@ -98,15 +98,15 @@ class ServerKilledIT
 
     @ParameterizedTest
     @MethodSource( "data" )
-    void shouldDropBrokenOldSessions( String name, Config.ConfigBuilder config )
+    void shouldDropBrokenOldSessions( String name, Config.ConfigBuilder configBuilder )
     {
         // config with set liveness check timeout
         int livenessCheckTimeoutMinutes = 10;
-        config.withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES );
+        configBuilder.withConnectionLivenessCheckTimeout( livenessCheckTimeoutMinutes, TimeUnit.MINUTES );
 
         FakeClock clock = new FakeClock();
 
-        try ( Driver driver = createDriver( clock, config.toConfig() ) )
+        try ( Driver driver = createDriver( clock, configBuilder.build() ) )
         {
             acquireAndReleaseConnections( 5, driver );
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionIT.java
@@ -839,11 +839,11 @@ class SessionIT
     void shouldNotRetryOnConnectionAcquisitionTimeout()
     {
         int maxPoolSize = 3;
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withMaxConnectionPoolSize( maxPoolSize )
                 .withConnectionAcquisitionTimeout( 0, TimeUnit.SECONDS )
                 .withMaxTransactionRetryTime( 42, TimeUnit.DAYS ) // retry for a really long time
-                .toConfig();
+                .build();
 
         driver = new DriverFactoryWithOneEventLoopThread().newInstance( neo4j.uri(), neo4j.authToken(), config );
 
@@ -999,10 +999,10 @@ class SessionIT
     void shouldAllowLongRunningQueryWithConnectTimeout() throws Exception
     {
         int connectionTimeoutMs = 3_000;
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( DEV_NULL_LOGGING )
                 .withConnectionTimeout( connectionTimeoutMs, TimeUnit.MILLISECONDS )
-                .toConfig();
+                .build();
 
         try ( Driver driver = GraphDatabase.driver( neo4j.uri(), neo4j.authToken(), config ) )
         {
@@ -1299,16 +1299,16 @@ class SessionIT
 
     private Driver newDriverWithLimitedRetries( int maxTxRetryTime, TimeUnit unit )
     {
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( DEV_NULL_LOGGING )
                 .withMaxTransactionRetryTime( maxTxRetryTime, unit )
-                .toConfig();
+                .build();
         return GraphDatabase.driver( neo4j.uri(), neo4j.authToken(), config );
     }
 
     private static Config noLoggingConfig()
     {
-        return Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        return Config.builder().withLogging( DEV_NULL_LOGGING ).build();
     }
 
     private static ThrowingWork newThrowingWorkSpy( String query, int failures )

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -1073,7 +1073,7 @@ class TransactionAsyncIT
     private void testCommitAndRollbackFailurePropagation( boolean commit )
     {
         ChannelTrackingDriverFactory driverFactory = new ChannelTrackingDriverFactory( 1, Clock.SYSTEM );
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).build();
 
         try ( Driver driver = driverFactory.newInstance( neo4j.uri(), neo4j.authToken(), RoutingSettings.DEFAULT, RetrySettings.DEFAULT, config ) )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionIT.java
@@ -411,7 +411,7 @@ class TransactionIT
     {
         ChannelTrackingDriverFactory factory = new ChannelTrackingDriverFactory( 1, Clock.SYSTEM );
         RoutingSettings instance = new RoutingSettings( 1, 0 );
-        Config config = Config.build().withLogging( DEV_NULL_LOGGING ).toConfig();
+        Config config = Config.builder().withLogging( DEV_NULL_LOGGING ).build();
 
         try ( Driver driver = factory.newInstance( session.uri(), session.authToken(), instance, DEFAULT, config ) )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -99,11 +99,11 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
         System.setProperty( DRIVER_METRICS_ENABLED_KEY, "true" );
         logging = new LoggerNameTrackingLogging();
 
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withLogging( logging )
                 .withMaxConnectionPoolSize( 100 )
                 .withConnectionAcquisitionTimeout( 1, MINUTES )
-                .toConfig();
+                .build();
 
         driver = (InternalDriver) GraphDatabase.driver( databaseUri(), authToken(), config );
         System.setProperty( DRIVER_METRICS_ENABLED_KEY, "false" );

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/FailedAuth.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/FailedAuth.java
@@ -44,7 +44,7 @@ public class FailedAuth<C extends AbstractContext> implements BlockingCommand<C>
     @Override
     public void execute( C context )
     {
-        Config config = Config.build().withLogging( logging ).toConfig();
+        Config config = Config.builder().withLogging( logging ).build();
 
         SecurityException e = assertThrows( SecurityException.class,
                 () -> GraphDatabase.driver( clusterUri, basic( "wrongUsername", "wrongPassword" ), config ) );

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/SessionPoolingStressIT.java
@@ -82,9 +82,9 @@ class SessionPoolingStressIT
     @Test
     void shouldWorkFine() throws Throwable
     {
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withoutEncryption()
-                .toConfig();
+                .build();
 
         driver = driver( neo4j.uri(), neo4j.authToken(), config );
 

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/DriverSecurityComplianceSteps.java
@@ -77,8 +77,8 @@ public class DriverSecurityComplianceSteps
         driver = GraphDatabase.driver(
                 neo4j.uri(),
                 Neo4jRunner.DEFAULT_AUTH_TOKEN,
-                Config.build().withEncryptionLevel( EncryptionLevel.REQUIRED )
-                        .withTrustStrategy( trustOnFirstUse( knownHostsFile ) ).toConfig() );
+                Config.builder().withEncryptionLevel( EncryptionLevel.REQUIRED )
+                        .withTrustStrategy( trustOnFirstUse( knownHostsFile ) ).build() );
 
     }
 
@@ -111,8 +111,8 @@ public class DriverSecurityComplianceSteps
             driver = GraphDatabase.driver(
                     neo4j.uri(),
                     Neo4jRunner.DEFAULT_AUTH_TOKEN,
-                    Config.build().withEncryptionLevel( EncryptionLevel.REQUIRED )
-                            .withTrustStrategy( trustOnFirstUse( knownHostsFile ) ).toConfig() );
+                    Config.builder().withEncryptionLevel( EncryptionLevel.REQUIRED )
+                            .withTrustStrategy( trustOnFirstUse( knownHostsFile ) ).build() );
         }
         catch ( Exception e )
         {
@@ -186,10 +186,10 @@ public class DriverSecurityComplianceSteps
         sessionsShouldSimplyWork();
 
         File tempFile = tempFile( "known_hosts", ".tmp" );
-        driverKittenConfig = Config.build()
+        driverKittenConfig = Config.builder()
                 .withEncryptionLevel( EncryptionLevel.REQUIRED )
                 .withTrustStrategy( trustOnFirstUse( tempFile ) )
-                .toConfig();
+                .build();
     }
 
     @Then( "^the two drivers should not interfere with one another's known hosts files$" )
@@ -250,8 +250,8 @@ public class DriverSecurityComplianceSteps
             driver = GraphDatabase.driver(
                     neo4j.uri(),
                     Neo4jRunner.DEFAULT_AUTH_TOKEN,
-                    Config.build().withEncryption()
-                            .withTrustStrategy( trustCustomCertificateSignedBy( certificate ) ).toConfig() );
+                    Config.builder().withEncryption()
+                            .withTrustStrategy( trustCustomCertificateSignedBy( certificate ) ).build() );
         }
         catch ( Exception e )
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/tck/ErrorReportingSteps.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/tck/ErrorReportingSteps.java
@@ -230,7 +230,7 @@ public class ErrorReportingSteps
     @Given( "^I have a driver with fixed pool size of (\\d+)$" )
     public void iHaveADriverWithFixedPoolSizeOf( int poolSize ) throws Throwable
     {
-        smallDriver = GraphDatabase.driver( "bolt://localhost:" + neo4j.boltPort(), Config.build().withMaxSessions( poolSize ).toConfig() );
+        smallDriver = GraphDatabase.driver( "bolt://localhost:" + neo4j.boltPort(), Config.builder().withMaxSessions( poolSize ).build() );
     }
 
     @And( "^I try to get a session$" )

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -59,7 +59,7 @@ public class Neo4jRunner
 
     private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.4.6";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
-    public static final Config DEFAULT_CONFIG = Config.build().withLogging( console( INFO ) ).toConfig();
+    public static final Config DEFAULT_CONFIG = Config.builder().withLogging( console( INFO ) ).build();
 
     public static final String USER = "neo4j";
     public static final String PASSWORD = "password";

--- a/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/StubServer.java
@@ -43,8 +43,7 @@ public class StubServer
 {
     private static final int SOCKET_CONNECT_ATTEMPTS = 20;
 
-    public static final Config INSECURE_CONFIG = Config.build()
-            .withoutEncryption().toConfig();
+    public static final Config INSECURE_CONFIG = Config.builder().withoutEncryption().build();
 
     private static final ExecutorService executor = newCachedThreadPool( daemon( "stub-server-output-reader-" ) );
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterDrivers.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/ClusterDrivers.java
@@ -64,11 +64,11 @@ public class ClusterDrivers implements AutoCloseable
 
     private static Config driverConfig()
     {
-        return Config.build()
+        return Config.builder()
                 .withLogging( DEV_NULL_LOGGING )
                 .withoutEncryption()
                 .withMaxConnectionPoolSize( 1 )
                 .withConnectionLivenessCheckTimeout( 0, TimeUnit.MILLISECONDS )
-                .toConfig();
+                .build();
     }
 }

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionPoolExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionPoolExample.java
@@ -33,11 +33,13 @@ public class ConfigConnectionPoolExample  implements AutoCloseable
     // tag::config-connection-pool[]
     public ConfigConnectionPoolExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), Config.build()
+        Config config = Config.builder()
                 .withMaxConnectionLifetime( 30, TimeUnit.MINUTES )
                 .withMaxConnectionPoolSize( 50 )
                 .withConnectionAcquisitionTimeout( 2, TimeUnit.MINUTES )
-                .toConfig() );
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-connection-pool[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionTimeoutExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionTimeoutExample.java
@@ -35,8 +35,11 @@ public class ConfigConnectionTimeoutExample implements AutoCloseable
     // tag::config-connection-timeout[]
     public ConfigConnectionTimeoutExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ),
-                Config.build().withConnectionTimeout( 15, SECONDS ).toConfig() );
+        Config config = Config.builder()
+                .withConnectionTimeout( 15, SECONDS )
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-connection-timeout[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigCustomResolverExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigCustomResolverExample.java
@@ -38,16 +38,22 @@ public class ConfigCustomResolverExample implements AutoCloseable
 
     public ConfigCustomResolverExample( String virtualUri, ServerAddress... addresses )
     {
-        driver = GraphDatabase.driver( virtualUri, AuthTokens.none(),
-                Config.build().withoutEncryption().withResolver( address -> new HashSet<>( Arrays.asList( addresses ) ) ).toConfig() );
+        Config config = Config.builder()
+                .withoutEncryption()
+                .withResolver( address -> new HashSet<>( Arrays.asList( addresses ) ) )
+                .build();
 
+        driver = GraphDatabase.driver( virtualUri, AuthTokens.none(), config );
     }
 
     // tag::config-custom-resolver[]
     private Driver createDriver( String virtualUri, String user, String password, ServerAddress... addresses )
     {
-        return GraphDatabase.driver( virtualUri, AuthTokens.basic( user, password ),
-                Config.build().withResolver( address -> new HashSet<>( Arrays.asList( addresses ) ) ).toConfig() );
+        Config config = Config.builder()
+                .withResolver( address -> new HashSet<>( Arrays.asList( addresses ) ) )
+                .build();
+
+        return GraphDatabase.driver( virtualUri, AuthTokens.basic( user, password ), config );
     }
 
     private void addPerson( String name )

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigLoadBalancingStrategyExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigLoadBalancingStrategyExample.java
@@ -31,9 +31,11 @@ public class ConfigLoadBalancingStrategyExample implements AutoCloseable
     // tag::config-load-balancing-strategy[]
     public ConfigLoadBalancingStrategyExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), Config.build()
+        Config config = Config.builder()
                 .withLoadBalancingStrategy( Config.LoadBalancingStrategy.LEAST_CONNECTED )
-                .toConfig() );
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-load-balancing-strategy[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigMaxRetryTimeExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigMaxRetryTimeExample.java
@@ -35,8 +35,11 @@ public class ConfigMaxRetryTimeExample implements AutoCloseable
     // tag::config-max-retry-time[]
     public ConfigMaxRetryTimeExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ),
-                Config.build().withMaxTransactionRetryTime( 15, SECONDS ).toConfig() );
+        Config config = Config.builder()
+                .withMaxTransactionRetryTime( 15, SECONDS )
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-max-retry-time[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigTrustExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigTrustExample.java
@@ -33,8 +33,11 @@ public class ConfigTrustExample implements AutoCloseable
     // tag::config-trust[]
     public ConfigTrustExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ),
-                Config.build().withTrustStrategy( Config.TrustStrategy.trustAllCertificates() ).toConfig() );
+        Config config = Config.builder()
+                .withTrustStrategy( Config.TrustStrategy.trustAllCertificates() )
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-trust[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigUnencryptedExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigUnencryptedExample.java
@@ -33,8 +33,11 @@ public class ConfigUnencryptedExample implements AutoCloseable
     // tag::config-unencrypted[]
     public ConfigUnencryptedExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ),
-                Config.build().withoutEncryption().toConfig() );
+        Config config = Config.builder()
+                .withoutEncryption()
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
     // end::config-unencrypted[]
 

--- a/examples/src/main/java/org/neo4j/docs/driver/HostnameVerificationExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/HostnameVerificationExample.java
@@ -34,10 +34,10 @@ public class HostnameVerificationExample implements AutoCloseable
 
     HostnameVerificationExample( String uri, String user, String password, File certFile )
     {
-        Config config = Config.build()
+        Config config = Config.builder()
                 .withEncryption()
                 .withTrustStrategy( trustCustomCertificateSignedBy( certFile ).withHostnameVerification() )
-                .toConfig();
+                .build();
 
         driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }

--- a/examples/src/main/java/org/neo4j/docs/driver/ServiceUnavailableExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ServiceUnavailableExample.java
@@ -24,13 +24,13 @@ import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 // end::service-unavailable-import[]
 
 public class ServiceUnavailableExample implements AutoCloseable
@@ -39,8 +39,12 @@ public class ServiceUnavailableExample implements AutoCloseable
 
     public ServiceUnavailableExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), Config.build()
-                .withMaxTransactionRetryTime( 3, SECONDS ).withLogging( DEV_NULL_LOGGING ).toConfig() );
+        Config config = Config.builder()
+                .withMaxTransactionRetryTime( 3, SECONDS )
+                .withLogging( Logging.none() )
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
 
     @Override

--- a/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/Slf4jLoggingExample.java
@@ -22,10 +22,10 @@ import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Logging;
 import org.neo4j.driver.v1.Session;
 
 import static java.util.Collections.singletonMap;
-import static org.neo4j.driver.v1.Logging.slf4j;
 
 public class Slf4jLoggingExample implements AutoCloseable
 {
@@ -33,7 +33,11 @@ public class Slf4jLoggingExample implements AutoCloseable
 
     public Slf4jLoggingExample( String uri, String user, String password )
     {
-        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), Config.build().withLogging( slf4j() ).toConfig() );
+        Config config = Config.builder()
+                .withLogging( Logging.slf4j() )
+                .build();
+
+        driver = GraphDatabase.driver( uri, AuthTokens.basic( user, password ), config );
     }
 
     public Object runReturnQuery( Object value )


### PR DESCRIPTION
Added static factory method `ConfigBuilder Config#builder()` and instance method `Config ConfigBuilder#build()`. They have same behaviour as existing `ConfigBuilder Config#build()` and `Config ConfigBuilder#toConfig()` but have more conventional names. Existing methods not deprecated to avoid all existing user code be marked as deprecated. New methods also consistent with `TransactionConfig`. Updated the codebase to use new methods.