### PR TITLE
Mute procedure tests on 4.0 servers

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -431,7 +431,7 @@ class ConnectionHandlingIT
 
     private StatementResult createNodes( int nodesToCreate, StatementRunner statementRunner )
     {
-        return statementRunner.run( "UNWIND range(1, {nodesToCreate}) AS i CREATE (n {index: i}) RETURN n",
+        return statementRunner.run( "UNWIND range(1, $nodesToCreate) AS i CREATE (n {index: i}) RETURN n",
                 parameters( "nodesToCreate", nodesToCreate ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
@@ -53,7 +53,7 @@ class LoadCSVIT
             // When
             StatementResult result = session.run(
                     "USING PERIODIC COMMIT 40\n" +
-                    "LOAD CSV WITH HEADERS FROM {csvFileUrl} AS l\n" +
+                    "LOAD CSV WITH HEADERS FROM $csvFileUrl AS l\n" +
                     "MATCH (c:Class {name: l.class_name})\n" +
                     "CREATE (s:Sample {sepal_length: l.sepal_length, sepal_width: l.sepal_width, petal_length: l.petal_length, petal_width: l.petal_width})\n" +
 
@@ -71,7 +71,7 @@ class LoadCSVIT
     {
         for ( String className : IRIS_CLASS_NAMES )
         {
-            session.run( "CREATE (c:Class {name: {className}}) RETURN c", parameters( "className", className ) );
+            session.run( "CREATE (c:Class {name: $className}) RETURN c", parameters( "className", className ) );
         }
 
         return neo4j.putTmpFile( "iris", ".csv", IRIS_DATA ).toExternalForm();

--- a/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
@@ -28,14 +28,12 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
-import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
-import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.StatementResult;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.SessionExtension;
 import org.neo4j.driver.util.TestUtil;
@@ -43,19 +41,18 @@ import org.neo4j.driver.util.TestUtil;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
-import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
-import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
 import static org.neo4j.driver.Values.ofInteger;
 import static org.neo4j.driver.Values.ofValue;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
+import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
+import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
 
 @ParallelizableIT
 class ParametersIT
@@ -70,7 +67,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", true ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", true ) );
 
         // Then
         for ( Record record : result.list() )
@@ -86,7 +83,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", (byte) 1 ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", (byte) 1 ) );
 
         // Then
         for ( Record record : result.list() )
@@ -102,7 +99,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", (short) 1 ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", (short) 1 ) );
 
         // Then
         for ( Record record : result.list() )
@@ -118,7 +115,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", 1 ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 1 ) );
 
         // Then
         for ( Record record : result.list() )
@@ -135,7 +132,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", 1L ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 1L ) );
 
         // Then
         for ( Record record : result.list() )
@@ -152,7 +149,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", 6.28 ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 6.28 ) );
 
         // Then
         for ( Record record : result.list() )
@@ -190,7 +187,7 @@ class ParametersIT
         // When
         boolean[] arrayValue = new boolean[]{true, true, true};
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
         for ( Record record : result.list() )
@@ -213,7 +210,7 @@ class ParametersIT
         // When
         int[] arrayValue = new int[]{42, 42, 42};
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
         for ( Record record : result.list() )
@@ -236,7 +233,7 @@ class ParametersIT
         // When
         double[] arrayValue = new double[]{6.28, 6.28, 6.28};
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
         for ( Record record : result.list() )
@@ -264,7 +261,7 @@ class ParametersIT
         String[] arrayValue = new String[]{str, str, str};
 
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", arrayValue ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
         for ( Record record : result.list() )
@@ -296,7 +293,7 @@ class ParametersIT
         String bigString = new String( bigStr );
 
         // When
-        Value val = session.run( "RETURN {p} AS p", parameters( "p", bigString ) ).peek().get( "p" );
+        Value val = session.run( "RETURN $p AS p", parameters( "p", bigString ) ).peek().get( "p" );
 
         // Then
         assertThat( val.asString(), equalTo( bigString ) );
@@ -307,7 +304,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}.v}) RETURN a.value",
+                "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", true ) ) );
 
         // Then
@@ -325,7 +322,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}.v}) RETURN a.value",
+                "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", 42 ) ) );
 
         // Then
@@ -343,7 +340,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}.v}) RETURN a.value",
+                "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", 6.28 ) ) );
 
         // Then
