### PR TITLE
`Transaction#commit` and `Transaction#rollback`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -88,8 +88,8 @@ public interface Session extends Resource, StatementRunner
     /**
      * Execute given unit of work in a  {@link AccessMode#READ read} transaction.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
-     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
+     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
      *
      * @param work the {@link TransactionWork} to be applied to a new read transaction.
      * @param <T> the return type of the given unit of work.
@@ -100,8 +100,8 @@ public interface Session extends Resource, StatementRunner
     /**
      * Execute given unit of work in a  {@link AccessMode#READ read} transaction with the specified {@link TransactionConfig configuration}.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
-     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
+     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
      *
      * @param work the {@link TransactionWork} to be applied to a new read transaction.
      * @param config configuration for all transactions started to execute the unit of work.
@@ -113,8 +113,8 @@ public interface Session extends Resource, StatementRunner
     /**
      * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
-     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
+     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
      *
      * @param work the {@link TransactionWork} to be applied to a new write transaction.
      * @param <T> the return type of the given unit of work.
@@ -125,8 +125,8 @@ public interface Session extends Resource, StatementRunner
     /**
      * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction with the specified {@link TransactionConfig configuration}.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or from
-     * {@link Transaction#close()} or transaction is explicitly marked for failure via {@link Transaction#failure()}.
+     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
+     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
      *
      * @param work the {@link TransactionWork} to be applied to a new write transaction.
      * @param config configuration for all transactions started to execute the unit of work.

--- a/driver/src/main/java/org/neo4j/driver/Transaction.java
+++ b/driver/src/main/java/org/neo4j/driver/Transaction.java
@@ -25,19 +25,17 @@ import org.neo4j.driver.util.Resource;
  * A driver Transaction object corresponds to a server transaction.
  * <p>
  * Transactions are typically wrapped in a try-with-resources block
- * which ensures that <code>COMMIT</code> or <code>ROLLBACK</code>
- * occurs correctly on close. Note that <code>ROLLBACK</code> is the
- * default action unless {@link #success()} is called before closing.
- * <pre class="docTest:TransactionDocIT#classDoc">
+ * which ensures in case of any error in try block, the transaction is
+ * automatically rolled back on close. Note that <code>ROLLBACK</code> is the
+ * default action unless {@link #commit()} is called before closing.
  * {@code
  * try(Transaction tx = session.beginTransaction())
  * {
  *     tx.run("CREATE (a:Person {name: {x}})", parameters("x", "Alice"));
- *     tx.success();
+ *     tx.commit();
  * }
  * }
- * </pre>
- * Blocking calls are: {@link #success()}, {@link #failure()}, {@link #close()}
+ * Blocking calls are: {@link #commit()}, {@link #rollback()}, {@link #close()}
  * and various overloads of {@link #run(Statement)}.
  *
  * @see Session#run
@@ -47,36 +45,60 @@ import org.neo4j.driver.util.Resource;
 public interface Transaction extends Resource, StatementRunner
 {
     /**
-     * Mark this transaction as successful. You must call this method before calling {@link #close()} to have your
-     * transaction committed.
-     */
-    void success();
-
-    /**
-     * Mark this transaction as failed. When you call {@link #close()}, the transaction will value rolled back.
+     * Commit this current transaction.
+     * When this method returns, all outstanding statements in the transaction are guaranteed to
+     * have completed, meaning any writes you performed are guaranteed to be durably stored.
+     * No more statement can be executed inside this transaction once this transaction is committed.
+     * After this method is called, the transaction cannot be committed or rolled back again.
+     * You must call this method before calling {@link #close()} to have your transaction committed.
+     * If a transaction is not committed or rolled back before close,
+     * the transaction will be rolled back by default in {@link #close}.
      *
-     * After this method has been called, there is nothing that can be done to "un-mark" it. This is a safety feature
-     * to make sure no other code calls {@link #success()} and makes a transaction commit that was meant to be rolled
-     * back.
+     Example:
      *
-     * Example:
-     *
-     * <pre class="docTest:TransactionDocIT#failure">
      * {@code
      * try(Transaction tx = session.beginTransaction() )
      * {
      *     tx.run("CREATE (a:Person {name: {x}})", parameters("x", "Alice"));
-     *     tx.failure();
+     *     tx.commit();
      * }
      * }
-     * </pre>
      */
