### PR TITLE
Providing possibility to share event loops among driver instances

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/BootstrapFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/BootstrapFactory.java
@@ -38,7 +38,7 @@ public final class BootstrapFactory
         return newBootstrap( EventLoopGroupFactory.newEventLoopGroup( threadCount ) );
     }
 
-    private static Bootstrap newBootstrap( EventLoopGroup eventLoopGroup )
+    public static Bootstrap newBootstrap( EventLoopGroup eventLoopGroup )
     {
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group( eventLoopGroup );

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -442,7 +442,7 @@ class ConnectionHandlingIT
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider ignored, Config config )
+                MetricsProvider ignored, Config config, boolean ownsEventLoopGroup )
         {
             ConnectionSettings connectionSettings = new ConnectionSettings( authToken, 1000 );
             PoolSettings poolSettings = new PoolSettings( config.maxConnectionPoolSize(),
@@ -450,7 +450,7 @@ class ConnectionHandlingIT
                     config.idleTimeBeforeConnectionTest() );
             Clock clock = createClock();
             ChannelConnector connector = super.createConnector( connectionSettings, securityPlan, config, clock );
-            connectionPool = new MemorizingConnectionPool( connector, bootstrap, poolSettings, config.logging(), clock );
+            connectionPool = new MemorizingConnectionPool( connector, bootstrap, poolSettings, config.logging(), clock, ownsEventLoopGroup );
             return connectionPool;
         }
     }
@@ -461,9 +461,9 @@ class ConnectionHandlingIT
         boolean memorize;
 
         MemorizingConnectionPool( ChannelConnector connector, Bootstrap bootstrap, PoolSettings settings,
-                Logging logging, Clock clock )
+                Logging logging, Clock clock, boolean ownsEventLoopGroup )
         {
-            super( connector, bootstrap, settings, DEV_NULL_METRICS, logging, clock );
+            super( connector, bootstrap, settings, DEV_NULL_METRICS, logging, clock, ownsEventLoopGroup );
         }
 
         void startMemorizing()

--- a/driver/src/test/java/org/neo4j/driver/integration/SharedEventLoopIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SharedEventLoopIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.cluster.RoutingSettings;
+import org.neo4j.driver.internal.retry.RetrySettings;
+import org.neo4j.driver.util.DatabaseExtension;
+import org.neo4j.driver.util.ParallelizableIT;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ParallelizableIT
+class SharedEventLoopIT
+{
+    private final DriverFactory driverFactory = new DriverFactory();
+
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    @Test
+    void testDriverShouldNotCloseSharedEventLoop()
+    {
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup( 1 );
+
+        try
+        {
+            Driver driver1 = createDriver( eventLoopGroup );
+            Driver driver2 = createDriver( eventLoopGroup );
+
+            testConnection( driver1 );
+            testConnection( driver2 );
+
+            driver1.close();
+
+            testConnection( driver2 );
+            driver2.close();
+        }
+        finally
+        {
+            eventLoopGroup.shutdownGracefully( 100, 100, TimeUnit.MILLISECONDS );
+        }
+    }
+
+    @Test
+    void testDriverShouldUseSharedEventLoop()
+    {
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup( 1 );
+
+        Driver driver = createDriver( eventLoopGroup );
+        testConnection( driver );
+
+        eventLoopGroup.shutdownGracefully( 100, 100, TimeUnit.MILLISECONDS );
+
+        // the driver should fail if it really uses the provided event loop
+        // if the call succeeds, it meas that the driver created its own event loop
+        try
+        {
+            testConnection( driver );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            // ignored
+        }
+    }
+
+    private Driver createDriver( EventLoopGroup eventLoopGroup )
+    {
+        RoutingSettings routingSettings = new RoutingSettings( 1000, 1000 );
+        RetrySettings retrySettings = new RetrySettings( 1000 );
+        return driverFactory.newInstance( neo4j.uri(), neo4j.authToken(), routingSettings, retrySettings, Config.build().build(), eventLoopGroup );
+    }
+
+    private void testConnection( Driver driver )
+    {
+        try ( Session session = driver.session() )
+        {
+            session.run( "RETURN 1" );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -223,7 +223,7 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config )
+                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
         {
             return connectionPool;
         }
@@ -259,7 +259,7 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config )
+                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
         {
             return connectionPoolMock();
         }
@@ -282,7 +282,7 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config )
+                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
         {
             return connectionPoolMock();
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -207,7 +207,7 @@ class ConnectionPoolImplIT
                 DEV_NULL_LOGGING, clock );
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
-        return new ConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_METRICS, DEV_NULL_LOGGING, clock );
+        return new ConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_METRICS, DEV_NULL_LOGGING, clock, true );
     }
 
     private static PoolSettings newSettings()
@@ -222,7 +222,7 @@ class ConnectionPoolImplIT
         TestConnectionPool( NettyChannelTracker nettyChannelTracker )
         {
             super( mock( ChannelConnector.class ), mock( Bootstrap.class ), nettyChannelTracker, newSettings(),
-                    DEV_NULL_METRICS, DEV_NULL_LOGGING, new FakeClock() );
+                    DEV_NULL_METRICS, DEV_NULL_LOGGING, new FakeClock(), true );
         }
 
         ChannelPool getPool( BoltServerAddress address )

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -42,9 +42,9 @@ public class FailingConnectionDriverFactory extends DriverFactory
 
     @Override
     protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-            MetricsProvider metricsProvider, Config config )
+            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
     {
-        ConnectionPool pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config );
+        ConnectionPool pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
         return new ConnectionPoolWithFailingConnections( pool, nextRunFailure );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
@@ -74,9 +74,9 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock
 
     @Override
     protected final ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-            MetricsProvider metricsProvider, Config config )
+            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
     {
-        pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config );
+        pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
         return pool;
     }
 


### PR DESCRIPTION
Each driver instance creates its own even loop group, which is
a very expensive resource that can be shared among drivers.

This change provides a way how to construct a driver
with a supplied event loop group