### PR TITLE
Avoid a queue for shaded record publisher

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxStatementResult.java
@@ -26,10 +26,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import org.neo4j.driver.Record;
+import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.reactive.RxStatementResult;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
 import org.neo4j.driver.summary.ResultSummary;
+
+import static reactor.core.publisher.FluxSink.OverflowStrategy.IGNORE;
 
 public class InternalRxStatementResult implements RxStatementResult
 {
@@ -83,7 +85,7 @@ public class InternalRxStatementResult implements RxStatementResult
                 Throwable error = Futures.completionExceptionCause( completionError );
                 sink.error( error );
             }
-        } ) );
+        } ), IGNORE );
     }
 
     private CompletionStage<RxStatementResultCursor> getCursorFuture()


### PR DESCRIPTION
By default, when creating a publisher via `Flux.create` a `BufferAsyncSink` will be used and a queue is created to buffer all data the client cannot process in time.
With reactor being shaded, the reactor users cannot benifit from this queue and will have to create this queue again when creating from driver's record publisher.
Thus we configure the driver to create a publisher without any active buffering. The application will be fully in charge of buffer consumed data instead.