### PR TITLE
Used channel tracking: Increment idle instead of use after channel is created.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
@@ -90,7 +90,7 @@ public class NettyChannelTracker implements ChannelPoolHandler
         log.debug( "Channel [%s] created. Local address: %s, remote address: %s",
                 channel.id(), channel.localAddress(), channel.remoteAddress() );
 
-        incrementInUse( channel );
+        incrementIdle( channel );
         metricsListener.afterCreated( serverAddress( channel ), creatingEvent );
 
         allChannels.add( channel );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelTrackerTest.java
@@ -49,15 +49,15 @@ class NettyChannelTrackerTest
     private final NettyChannelTracker tracker = new NettyChannelTracker( DEV_NULL_METRICS, mock( ChannelGroup.class ), DEV_NULL_LOGGING );
 
     @Test
-    void shouldIncrementInUseCountWhenChannelCreated()
+    void shouldIncrementIdleCountWhenChannelCreated()
     {
         Channel channel = newChannel();
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
         tracker.channelCreated( channel, null );
-        assertEquals( 1, tracker.inUseChannelCount( address ) );
-        assertEquals( 0, tracker.idleChannelCount( address ) );
+        assertEquals( 0, tracker.inUseChannelCount( address ) );
+        assertEquals( 1, tracker.idleChannelCount( address ) );
     }
 
     @Test
@@ -68,16 +68,16 @@ class NettyChannelTrackerTest
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
         tracker.channelCreated( channel, null );
-        assertEquals( 1, tracker.inUseChannelCount( address ) );
-        assertEquals( 0, tracker.idleChannelCount( address ) );
-
-        tracker.channelReleased( channel );
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         assertEquals( 1, tracker.idleChannelCount( address ) );
 
         tracker.channelAcquired( channel );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
+
+        tracker.channelReleased( channel );
+        assertEquals( 0, tracker.inUseChannelCount( address ) );
+        assertEquals( 1, tracker.idleChannelCount( address ) );
     }
 
     @Test
@@ -89,10 +89,13 @@ class NettyChannelTrackerTest
 
         assertEquals( 0, tracker.inUseChannelCount( address ) );
         tracker.channelCreated( channel1, null );
+        tracker.channelAcquired( channel1 );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         tracker.channelCreated( channel2, null );
+        tracker.channelAcquired( channel2 );
         assertEquals( 2, tracker.inUseChannelCount( address ) );
         tracker.channelCreated( channel3, null );
+        tracker.channelAcquired( channel3 );
         assertEquals( 3, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
     }
@@ -105,8 +108,11 @@ class NettyChannelTrackerTest
         Channel channel3 = newChannel();
 
         tracker.channelCreated( channel1, null );
+        tracker.channelAcquired( channel1 );
         tracker.channelCreated( channel2, null );
+        tracker.channelAcquired( channel2 );
         tracker.channelCreated( channel3, null );
+        tracker.channelAcquired( channel3 );
         assertEquals( 3, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
@@ -127,6 +133,7 @@ class NettyChannelTrackerTest
         // Given
         Channel channel = newChannel();
         tracker.channelCreated( channel, null );
+        tracker.channelAcquired( channel );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 
@@ -148,6 +155,7 @@ class NettyChannelTrackerTest
         // Given
         Channel channel = newChannel();
         tracker.channelCreated( channel, null );
+        tracker.channelAcquired( channel );
         assertEquals( 1, tracker.inUseChannelCount( address ) );
         assertEquals( 0, tracker.idleChannelCount( address ) );
 


### PR DESCRIPTION
I'm pretty sure that needs to be idle to be incremented. 

I'm playing with Netty 4.1.36 and there timing seems a bit different, and as a result when returning the used channel, an `IllegalStateException` is thrown.