### PR TITLE
Add unresolved inital router address to list of resolved initial roter addresses

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -208,6 +208,7 @@ public class Rediscovery
         try
         {
             addresses = resolve( initialRouter );
+            addresses.add( initialRouter );
         }
         catch ( Throwable error )
         {


### PR DESCRIPTION
In scenarios with SNI, connecting to resolved addresses does not work.
The driver consistently fails to retrieve a routing table using the `initialRouter` because the address is explicitly resolved before making connection(s). It succeeds to get a routing table only because the same initial address is also put into the table as a router.

By adding the initial router address unresolved to the list of addresses to try, the driver should be able to work both with SNI and with multi-record DNS bootstrap addresses.