@@ -361,7 +358,7 @@ class ParametersIT
     {
         // When
         StatementResult result = session.run(
-                "CREATE (a {value:{value}.v}) RETURN a.value",
+                "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", "Mjölnir" ) ) );
 
         // Then
@@ -466,7 +463,7 @@ class ParametersIT
 
     private static void testBytesProperty( byte[] array )
     {
-        StatementResult result = session.run( "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", array ) );
+        StatementResult result = session.run( "CREATE (a {value:$value}) RETURN a.value", parameters( "value", array ) );
 
         for ( Record record : result.list() )
         {
@@ -479,7 +476,7 @@ class ParametersIT
     private static void testStringProperty( String string )
     {
         StatementResult result = session.run(
-                "CREATE (a {value:{value}}) RETURN a.value", parameters( "value", string ) );
+                "CREATE (a {value:$value}) RETURN a.value", parameters( "value", string ) );
 
         for ( Record record : result.list() )
         {

--- a/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
@@ -88,7 +88,7 @@ class ResultStreamIT
     {
         // Given
         StatementResult rs =
-                session.run( "CREATE (n:Person {name:{name}}) RETURN n", parameters( "name", "Tom Hanks" ) );
+                session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
         Record single = rs.single();
@@ -102,7 +102,7 @@ class ResultStreamIT
     {
         // Given
         StatementResult rs =
-                session.run( "CREATE (n:Person {name:{name}}) RETURN n", parameters( "name", "Tom Hanks" ) );
+                session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
         Record record = rs.single();
@@ -115,7 +115,7 @@ class ResultStreamIT
     void shouldNotReturnNullKeysOnEmptyResult()
     {
         // Given
-        StatementResult rs = session.run( "CREATE (n:Person {name:{name}})", parameters( "name", "Tom Hanks" ) );
+        StatementResult rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
 
         // THEN
         assertNotNull( rs.keys() );

--- a/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
@@ -245,7 +245,7 @@ class ScalarTypeIT
     private void verifyCanEncodeAndDecode( Value input )
     {
         // When
-        StatementResult cursor = session.run( "RETURN {x} as y", parameters( "x", input ) );
+        StatementResult cursor = session.run( "RETURN $x as y", parameters( "x", input ) );
 
         // Then
         assertThat( cursor.single().get( "y" ), equalTo( input ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -60,8 +60,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.neo4j.driver.Config.defaultConfig;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
+import static org.neo4j.driver.util.TestUtil.TX_TIMEOUT_TEST_TIMEOUT;
 import static org.neo4j.driver.util.TestUtil.await;
 
 @EnabledOnNeo4jWith( BOLT_V3 )
@@ -124,15 +126,14 @@ class SessionBoltV3IT
                 // lock dummy node but keep the transaction open
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
-                TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofMillis( 1 ) )
-                        .build();
+                assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
+                    TransactionConfig config = TransactionConfig.builder().withTimeout( ofMillis( 1 ) ).build();
 
-                // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
-                TransientException error = assertThrows( TransientException.class,
-                        () -> session.run( "MATCH (n:Node) SET n.prop = 2", config ).consume() );
-
-                assertThat( error.getMessage(), containsString( "terminated" ) );
+                    // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
+                    TransientException error = assertThrows( TransientException.class,
+                            () -> session.run( "MATCH (n:Node) SET n.prop = 2", config ).consume() );
+                    assertThat( error.getMessage(), containsString( "terminated" ) );
+                } );
             }
         }
     }
@@ -151,17 +152,19 @@ class SessionBoltV3IT
                 // lock dummy node but keep the transaction open
                 otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
-                TransactionConfig config = TransactionConfig.builder()
-                        .withTimeout( ofMillis( 1 ) )
-                        .build();
+                assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
+                    TransactionConfig config = TransactionConfig.builder()
+                            .withTimeout( ofMillis( 1 ) )
+                            .build();
 
-                // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
-                CompletionStage<ResultSummary> resultFuture = asyncSession.runAsync( "MATCH (n:Node) SET n.prop = 2", config )
-                        .thenCompose( StatementResultCursor::consumeAsync );
+                    // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
+                    CompletionStage<ResultSummary> resultFuture = asyncSession.runAsync( "MATCH (n:Node) SET n.prop = 2", config )
+                            .thenCompose( StatementResultCursor::consumeAsync );
 
-                TransientException error = assertThrows( TransientException.class, () -> await( resultFuture ) );
+                    TransientException error = assertThrows( TransientException.class, () -> await( resultFuture ) );
 
-                MatcherAssert.assertThat( error.getMessage(), containsString( "terminated" ) );
+                    MatcherAssert.assertThat( error.getMessage(), containsString( "terminated" ) );
+                } );
             }
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -1479,7 +1479,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "MATCH (n {id: {id}}) RETURN count(n)", parameters( "id", id ) );
+            StatementResult result = session.run( "MATCH (n {id: $id}) RETURN count(n)", parameters( "id", id ) );
             return result.single().get( 0 ).asInt();
         }
     }
