### PR TITLE
Apply ServicesResourceTransformer on shaded libraries.

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -229,6 +229,9 @@
                   <shadedPattern>org.neo4j.driver.internal.shaded.reactor</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
               <shadeTestJar>true</shadeTestJar>
               <createSourcesJar>true</createSourcesJar>
             </configuration>


### PR DESCRIPTION
The maven shade plugin can transform several types of resources, i.e. Java Service Loader SPI. This is done by

```
      <transformers>
                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
              </transformers>
```

Thus we make our shaded version of project reactor compatible with https://github.com/reactor/BlockHound in the future.

Note: As we are on 3.2, this has no immediate affect, but will have once we upgrade to a final version 3.3.