### PR TITLE
Use only BookmarksHolder contract instead of concrete NetworkSession.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BookmarksHolder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BookmarksHolder.java
@@ -24,6 +24,8 @@ public interface BookmarksHolder
 
     void setBookmarks( Bookmarks bookmarks );
 
+    String lastBookmark();
+
     BookmarksHolder NO_OP = new BookmarksHolder()
     {
         @Override
@@ -35,6 +37,12 @@ public interface BookmarksHolder
         @Override
         public void setBookmarks( Bookmarks bookmarks )
         {
+        }
+
+        @Override
+        public String lastBookmark()
+        {
+            return null;
         }
     };
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DefaultBookmarksHolder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DefaultBookmarksHolder.java
@@ -18,11 +18,19 @@
  */
 package org.neo4j.driver.internal;
 
-public class SimpleBookmarksHolder implements BookmarksHolder
+/**
+ * @since 2.0
+ */
+public class DefaultBookmarksHolder implements BookmarksHolder
 {
     private volatile Bookmarks bookmarks;
 
-    public SimpleBookmarksHolder( Bookmarks bookmarks )
+    public DefaultBookmarksHolder()
+    {
+        this( Bookmarks.empty() );
+    }
+
+    public DefaultBookmarksHolder( Bookmarks bookmarks )
     {
         this.bookmarks = bookmarks;
     }
@@ -36,6 +44,15 @@ public class SimpleBookmarksHolder implements BookmarksHolder
     @Override
     public void setBookmarks( Bookmarks bookmarks )
     {
-        this.bookmarks = bookmarks;
+        if ( bookmarks != null && !bookmarks.isEmpty() )
+        {
+            this.bookmarks = bookmarks;
+        }
+    }
+
+    @Override
+    public String lastBookmark()
+    {
+        return bookmarks == null ? null : bookmarks.maxBookmarkAsString();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/LeakLoggingNetworkSession.java
@@ -30,9 +30,9 @@ class LeakLoggingNetworkSession extends NetworkSession
 {
     private final String stackTrace;
 
-    LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic, Logging logging )
+    LeakLoggingNetworkSession( ConnectionProvider connectionProvider, AccessMode mode, RetryLogic retryLogic, Logging logging, BookmarksHolder bookmarksHolder )
     {
-        super( connectionProvider, mode, retryLogic, logging );
+        super( connectionProvider, mode, retryLogic, logging, bookmarksHolder );
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -44,8 +44,8 @@ public class SessionFactoryImpl implements SessionFactory
     @Override
     public NetworkSession newInstance( AccessMode mode, Bookmarks bookmarks )
     {
-        NetworkSession session = createSession( connectionProvider, retryLogic, mode, logging );
-        session.setBookmarks( bookmarks );
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( bookmarks );
+        NetworkSession session = createSession( connectionProvider, retryLogic, mode, logging, bookmarksHolder );
         return session;
     }
 
@@ -74,10 +74,10 @@ public class SessionFactoryImpl implements SessionFactory
     }
 
     private NetworkSession createSession( ConnectionProvider connectionProvider, RetryLogic retryLogic,
-            AccessMode mode, Logging logging )
+            AccessMode mode, Logging logging, BookmarksHolder bookmarksHolder )
     {
         return leakedSessionsLoggingEnabled
-               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, logging )
-               : new NetworkSession( connectionProvider, mode, retryLogic, logging );
+               ? new LeakLoggingNetworkSession( connectionProvider, mode, retryLogic, logging, bookmarksHolder )
+               : new NetworkSession( connectionProvider, mode, retryLogic, logging, bookmarksHolder );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DefaultBookmarksHolderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DefaultBookmarksHolderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DefaultBookmarksHolderTest
+{
+    @Test
+    void shouldAllowToGetAndSetBookmarks()
+    {
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder();
+        assertEquals( Bookmarks.empty(), bookmarksHolder.getBookmarks() );
+
+        bookmarksHolder.setBookmarks( null );
+        assertEquals( Bookmarks.empty(), bookmarksHolder.getBookmarks() );
+
+        bookmarksHolder.setBookmarks( Bookmarks.empty() );
+        assertEquals( Bookmarks.empty(), bookmarksHolder.getBookmarks() );
+
+        Bookmarks bookmarks1 = Bookmarks.from( "neo4j:bookmark:v1:tx1" );
+        bookmarksHolder.setBookmarks( bookmarks1 );
+        assertEquals( bookmarks1, bookmarksHolder.getBookmarks() );
+
+        bookmarksHolder.setBookmarks( null );
+        assertEquals( bookmarks1, bookmarksHolder.getBookmarks() );
+
+        bookmarksHolder.setBookmarks( Bookmarks.empty() );
+        assertEquals( bookmarks1, bookmarksHolder.getBookmarks() );
+
+        Bookmarks bookmarks2 = Bookmarks.from( "neo4j:bookmark:v1:tx2" );
+        bookmarksHolder.setBookmarks( bookmarks2 );
+        assertEquals( bookmarks2, bookmarksHolder.getBookmarks() );
+
+        Bookmarks bookmarks3 = Bookmarks.from( "neo4j:bookmark:v1:tx42" );
+        bookmarksHolder.setBookmarks( bookmarks3 );
+        assertEquals( bookmarks3, bookmarksHolder.getBookmarks() );
+    }
+
+    @Test
+    void bookmarkCanBeSet()
+    {
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder();
+        Bookmarks bookmarks = Bookmarks.from( "neo4j:bookmark:v1:tx100" );
+
+        bookmarksHolder.setBookmarks( bookmarks );
+
+        assertEquals( bookmarks.maxBookmarkAsString(), bookmarksHolder.lastBookmark() );
+    }
+
+    @Test
+    void shouldNotOverwriteBookmarkWithNull()
+    {
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( Bookmarks.from( "Cat" ) );
+        assertEquals( "Cat", bookmarksHolder.lastBookmark() );
+        bookmarksHolder.setBookmarks( null );
+        assertEquals( "Cat", bookmarksHolder.lastBookmark() );
+    }
+
+    @Test
+    void shouldNotOverwriteBookmarkWithEmptyBookmark()
+    {
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( Bookmarks.from( "Cat" ) );
+        assertEquals( "Cat", bookmarksHolder.lastBookmark() );
+        bookmarksHolder.setBookmarks( Bookmarks.empty() );
+        assertEquals( "Cat", bookmarksHolder.lastBookmark() );
+    }
+
+    @Test
+    void setLastBookmark()
+    {
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder();
+
+        bookmarksHolder.setBookmarks( Bookmarks.from( "TheBookmark" ) );
+
+        assertEquals( "TheBookmark", bookmarksHolder.lastBookmark() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/LeakLoggingNetworkSessionTest.java
@@ -95,7 +95,7 @@ class LeakLoggingNetworkSessionTest
 
     private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
-        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ, new FixedRetryLogic( 0 ), logging );
+        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), READ, new FixedRetryLogic( 0 ), logging, new DefaultBookmarksHolder(  ) );
     }
 
     private static ConnectionProvider connectionProviderMock( boolean openConnection )

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/ExplicitTransactionTest.java
@@ -24,8 +24,8 @@ import org.mockito.InOrder;
 import java.util.function.Consumer;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.DefaultBookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