-    void failure();
+    void commit();
 
     /**
-     * Closing the transaction will complete it - it will commit if {@link #success()} has been called.
-     * When this method returns, all outstanding statements in the transaction are guaranteed to
-     * have completed, meaning any writes you performed are guaranteed to be durably stored.
+     * Roll back this current transaction.
+     * No more statement can be executed inside this transaction once this transaction is committed.
+     * After this method has been called, the transaction cannot be committed or rolled back again.
+     * If a transaction is not committed or rolled back before close,
+     * the transaction will be rolled back by default in {@link #close}.
+     *
+     * Example:
+     *
+     * {@code
+     * try(Transaction tx = session.beginTransaction() )
+     * {
+     *     tx.run("CREATE (a:Person {name: {x}})", parameters("x", "Alice"));
+     *     tx.rollback();
+     * }
+     * }
+     */
+    void rollback();
+
+    /**
+     * Close the transaction.
+     * If the transaction has been {@link #commit() committed} or {@link #rollback() rolled back},
+     * the close is optional and no operation is performed inside.
+     * Otherwise, the transaction will be rolled back by default by this method.
+     *
+     * Example:
+     *
+     * {@code
+     * try(Transaction tx = session.beginTransaction() )
+     * {
+     *     tx.run("CREATE (a:Person {name: {x}})", parameters("x", "Alice"));
+     * }
+     * }
      */
     @Override
     void close();

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
@@ -34,15 +34,17 @@ public class InternalTransaction extends AbstractStatementRunner implements Tran
     }
 
     @Override
