### PR TITLE
Suppress subsequent connection errors into existing error

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -31,7 +31,6 @@ import org.neo4j.driver.internal.async.ChannelConnector;
 import org.neo4j.driver.internal.async.ChannelConnectorImpl;
 import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
 import org.neo4j.driver.internal.async.pool.PoolSettings;
-import org.neo4j.driver.internal.cluster.IdentityResolver;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.cluster.loadbalancing.LeastConnectedLoadBalancingStrategy;
@@ -66,6 +65,7 @@ import static org.neo4j.driver.internal.cluster.IdentityResolver.IDENTITY_RESOLV
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 import static org.neo4j.driver.internal.metrics.spi.Metrics.isMetricsEnabled;
 import static org.neo4j.driver.internal.security.SecurityPlan.insecure;
+import static org.neo4j.driver.internal.util.ErrorUtil.addSuppressed;
 
 public class DriverFactory
 {
@@ -371,10 +371,7 @@ public class DriverFactory
         }
         catch ( Throwable closeError )
         {
-            if ( mainError != closeError )
-            {
-                mainError.addSuppressed( closeError );
-            }
+            addSuppressed( mainError, closeError );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/NetworkSession.java
@@ -43,6 +43,7 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.ErrorUtil.addSuppressed;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
@@ -403,7 +404,7 @@ public class NetworkSession extends AbstractStatementRunner implements Session, 
             {
                 if ( rollbackError != null )
                 {
-                    error.addSuppressed( rollbackError );
+                    addSuppressed( error, rollbackError );
                 }
                 resultFuture.completeExceptionally( error );
             } );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
@@ -88,7 +88,7 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
         else
         {
             failed = true;
-            log.error( "Fatal error occurred in the pipeline", error );
+            log.warn( "Fatal error occurred in the pipeline", error );
             fail( ctx, error );
         }
     }
@@ -96,7 +96,7 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
     private void fail( ChannelHandlerContext ctx, Throwable error )
     {
         Throwable cause = transformError( error );
-        messageDispatcher.handleFatalError( cause );
+        messageDispatcher.handleChannelError( cause );
         log.debug( "Closing channel because of a failure '%s'", error );
         ctx.close();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -37,6 +37,7 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
+import static org.neo4j.driver.internal.util.ErrorUtil.addSuppressed;
 
 public class InboundMessageDispatcher implements ResponseMessageHandler
 {
@@ -146,7 +147,7 @@ public class InboundMessageDispatcher implements ResponseMessageHandler
         if ( currentError != null )
         {
             // we already have an error, this new error probably is caused by the existing one, thus we chain the new error on this current error
-            currentError.addSuppressed( error );
+            addSuppressed( currentError, error );
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcher.java
@@ -141,9 +141,17 @@ public class InboundMessageDispatcher implements ResponseMessageHandler
         handler.onFailure( error );
     }
 
-    public void handleFatalError( Throwable error )
+    public void handleChannelError( Throwable error )
     {
-        currentError = error;
+        if ( currentError != null )
+        {
+            // we already have an error, this new error probably is caused by the existing one, thus we chain the new error on this current error
+            currentError.addSuppressed( error );
+        }
+        else
+        {
+            currentError = error;
+        }
         fatalErrorOccurred = true;
 
         while ( !handlers.isEmpty() )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
@@ -62,7 +62,7 @@ public class NettyChannelTracker implements ChannelPoolHandler
     @Override
     public void channelReleased( Channel channel )
     {
-        log.debug( "Channel [%s] released back to the pool", channel.id() );
+        log.debug( "Channel [0x%s] released back to the pool", channel.id() );
         decrementInUse( channel );
         incrementIdle( channel );
         channel.closeFuture().addListener( closeListener );

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -127,6 +127,14 @@ public final class ErrorUtil
         return parts[1];
     }
 
+    public static void addSuppressed( Throwable mainError, Throwable error )
+    {
+        if ( mainError != error )
+        {
+            mainError.addSuppressed( error );
+        }
+    }
+
     /**
      * Exception which is merely a holder of an async stacktrace, which is not the primary stacktrace users are interested in.
      * Used for blocking API calls that block on async API calls.

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -29,6 +29,7 @@ import java.util.function.BiFunction;
 import org.neo4j.driver.internal.async.EventLoopGroupFactory;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.neo4j.driver.internal.util.ErrorUtil.addSuppressed;
 
 public final class Futures
 {
@@ -184,10 +185,7 @@ public final class Futures
         {
             Throwable cause1 = completionExceptionCause( error1 );
             Throwable cause2 = completionExceptionCause( error2 );
-            if ( cause1 != cause2 )
-            {
-                cause1.addSuppressed( cause2 );
-            }
+            addSuppressed( cause1, cause2 );
             return asCompletionException( cause1 );
         }
         else if ( error1 != null )

--- a/driver/src/test/resources/database_shutdown.script
+++ b/driver/src/test/resources/database_shutdown.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RESET
+S: SUCCESS {}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx0"]}
+S: SUCCESS {}
+C: RUN "RETURN 1" {} {}
+   PULL_ALL
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database shut down."}
+S: <EXIT>

--- a/driver/src/test/resources/database_shutdown_at_commit.script
+++ b/driver/src/test/resources/database_shutdown_at_commit.script
@@ -1,0 +1,14 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: BEGIN {}
+   RUN "CREATE (n {name:'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+   SUCCESS {}
+C: COMMIT
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database shut down."}
+S: <EXIT>


### PR DESCRIPTION
When a server is shutting down, it is possible that a transaction is killed in the middle, followed by the termination of connection. Before the connection is shutting down, the server might send an error message if there is at least one pending message sent by client. However the server will also ignore any further messages that are queued in the server inbound message queue. Thus when the client trying to send or reading more with the closed connection, the client will receive a connection terminated error.

This PR makes sure when the above situation happens, the client will throw the original error with connection error as suppressed error.