-import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.RunMessage;
 import org.neo4j.driver.internal.spi.Connection;

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/ExplicitTransactionTest.java
@@ -208,7 +208,7 @@ class ExplicitTransactionTest
     {
         RuntimeException error = new RuntimeException( "Wrong bookmark!" );
         Connection connection = connectionWithBegin( handler -> handler.onFailure( error ) );
-        ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
+        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarksHolder() );
 
         Bookmarks bookmarks = Bookmarks.from( "SomeBookmark" );
         TransactionConfig txConfig = TransactionConfig.empty();
@@ -223,7 +223,7 @@ class ExplicitTransactionTest
     void shouldNotReleaseConnectionWhenBeginSucceeds()
     {
         Connection connection = connectionWithBegin( handler -> handler.onSuccess( emptyMap() ) );
-        ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
+        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarksHolder() );
 
         Bookmarks bookmarks = Bookmarks.from( "SomeBookmark" );
         TransactionConfig txConfig = TransactionConfig.empty();
@@ -237,7 +237,7 @@ class ExplicitTransactionTest
     void shouldReleaseConnectionWhenTerminatedAndCommitted()
     {
         Connection connection = connectionMock();
-        ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
+        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarksHolder() );
 
         tx.markTerminated();
 
@@ -251,7 +251,7 @@ class ExplicitTransactionTest
     void shouldReleaseConnectionWhenTerminatedAndRolledBack()
     {
         Connection connection = connectionMock();
-        ExplicitTransaction tx = new ExplicitTransaction( connection, mock( NetworkSession.class ) );
+        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarksHolder() );
 
         tx.markTerminated();
         await( tx.rollbackAsync() );