-    public void success()
+    public void commit()
     {
-        tx.success();
+        Futures.blockingGet( tx.commitAsync(),
+                () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while committing the transaction" ) );
     }
 
     @Override
-    public void failure()
+    public void rollback()
     {
-        tx.failure();
+        Futures.blockingGet( tx.rollbackAsync(),
+                () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while rolling back the transaction" ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
@@ -196,8 +196,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
     {
         if ( tx.isOpen() )
         {
-            tx.success();
-            tx.closeAsync().whenComplete( ( ignore, completionError ) -> {
+            tx.commitAsync().whenComplete( ( ignore, completionError ) -> {
                 Throwable commitError = Futures.completionExceptionCause( completionError );
                 if ( commitError != null )
                 {

--- a/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
@@ -112,7 +112,7 @@ class BookmarkIT
         try ( Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE (a:Person)" );
-            tx.failure();
+            tx.rollback();
         }
 
         assertEquals( bookmark, session.lastBookmark() );
@@ -130,9 +130,8 @@ class BookmarkIT
 
         Transaction tx = session.beginTransaction();
         tx.run( "RETURN" );
-        tx.success();
 
-        assertThrows( ClientException.class, tx::close );
+        assertThrows( ClientException.class, tx::commit );
         assertEquals( bookmark, session.lastBookmark() );
     }
 
@@ -210,7 +209,7 @@ class BookmarkIT
         try ( Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE (a:Person)" );
-            tx.success();
+            tx.commit();
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -219,7 +219,7 @@ class ConnectionHandlingIT
         verify( connection1, never() ).release();
 
         StatementResult result = createNodes( 5, tx );
-        tx.success();
+        tx.commit();
         tx.close();
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
@@ -240,7 +240,7 @@ class ConnectionHandlingIT
         verify( connection1, never() ).release();
 
         StatementResult result = createNodes( 8, tx );
-        tx.failure();
+        tx.rollback();
         tx.close();
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
@@ -268,9 +268,8 @@ class ConnectionHandlingIT
 
         // property existence constraints are verified on commit, try to violate it
         tx.run( "CREATE (:Book)" );
-        tx.success();
 
-        assertThrows( ClientException.class, tx::close );
+        assertThrows( ClientException.class, tx::commit );
 
         // connection should have been released after failed node creation
         verify( connection2 ).release();

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
@@ -177,8 +177,7 @@ class ConnectionPoolIT
             }
             for ( Transaction tx : transactions )
             {
-                tx.success();
-                tx.close();
+                tx.commit();
             }
             for ( Session session : sessions )
             {

--- a/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
@@ -158,16 +158,14 @@ class ErrorIT
         // given
         Transaction tx = session.beginTransaction();
         tx.run( "CREATE CONSTRAINT ON (a:`" + label + "`) ASSERT a.name IS UNIQUE" );
-        tx.success();
-        tx.close();
+        tx.commit();
 
         // and
         tx = session.beginTransaction();
         tx.run( "CREATE INDEX ON :`" + label + "`(name)" );
-        tx.success();
 
         // then expect
-        ClientException e = assertThrows( ClientException.class, tx::close );
+        ClientException e = assertThrows( ClientException.class, tx::commit );
         assertThat( e.getMessage(), containsString( label ) );
         assertThat( e.getMessage(), containsString( "name" ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/ExplicitTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ExplicitTransactionIT.java
@@ -168,17 +168,6 @@ class ExplicitTransactionIT
     }
 
     @Test
-    void shouldFailToRunQueryWhenMarkedForFailure()
-    {
-        ExplicitTransaction tx = beginTransaction();
-        txRun( tx, "CREATE (:MyLabel)" );
-        tx.failure();
-
-        ClientException e = assertThrows( ClientException.class, () -> txRun( tx, "CREATE (:MyOtherLabel)" ) );
-        assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
-    }
-
-    @Test
     void shouldFailToRunQueryWhenTerminated()
     {
         ExplicitTransaction tx = beginTransaction();
@@ -187,21 +176,6 @@ class ExplicitTransactionIT
 
         ClientException e = assertThrows( ClientException.class, () -> txRun( tx, "CREATE (:MyOtherLabel)" ) );
         assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
-    }
-
-    @Test
-    void shouldAllowQueriesWhenMarkedForSuccess()
-    {
-        ExplicitTransaction tx = beginTransaction();
-        txRun( tx, "CREATE (:MyLabel)" );
-
-        tx.success();
-
-        txRun( tx, "CREATE (:MyLabel)" );
-        assertNull( await( tx.commitAsync() ) );
-
-        StatementResultCursor cursor = sessionRun( session, new Statement( "MATCH (n:MyLabel) RETURN count(n)" ) );
-        assertEquals( 2, await( cursor.singleAsync() ).get( 0 ).asInt() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
@@ -46,7 +46,7 @@ public interface NestedQueries
         try ( Session session = newSession( AccessMode.READ ); Transaction tx = session.beginTransaction() )
         {
             testNestedQueriesConsumedAsIterators( tx );
-            tx.success();
+            tx.commit();
         }
     }
 
@@ -56,7 +56,7 @@ public interface NestedQueries
         try ( Session session = newSession( AccessMode.READ ); Transaction tx = session.beginTransaction() )
         {
             testNestedQueriesConsumedAsLists( tx );
-            tx.success();
+            tx.commit();
         }
     }
 
@@ -66,7 +66,7 @@ public interface NestedQueries
         try ( Session session = newSession( AccessMode.READ ); Transaction tx = session.beginTransaction() )
         {
             testNestedQueriesConsumedAsIteratorAndList( tx );
-            tx.success();
+            tx.commit();
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
@@ -174,7 +174,7 @@ class ResultStreamIT
             {
                 StatementResult result = tx.run( "UNWIND [1,2,0] AS x RETURN 10/x" );
                 resultRef.set( result );
-                tx.success();
+                tx.commit();
             }
         } );
 

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -140,7 +140,7 @@ class RoutingDriverBoltKitTest
             List<String> result = tx.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() );
 
             assertThat( result, equalTo( asList( "Bob", "Alice", "Tina" ) ) );
-            tx.success();
+            tx.commit();
         }
         // Finally
         assertThat( server.exitStatus(), equalTo( 0 ) );
@@ -194,7 +194,7 @@ class RoutingDriverBoltKitTest
                 {
                     assertThat( tx.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() ),
                             equalTo( asList( "Bob", "Alice", "Tina" ) ) );
-                    tx.success();
+                    tx.commit();
                 }
             }
         }
@@ -243,7 +243,7 @@ class RoutingDriverBoltKitTest
                     Transaction tx = session.beginTransaction() )
             {
                 tx.run( "MATCH (n) RETURN n.name" );
-                tx.success();
+                tx.commit();
             }
         } );
         assertEquals( "Server at 127.0.0.1:9005 is no longer available", e.getMessage() );
@@ -290,7 +290,6 @@ class RoutingDriverBoltKitTest
                 Transaction tx = session.beginTransaction() )
         {
             assertThrows( SessionExpiredException.class, () -> tx.run( "MATCH (n) RETURN n.name" ).consume() );
-            tx.success();
         }
         finally
         {
@@ -350,7 +349,7 @@ class RoutingDriverBoltKitTest
                 Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE (n {name:'Bob'})" );
-            tx.success();
+            tx.commit();
         }
         // Finally
         assertThat( server.exitStatus(), equalTo( 0 ) );
@@ -400,7 +399,7 @@ class RoutingDriverBoltKitTest
                 try ( Session session = driver.session(); Transaction tx = session.beginTransaction() )
                 {
                     tx.run( "CREATE (n {name:'Bob'})" );
-                    tx.success();
+                    tx.commit();
                 }
             }
         }
