### PR TITLE
Fixed the bug where original host name is lost in ssl handshake.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
@@ -137,7 +137,6 @@ public class BoltServerAddress implements ServerAddress
         return host;
     }
 
-    @Override
     public String originalHost()
     {
         return originalHost;

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NettyChannelInitializer.java
@@ -77,7 +77,7 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel>
     private SSLEngine createSslEngine()
     {
         SSLContext sslContext = securityPlan.sslContext();
-        SSLEngine sslEngine = sslContext.createSSLEngine( address.host(), address.port() );
+        SSLEngine sslEngine = sslContext.createSSLEngine( address.originalHost(), address.port() );
         sslEngine.setUseClientMode( true );
         if ( securityPlan.requiresHostnameVerification() )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/DnsResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/DnsResolver.java
@@ -47,7 +47,7 @@ public class DnsResolver implements ServerAddressResolver
         try
         {
             return Stream.of( InetAddress.getAllByName( initialRouter.host() ) )
-                    .map( address -> new BoltServerAddress( address.getHostAddress(), initialRouter.port() ) )
+                    .map( address -> new BoltServerAddress( initialRouter.host(), address.getHostAddress(), initialRouter.port() ) )
                     .collect( toSet() );
         }
         catch ( UnknownHostException e )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -31,6 +31,7 @@ public class ServerVersion
 {
     public static final String NEO4J_PRODUCT = "Neo4j";
 
+    public static final ServerVersion v4_0_0 = new ServerVersion( NEO4J_PRODUCT, 4, 0, 0 );
     public static final ServerVersion v3_5_0 = new ServerVersion( NEO4J_PRODUCT, 3, 5, 0 );
     public static final ServerVersion v3_4_0 = new ServerVersion( NEO4J_PRODUCT, 3, 4, 0 );
     public static final ServerVersion v3_2_0 = new ServerVersion( NEO4J_PRODUCT, 3, 2, 0 );

--- a/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
@@ -34,6 +34,13 @@ public interface ServerAddress
     String host();
 
     /**
+     * Returns the original host name of this {@link ServerAddress}.
+     * This value might different from {@link #host()} when the host is a resolved IP address.
+     * @return the original host name, never {@code null}.
+     */
+    String originalHost();
+
+    /**
      * Retrieve the port portion of this {@link ServerAddress}.
      *
      * @return the port, always in range [0, 65535].
@@ -49,6 +56,6 @@ public interface ServerAddress
      */
     static ServerAddress of( String host, int port )
     {
-        return new BoltServerAddress( host, port );
+        return new BoltServerAddress( host, host, port );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/net/ServerAddress.java
@@ -34,13 +34,6 @@ public interface ServerAddress
     String host();
 
     /**
-     * Returns the original host name of this {@link ServerAddress}.
-     * This value might different from {@link #host()} when the host is a resolved IP address.
-     * @return the original host name, never {@code null}.
-     */
-    String originalHost();
-
-    /**
      * Retrieve the port portion of this {@link ServerAddress}.
      *
      * @return the port, always in range [0, 65535].

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NettyChannelInitializerTest.java
@@ -114,7 +114,7 @@ class NettyChannelInitializerTest
     @Test
     void shouldIncludeSniHostName() throws Exception
     {
-        BoltServerAddress address = new BoltServerAddress( "database.neo4j.com", 8989 );
+        BoltServerAddress address = new BoltServerAddress( "database.neo4j.com", "10.0.0.18", 8989 );
         NettyChannelInitializer initializer = new NettyChannelInitializer( address, trustAllCertificates(), 10000, Clock.SYSTEM, DEV_NULL_LOGGING );
 
         initializer.initChannel( channel );
@@ -125,7 +125,7 @@ class NettyChannelInitializerTest
         List<SNIServerName> sniServerNames = sslParameters.getServerNames();
         assertThat( sniServerNames, hasSize( 1 ) );
         assertThat( sniServerNames.get( 0 ), instanceOf( SNIHostName.class ) );
-        assertThat( ((SNIHostName) sniServerNames.get( 0 )).getAsciiName(), equalTo( address.host() ) );
+        assertThat( ((SNIHostName) sniServerNames.get( 0 )).getAsciiName(), equalTo( address.originalHost() ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
@@ -23,6 +23,7 @@ import static org.neo4j.driver.internal.util.ServerVersion.v3_1_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_2_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_5_0;
+import static org.neo4j.driver.internal.util.ServerVersion.v4_0_0;
 
 public enum Neo4jFeature
 {
@@ -36,7 +37,8 @@ public enum Neo4jFeature
     STATEMENT_RESULT_TIMINGS( v3_1_0 ),
     LIST_QUERIES_PROCEDURE( v3_1_0 ),
     CONNECTOR_LISTEN_ADDRESS_CONFIGURATION( v3_1_0 ),
-    BOLT_V3( v3_5_0 );
+    BOLT_V3( v3_5_0 ),
+    BOLT_V4( v4_0_0 );
 
     private final ServerVersion availableFromVersion;
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.ChannelTrackingDriverFactory;
+import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.FailingConnectionDriverFactory;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.internal.util.ServerVersion;
@@ -86,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.Matchers.connectionAcquisitionTimeoutError;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
 import static org.neo4j.driver.v1.Values.parameters;
 import static org.neo4j.driver.v1.util.DaemonThreadFactory.daemon;
 import static org.neo4j.driver.v1.util.TestUtil.await;
@@ -137,6 +139,7 @@ public class CausalClusteringIT implements NestedQueries
     }
 
     @Test
+    @DisabledOnNeo4jWith( BOLT_V4 )
     void shouldExecuteReadAndWritesWhenRouterIsDiscovered() throws Exception
     {
         Cluster cluster = clusterRule.getCluster();
@@ -157,6 +160,7 @@ public class CausalClusteringIT implements NestedQueries
     }
 
     @Test
+    @DisabledOnNeo4jWith( BOLT_V4 )
     void sessionCreationShouldFailIfCallingDiscoveryProcedureOnEdgeServer()
     {
         Cluster cluster = clusterRule.getCluster();

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/ConnectionHandlingIT.java
@@ -189,7 +189,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        assertThrows( ClientException.class, result::hasNext );
+        assertThrows( ClientException.class, result::consume );
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
         assertSame( connection1, connection2 );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/Neo4jRunner.java
@@ -86,7 +86,7 @@ public class Neo4jRunner
 
     public BoltServerAddress boltAddress()
     {
-        return new BoltServerAddress( "localhost", boltPort() );
+        return new BoltServerAddress( boltUri() );
     }
 
     public URI boltUri()


### PR DESCRIPTION
The driver resolves host address to IP addresses. In the scenarios with SNI, the original host name is required to be part of ssl handshake to indicate the server to connect to.
Fixed the bug where driver uses IP address rather than the original host name in ssl handshake.