@@ -266,12 +266,7 @@ class ExplicitTransactionTest
 
     private static ExplicitTransaction beginTx( Connection connection, Bookmarks initialBookmarks )
     {
-        return beginTx( connection, mock( NetworkSession.class ), initialBookmarks );
-    }
-
-    private static ExplicitTransaction beginTx( Connection connection, NetworkSession session, Bookmarks initialBookmarks )
-    {
-        ExplicitTransaction tx = new ExplicitTransaction( connection, session );
+        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarksHolder() );
         return await( tx.beginAsync( initialBookmarks, TransactionConfig.empty() ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/NetworkSessionTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.internal.DefaultBookmarksHolder;
 import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -34,8 +34,8 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.Bookmarks;
 import org.neo4j.driver.internal.BookmarksHolder;
+import org.neo4j.driver.internal.DefaultBookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
-import org.neo4j.driver.internal.SimpleBookmarksHolder;
 import org.neo4j.driver.internal.async.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
@@ -353,7 +353,7 @@ public class BoltProtocolV3Test
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( autoCommitTx )
         {
-            BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( initialBookmarks );
+            BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( initialBookmarks );
             cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, false ).asyncResult();
         }
         else
@@ -378,7 +378,7 @@ public class BoltProtocolV3Test
     protected void testSuccessfulRunInAutoCommitTxWithWaitingForResponse( Bookmarks bookmarks, TransactionConfig config, AccessMode mode ) throws Exception
     {
         Connection connection = connectionMock( mode, protocol );
-        BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( bookmarks );
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( bookmarks );
 
         CompletableFuture<InternalStatementResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, true ).asyncResult().toCompletableFuture();
@@ -398,7 +398,7 @@ public class BoltProtocolV3Test
     protected void testFailedRunInAutoCommitTxWithWaitingForResponse( Bookmarks bookmarks, TransactionConfig config, AccessMode mode ) throws Exception
     {
         Connection connection = connectionMock( mode, protocol );
-        BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( bookmarks );
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( bookmarks );
 
         CompletableFuture<InternalStatementResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, true ).asyncResult().toCompletableFuture();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.internal.Bookmarks;
 import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
-import org.neo4j.driver.internal.SimpleBookmarksHolder;
+import org.neo4j.driver.internal.DefaultBookmarksHolder;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
@@ -71,7 +71,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
     {
         // Given
         Connection connection = connectionMock( mode, protocol );
-        BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( bookmarks );
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( bookmarks );
 
         CompletableFuture<InternalStatementResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, true ).asyncResult().toCompletableFuture();
@@ -93,7 +93,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
     {
         // Given
         Connection connection = connectionMock( mode, protocol );
-        BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( bookmarks );
+        BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( bookmarks );
 
         CompletableFuture<InternalStatementResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, true ).asyncResult().toCompletableFuture();
@@ -147,7 +147,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( autoCommitTx )
         {
-            BookmarksHolder bookmarksHolder = new SimpleBookmarksHolder( initialBookmarks );
+            BookmarksHolder bookmarksHolder = new DefaultBookmarksHolder( initialBookmarks );
             cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarksHolder, config, false ).asyncResult();
         }
         else

--- a/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/ParametersTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import org.neo4j.driver.internal.DefaultBookmarksHolder;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.NetworkSession;
 import org.neo4j.driver.internal.retry.RetryLogic;
@@ -105,6 +106,6 @@ class ParametersTest
     {
         ConnectionProvider provider = mock( ConnectionProvider.class );
         RetryLogic retryLogic = mock( RetryLogic.class );
-        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING );
+        return new NetworkSession( provider, AccessMode.WRITE, retryLogic, DEV_NULL_LOGGING, new DefaultBookmarksHolder() );
     }
 }


### PR DESCRIPTION
I'd fancy using only the necessary contract not only because I need this for the embedded connector, but because it reduces the exposed methods on that level.