@@ -527,7 +526,7 @@ class RoutingDriverBoltKitTest
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "CREATE (n {name:'Bob'})" );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "NewBookmark" ), session.lastBookmark() );
@@ -549,7 +548,7 @@ class RoutingDriverBoltKitTest
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "CREATE (n {name:'Bob'})" );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "NewBookmark" ), session.lastBookmark() );
@@ -574,7 +573,7 @@ class RoutingDriverBoltKitTest
                 assertEquals( 2, records.size() );
                 assertEquals( "Bob", records.get( 0 ).get( "name" ).asString() );
                 assertEquals( "Alice", records.get( 1 ).get( "name" ).asString() );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "NewBookmark" ), session.lastBookmark() );
@@ -596,7 +595,7 @@ class RoutingDriverBoltKitTest
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "CREATE (n {name:'Bob'})" );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "BookmarkB" ), session.lastBookmark() );
@@ -606,7 +605,7 @@ class RoutingDriverBoltKitTest
                 List<Record> records = tx.run( "MATCH (n) RETURN n.name AS name" ).list();
                 assertEquals( 1, records.size() );
                 assertEquals( "Bob", records.get( 0 ).get( "name" ).asString() );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "BookmarkC" ), session.lastBookmark() );
@@ -991,7 +990,7 @@ class RoutingDriverBoltKitTest
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "CREATE (n {name:'Bob'})" );
-                tx.success();
+                tx.commit();
             }
 
             assertEquals( parse( "neo4j:bookmark:v1:tx95" ), session.lastBookmark() );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -224,7 +224,7 @@ class SessionBoltV3IT
         try ( Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE ()" );
-            tx.success();
+            tx.commit();
         }
         Bookmark bookmark1 = session.lastBookmark();
         assertNotNull( bookmark1 );
@@ -239,7 +239,7 @@ class SessionBoltV3IT
         try ( Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE ()" );
-            tx.success();
+            tx.commit();
         }
         Bookmark bookmark3 = session.lastBookmark();
         assertNotNull( bookmark3 );
@@ -297,8 +297,7 @@ class SessionBoltV3IT
                 Transaction tx = txs.get( i );
 
                 tx.run( "CREATE ()" );