@@ -1488,13 +1488,13 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            session.run( "CREATE (n {id: {id}})", parameters( "id", id ) );
+            session.run( "CREATE (n {id: $id})", parameters( "id", id ) );
         }
     }
 
     private static StatementResult updateNodeId( StatementRunner statementRunner, int currentId, int newId )
     {
-        return statementRunner.run( "MATCH (n {id: {currentId}}) SET n.id = {newId}",
+        return statementRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
                 parameters( "currentId", currentId, "newId", newId ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
@@ -608,13 +608,13 @@ class SessionResetIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            session.run( "CREATE (n {id: {id}})", parameters( "id", id ) );
+            session.run( "CREATE (n {id: $id})", parameters( "id", id ) );
         }
     }
 
     private static StatementResult updateNodeId( StatementRunner statementRunner, int currentId, int newId )
     {
-        return statementRunner.run( "MATCH (n {id: {currentId}}) SET n.id = {newId}",
+        return statementRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
                 parameters( "currentId", currentId, "newId", newId ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/StatementIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/StatementIT.java
@@ -73,7 +73,7 @@ class StatementIT
     void shouldRunWithParameters()
     {
         // When
-        session.run( "CREATE (n:FirstNode {name:{name}})", parameters( "name", "Steven" ) );
+        session.run( "CREATE (n:FirstNode {name:$name})", parameters( "name", "Steven" ) );
 
         // Then nothing should've failed
     }
@@ -121,7 +121,7 @@ class StatementIT
     void shouldRunWithCollectionAsParameter()
     {
         // When
-        session.run( "RETURN {param}", parameters( "param", Collections.singleton( "FOO" ) ) );
+        session.run( "RETURN $param", parameters( "param", Collections.singleton( "FOO" ) ) );
 
         // Then nothing should've failed
     }
@@ -131,7 +131,7 @@ class StatementIT
     {
         Iterator<String> values = asList( "FOO", "BAR", "BAZ" ).iterator();
         // When
-        session.run( "RETURN {param}", parameters( "param", values ) );
+        session.run( "RETURN $param", parameters( "param", values ) );
 
         // Then nothing should've failed
     }
@@ -150,7 +150,7 @@ class StatementIT
     {
         // When
         List<Record> result =
-                session.run( "UNWIND {list} AS k RETURN k", parameters( "list", asList( 1, 2, 3 ) ) ).list();
+                session.run( "UNWIND $list AS k RETURN k", parameters( "list", asList( 1, 2, 3 ) ) ).list();
 
         // Then
         assertThat( result.size(), equalTo( 3 ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.StatementResult;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -57,7 +56,7 @@ class SummaryIT
     {
         // Given
         Value statementParameters = Values.parameters( "limit", 10 );
-        String statementText = "UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT {limit}";
+        String statementText = "UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT $limit";
 
         // When
         StatementResult result = session.run( statementText, statementParameters );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxStatementResultIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxStatementResultIT.java
@@ -148,7 +148,7 @@ class RxStatementResultIT
         // Given
         RxSession session = neo4j.driver().rxSession();
         RxStatementResult rs =
-                session.run( "CREATE (n:Person {name:{name}}) RETURN n", parameters( "name", "Tom Hanks" ) );
+                session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
         StepVerifier.create( Flux.from( rs.records() ).single() ).assertNext( record -> {
@@ -163,7 +163,7 @@ class RxStatementResultIT
         // Given
         RxSession session = neo4j.driver().rxSession();
         RxStatementResult rs =
-                session.run( "CREATE (n:Person {name:{name}}) RETURN n", parameters( "name", "Tom Hanks" ) );
+                session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
         StepVerifier.create( Flux.from( rs.records() ).single() ).assertNext( record -> {
@@ -194,7 +194,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult rs = session.run( "CREATE (n:Person {name:{name}})", parameters( "name", "Tom Hanks" ) );
+        RxStatementResult rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
 
         // Then
         StepVerifier.create( rs.keys() ).expectComplete().verify();

--- a/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
@@ -191,7 +191,7 @@ public class CausalClusteringIT implements NestedQueries
             {
                 try ( Transaction tx = session.beginTransaction() )
                 {
-                    tx.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Alistair" ) );
+                    tx.run( "CREATE (p:Person {name: $name })", Values.parameters( "name", "Alistair" ) );
                     tx.commit();
                 }
 
@@ -220,7 +220,7 @@ public class CausalClusteringIT implements NestedQueries
         {
             inExpirableSession( driver, createWritableSession( null ), session ->
             {
-                session.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Jim" ) );
+                session.run( "CREATE (p:Person {name: $name })", Values.parameters( "name", "Jim" ) );
                 return null;
             } );
 
@@ -242,7 +242,7 @@ public class CausalClusteringIT implements NestedQueries
             {
                 try ( Transaction tx = session.beginTransaction() )
                 {
-                    tx.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Alistair" ) );
+                    tx.run( "CREATE (p:Person {name: $name })", Values.parameters( "name", "Alistair" ) );
                     tx.commit();
                 }
 
@@ -338,7 +338,7 @@ public class CausalClusteringIT implements NestedQueries
             // gracefully stop current leader to force re-election
             cluster.stop( leader );
 
-            tx1.run( "CREATE (person:Person {name: {name}, title: {title}})",
+            tx1.run( "CREATE (person:Person {name: $name, title: $title})",
                     parameters( "name", "Webber", "title", "Mr" ) );
 
             assertThrows( (Class<? extends Exception>) SessionExpiredException.class, tx1::commit );
@@ -348,7 +348,7 @@ public class CausalClusteringIT implements NestedQueries
             {
                 try ( Transaction tx = session.beginTransaction() )
                 {
-                    tx.run( "CREATE (person:Person {name: {name}, title: {title}})",
+                    tx.run( "CREATE (person:Person {name: $name, title: $title})",
                             parameters( "name", "Webber", "title", "Mr" ) );
                     tx.commit();
                 }
@@ -799,7 +799,7 @@ public class CausalClusteringIT implements NestedQueries
         {
             return session.readTransaction( tx ->
             {
-                StatementResult result = tx.run( "MATCH (:Person {name: {name}}) RETURN count(*)",
+                StatementResult result = tx.run( "MATCH (:Person {name: $name}) RETURN count(*)",
                         parameters( "name", name ) );
                 return result.single().get( 0 ).asInt();
             } );

--- a/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.types.TypeSystem;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.util.Neo4jRunner.DEFAULT_AUTH_TOKEN;
 import static org.neo4j.driver.util.Neo4jRunner.HOME_DIR;
 import static org.neo4j.driver.util.Neo4jRunner.debug;
@@ -146,6 +147,9 @@ public class DatabaseExtension implements BeforeEachCallback
 
     public void ensureProcedures( String jarName ) throws IOException
     {
+        // These procedures was written against 3.x API.
+        // As graph database service API is totally changed since 4.0. These procedures are no long valid.
+        assumeTrue( version().lessThan( ServerVersion.v4_0_0 ) );
         File procedureJar = new File( HOME_DIR, "plugins/" + jarName );
         if ( !procedureJar.exists() )
         {

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -104,6 +104,7 @@ public final class TestUtil
 
     private static final long DEFAULT_WAIT_TIME_MS = MINUTES.toMillis( 1 );
     private static final String ALPHANUMERICS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789";
+    public static final Duration TX_TIMEOUT_TEST_TIMEOUT = Duration.ofSeconds( 10 );
 
     private TestUtil()
     {


### PR DESCRIPTION
Some driver tests use procedure to simulate an infinite stream or execution of a query.
However these proceudres are created against 3.x server API.
So mute them for 4.0 servers. We shall eventually re-write them in some other way.