### PR TITLE
Provide defaultTypeSystem() on the driver.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -25,6 +25,8 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.SessionParameters;
 import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.types.TypeSystem;
+import org.neo4j.driver.util.Experimental;
 
 /**
  * Accessor for a specific Neo4j graph database.
@@ -149,4 +151,13 @@ public interface Driver extends AutoCloseable
      * @return a new {@link AsyncSession} object.
      */
     AsyncSession asyncSession( Consumer<SessionParametersTemplate> templateConsumer );
+
+    /**
+     * This will return the type system supported by the driver.
+     * The types supported on a particular server a session is connected against might not contain all of the types defined here.
+     *
+     * @return type system used by this statement runner for classifying values
+     */
+    @Experimental
+    TypeSystem defaultTypeSystem();
 }

--- a/driver/src/main/java/org/neo4j/driver/StatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/StatementRunner.java
@@ -164,10 +164,4 @@ public interface StatementRunner
      * @return a stream of result values and associated metadata
      */
     StatementResult run( Statement statement );
-
-    /**
-     * @return type system used by this statement runner for classifying values
-     */
-    @Experimental
-    TypeSystem typeSystem();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
@@ -57,12 +57,6 @@ public abstract class AbstractStatementRunner implements StatementRunner
         return run( statementText, Values.EmptyMap );
     }
 
-    @Override
-    public final TypeSystem typeSystem()
-    {
-        return InternalTypeSystem.TYPE_SYSTEM;
-    }
-
     public static Value parameters( Record record )
     {
         return record == null ? Values.EmptyMap : parameters( record.asMap() );

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -34,8 +34,10 @@ import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.metrics.MetricsProvider;
 import org.neo4j.driver.internal.reactive.InternalRxSession;
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.types.TypeSystem;
 
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
@@ -126,6 +128,12 @@ public class InternalDriver implements Driver
             return sessionFactory.close();
         }
         return completedWithNull();
+    }
+
+    @Override
+    public final TypeSystem defaultTypeSystem()
+    {
+        return InternalTypeSystem.TYPE_SYSTEM;
     }
 
     public CompletionStage<Void> verifyConnectivity()

--- a/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.types.TypeSystem;
 
 import static org.neo4j.driver.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 import static org.neo4j.driver.util.Neo4jRunner.HOME_DIR;
@@ -67,6 +68,11 @@ public class DatabaseExtension implements BeforeEachCallback
     public Driver driver()
     {
         return runner.driver();
+    }
+
+    public TypeSystem typeSystem()
+    {
+        return driver().defaultTypeSystem();
     }
 
     public void restartDb()

--- a/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
@@ -166,10 +166,4 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     {
         return realSession.run( statement, config );
     }
-
-    @Override
-    public TypeSystem typeSystem()
-    {
-        return realSession.typeSystem();
-    }
 }


### PR DESCRIPTION
At the moment, the type system is exposed on the standard session and statement runner, with the idea, that session might are connected against a server that has different supported types than another, so that it might change during sessions.

This is incomplete in two areas:
* The type system in the driver currently has always all the types that the driver supports, the type system has not yet an idea about the server
* If it had, than it would needed to be exposed on all session types (standard, async and reactive)

As `typeSystem()` has been marked experimental on the session anyway, it should be save to remove (we don't use it in Neo4j-OGM atm anyway).

This PR adds `defaultTypeSystem()` on the driver instead.
The advantage being that this marks the intention of the method and the type system in used clearly.
And it also can be used without opening a session.