-                tx.success();
-                tx.close();
+                tx.commit();
                 session.close();
             }
         }

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.StatementResult;
@@ -235,7 +234,7 @@ class SessionResetIT
             try ( Transaction tx2 = session.beginTransaction() )
             {
                 tx2.run( "CREATE (n:FirstNode)" );
-                tx2.success();
+                tx2.commit();
             }
 
             StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
@@ -358,7 +357,7 @@ class SessionResetIT
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "RETURN 1" );
-                tx.success();
+                tx.commit();
             }
 
             // When reset the state of this session
@@ -368,7 +367,7 @@ class SessionResetIT
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "RETURN 2" );
-                tx.success();
+                tx.commit();
             }
         }
     }
@@ -387,8 +386,7 @@ class SessionResetIT
             Exception e = assertThrows( Exception.class, () ->
             {
                 tx.run( "RETURN 1" );
-                tx.success();
-                tx.close();
+                tx.commit();
             } );
             assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
         }
@@ -410,7 +408,7 @@ class SessionResetIT
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( "RETURN 2" );
-                tx.success();
+                tx.commit();
             }
         }
     }
@@ -497,8 +495,7 @@ class SessionResetIT
             // When
             Transaction tx = session.beginTransaction();
             tx.run( "CREATE (n:FirstNode)" );
-            tx.success();
-            tx.close();
+            tx.commit();
 
             // Then the outcome of both statements should be visible
             StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
@@ -538,8 +535,7 @@ class SessionResetIT
             // session has been reset, it should not be possible to commit the transaction
             try
             {
-                tx1.success();
-                tx1.close();
+                tx1.commit();
             }
             catch ( Neo4jException ignore )
             {
@@ -548,7 +544,7 @@ class SessionResetIT
             try ( Transaction tx2 = session.beginTransaction() )
             {
                 tx2.run( "CREATE (n:SecondNode)" );
-                tx2.success();
+                tx2.commit();
             }
 
             return null;
@@ -590,7 +586,6 @@ class SessionResetIT
 
             StatementResult result = updateNodeId( tx, nodeId, newNodeId2 );
             result.consume();
-            tx.success();
 
             nodeLocked.countDown();
             // give separate thread some time to block on a lock
@@ -598,6 +593,7 @@ class SessionResetIT
             otherSessionRef.get().reset();
 
             assertTransactionTerminated( txResult );
+            tx.commit();
         }
 
         try ( Session session = neo4j.driver().session() )
@@ -732,7 +728,7 @@ class SessionResetIT
             try ( Transaction tx = session.beginTransaction() )
             {
                 tx.run( query );
-                tx.success();
+                tx.commit();
             }
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
@@ -125,7 +125,7 @@ class TransactionBoltV3IT
                     try ( Transaction tx = session.beginTransaction( config ) )
                     {
                         tx.run( "MATCH (n:Node) SET n.prop = 2" );
-                        tx.success();
+                        tx.commit();
                     }
                 } );
 

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -307,30 +307,27 @@ class AsyncTransactionIT
     }
 
     @Test
-    void shouldBePossibleToCommitWhenCommitted()
+    void shouldFailToCommitWhenCommitted()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
         assertNull( await( tx.commitAsync() ) );
 
-        CompletionStage<Void> secondCommit = tx.commitAsync();
-        // second commit should return a completed future
-        assertTrue( secondCommit.toCompletableFuture().isDone() );
-        assertNull( await( secondCommit ) );
+        // should not be possible to commit after commit
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertThat( e.getMessage(), containsString( "transaction has been committed" ) );
     }
 
     @Test
-    void shouldBePossibleToRollbackWhenRolledBack()
+    void shouldFailToRollbackWhenRolledBack()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         tx.runAsync( "CREATE ()" );
         assertNull( await( tx.rollbackAsync() ) );
 
