### PR TITLE
Fix shading of Project Reactor.

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -225,8 +225,8 @@
                   <shadedPattern>org.neo4j.driver.internal.shaded.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>io.projectreactor</pattern>
-                  <shadedPattern>org.neo4j.driver.internal.shaded.io.projectreactor</shadedPattern>
+                  <pattern>reactor</pattern>
+                  <shadedPattern>org.neo4j.driver.internal.shaded.reactor</shadedPattern>
                 </relocation>
               </relocations>
               <shadeTestJar>true</shadeTestJar>

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.file.Files;
@@ -570,7 +571,8 @@ class ExamplesIT
             // print all 'Product' nodes to fake stdout
             try ( AutoCloseable ignore = stdIOCapture.capture() )
             {
-                Mono.from( example.printAllProductsReactor() )
+                example.printAllProductsReactor()
+                        .single()
                         .doAfterTerminate( () -> latch.countDown() )
                         .subscribe( summary -> assertEquals( StatementType.READ_ONLY, summary.statementType() ) );
             }
@@ -601,7 +603,8 @@ class ExamplesIT
             // print all 'Product' nodes to fake stdout
             try ( AutoCloseable ignore = stdIOCapture.capture() )
             {
-                Mono.from( example.printAllProductsRxJava() )
+                Flux.from( example.printAllProductsRxJava() )
+                        .single()
                         .doAfterTerminate( () -> latch.countDown() )
                         .subscribe( summary -> assertEquals( StatementType.READ_ONLY, summary.statementType() ) );
             }


### PR DESCRIPTION
Project reactors package is just reactor.

We cannot use the internal TestUtils in our ExamplesIT, as the internal TestUtils now expose reactors types under the shaded coordinates.