### PR TITLE
Relax discovery logic

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/Rediscovery.java
@@ -246,7 +246,7 @@ public class Rediscovery
             }
             else
             {
-                return response.clusterComposition();
+                return handleClusterComposition( routerAddress, response );
             }
         } );
     }
@@ -266,6 +266,22 @@ public class Rediscovery
             routingTable.forget( routerAddress );
             return null;
         }
+    }
+
+    private ClusterComposition handleClusterComposition( BoltServerAddress routerAddress, ClusterCompositionResponse response )
+    {
+        ClusterComposition result = null;
+
+        try
+        {
+            result = response.clusterComposition();
+        }
+        catch ( Exception exc )
+        {
+            logger.warn( format( "Unable to process routing table received from '%s'.", routerAddress ), exc );
+        }
+
+        return result;
     }
 
     private List<BoltServerAddress> resolve( BoltServerAddress address )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -39,7 +39,7 @@ public class RoutingProcedureRunner
 {
     static final String GET_SERVERS = "dbms.cluster.routing.getServers";
     static final String GET_ROUTING_TABLE_PARAM = "context";
-    static final String GET_ROUTING_TABLE = "dbms.cluster.routing.getRoutingTable({" + GET_ROUTING_TABLE_PARAM + "})";
+    static final String GET_ROUTING_TABLE = "dbms.cluster.routing.getRoutingTable($" + GET_ROUTING_TABLE_PARAM + ")";
 
     private final RoutingContext context;
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -167,7 +167,7 @@ public class CausalClusteringIT implements NestedQueries
 
         ClusterMember readReplica = cluster.anyReadReplica();
         ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> createDriver( readReplica.getRoutingUri() ) );
-        assertThat( e.getMessage(), containsString( "Failed to run 'CALL dbms.cluster.routing" ) );
+        assertThat( e.getMessage(), containsString( "Could not perform discovery. No routing servers available." ) );
     }
 
     // Ensure that Bookmarks work with single instances using a driver created using a bolt[not+routing] URI.
@@ -193,7 +193,7 @@ public class CausalClusteringIT implements NestedQueries
             assertNotNull( bookmark );
 
             try ( Session session = driver.session( bookmark );
-                  Transaction tx = session.beginTransaction() )
+                    Transaction tx = session.beginTransaction() )
             {
                 Record record = tx.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
                 assertEquals( 1, record.get( "count" ).asInt() );
@@ -309,7 +309,7 @@ public class CausalClusteringIT implements NestedQueries
         ClusterMember leader = clusterRule.getCluster().leader();
 
         try ( Driver driver = createDriver( leader.getBoltUri() );
-              Session session = driver.session( invalidBookmark ) )
+                Session session = driver.session( invalidBookmark ) )
         {
             ClientException e = assertThrows( ClientException.class, session::beginTransaction );
             assertThat( e.getMessage(), containsString( invalidBookmark ) );
@@ -323,7 +323,7 @@ public class CausalClusteringIT implements NestedQueries
         ClusterMember leader = clusterRule.getCluster().leader();
 
         try ( Driver driver = createDriver( leader.getBoltUri() );
-              Session session = driver.session() )
+                Session session = driver.session() )
         {
             try ( Transaction tx = session.beginTransaction() )
             {
@@ -373,7 +373,7 @@ public class CausalClusteringIT implements NestedQueries
             } );
 
             try ( Session session2 = driver.session( AccessMode.READ, bookmark );
-                  Transaction tx2 = session2.beginTransaction() )
+                    Transaction tx2 = session2.beginTransaction() )
             {
                 Record record = tx2.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
                 tx2.success();
@@ -1059,8 +1059,8 @@ public class CausalClusteringIT implements NestedQueries
             return false;
         }
         return overview.leaderCount == 0 &&
-               overview.followerCount == 1 &&
-               overview.readReplicaCount == ClusterExtension.READ_REPLICA_COUNT;
+                overview.followerCount == 1 &&
+                overview.readReplicaCount == ClusterExtension.READ_REPLICA_COUNT;
     }
 
     private static void makeAllChannelsFailToRunQueries( ChannelTrackingDriverFactory driverFactory, ServerVersion dbVersion )