-        CompletionStage<Void> secondRollback = tx.rollbackAsync();
-        // second rollback should return a completed future
-        assertTrue( secondRollback.toCompletableFuture().isDone() );
-        assertNull( await( secondRollback ) );
-    }
+        // should not be possible to rollback after rollback
+        ClientException e = assertThrows( ClientException.class, () -> await( tx.rollbackAsync() ) );
+        assertThat( e.getMessage(), containsString( "transaction has been rolled back" ) );    }
 
     @Test
     void shouldFailToCommitWhenRolledBack()

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ExplicitTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ExplicitTransactionTest.java
@@ -107,43 +107,6 @@ class ExplicitTransactionTest
     }
 
     @Test
-    void shouldRollbackOnExplicitFailure()
-    {
-        // Given
-        Connection connection = connectionMock();
-        ExplicitTransaction tx = beginTx( connection );
-
-        // When
-        tx.failure();
-        tx.success(); // even if success is called after the failure call!
-        await( tx.closeAsync() );
-
-        // Then
-        InOrder order = inOrder( connection );
-        order.verify( connection ).write( eq( new RunMessage( "BEGIN" ) ), any(), eq( PullAllMessage.PULL_ALL ), any() );
-        order.verify( connection ).writeAndFlush( eq( new RunMessage( "ROLLBACK" ) ), any(), eq( PullAllMessage.PULL_ALL ), any() );
-        order.verify( connection ).release();
-    }
-
-    @Test
-    void shouldCommitOnSuccess()
-    {
-        // Given
-        Connection connection = connectionMock();
-        ExplicitTransaction tx = beginTx( connection );
-
-        // When
-        tx.success();
-        await( tx.closeAsync() );
-
-        // Then
-        InOrder order = inOrder( connection );
-        order.verify( connection ).write( eq( new RunMessage( "BEGIN" ) ), any(), eq( PullAllMessage.PULL_ALL ), any() );
-        order.verify( connection ).writeAndFlush( eq( new RunMessage( "COMMIT" ) ), any(), eq( PullAllMessage.PULL_ALL ), any() );
-        order.verify( connection ).release();
-    }
-
-    @Test
     void shouldOnlyQueueMessagesWhenNoBookmarkGiven()
     {
         Connection connection = connectionMock();
@@ -175,26 +138,6 @@ class ExplicitTransactionTest
     }
 
     @Test
