### PR TITLE
Pass AccessMode in BEGIN and RUN messages

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DirectConnectionProvider.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal;
 
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.internal.async.AccessModeConnection;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -45,7 +46,7 @@ public class DirectConnectionProvider implements ConnectionProvider
     @Override
     public CompletionStage<Connection> acquireConnection( AccessMode mode )
     {
-        return connectionPool.acquire( address );
+        return connectionPool.acquire( address ).thenApply( connection -> new AccessModeConnection( connection, mode ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/AccessModeConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/AccessModeConnection.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.messaging.BoltProtocol;
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.AccessMode;
+
+public class AccessModeConnection implements Connection
+{
+    private final Connection delegate;
+    private final AccessMode mode;
+
+    public AccessModeConnection( Connection delegate, AccessMode mode )
+    {
+        this.delegate = delegate;
+        this.mode = mode;
+    }
+
+    public Connection connection()
+    {
+        return delegate;
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public void enableAutoRead()
+    {
+        delegate.enableAutoRead();
+    }
+
+    @Override
+    public void disableAutoRead()
+    {
+        delegate.disableAutoRead();
+    }
+
+    @Override
+    public void write( Message message, ResponseHandler handler )
+    {
+        delegate.write( message, handler );
+    }
+
+    @Override
+    public void write( Message message1, ResponseHandler handler1, Message message2, ResponseHandler handler2 )
+    {
+        delegate.write( message1, handler1, message2, handler2 );
+    }
+
+    @Override
+    public void writeAndFlush( Message message, ResponseHandler handler )
+    {
+        delegate.writeAndFlush( message, handler );
+    }
+
+    @Override
+    public void writeAndFlush( Message message1, ResponseHandler handler1, Message message2, ResponseHandler handler2 )
+    {
+        delegate.writeAndFlush( message1, handler1, message2, handler2 );
+    }
+
+    @Override
+    public CompletionStage<Void> reset()
+    {
+        return delegate.reset();
+    }
+
+    @Override
+    public CompletionStage<Void> release()
+    {
+        return delegate.release();
+    }
+
+    @Override
+    public void terminateAndRelease( String reason )
+    {
+        delegate.terminateAndRelease( reason );
+    }
+
+    @Override
+    public BoltServerAddress serverAddress()
+    {
+        return delegate.serverAddress();
+    }
+
+    @Override
+    public ServerVersion serverVersion()
+    {
+        return delegate.serverVersion();
+    }
+
+    @Override
+    public BoltProtocol protocol()
+    {
+        return delegate.protocol();
+    }
+
+    @Override
+    public AccessMode mode()
+    {
+        return mode;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.async.AccessModeConnection;
 import org.neo4j.driver.internal.async.RoutingConnection;
 import org.neo4j.driver.internal.cluster.AddressSet;
 import org.neo4j.driver.internal.cluster.ClusterComposition;
@@ -95,7 +96,8 @@ public class LoadBalancer implements ConnectionProvider, RoutingErrorHandler
     {
         return freshRoutingTable( mode )
                 .thenCompose( routingTable -> acquire( mode, routingTable ) )
-                .thenApply( connection -> new RoutingConnection( connection, mode, this ) );
+                .thenApply( connection -> new RoutingConnection( connection, mode, this ) )
+                .thenApply( connection -> new AccessModeConnection( connection, mode ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 
@@ -30,14 +31,14 @@ public class BeginMessage extends TransactionStartingMessage
 {
     public static final byte SIGNATURE = 0x11;
 
-    public BeginMessage( Bookmarks bookmarks, TransactionConfig config )
+    public BeginMessage( Bookmarks bookmarks, TransactionConfig config, AccessMode mode )
     {
-        this( bookmarks, config.timeout(), config.metadata() );
+        this( bookmarks, config.timeout(), config.metadata(), mode );
     }
 
-    public BeginMessage( Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata )
+    public BeginMessage( Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata, AccessMode mode )
     {
-        super( bookmarks, txTimeout, txMetadata );
+        super( bookmarks, txTimeout, txMetadata, mode );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.TransactionConfig;
 import org.neo4j.driver.v1.Value;
 
@@ -33,14 +34,15 @@ public class RunWithMetadataMessage extends TransactionStartingMessage
     private final String statement;
     private final Map<String,Value> parameters;
 
-    public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, TransactionConfig config )
+    public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, TransactionConfig config, AccessMode mode )
     {
-        this( statement, parameters, bookmarks, config.timeout(), config.metadata() );
+        this( statement, parameters, bookmarks, config.timeout(), config.metadata(), mode );
     }
 
-    public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata )
+    public RunWithMetadataMessage( String statement, Map<String,Value> parameters, Bookmarks bookmarks, Duration txTimeout, Map<String,Value> txMetadata,
+            AccessMode mode )
     {
-        super( bookmarks, txTimeout, txMetadata );
+        super( bookmarks, txTimeout, txMetadata, mode );
         this.statement = statement;
         this.parameters = parameters;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -96,7 +96,7 @@ public class BoltProtocolV3 implements BoltProtocol
     @Override
     public CompletionStage<Void> beginTransaction( Connection connection, Bookmarks bookmarks, TransactionConfig config )
     {
-        BeginMessage beginMessage = new BeginMessage( bookmarks, config );
+        BeginMessage beginMessage = new BeginMessage( bookmarks, config, connection.mode() );
 
         if ( bookmarks.isEmpty() )
         {
@@ -148,7 +148,7 @@ public class BoltProtocolV3 implements BoltProtocol
         Map<String,Value> params = statement.parameters().asMap( ofValue() );
 
         CompletableFuture<Void> runCompletedFuture = new CompletableFuture<>();
-        Message runMessage = new RunWithMetadataMessage( query, params, bookmarksHolder.getBookmarks(), config );
+        Message runMessage = new RunWithMetadataMessage( query, params, bookmarksHolder.getBookmarks(), config, connection.mode() );
         RunResponseHandler runHandler = new RunResponseHandler( runCompletedFuture, METADATA_EXTRACTOR );
         PullAllResponseHandler pullAllHandler = newPullAllHandler( statement, runHandler, connection, bookmarksHolder, tx );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -24,6 +24,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.AccessMode;
 
 public interface Connection
 {
@@ -52,4 +53,9 @@ public interface Connection
     ServerVersion serverVersion();
 
     BoltProtocol protocol();
+
+    default AccessMode mode()
+    {
+        return AccessMode.WRITE;
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -175,7 +175,7 @@ class DirectDriverBoltKitTest
                 .build();
 
         try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", config );
-                Session session = driver.session( AccessMode.READ ) )
+                Session session = driver.session( AccessMode.WRITE ) )
         {
             List<String> names = session.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( 0 ).asString() );
             assertEquals( asList( "Foo", "Bar" ), names );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AccessModeConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AccessModeConnectionTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.messaging.BoltProtocol;
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.net.ServerAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.v1.AccessMode.READ;
+
+class AccessModeConnectionTest
+{
+
+    @ParameterizedTest
+    @ValueSource( strings = {"true", "false"} )
+    void shouldDelegateIsOpen( String open )
+    {
+        Connection mockConnection = mock( Connection.class );
+        when( mockConnection.isOpen() ).thenReturn( Boolean.valueOf( open ) );
+
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        assertEquals( Boolean.valueOf( open ).booleanValue(), connection.isOpen() );
+        verify( mockConnection ).isOpen();
+    }
+
+    @Test
+    void shouldDelegateEnableAutoRead()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        connection.enableAutoRead();
+
+        verify( mockConnection ).enableAutoRead();
+    }
+
+    @Test
+    void shouldDelegateDisableAutoRead()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        connection.disableAutoRead();
+
+        verify( mockConnection ).disableAutoRead();
+    }
+
+    @Test
+    void shouldDelegateWrite()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        Message message = mock( Message.class );
+        ResponseHandler handler = mock( ResponseHandler.class );
+
+        connection.write( message, handler );
+
+        verify( mockConnection ).write( message, handler );
+    }
+
+    @Test
+    void shouldDelegateWriteTwoMessages()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        Message message1 = mock( Message.class );
+        ResponseHandler handler1 = mock( ResponseHandler.class );
+        Message message2 = mock( Message.class );
+        ResponseHandler handler2 = mock( ResponseHandler.class );
+
+        connection.write( message1, handler1, message2, handler2 );
+
+        verify( mockConnection ).write( message1, handler1, message2, handler2 );
+    }
+
+    @Test
+    void shouldDelegateWriteAndFlush()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        Message message = mock( Message.class );
+        ResponseHandler handler = mock( ResponseHandler.class );
+
+        connection.writeAndFlush( message, handler );
+
+        verify( mockConnection ).writeAndFlush( message, handler );
+    }
+
+    @Test
+    void shouldDelegateWriteAndFlush1()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        Message message1 = mock( Message.class );
+        ResponseHandler handler1 = mock( ResponseHandler.class );
+        Message message2 = mock( Message.class );
+        ResponseHandler handler2 = mock( ResponseHandler.class );
+
+        connection.writeAndFlush( message1, handler1, message2, handler2 );
+
+        verify( mockConnection ).writeAndFlush( message1, handler1, message2, handler2 );
+    }
+
+    @Test
+    void shouldDelegateReset()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        connection.reset();
+
+        verify( mockConnection ).reset();
+    }
+
+    @Test
+    void shouldDelegateRelease()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        connection.release();
+
+        verify( mockConnection ).release();
+    }
+
+    @Test
+    void shouldDelegateTerminateAndRelease()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        connection.terminateAndRelease( "a reason" );
+
+        verify( mockConnection ).terminateAndRelease( "a reason" );
+    }
+
+    @Test
+    void shouldDelegateServerAddress()
+    {
+        BoltServerAddress address = BoltServerAddress.from( ServerAddress.of( "localhost", 9999 ) );
+        Connection mockConnection = mock( Connection.class );
+        when( mockConnection.serverAddress() ).thenReturn( address );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        assertSame( address, connection.serverAddress() );
+        verify( mockConnection ).serverAddress();
+    }
+
+    @Test
+    void shouldDelegateServerVersion()
+    {
+        ServerVersion version = ServerVersion.version( "Neo4j/3.5.3" );
+        Connection mockConnection = mock( Connection.class );
+        when( mockConnection.serverVersion() ).thenReturn( version );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        assertSame( version, connection.serverVersion() );
+        verify( mockConnection ).serverVersion();
+    }
+
+    @Test
+    void shouldDelegateProtocol()
+    {
+        BoltProtocol protocol = mock( BoltProtocol.class );
+        Connection mockConnection = mock( Connection.class );
+        when( mockConnection.protocol() ).thenReturn( protocol );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        assertSame( protocol, connection.protocol() );
+        verify( mockConnection ).protocol();
+    }
+
+    @ParameterizedTest
+    @EnumSource( AccessMode.class )
+    void shouldReturnModeFromConstructor( AccessMode mode )
+    {
+        AccessModeConnection connection = new AccessModeConnection( mock( Connection.class ), mode );
+
+        assertEquals( mode, connection.mode() );
+    }
+
+    @Test
+    void shouldReturnConnection()
+    {
+        Connection mockConnection = mock( Connection.class );
+        AccessModeConnection connection = new AccessModeConnection( mockConnection, READ );
+
+        assertSame( mockConnection, connection.connection() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/BeginMessageTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/BeginMessageTest.java
@@ -18,23 +18,27 @@
  */
 package org.neo4j.driver.internal.messaging.request;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.driver.internal.Bookmarks;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Value;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.neo4j.driver.v1.AccessMode.READ;
 import static org.neo4j.driver.v1.Values.value;
 
 class BeginMessageTest
 {
-    @Test
-    void shouldHaveCorrectMetadata()
+    @ParameterizedTest
+    @EnumSource( AccessMode.class )
+    void shouldHaveCorrectMetadata( AccessMode mode )
     {
         Bookmarks bookmarks = Bookmarks.from( asList( "neo4j:bookmark:v1:tx42", "neo4j:bookmark:v1:tx4242", "neo4j:bookmark:v1:tx424242" ) );
 
@@ -45,12 +49,16 @@ class BeginMessageTest
 
         Duration txTimeout = Duration.ofSeconds( 13 );
 
-        BeginMessage message = new BeginMessage( bookmarks, txTimeout, txMetadata );
+        BeginMessage message = new BeginMessage( bookmarks, txTimeout, txMetadata, mode );
 
         Map<String,Value> expectedMetadata = new HashMap<>();
         expectedMetadata.put( "bookmarks", value( bookmarks.values() ) );
         expectedMetadata.put( "tx_timeout", value( 13_000 ) );
         expectedMetadata.put( "tx_metadata", value( txMetadata ) );
+        if ( mode == READ )
+        {
+            expectedMetadata.put( "mode", value( "r" ) );
+        }
 
         assertEquals( expectedMetadata, message.metadata() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.messaging.request.RunMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
 import org.neo4j.driver.internal.packstream.PackOutput;
 import org.neo4j.driver.internal.security.InternalAuthToken;
+import org.neo4j.driver.v1.AccessMode;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -42,6 +43,7 @@ import static org.neo4j.driver.internal.messaging.request.GoodbyeMessage.GOODBYE
 import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_ALL;
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
+import static org.neo4j.driver.v1.AccessMode.*;
 import static org.neo4j.driver.v1.AuthTokens.basic;
 import static org.neo4j.driver.v1.Values.point;
 import static org.neo4j.driver.v1.Values.value;
@@ -61,20 +63,27 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
                 // Bolt V3 messages
                 new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap() ),
                 GOODBYE,
-                new BeginMessage( Bookmarks.from( "neo4j:bookmark:v1:tx123" ), Duration.ofSeconds( 5 ), singletonMap( "key", value( 42 ) ) ),
+                new BeginMessage( Bookmarks.from( "neo4j:bookmark:v1:tx123" ), Duration.ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ ),
+                new BeginMessage( Bookmarks.from( "neo4j:bookmark:v1:tx123" ), Duration.ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE ),
                 COMMIT,
                 ROLLBACK,
                 new RunWithMetadataMessage( "RETURN 1", emptyMap(), Bookmarks.from( "neo4j:bookmark:v1:tx1" ), Duration.ofSeconds( 5 ),
-                        singletonMap( "key", value( 42 ) ) ),
+                        singletonMap( "key", value( 42 ) ), READ ),
+                new RunWithMetadataMessage( "RETURN 1", emptyMap(), Bookmarks.from( "neo4j:bookmark:v1:tx1" ), Duration.ofSeconds( 5 ),
+                        singletonMap( "key", value( 42 ) ), WRITE ),
                 PULL_ALL,
                 DISCARD_ALL,
                 RESET,
 
                 // Bolt V3 messages with struct values
                 new RunWithMetadataMessage( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ), Bookmarks.empty(),
-                        Duration.ofSeconds( 1 ), emptyMap() ),
+                        Duration.ofSeconds( 1 ), emptyMap(), READ ),
+                new RunWithMetadataMessage( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ), Bookmarks.empty(),
+                        Duration.ofSeconds( 1 ), emptyMap(), WRITE ),
                 new RunWithMetadataMessage( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) ), Bookmarks.empty(),
-                        Duration.ofSeconds( 1 ), emptyMap() )
+                        Duration.ofSeconds( 1 ), emptyMap(), READ ),
+                new RunWithMetadataMessage( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) ), Bookmarks.empty(),
+                        Duration.ofSeconds( 1 ), emptyMap(), WRITE )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/TestUtil.java
@@ -22,8 +22,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.PlatformDependent;
 import org.mockito.ArgumentMatcher;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -49,6 +47,7 @@ import org.neo4j.driver.internal.messaging.v2.BoltProtocolV2;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