@@ -1108,10 +1108,10 @@ public class CausalClusteringIT implements NestedQueries
         public String toString()
         {
             return "ClusterOverview{" +
-                   "leaderCount=" + leaderCount +
-                   ", followerCount=" + followerCount +
-                   ", readReplicaCount=" + readReplicaCount +
-                   '}';
+                    "leaderCount=" + leaderCount +
+                    ", followerCount=" + followerCount +
+                    ", readReplicaCount=" + readReplicaCount +
+                    '}';
         }
     }
 }

--- a/driver/src/test/resources/acquire_endpoints.script
+++ b/driver/src/test/resources/acquire_endpoints.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/acquire_endpoints_v3.script
+++ b/driver/src/test/resources/acquire_endpoints_v3.script
@@ -3,7 +3,7 @@
 
 C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/acquire_endpoints_v3_empty.script
+++ b/driver/src/test/resources/acquire_endpoints_v3_empty.script
@@ -1,0 +1,10 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, []]
+   SUCCESS {}

--- a/driver/src/test/resources/acquire_endpoints_v3_leader_killed.script
+++ b/driver/src/test/resources/acquire_endpoints_v3_leader_killed.script
@@ -3,22 +3,22 @@
 
 C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
 S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9004"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9004"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}} {}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/acquire_endpoints_v3_point_to_empty_router_and_exit.script
+++ b/driver/src/test/resources/acquire_endpoints_v3_point_to_empty_router_and_exit.script
@@ -1,0 +1,13 @@
+!: BOLT 3
+!: AUTO RESET
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9010"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9011"], "role": "READ"},{"addresses": ["127.0.0.1:9004"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RESET
+S: SUCCESS {}
+   <EXIT>

--- a/driver/src/test/resources/acquire_endpoints_v3_three_servers_and_exit.script
+++ b/driver/src/test/resources/acquire_endpoints_v3_three_servers_and_exit.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+S: SUCCESS {"server": "Neo4j/9.9.9", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RESET
+S: SUCCESS {}
+   <EXIT>

--- a/driver/src/test/resources/discover_no_writers.script
+++ b/driver/src/test/resources/discover_no_writers.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9004","127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/discover_one_router.script
+++ b/driver/src/test/resources/discover_one_router.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001","127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9005"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/discover_servers.script
+++ b/driver/src/test/resources/discover_servers.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002","127.0.0.1:9003","127.0.0.1:9004"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/failed_discovery.script
+++ b/driver/src/test/resources/failed_discovery.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
 S: IGNORED

--- a/driver/src/test/resources/get_routing_table.script
+++ b/driver/src/test/resources/get_routing_table.script
@@ -3,7 +3,7 @@
 !: AUTO PULL_ALL
 
 S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/get_routing_table_with_context.script
+++ b/driver/src/test/resources/get_routing_table_with_context.script
@@ -3,7 +3,7 @@
 !: AUTO PULL_ALL
 
 S: SUCCESS {"server": "Neo4j/3.2.3"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {"policy": "my_policy", "region": "china"}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"policy": "my_policy", "region": "china"}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/non_discovery_server.script
+++ b/driver/src/test/resources/non_discovery_server.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
 C: PULL_ALL
 S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
 S: IGNORED

--- a/driver/src/test/resources/rediscover_using_initial_router.script
+++ b/driver/src/test/resources/rediscover_using_initial_router.script
@@ -5,7 +5,7 @@
 !: AUTO RUN "COMMIT" {}
 !: AUTO RUN "ROLLBACK" {}
 
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001","127.0.0.1:9009","127.0.0.1:9010"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9011"], "role": "ROUTE"}]]

--- a/examples/src/test/resources/get_routing_table_only.script
+++ b/examples/src/test/resources/get_routing_table_only.script
@@ -3,7 +3,7 @@
 !: AUTO PULL_ALL
 
 S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]


### PR DESCRIPTION
Currently, discovery process is very picky on errors related with discovery responses. This PR relaxes the existing logic, and treats those exception as a try-next-router action and logs those exceptions at warning level.