-    void shouldBeOpenWhenMarkedForSuccess()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-
-        tx.success();
-
-        assertTrue( tx.isOpen() );
-    }
-
-    @Test
-    void shouldBeOpenWhenMarkedForFailure()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-
-        tx.failure();
-
-        assertTrue( tx.isOpen() );
-    }
-
-    @Test
     void shouldBeClosedWhenMarkedAsTerminated()
     {
         ExplicitTransaction tx = beginTx( connectionMock() );
@@ -202,28 +145,6 @@ class ExplicitTransactionTest
         tx.markTerminated();
 
         assertTrue( tx.isOpen() );
-    }
-
-    @Test
-    void shouldBeClosedAfterCommit()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-
-        tx.success();
-        await( tx.closeAsync() );
-
-        assertFalse( tx.isOpen() );
-    }
-
-    @Test
-    void shouldBeClosedAfterRollback()
-    {
-        ExplicitTransaction tx = beginTx( connectionMock() );
-
-        tx.failure();
-        await( tx.closeAsync() );
-
-        assertFalse( tx.isOpen() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -242,8 +242,7 @@ class NetworkSessionTest
         InternalBookmark bookmark = (InternalBookmark) session.lastBookmark();
         assertTrue( bookmark.isEmpty() );
 
-        tx.success();
-        await( tx.closeAsync() );
+        await( tx.commitAsync() );
         assertEquals( bookmarkAfterCommit, session.lastBookmark() );
     }
 
@@ -288,14 +287,12 @@ class NetworkSessionTest
         when( connection.protocol() ).thenReturn( protocol );
 
         ExplicitTransaction tx1 = beginTransaction( session );
-        tx1.success();
-        await( tx1.closeAsync() );
+        await( tx1.commitAsync() );
         assertEquals( bookmark1, session.lastBookmark() );
 
         ExplicitTransaction tx2 = beginTransaction( session );
         verifyBeginTx( connection, bookmark1 );
-        tx2.success();
-        await( tx2.closeAsync() );
+        await( tx2.commitAsync() );
 
         assertEquals( bookmark2, session.lastBookmark() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/BookmarkUtils.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/BookmarkUtils.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.util.Iterables.asList;
@@ -45,6 +46,16 @@ public class BookmarkUtils
         assertNotNull( bookmark );
         assertThat( bookmark, instanceOf( InternalBookmark.class ) );
         assertTrue( ((InternalBookmark) bookmark).isEmpty() );
+    }
+
+    /**
+     * Bookmark is not empty but I do not care what value it has.
+     */
+    public static void assertBookmarkIsNotEmpty( Bookmark bookmark )
+    {
+        assertNotNull( bookmark );
+        assertThat( bookmark, instanceOf( InternalBookmark.class ) );
+        assertFalse( ((InternalBookmark) bookmark).isEmpty() );
     }
 
     /**

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
@@ -54,7 +54,7 @@ public class BlockingReadQueryInTx<C extends AbstractContext> extends AbstractBl
             }
 
             context.readCompleted( result.summary() );
-            tx.success();
+            tx.commit();
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
@@ -47,7 +47,7 @@ public class BlockingWriteQueryInTx<C extends AbstractContext> extends AbstractB
             try ( Transaction tx = beginTransaction( session, context ) )
             {
                 result = tx.run( "CREATE ()" );
-                tx.success();
+                tx.commit();
             }
 
             context.setBookmark( session.lastBookmark() );

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
@@ -49,7 +49,7 @@ public class BlockingWriteQueryUsingReadSessionInTx<C extends AbstractContext> e
             {
                 StatementResult result = tx.run( "CREATE ()" );
                 resultRef.set( result );
-                tx.success();
+                tx.commit();
             }
         } );
         assertNotNull( resultRef.get() );

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
@@ -38,7 +38,6 @@ public class Neo4jSettings
     private static final String DEFAULT_CERT_DIR = "certificates";
     public static final String DEFAULT_TLS_CERT_PATH = DEFAULT_CERT_DIR + "/neo4j.cert";
     public static final String DEFAULT_TLS_KEY_PATH = DEFAULT_CERT_DIR + "/neo4j.key";
-    public static final String DEFAULT_PAGE_CACHE_SIZE = "512m";
     public static final String DEFAULT_BOLT_TLS_LEVEL = BoltTlsLevel.OPTIONAL.toString();
 
     public static final String DEFAULT_DATA_DIR = "data";
@@ -59,7 +58,6 @@ public class Neo4jSettings
     private final Set<String> excludes;
 
     public static final Neo4jSettings TEST_SETTINGS = new Neo4jSettings( map(
-            "dbms.backup.enabled", "false",
             "dbms.connector.http.listen_address", ":" + CURRENT_HTTP_PORT,
             "dbms.connector.https.listen_address", ":" + CURRENT_HTTPS_PORT,
             "dbms.connector.bolt.listen_address", ":" + CURRENT_BOLT_PORT,

--- a/examples/src/main/java/org/neo4j/docs/driver/CypherErrorExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/CypherErrorExample.java
@@ -61,6 +61,7 @@ public class CypherErrorExample extends BaseApplication
         }
         catch ( ClientException ex )
         {
+            tx.rollback();
             System.err.println( ex.getMessage() );
             return -1;
         }


### PR DESCRIPTION
Replaced `Transaction#success` and `Transaction#failure`
Changed the behaviour of `AsyncTransaction#commitAsync` and `AsyncTransaction#rollbackAsync` to throw error when committing/rolling back second time.
A transaction can be allowed to commit or rollback once, but closed multiple times.
This bring the behaviour of commit and rollback the same as 4.0 core API, as well as all other language drivers.