### PR TITLE
Ensure that in-flight reactive result streams are DISCARDed

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxStatementResultCursor.java
@@ -40,7 +40,7 @@ public class RxStatementResultCursor implements Subscription, FailableCursor
     private final BasicPullResponseHandler pullHandler;
     private final Throwable runResponseError;
     private final CompletableFuture<ResultSummary> summaryFuture = new CompletableFuture<>();
-    boolean isRecordHandlerInstalled = false;
+    private boolean isRecordHandlerInstalled = false;
 
     public RxStatementResultCursor( RunResponseHandler runHandler, BasicPullResponseHandler pullHandler )
     {

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
@@ -43,7 +43,7 @@ public interface RxStatementResult
     /**
      * Returns a cold publisher of keys.
      * <p>
-     * When this publisher is {@linkplain Publisher#subscribe(Subscriber) subscribed}, the query statement is sent to the server and get executed.
+     * When this publisher is {@linkplain Publisher#subscribe(Subscriber) subscribed}, the query statement is sent to the server and executed.
      * This method does not start the record streaming nor publish query execution error.
      * To retrieve the execution result, either {@link #records()} or {@link #summary()} can be used.
      * {@link #records()} starts record streaming and reports query execution error.

--- a/driver/src/test/resources/read_tx_v4_discard.script
+++ b/driver/src/test/resources/read_tx_v4_discard.script
@@ -1,0 +1,13 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+
+C: BEGIN { "mode": "r" }
+   RUN "UNWIND [1,2,3,4] AS a RETURN a" {} {}
+S: SUCCESS {}
+   SUCCESS {"t_first": 110, "fields": ["a"], "qid": 0}
+C: DISCARD {"qid": 0, "n": -1}
+S: SUCCESS {"type": "r", "t_last": 3, "db": "neo4j"}
+C: COMMIT
+S: SUCCESS {"bookmark": "e57085e2-727f-43f3-b632-7ec57978806e:117"}


### PR DESCRIPTION
Reactive shall discard records on commit and/or rollback.
If summary has not yet arrived, tx.commit/rollback -> DISCARD n=-1, COMMIT/ROLL_BACK