### PR TITLE
Not retry transaction on connection errors when committing a write transaction

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/AbstractCommitTxResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/AbstractCommitTxResponseHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.handlers;
+
+import org.neo4j.driver.internal.spi.ResponseHandler;
+
+interface AbstractCommitTxResponseHandler extends ResponseHandler
+{
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/CommitTxNoOpResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/CommitTxNoOpResponseHandler.java
@@ -18,48 +18,26 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.driver.internal.Bookmarks;
 import org.neo4j.driver.v1.Value;
 
-import static java.util.Objects.requireNonNull;
-
-public class CommitTxResponseHandler implements AbstractCommitTxResponseHandler
+public class CommitTxNoOpResponseHandler implements AbstractCommitTxResponseHandler
 {
-    private final CompletableFuture<Bookmarks> commitFuture;
-
-    public CommitTxResponseHandler( CompletableFuture<Bookmarks> commitFuture )
-    {
-        this.commitFuture = requireNonNull( commitFuture );
-    }
+    public static final CommitTxNoOpResponseHandler INSTANCE = new CommitTxNoOpResponseHandler();
 
     @Override
     public void onSuccess( Map<String,Value> metadata )
     {
-        Value bookmarkValue = metadata.get( "bookmark" );
-        if ( bookmarkValue == null )
-        {
-            commitFuture.complete( null );
-        }
-        else
-        {
-            commitFuture.complete( Bookmarks.from( bookmarkValue.asString() ) );
-        }
     }
 
     @Override
     public void onFailure( Throwable error )
     {
-        commitFuture.completeExceptionally( error );
     }
 
     @Override
     public void onRecord( Value[] fields )
     {
-        throw new UnsupportedOperationException(
-                "Transaction commit is not expected to receive records: " + Arrays.toString( fields ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.ConnectionBrokenAtCommitException;
+import org.neo4j.driver.v1.exceptions.IncompleteCommitException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.exceptions.TransientException;
@@ -110,7 +110,7 @@ public class RoutingResponseHandler implements ResponseHandler
         if ( accessMode == AccessMode.WRITE && delegate instanceof AbstractCommitTxResponseHandler )
         {
             // cannot be retried
-            return new ConnectionBrokenAtCommitException( format( "Connection with server at %s is broken at commit. The commit status is unknown. " +
+            return new IncompleteCommitException( format( "Connection with server at %s is broken at commit. The commit status is unknown. " +
                             "Before retrying your transaction, you might want to double check if the previous transaction has been successfully committed by database or not.",
                     address ), e );
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
@@ -28,6 +28,7 @@ import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.driver.v1.exceptions.ConnectionBrokenAtCommitException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.exceptions.TransientException;
@@ -106,6 +107,14 @@ public class RoutingResponseHandler implements ResponseHandler
     private Throwable handledServiceUnavailableException( ServiceUnavailableException e )
     {
         errorHandler.onConnectionFailure( address );
+        if ( accessMode == AccessMode.WRITE && delegate instanceof AbstractCommitTxResponseHandler )
+        {
+            // cannot be retried
+            return new ConnectionBrokenAtCommitException( format( "Connection with server at %s is broken at commit. The commit status is unknown. " +
+                            "Before retrying your transaction, you might want to double check if the previous transaction has been successfully committed by database or not.",
+                    address ), e );
+        }
+        // can be retried
         return new SessionExpiredException( format( "Server at %s is no longer available", address ), e );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.internal.BookmarksHolder;
 import org.neo4j.driver.internal.ExplicitTransaction;
 import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
+import org.neo4j.driver.internal.handlers.CommitTxNoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
 import org.neo4j.driver.internal.handlers.InitResponseHandler;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
@@ -128,7 +129,7 @@ public class BoltProtocolV1 implements BoltProtocol
 
         ResponseHandler pullAllHandler = new CommitTxResponseHandler( commitFuture );
         connection.writeAndFlush(
-                COMMIT_MESSAGE, NoOpResponseHandler.INSTANCE,
+                COMMIT_MESSAGE, CommitTxNoOpResponseHandler.INSTANCE,
                 PullAllMessage.PULL_ALL, pullAllHandler );
 
         return commitFuture;

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/ConnectionBrokenAtCommitException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/ConnectionBrokenAtCommitException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.v1.exceptions;
+
+public class ConnectionBrokenAtCommitException extends Neo4jException
+{
+    public ConnectionBrokenAtCommitException( String message, Throwable e )
+    {
+        super( message, e );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/v1/exceptions/IncompleteCommitException.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/exceptions/IncompleteCommitException.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.driver.v1.exceptions;
 
-public class ConnectionBrokenAtCommitException extends Neo4jException
+public class IncompleteCommitException extends Neo4jException
 {
-    public ConnectionBrokenAtCommitException( String message, Throwable e )
+    public IncompleteCommitException( String message, Throwable e )
     {
         super( message, e );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/RoutingDriverBoltKitTest.java
@@ -46,7 +46,7 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.TransactionWork;
-import org.neo4j.driver.v1.exceptions.ConnectionBrokenAtCommitException;
+import org.neo4j.driver.v1.exceptions.IncompleteCommitException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.net.ServerAddress;
@@ -778,7 +778,7 @@ class RoutingDriverBoltKitTest
                 Session session = driver.session() )
         {
             AtomicInteger invocations = new AtomicInteger();
-            assertThrows( ConnectionBrokenAtCommitException.class,
+            assertThrows( IncompleteCommitException.class,
                     () -> session.writeTransaction( queryWork( "CREATE (n {name:'Bob'})", invocations ) ) );
 
             assertEquals( 1, invocations.get() );
@@ -803,7 +803,7 @@ class RoutingDriverBoltKitTest
                 Session session = driver.session() )
         {
             AtomicInteger invocations = new AtomicInteger();
-            assertThrows( ConnectionBrokenAtCommitException.class,
+            assertThrows( IncompleteCommitException.class,
                     () -> session.writeTransaction( queryWork( "CREATE (n {name:'Bob'})", invocations ) ) );
 
             assertEquals( 1, invocations.get() );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/RoutingResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/RoutingResponseHandlerTest.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.internal.RoutingErrorHandler;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.driver.v1.exceptions.ConnectionBrokenAtCommitException;
+import org.neo4j.driver.v1.exceptions.IncompleteCommitException;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.exceptions.TransientException;
@@ -75,7 +75,7 @@ class RoutingResponseHandlerTest
         Throwable handledError = handle( mock( AbstractCommitTxResponseHandler.class ), error, errorHandler, AccessMode.WRITE );
 
         verify( errorHandler ).onConnectionFailure( LOCAL_DEFAULT );
-        assertThat( handledError, instanceOf( ConnectionBrokenAtCommitException.class ) );
+        assertThat( handledError, instanceOf( IncompleteCommitException.class ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.internal.InternalStatementResultCursor;
 import org.neo4j.driver.internal.async.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
+import org.neo4j.driver.internal.handlers.CommitTxNoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
@@ -192,7 +193,7 @@ public class BoltProtocolV1Test
         CompletionStage<Bookmarks> stage = protocol.commitTransaction( connection );
 
         verify( connection ).writeAndFlush(
-                eq( new RunMessage( "COMMIT" ) ), eq( NoOpResponseHandler.INSTANCE ),
+                eq( new RunMessage( "COMMIT" ) ), eq( CommitTxNoOpResponseHandler.INSTANCE ),
                 eq( PullAllMessage.PULL_ALL ), any( CommitTxResponseHandler.class ) );
 
         assertEquals( Bookmarks.from( bookmarkString ), await( stage ) );

--- a/driver/src/test/resources/dead_write_server_at_commit.script
+++ b/driver/src/test/resources/dead_write_server_at_commit.script
@@ -1,0 +1,13 @@
+!: AUTO RESET
+!: AUTO INIT
+
+C: RUN "BEGIN" {}
+   PULL_ALL
+   RUN "CREATE (n {name:'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+   SUCCESS {"fields": []}
+   SUCCESS {}
+C: RUN "COMMIT" {}
+S: <EXIT>

--- a/driver/src/test/resources/dead_write_server_at_commit_v3.script
+++ b/driver/src/test/resources/dead_write_server_at_commit_v3.script
@@ -1,0 +1,14 @@
+!: BOLT 3
+!: AUTO RESET
+!: AUTO HELLO
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN {}
+   RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {"fields": []}
+   SUCCESS {}
+C: COMMIT
+S: <EXIT>


### PR DESCRIPTION
When committing a transaction, if we get a reply from the server, we know the status of the transaction (success or fail).
However if we fail to get a reply from the server due to database crash or network crash, then we are uncertain about the status of this transaction. Because it is possible that this tx has been committed by server, but it just has failed to send us the reply via wire.
It is okay if this transaction is a read only transaction, however if this is a write transaction, if we retry automatically, we might commit the same data twice.

This PR marks the connection error happened at committing for write tx differently (ServiceUnavailable -> `IncompleteCommitException`) from normal retriable connection errors (ServiceUnavailable -> `SessionExpired`). As a result, on receiving of this error, the tx will not be retried.