### PR TITLE
Update netty version to the latest.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
@@ -19,7 +19,6 @@
 package org.neo4j.driver.internal.async;
 
 import io.netty.channel.Channel;
-import io.netty.channel.pool.ChannelPool;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -28,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.async.pool.ExtendedChannelPool;
 import org.neo4j.driver.internal.handlers.ChannelReleasingResetResponseHandler;
 import org.neo4j.driver.internal.handlers.ResetResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
@@ -57,7 +57,7 @@ public class NetworkConnection implements Connection
     private final BoltServerAddress serverAddress;
     private final ServerVersion serverVersion;
     private final BoltProtocol protocol;
-    private final ChannelPool channelPool;
+    private final ExtendedChannelPool channelPool;
     private final CompletableFuture<Void> releaseFuture;
     private final Clock clock;
 
@@ -65,7 +65,7 @@ public class NetworkConnection implements Connection
     private final MetricsListener metricsListener;
     private final ListenerEvent inUseEvent;
 
-    public NetworkConnection( Channel channel, ChannelPool channelPool, Clock clock, MetricsListener metricsListener )
+    public NetworkConnection( Channel channel, ExtendedChannelPool channelPool, Clock clock, MetricsListener metricsListener )
     {
         this.channel = channel;
         this.messageDispatcher = ChannelAttributes.messageDispatcher( channel );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ExtendedChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ExtendedChannelPool.java
@@ -18,15 +18,19 @@
  */
 package org.neo4j.driver.internal.async.pool;
 
-import io.netty.channel.pool.ChannelPool;
+import io.netty.channel.Channel;
 
 import java.util.concurrent.CompletionStage;
 
-public interface ExtendedChannelPool extends ChannelPool
+public interface ExtendedChannelPool
 {
+    CompletionStage<Channel> acquire();
+
+    CompletionStage<Void> release( Channel channel );
+
     boolean isClosed();
 
     String id();
 
-    CompletionStage<Void> repeatableCloseAsync();
+    CompletionStage<Void> close();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ExtendedChannelPool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ExtendedChannelPool.java
@@ -20,9 +20,13 @@ package org.neo4j.driver.internal.async.pool;
 
 import io.netty.channel.pool.ChannelPool;
 
+import java.util.concurrent.CompletionStage;
+
 public interface ExtendedChannelPool extends ChannelPool
 {
     boolean isClosed();
 
     String id();
+
+    CompletionStage<Void> repeatableCloseAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
@@ -91,9 +91,8 @@ public class NettyChannelTracker implements ChannelPoolHandler
         log.debug( "Channel [0x%s] created. Local address: %s, remote address: %s",
                 channel.id(), channel.localAddress(), channel.remoteAddress() );
 
-        incrementInUse( channel );
+        incrementIdle( channel ); // when it is created, we count it as idle as it has not been acquired out of the pool
         metricsListener.afterCreated( poolId( channel ), creatingEvent );
-
         allChannels.add( channel );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -45,9 +45,27 @@ public final class Futures
         return (CompletableFuture) COMPLETED_WITH_NULL;
     }
 
+    public static <T> CompletableFuture<T> completedWithNullIfNonError( CompletableFuture<T> future, Throwable error )
+    {
+        if ( error != null )
+        {
+            future.completeExceptionally( error );
+        }
+        else
+        {
+            future.complete( null );
+        }
+        return future;
+    }
+
     public static <T> CompletionStage<T> asCompletionStage( io.netty.util.concurrent.Future<T> future )
     {
         CompletableFuture<T> result = new CompletableFuture<>();
+        return asCompletionStage( future, result );
+    }
+
+    public static <T> CompletionStage<T> asCompletionStage( io.netty.util.concurrent.Future<T> future, CompletableFuture<T> result )
+    {
         if ( future.isCancelled() )
         {
             result.cancel( true );

--- a/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/Futures.java
@@ -45,7 +45,7 @@ public final class Futures
         return (CompletableFuture) COMPLETED_WITH_NULL;
     }
 
-    public static <T> CompletableFuture<T> completedWithNullIfNonError( CompletableFuture<T> future, Throwable error )
+    public static <T> CompletableFuture<T> completeWithNullIfNoError( CompletableFuture<T> future, Throwable error )
     {
         if ( error != null )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.channel.pool.ChannelPool;
 import io.netty.util.internal.ConcurrentSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,7 @@ import java.util.function.Consumer;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.async.pool.ExtendedChannelPool;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.messaging.request.RunMessage;
 import org.neo4j.driver.internal.spi.ResponseHandler;
@@ -447,7 +447,7 @@ class NetworkConnectionTest
     void shouldReleaseChannelWhenTerminated()
     {
         EmbeddedChannel channel = newChannel();
-        ChannelPool pool = mock( ChannelPool.class );
+        ExtendedChannelPool pool = mock( ExtendedChannelPool.class );
         NetworkConnection connection = newConnection( channel, pool );
         verify( pool, never() ).release( any() );
 
@@ -460,7 +460,7 @@ class NetworkConnectionTest
     void shouldNotReleaseChannelMultipleTimesWhenTerminatedMultipleTimes()
     {
         EmbeddedChannel channel = newChannel();
-        ChannelPool pool = mock( ChannelPool.class );
+        ExtendedChannelPool pool = mock( ExtendedChannelPool.class );
         NetworkConnection connection = newConnection( channel, pool );
         verify( pool, never() ).release( any() );
 
@@ -478,7 +478,7 @@ class NetworkConnectionTest
     void shouldNotReleaseAfterTermination()
     {
         EmbeddedChannel channel = newChannel();
-        ChannelPool pool = mock( ChannelPool.class );
+        ExtendedChannelPool pool = mock( ExtendedChannelPool.class );
         NetworkConnection connection = newConnection( channel, pool );
         verify( pool, never() ).release( any() );
 
@@ -611,10 +611,10 @@ class NetworkConnectionTest
 
     private static NetworkConnection newConnection( Channel channel )
     {
-        return newConnection( channel, mock( ChannelPool.class ) );
+        return newConnection( channel, mock( ExtendedChannelPool.class ) );
     }
 
-    private static NetworkConnection newConnection( Channel channel, ChannelPool pool )
+    private static NetworkConnection newConnection( Channel channel, ExtendedChannelPool pool )
     {
         return new NetworkConnection( channel, pool, new FakeClock(), DEV_NULL_METRICS );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -123,7 +123,7 @@ class ConnectionPoolImplIT
                 assertThrows( ServiceUnavailableException.class, () -> await( pool.acquire( neo4j.address() ) ) );
         assertThat( error.getMessage(), containsString( "closed while acquiring a connection" ) );
         assertThat( error.getCause(), instanceOf( IllegalStateException.class ) );
-        assertThat( error.getCause().getMessage(), containsString( "FixedChannelPooled was closed" ) );
+        assertThat( error.getCause().getMessage(), containsString( "FixedChannelPool was closed" ) );
     }
 
     private ConnectionPoolImpl newPool() throws Exception

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -133,7 +133,7 @@ class ConnectionPoolImplIT
     {
         await( pool.acquire( neo4j.address() ) );
         ExtendedChannelPool channelPool = this.pool.getPool( neo4j.address() );
-        await( channelPool.repeatableCloseAsync() );
+        await( channelPool.close() );
         ServiceUnavailableException error =
                 assertThrows( ServiceUnavailableException.class, () -> await( pool.acquire( neo4j.address() ) ) );
         assertThat( error.getMessage(), containsString( "closed while acquiring a connection" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplTest.java
@@ -19,31 +19,23 @@
 package org.neo4j.driver.internal.async.pool;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.util.FakeClock;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.doReturn;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
-import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 class ConnectionPoolImplTest
 {
@@ -55,7 +47,7 @@ class ConnectionPoolImplTest
     void shouldDoNothingWhenRetainOnEmptyPool()
     {
         NettyChannelTracker nettyChannelTracker = mock( NettyChannelTracker.class );
-        TestConnectionPool pool = new TestConnectionPool( nettyChannelTracker );
+        TestConnectionPool pool = newConnectionPool( nettyChannelTracker );
 
         pool.retainAll( singleton( LOCAL_DEFAULT ) );
 
@@ -66,7 +58,7 @@ class ConnectionPoolImplTest
     void shouldRetainSpecifiedAddresses()
     {
         NettyChannelTracker nettyChannelTracker = mock( NettyChannelTracker.class );
-        TestConnectionPool pool = new TestConnectionPool( nettyChannelTracker );
+        TestConnectionPool pool = newConnectionPool( nettyChannelTracker );
 
         pool.acquire( ADDRESS_1 );
         pool.acquire( ADDRESS_2 );
@@ -75,7 +67,7 @@ class ConnectionPoolImplTest
         pool.retainAll( new HashSet<>( asList( ADDRESS_1, ADDRESS_2, ADDRESS_3 ) ) );
         for ( ExtendedChannelPool channelPool : pool.channelPoolsByAddress.values() )
         {
-            verify( channelPool, never() ).repeatableCloseAsync();
+            assertFalse( channelPool.isClosed() );
         }
     }
 
@@ -83,7 +75,7 @@ class ConnectionPoolImplTest
     void shouldClosePoolsWhenRetaining()
     {
         NettyChannelTracker nettyChannelTracker = mock( NettyChannelTracker.class );
-        TestConnectionPool pool = new TestConnectionPool( nettyChannelTracker );
+        TestConnectionPool pool = newConnectionPool( nettyChannelTracker );
 
         pool.acquire( ADDRESS_1 );
         pool.acquire( ADDRESS_2 );
@@ -94,16 +86,16 @@ class ConnectionPoolImplTest
         when( nettyChannelTracker.inUseChannelCount( ADDRESS_3 ) ).thenReturn( 3 );
 
         pool.retainAll( new HashSet<>( asList( ADDRESS_1, ADDRESS_3 ) ) );
-        verify( pool.getPool( ADDRESS_1 ), never() ).repeatableCloseAsync();
-        verify( pool.getPool( ADDRESS_2 ) ).repeatableCloseAsync();
-        verify( pool.getPool( ADDRESS_3 ), never() ).repeatableCloseAsync();
+        assertFalse( pool.getPool( ADDRESS_1 ).isClosed() );
+        assertTrue( pool.getPool( ADDRESS_2 ).isClosed() );
+        assertFalse( pool.getPool( ADDRESS_3 ).isClosed() );
     }
 
     @Test
     void shouldNotClosePoolsWithActiveConnectionsWhenRetaining()
     {
         NettyChannelTracker nettyChannelTracker = mock( NettyChannelTracker.class );
-        TestConnectionPool pool = new TestConnectionPool( nettyChannelTracker );
+        TestConnectionPool pool = newConnectionPool( nettyChannelTracker );
 
         pool.acquire( ADDRESS_1 );
         pool.acquire( ADDRESS_2 );
@@ -114,9 +106,9 @@ class ConnectionPoolImplTest
         when( nettyChannelTracker.inUseChannelCount( ADDRESS_3 ) ).thenReturn( 0 );
 
         pool.retainAll( singleton( ADDRESS_2 ) );
-        verify( pool.getPool( ADDRESS_1 ), never() ).repeatableCloseAsync();
-        verify( pool.getPool( ADDRESS_2 ), never() ).repeatableCloseAsync();
-        verify( pool.getPool( ADDRESS_3 ) ).repeatableCloseAsync();
+        assertFalse( pool.getPool( ADDRESS_1 ).isClosed() );
+        assertFalse( pool.getPool( ADDRESS_2 ).isClosed() );
+        assertTrue( pool.getPool( ADDRESS_3 ).isClosed() );
     }
 
     private static PoolSettings newSettings()
@@ -124,32 +116,9 @@ class ConnectionPoolImplTest
         return new PoolSettings( 10, 5000, -1, -1 );
     }
 
-    private static class TestConnectionPool extends ConnectionPoolImpl
+    private static TestConnectionPool newConnectionPool( NettyChannelTracker nettyChannelTracker )
     {
-        final Map<BoltServerAddress,ExtendedChannelPool> channelPoolsByAddress = new HashMap<>();
-
-        TestConnectionPool( NettyChannelTracker nettyChannelTracker )
-        {
-            super( mock( ChannelConnector.class ), mock( Bootstrap.class ), nettyChannelTracker, newSettings(), DEV_NULL_METRICS, DEV_NULL_LOGGING,
-                    new FakeClock(), true, mock( ConnectionFactory.class ) );
-        }
-
-        ExtendedChannelPool getPool( BoltServerAddress address )
-        {
-            ExtendedChannelPool pool = channelPoolsByAddress.get( address );
-            assertNotNull( pool );
-            return pool;
-        }
-
-        @Override
-        ExtendedChannelPool newPool( BoltServerAddress address )
-        {
-            ExtendedChannelPool channelPool = mock( ExtendedChannelPool.class );
-            Channel channel = mock( Channel.class );
-            doReturn( ImmediateEventExecutor.INSTANCE.newSucceededFuture( channel ) ).when( channelPool ).acquire();
-            doReturn( completedWithNull() ).when( channelPool ).repeatableCloseAsync();
-            channelPoolsByAddress.put( address, channelPool );
-            return channelPool;
-        }
+        return new TestConnectionPool( mock( Bootstrap.class ), nettyChannelTracker, newSettings(), DEV_NULL_METRICS, DEV_NULL_LOGGING,
+                new FakeClock(), true );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/TestConnectionPool.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/TestConnectionPool.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.driver.Logging;
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.async.connection.ChannelConnector;
+import org.neo4j.driver.internal.metrics.ListenerEvent;
+import org.neo4j.driver.internal.metrics.MetricsListener;
+import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.util.Clock;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setPoolId;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerAddress;
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
+
+public class TestConnectionPool extends ConnectionPoolImpl
+{
+    final Map<BoltServerAddress,ExtendedChannelPool> channelPoolsByAddress = new HashMap<>();
+    private final NettyChannelTracker nettyChannelTracker;
+
+    public TestConnectionPool( Bootstrap bootstrap, NettyChannelTracker nettyChannelTracker, PoolSettings settings,
+            MetricsListener metricsListener, Logging logging, Clock clock, boolean ownsEventLoopGroup )
+    {
+        super( mock( ChannelConnector.class ), bootstrap, nettyChannelTracker, settings, metricsListener, logging, clock, ownsEventLoopGroup,
+                newConnectionFactory() );
+        this.nettyChannelTracker = nettyChannelTracker;
+    }
+
+    ExtendedChannelPool getPool( BoltServerAddress address )
+    {
+        return channelPoolsByAddress.get( address );
+    }
+
+    @Override
+    ExtendedChannelPool newPool( BoltServerAddress address )
+    {
+        ExtendedChannelPool channelPool = new ExtendedChannelPool()
+        {
+            private final AtomicBoolean isClosed = new AtomicBoolean( false );
+            @Override
+            public CompletionStage<Channel> acquire()
+            {
+                EmbeddedChannel channel = new EmbeddedChannel();
+                setServerAddress( channel, address );
+                setPoolId( channel, id() );
+
+                ListenerEvent event = nettyChannelTracker.channelCreating( id() );
+                nettyChannelTracker.channelCreated( channel, event );
+                nettyChannelTracker.channelAcquired( channel );
+
+                return completedFuture( channel );
+            }
+
+            @Override
+            public CompletionStage<Void> release( Channel channel )
+            {
+                nettyChannelTracker.channelReleased( channel );
+                nettyChannelTracker.channelClosed( channel );
+                return completedWithNull();
+            }
+
+            @Override
+            public boolean isClosed()
+            {
+                return isClosed.get();
+            }
+
+            @Override
+            public String id()
+            {
+                return "Pool-" + this.hashCode();
+            }
+
+            @Override
+            public CompletionStage<Void> close()
+            {
+                isClosed.set( true );
+                return completedWithNull();
+            }
+        };
+        channelPoolsByAddress.put( address, channelPool );
+        return channelPool;
+    }
+
+    private static ConnectionFactory newConnectionFactory()
+    {
+        return ( channel, pool ) -> {
+            Connection conn = mock( Connection.class );
+            when( conn.release() ).thenAnswer( invocation -> pool.release( channel ) );
+            return conn;
+        };
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
@@ -407,7 +407,10 @@ class RoutingTableAndConnectionPoolTest
             this.channel = channel;
             this.pool = pool;
 
-            this.channel.attr( AttributeKey.valueOf( "channelPool" ) ).setIfAbsent( pool );
+            // This is needed to make netty connection pool to believe this channel is created by the pool.
+            // Otherwise the netty connection pool will refuse to release the channel back to the pool.
+            AttributeKey<ExtendedChannelPool> poolKey = AttributeKey.valueOf( "channelPool." + System.identityHashCode( pool ) );
+            this.channel.attr( poolKey ).setIfAbsent( pool );
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.22.Final</version>
+        <version>4.1.41.Final</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor</groupId>


### PR DESCRIPTION
## Connection Counters
In the updated netty pool,
`ChannelPoolHandler#channelCreated` is called at channel creation, and then `ChannelPoolHandler#channelAcquired` is called when the connection is borrowed out of the pool. Whereas in previous netty version, when a connection is created, then it is directly lent out of the pool without being acquired. Thus some changes are made to maintain the counters for in use and idle connections.

## Deadlock Issues Caused by Netty Blocking `ChannelPool#close`.

The new netty version provides both blocking pool close `FixedChannelPool#close` and async pool close `FixedChannelPool#closeAsync`.
The blocking close causes deadlock issues in our code.

One deadlock issue happens when `ConnectionPoolImpl#retainAll` trying to close a netty pool inside an IO thread that is used by one of the channels owned by the closing pool.

The deadlock happens because
1) The channel cannot be closed until the IO thread is fully free.
2) The pool cannot be closed until the channel is closed.
3) However the IO thread cannot be free until the pool is closed.
`pool --wait-on--> channel --wait-on--> IO thread --wait-on--> pool`

The fix is to change 3) to let the IO thread to call async pool close to not block the close operation.

Another deadlock issue happens in `Driver#close`.

In `Driver#close`, we need to chain the event loop group shutdown after all pool close.
As pool close tasks are executed on event loop group, if we shutdown event loop group first,
then the pool close will be stuck because of no thread to pick up any shutdown tasks.