@@ -68,6 +67,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.util.Neo4jFeature.LIST_QUERIES_PROCEDURE;
 import static org.neo4j.driver.internal.util.ServerVersion.version;
+import static org.neo4j.driver.v1.AccessMode.*;
 
 public final class TestUtil
 {
@@ -194,10 +194,16 @@ public final class TestUtil
 
     public static Connection connectionMock()
     {
+        return connectionMock( WRITE );
+    }
+
+    public static Connection connectionMock( AccessMode mode )
+    {
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( ServerVersion.vInDev );
         when( connection.protocol() ).thenReturn( DEFAULT_TEST_PROTOCOL );
+        when( connection.mode() ).thenReturn( mode );
         setupSuccessfulPullAll( connection, "COMMIT" );
         setupSuccessfulPullAll( connection, "ROLLBACK" );
         setupSuccessfulPullAll( connection, "BEGIN" );

--- a/driver/src/test/resources/acquire_endpoints_v3.script
+++ b/driver/src/test/resources/acquire_endpoints_v3.script
@@ -1,0 +1,10 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}

--- a/driver/src/test/resources/hello_run_exit_read.script
+++ b/driver/src/test/resources/hello_run_exit_read.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "MATCH (n) RETURN n.name" {} {"mode": "r"}
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {}
+S: <EXIT>

--- a/driver/src/test/resources/read_server_v3_read.script
+++ b/driver/src/test/resources/read_server_v3_read.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "MATCH (n) RETURN n.name" {} { "mode": "r" }
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}

--- a/driver/src/test/resources/read_server_v3_read_tx.script
+++ b/driver/src/test/resources/read_server_v3_read_tx.script
@@ -1,0 +1,16 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN { "mode": "r" }
+S: SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {} { "mode": "r" }
+   PULL_ALL
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   RECORD ["Tina"]
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS { "bookmark": "ABookmark" }

--- a/driver/src/test/resources/write_server_v3_write.script
+++ b/driver/src/test/resources/write_server_v3_write.script
@@ -1,0 +1,9 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}

--- a/driver/src/test/resources/write_server_v3_write_tx.script
+++ b/driver/src/test/resources/write_server_v3_write_tx.script
@@ -1,0 +1,13 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN {}
+S: SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS { "bookmark": "ABookmark" }


### PR DESCRIPTION
This PR makes the `AccessMode` set on client side available on messages BEGIN and RUN in Bolt V3.

No `mode` parameter in statement metadata means that the access mode set by client is `WRITE`, whereas a value of `r` means it is set as `READ`.