### PR TITLE
Upgrade JUnit 5 to 5.4.0.

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -52,11 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.rauschig</groupId>

--- a/driver/src/main/javadoc/overview.html
+++ b/driver/src/main/javadoc/overview.html
@@ -32,7 +32,7 @@ public class SmallExample
             // and makes handling errors much easier.
             try (Transaction tx = session.beginTransaction())
             {
-                tx.run("MERGE (a:Person {name: {x}})", parameters("x", name));
+                tx.run("MERGE (a:Person {name: $x})", parameters("x", name));
                 tx.success();  // Mark this write as successful.
             }
         }
@@ -44,7 +44,7 @@ public class SmallExample
         {
             // Auto-commit transactions are a quick and easy way to wrap a read.
             StatementResult result = session.run(
-                    "MATCH (a:Person) WHERE a.name STARTS WITH {x} RETURN a.name AS name",
+                    "MATCH (a:Person) WHERE a.name STARTS WITH $x RETURN a.name AS name",
                     parameters("x", initial));
             // Each Cypher execution returns a stream of records.
             while (result.hasNext())

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.rauschig</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <rootDir>${project.basedir}</rootDir>
     <surefire.and.failsafe.version>2.22.1</surefire.and.failsafe.version>
-    <junit.version>5.3.1</junit.version>
-    <junit.platform.version>1.3.1</junit.platform.version>
+    <junit.version>5.4.0</junit.version>
     <parallelizable.it.forkCount>1C</parallelizable.it.forkCount>
     <!-- All tests tagged are to be executed in parallel -->
     <parallelizable.it.tags>parallelizableIT</parallelizable.it.tags>
@@ -90,13 +89,7 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
+        <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
@@ -344,18 +337,6 @@
           <argLine>${surefire.and.failsafe.argLine}</argLine>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -394,18 +375,6 @@
             </configuration>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This change removes the need for several dependency artifacts and the
manual configuration of surefire.

I can make good use of the `@TempDir` annotation later on, too.