### PR TITLE
Better error message for default database routing table update

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/SessionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/SessionConfig.java
@@ -26,7 +26,6 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.reactive.RxSession;
 
 import static java.util.Objects.requireNonNull;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 
 /**
  * The session configurations used to configure a session.
@@ -222,9 +221,9 @@ public class SessionConfig
         public Builder withDatabase( String database )
         {
             requireNonNull( database, "Database name should not be null." );
-            if ( ABSENT_DB_NAME.equals( database ) )
+            if ( database.isEmpty() )
             {
-                // Disallow users to use bolt internal value directly. To users, this is totally an illegal database name.
+                // Empty string is an illegal database name. Fail fast on client.
                 throw new IllegalArgumentException( String.format( "Illegal database name '%s'.", database ) );
             }
             this.database = database;

--- a/driver/src/main/java/org/neo4j/driver/internal/DatabaseName.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DatabaseName.java
@@ -16,19 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging.request;
+package org.neo4j.driver.internal;
 
-import org.neo4j.driver.exceptions.ClientException;
-import org.neo4j.driver.internal.DatabaseName;
+import java.util.Optional;
 
-public final class MultiDatabaseUtil
+public interface DatabaseName
 {
-    public static void assertEmptyDatabaseName( DatabaseName databaseName, int boltVersion )
-    {
-        if ( databaseName.databaseName().isPresent() )
-        {
-            throw new ClientException( String.format( "Database name parameter for selecting database is not supported in Bolt Protocol Version %s. " +
-                    "Database name: '%s'", boltVersion, databaseName.description() ) );
-        }
-    }
+    Optional<String> databaseName();
+
+    String description();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DatabaseNameUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DatabaseNameUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class DatabaseNameUtil
+{
+    static final String DEFAULT_DATABASE_NAME = null;
+    public static final String SYSTEM_DATABASE_NAME = "system";
+
+    private static final DatabaseName DEFAULT_DATABASE = new DatabaseName()
+    {
+        @Override
+        public Optional<String> databaseName()
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public String description()
+        {
+            return "<default database>";
+        }
+    };
+    private static final DatabaseName SYSTEM_DATABASE = new InternalDatabaseName( SYSTEM_DATABASE_NAME );
+
+    public static DatabaseName defaultDatabase()
+    {
+        return DEFAULT_DATABASE;
+    }
+
+    public static DatabaseName systemDatabase()
+    {
+        return SYSTEM_DATABASE;
+    }
+
+    public static DatabaseName database( String name )
+    {
+        if ( Objects.equals( name, DEFAULT_DATABASE_NAME ) )
+        {
+            return defaultDatabase();
+        }
+        else if ( Objects.equals( name, SYSTEM_DATABASE_NAME ) )
+        {
+            return systemDatabase();
+        }
+        return new InternalDatabaseName( name );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDatabaseName.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDatabaseName.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class InternalDatabaseName implements DatabaseName
+{
+    private final String databaseName;
+
+    InternalDatabaseName( String databaseName )
+    {
+        this.databaseName = requireNonNull( databaseName );
+    }
+
+    @Override
+    public Optional<String> databaseName()
+    {
+        return Optional.of( databaseName );
+    }
+
+    @Override
+    public String description()
+    {
+        return databaseName;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        InternalDatabaseName that = (InternalDatabaseName) o;
+        return databaseName.equals( that.databaseName );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( databaseName );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "InternalDatabaseName{" + "databaseName='" + databaseName + '\'' + '}';
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ConnectionContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ConnectionContext.java
@@ -19,11 +19,12 @@
 package org.neo4j.driver.internal.async;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 
 public interface ConnectionContext
 {
-    String databaseName();
+    DatabaseName databaseName();
 
     AccessMode mode();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ImmutableConnectionContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ImmutableConnectionContext.java
@@ -19,24 +19,25 @@
 package org.neo4j.driver.internal.async;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.spi.Connection;
 
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 
 /**
  * A {@link Connection} shall fulfil this {@link ImmutableConnectionContext} when acquired from a connection provider.
  */
 public class ImmutableConnectionContext implements ConnectionContext
 {
-    private static final ConnectionContext SIMPLE = new ImmutableConnectionContext( ABSENT_DB_NAME, empty(), AccessMode.READ );
+    private static final ConnectionContext SIMPLE = new ImmutableConnectionContext( defaultDatabase(), empty(), AccessMode.READ );
 
-    private final String databaseName;
+    private final DatabaseName databaseName;
     private final AccessMode mode;
     private final InternalBookmark rediscoveryBookmark;
 
-    public ImmutableConnectionContext( String databaseName, InternalBookmark bookmark, AccessMode mode )
+    public ImmutableConnectionContext( DatabaseName databaseName, InternalBookmark bookmark, AccessMode mode )
     {
         this.databaseName = databaseName;
         this.rediscoveryBookmark = bookmark;
@@ -44,7 +45,7 @@ public class ImmutableConnectionContext implements ConnectionContext
     }
 
     @Override
-    public String databaseName()
+    public DatabaseName databaseName()
     {
         return databaseName;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.async;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.internal.BookmarkHolder;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.internal.util.Futures;
@@ -31,7 +32,7 @@ public class LeakLoggingNetworkSession extends NetworkSession
 {
     private final String stackTrace;
 
-    public LeakLoggingNetworkSession( ConnectionProvider connectionProvider, RetryLogic retryLogic, String databaseName, AccessMode mode,
+    public LeakLoggingNetworkSession( ConnectionProvider connectionProvider, RetryLogic retryLogic, DatabaseName databaseName, AccessMode mode,
             BookmarkHolder bookmarkHolder, Logging logging )
     {
         super( connectionProvider, retryLogic, databaseName, mode, bookmarkHolder, logging );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -23,14 +23,15 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.StatementResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
-import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.BookmarkHolder;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.FailableCursor;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.cursor.InternalStatementResultCursor;
@@ -62,7 +63,7 @@ public class NetworkSession
 
     private final AtomicBoolean open = new AtomicBoolean( true );
 
-    public NetworkSession( ConnectionProvider connectionProvider, RetryLogic retryLogic, String databaseName, AccessMode mode,
+    public NetworkSession( ConnectionProvider connectionProvider, RetryLogic retryLogic, DatabaseName databaseName, AccessMode mode,
             BookmarkHolder bookmarkHolder, Logging logging )
     {
         this.connectionProvider = connectionProvider;
@@ -344,9 +345,9 @@ public class NetworkSession
     /**
      * A {@link Connection} shall fulfil this {@link ImmutableConnectionContext} when acquired from a connection provider.
      */
-    private class NetworkSessionConnectionContext implements ConnectionContext
+    private static class NetworkSessionConnectionContext implements ConnectionContext
     {
-        private final String databaseName;
+        private final DatabaseName databaseName;
         private AccessMode mode;
 
         // This bookmark is only used for rediscovery.
@@ -354,7 +355,7 @@ public class NetworkSession
         // As only that bookmark could carry extra system bookmarks
         private final InternalBookmark rediscoveryBookmark;
 
-        private NetworkSessionConnectionContext( String databaseName, InternalBookmark bookmark )
+        private NetworkSessionConnectionContext( DatabaseName databaseName, InternalBookmark bookmark )
         {
             this.databaseName = databaseName;
             this.rediscoveryBookmark = bookmark;
@@ -367,7 +368,7 @@ public class NetworkSession
         }
 
         @Override
-        public String databaseName()
+        public DatabaseName databaseName()
         {
             return databaseName;
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.async.connection;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.DirectConnectionProvider;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
@@ -36,9 +37,9 @@ public class DirectConnection implements Connection
 {
     private final Connection delegate;
     private final AccessMode mode;
-    private final String databaseName;
+    private final DatabaseName databaseName;
 
-    public DirectConnection( Connection delegate, String databaseName, AccessMode mode )
+    public DirectConnection( Connection delegate, DatabaseName databaseName, AccessMode mode )
     {
         this.delegate = delegate;
         this.mode = mode;
@@ -135,7 +136,7 @@ public class DirectConnection implements Connection
     }
 
     @Override
-    public String databaseName()
+    public DatabaseName databaseName()
     {
         return this.databaseName;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.async.connection;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.RoutingErrorHandler;
 import org.neo4j.driver.internal.handlers.RoutingResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
@@ -38,9 +39,9 @@ public class RoutingConnection implements Connection
     private final Connection delegate;
     private final AccessMode accessMode;
     private final RoutingErrorHandler errorHandler;
-    private final String databaseName;
+    private final DatabaseName databaseName;
 
-    public RoutingConnection( Connection delegate, String databaseName, AccessMode accessMode, RoutingErrorHandler errorHandler )
+    public RoutingConnection( Connection delegate, DatabaseName databaseName, AccessMode accessMode, RoutingErrorHandler errorHandler )
     {
         this.delegate = delegate;
         this.databaseName = databaseName;
@@ -139,7 +140,7 @@ public class RoutingConnection implements Connection
     }
 
     @Override
-    public String databaseName()
+    public DatabaseName databaseName()
     {
         return this.databaseName;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
@@ -20,10 +20,11 @@ package org.neo4j.driver.internal.cluster;
 
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.spi.Connection;
 
 public interface ClusterCompositionProvider
 {
-    CompletionStage<ClusterComposition> getClusterComposition( Connection connection, String databaseName, InternalBookmark bookmark );
+    CompletionStage<ClusterComposition> getClusterComposition( Connection connection, DatabaseName databaseName, InternalBookmark bookmark );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.util.Clock;
 
 import static java.lang.String.format;
@@ -40,16 +41,16 @@ public class ClusterRoutingTable implements RoutingTable
     private final AddressSet writers;
     private final AddressSet routers;
 
-    private final String databaseName; // specifies the database this routing table is acquired for
+    private final DatabaseName databaseName; // specifies the database this routing table is acquired for
     private boolean preferInitialRouter;
 
-    public ClusterRoutingTable( String ofDatabase, Clock clock, BoltServerAddress... routingAddresses )
+    public ClusterRoutingTable( DatabaseName ofDatabase, Clock clock, BoltServerAddress... routingAddresses )
     {
         this( ofDatabase, clock );
         routers.update( new LinkedHashSet<>( asList( routingAddresses ) ) );
     }
 
-    private ClusterRoutingTable( String ofDatabase, Clock clock )
+    private ClusterRoutingTable( DatabaseName ofDatabase, Clock clock )
     {
         this.databaseName = ofDatabase;
         this.clock = clock;
@@ -127,7 +128,8 @@ public class ClusterRoutingTable implements RoutingTable
         return servers;
     }
 
-    public String database()
+    @Override
+    public DatabaseName database()
     {
         return databaseName;
     }
@@ -147,6 +149,7 @@ public class ClusterRoutingTable implements RoutingTable
     @Override
     public synchronized String toString()
     {
-        return format( "Ttl %s, currentTime %s, routers %s, writers %s, readers %s, database '%s'", expirationTimestamp, clock.millis(), routers, writers, readers, databaseName );
+        return format( "Ttl %s, currentTime %s, routers %s, writers %s, readers %s, database '%s'",
+                expirationTimestamp, clock.millis(), routers, writers, readers, databaseName.description() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
@@ -55,7 +55,7 @@ public class MultiDatabasesRoutingProcedureRunner extends RoutingProcedureRunner
     {
         HashMap<String,Value> map = new HashMap<>();
         map.put( ROUTING_CONTEXT, value( context.asMap() ) );
-        databaseName.databaseName().ifPresent( name -> map.put( DATABASE_NAME, value( name ) ) );
+        map.put( DATABASE_NAME, value( (Object) databaseName.databaseName().orElse( null ) ) );
         return new Statement( MULTI_DB_GET_ROUTING_TABLE, value( map ) );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -109,7 +109,7 @@ public class RediscoveryImpl implements Rediscovery
                 int newFailures = failures + 1;
                 if ( newFailures >= settings.maxRoutingFailures() )
                 {
-                    result.completeExceptionally( new ServiceUnavailableException( String.format( NO_ROUTERS_AVAILABLE, routingTable.database() ) ) );
+                    result.completeExceptionally( new ServiceUnavailableException( String.format( NO_ROUTERS_AVAILABLE, routingTable.database().description() ) ) );
                 }
                 else
                 {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.value.ValueException;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Clock;
@@ -55,7 +56,7 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
     }
 
     @Override
-    public CompletionStage<ClusterComposition> getClusterComposition( Connection connection, String databaseName, InternalBookmark bookmark )
+    public CompletionStage<ClusterComposition> getClusterComposition( Connection connection, DatabaseName databaseName, InternalBookmark bookmark )
     {
         RoutingProcedureRunner runner;
         if ( connection.serverVersion().greaterThanOrEqual( ServerVersion.v4_0_0 ) )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.internal.DatabaseName;
 
 public interface RoutingTable
 {
@@ -41,7 +42,7 @@ public interface RoutingTable
 
     Set<BoltServerAddress> servers();
 
-    String database();
+    DatabaseName database();
 
     void forgetWriter( BoltServerAddress toRemove );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistry.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistry.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.async.ConnectionContext;
 
 /**
@@ -45,10 +46,10 @@ public interface RoutingTableRegistry
     /**
      * Removes a routing table of the given database from registry.
      */
-    void remove( String databaseName );
+    void remove( DatabaseName databaseName );
 
     /**
      * Removes all routing tables that has been not used for a long time.
      */
-    void purgeAged();
+    void removeAged();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 
 import static org.neo4j.driver.internal.messaging.request.TransactionMetadataBuilder.buildMetadata;
@@ -33,12 +34,12 @@ public class BeginMessage extends MessageWithMetadata
 {
     public static final byte SIGNATURE = 0x11;
 
-    public BeginMessage( InternalBookmark bookmark, TransactionConfig config, String databaseName, AccessMode mode )
+    public BeginMessage( InternalBookmark bookmark, TransactionConfig config, DatabaseName databaseName, AccessMode mode )
     {
         this( bookmark, config.timeout(), config.metadata(), mode, databaseName );
     }
 
-    public BeginMessage( InternalBookmark bookmark, Duration txTimeout, Map<String,Value> txMetadata, AccessMode mode, String databaseName )
+    public BeginMessage( InternalBookmark bookmark, Duration txTimeout, Map<String,Value> txMetadata, AccessMode mode, DatabaseName databaseName )
     {
         super( buildMetadata( txTimeout, txMetadata, databaseName, mode, bookmark ) );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 
 import static java.util.Collections.emptyMap;
@@ -39,13 +40,13 @@ public class RunWithMetadataMessage extends MessageWithMetadata
     private final String statement;
     private final Map<String,Value> parameters;
 
-    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, TransactionConfig config, String databaseName, AccessMode mode,
+    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, TransactionConfig config, DatabaseName databaseName, AccessMode mode,
             InternalBookmark bookmark )
     {
         return autoCommitTxRunMessage( statement, config.timeout(), config.metadata(), databaseName, mode, bookmark );
     }
 
-    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, Duration txTimeout, Map<String,Value> txMetadata, String databaseName,
+    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, Duration txTimeout, Map<String,Value> txMetadata, DatabaseName databaseName,
             AccessMode mode, InternalBookmark bookmark )
     {
         Map<String,Value> metadata = buildMetadata( txTimeout, txMetadata, databaseName, mode, bookmark );

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.ExplicitTransaction;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
@@ -192,7 +193,7 @@ public class BoltProtocolV1 implements BoltProtocol
         return new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullAllHandler, waitForRunResponse );
     }
 
-    private void verifyBeforeTransaction( TransactionConfig config, String databaseName )
+    private void verifyBeforeTransaction( TransactionConfig config, DatabaseName databaseName )
     {
         if ( config != null && !config.isEmpty() )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.ExplicitTransaction;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
@@ -162,7 +163,7 @@ public class BoltProtocolV3 implements BoltProtocol
         return new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullHandler, waitForRunResponse );
     }
 
-    protected void verifyDatabaseNameBeforeTransaction( String databaseName )
+    protected void verifyDatabaseNameBeforeTransaction( DatabaseName databaseName )
     {
         assertEmptyDatabaseName( databaseName, version() );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.messaging.v4;
 
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.BookmarkHolder;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.async.ExplicitTransaction;
 import org.neo4j.driver.internal.cursor.InternalStatementResultCursorFactory;
 import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
@@ -58,7 +59,8 @@ public class BoltProtocolV4 extends BoltProtocolV3
         return new InternalStatementResultCursorFactory( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRunResponse );
     }
 
-    protected void verifyDatabaseNameBeforeTransaction( String databaseName )
+    @Override
+    protected void verifyDatabaseNameBeforeTransaction( DatabaseName databaseName )
     {
         // Bolt V4 accepts database name
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.util.ServerVersion;
@@ -61,7 +62,7 @@ public interface Connection
         throw new UnsupportedOperationException( format( "%s does not support access mode.", getClass() ) );
     }
 
-    default String databaseName()
+    default DatabaseName databaseName()
     {
         throw new UnsupportedOperationException( format( "%s does not support database name.", getClass() ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ParametersTest.java
@@ -41,8 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
@@ -109,7 +109,7 @@ class ParametersTest
         ConnectionProvider provider = mock( ConnectionProvider.class );
         RetryLogic retryLogic = mock( RetryLogic.class );
         NetworkSession session =
-                new NetworkSession( provider, retryLogic, ABSENT_DB_NAME, AccessMode.WRITE, new DefaultBookmarkHolder(), DEV_NULL_LOGGING );
+                new NetworkSession( provider, retryLogic, defaultDatabase(), AccessMode.WRITE, new DefaultBookmarkHolder(), DEV_NULL_LOGGING );
         return new InternalSession( session );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/SessionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/SessionConfigTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -41,7 +42,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.neo4j.driver.SessionConfig.builder;
 import static org.neo4j.driver.SessionConfig.defaultConfig;
 import static org.neo4j.driver.internal.InternalBookmark.parse;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 
 class SessionConfigTest
 {
@@ -64,7 +64,7 @@ class SessionConfigTest
     }
 
     @ParameterizedTest
-    @ValueSource( strings = {"foo", "data", "my awesome database", " "} )
+    @ValueSource( strings = {"foo", "data", "my awesome database", "    "} )
     void shouldChangeDatabaseName( String databaseName )
     {
         SessionConfig config = builder().withDatabase( databaseName ).build();
@@ -95,11 +95,11 @@ class SessionConfigTest
     }
 
     @ParameterizedTest
-    @ValueSource( strings = {"", ABSENT_DB_NAME} )
+    @ValueSource( strings = {""} )
     void shouldForbiddenEmptyStringDatabaseName( String databaseName ) throws Throwable
     {
         IllegalArgumentException error = assertThrows( IllegalArgumentException.class, () -> builder().withDatabase( databaseName ) );
-        assertThat( error.getMessage(), equalTo( "Illegal database name ''." ) );
+        assertThat( error.getMessage(), startsWith( "Illegal database name " ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -255,7 +255,7 @@ class ConnectionHandlingIT
     {
         try ( Session session = driver.session() )
         {
-            session.run( "CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)" );
+            session.run( "CREATE CONSTRAINT ON (book:Library) ASSERT exists(book.isbn)" );
         }
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
@@ -267,7 +267,7 @@ class ConnectionHandlingIT
         verify( connection2, never() ).release();
 
         // property existence constraints are verified on commit, try to violate it
-        tx.run( "CREATE (:Book)" );
+        tx.run( "CREATE (:Library)" );
 
         assertThrows( ClientException.class, tx::commit );
 

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -158,7 +158,7 @@ class SummaryIT
     void shouldContainNotifications()
     {
         // When
-        ResultSummary summary = session.run( "EXPLAIN MATCH (n), (m) RETURN n, m" ).consume();
+        ResultSummary summary = session.run( "EXPLAIN MATCH (n:ThisLabelDoesNotExist) RETURN n" ).consume();
 
         // Then
         List<Notification> notifications = summary.notifications();

--- a/driver/src/test/java/org/neo4j/driver/internal/DatabaseNameUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DatabaseNameUtilTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.neo4j.driver.internal.DatabaseNameUtil.DEFAULT_DATABASE_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.SYSTEM_DATABASE_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
+import static org.neo4j.driver.internal.DatabaseNameUtil.systemDatabase;
+
+class DatabaseNameUtilTest
+{
+    @Test
+    void shouldDatabaseNameBeEqual() throws Throwable
+    {
+        assertEquals( defaultDatabase(), defaultDatabase() );
+        assertEquals( defaultDatabase(), database( null ) );
+        assertEquals( defaultDatabase(), database( DEFAULT_DATABASE_NAME ) );
+
+        assertEquals( systemDatabase(), systemDatabase() );
+        assertEquals( systemDatabase(), database( "system" ) );
+        assertEquals( systemDatabase(), database( SYSTEM_DATABASE_NAME ) );
+
+        assertEquals( database( "hello" ), database( "hello" ) );
+    }
+
+    @Test
+    void shouldReturnDatabaseNameInDescription() throws Throwable
+    {
+        assertEquals( "<default database>", defaultDatabase().description() );
+        assertEquals( "system", systemDatabase().description() );
+        assertEquals( "hello", database( "hello" ).description() );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectConnectionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectConnectionProviderTest.java
@@ -41,9 +41,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.READ;
 import static org.neo4j.driver.AccessMode.WRITE;
-import static org.neo4j.driver.internal.cluster.RediscoveryUtils.contextWithDatabase;
-import static org.neo4j.driver.internal.cluster.RediscoveryUtils.contextWithMode;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.cluster.RediscoveryUtil.contextWithDatabase;
+import static org.neo4j.driver.internal.cluster.RediscoveryUtil.contextWithMode;
 import static org.neo4j.driver.util.TestUtil.await;
 
 class DirectConnectionProviderTest
@@ -120,7 +119,7 @@ class DirectConnectionProviderTest
 
 
     @ParameterizedTest
-    @ValueSource( strings = {"", "foo", "data", ABSENT_DB_NAME} )
+    @ValueSource( strings = {"", "foo", "data"} )
     void shouldObtainDatabaseNameOnConnection( String databaseName ) throws Throwable
     {
         BoltServerAddress address = BoltServerAddress.LOCAL_DEFAULT;
@@ -129,7 +128,7 @@ class DirectConnectionProviderTest
 
         Connection acquired = await( provider.acquireConnection( contextWithDatabase( databaseName ) ) );
 
-        assertEquals( databaseName, acquired.databaseName() );
+        assertEquals( databaseName, acquired.databaseName().description() );
     }
 
     @SuppressWarnings( "unchecked" )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.READ;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.util.TestUtil.DEFAULT_TEST_PROTOCOL;
 
 class LeakLoggingNetworkSessionTest
@@ -96,7 +96,7 @@ class LeakLoggingNetworkSessionTest
 
     private static LeakLoggingNetworkSession newSession( Logging logging, boolean openConnection )
     {
-        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), new FixedRetryLogic( 0 ), ABSENT_DB_NAME, READ,
+        return new LeakLoggingNetworkSession( connectionProviderMock( openConnection ), new FixedRetryLogic( 0 ), defaultDatabase(), READ,
                 new DefaultBookmarkHolder(), logging );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/DecoratedConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/DecoratedConnectionTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.READ;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 
 class DecoratedConnectionTest
 {
@@ -210,7 +210,7 @@ class DecoratedConnectionTest
     @EnumSource( AccessMode.class )
     void shouldReturnModeFromConstructor( AccessMode mode )
     {
-        DirectConnection connection = new DirectConnection( mock( Connection.class ), ABSENT_DB_NAME, mode );
+        DirectConnection connection = new DirectConnection( mock( Connection.class ), defaultDatabase(), mode );
 
         assertEquals( mode, connection.mode() );
     }
@@ -226,6 +226,6 @@ class DecoratedConnectionTest
     
     private static DirectConnection newConnection( Connection connection )
     {
-        return new DirectConnection( connection, ABSENT_DB_NAME, READ );
+        return new DirectConnection( connection, defaultDatabase(), READ );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/RoutingConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/RoutingConnectionTest.java
@@ -32,8 +32,8 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.AccessMode.READ;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.messaging.request.DiscardAllMessage.DISCARD_ALL;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_ALL;
 
 class RoutingConnectionTest
@@ -66,7 +66,7 @@ class RoutingConnectionTest
     {
         Connection connection = mock( Connection.class );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
-        RoutingConnection routingConnection = new RoutingConnection( connection, ABSENT_DB_NAME, READ, errorHandler );
+        RoutingConnection routingConnection = new RoutingConnection( connection, defaultDatabase(), READ, errorHandler );
 
         if ( flush )
         {
@@ -95,7 +95,7 @@ class RoutingConnectionTest
     {
         Connection connection = mock( Connection.class );
         RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
-        RoutingConnection routingConnection = new RoutingConnection( connection, ABSENT_DB_NAME, READ, errorHandler );
+        RoutingConnection routingConnection = new RoutingConnection( connection, defaultDatabase(), READ, errorHandler );
 
         if ( flush )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/AbstractRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/AbstractRoutingProcedureRunnerTest.java
@@ -34,8 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.util.TestUtil.await;
@@ -48,7 +48,7 @@ abstract class AbstractRoutingProcedureRunnerTest
         ClientException error = new ClientException( "Hi" );
         RoutingProcedureRunner runner = routingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
 
-        RoutingProcedureResponse response = await( runner.run( connection(), ABSENT_DB_NAME, empty() ) );
+        RoutingProcedureResponse response = await( runner.run( connection(), defaultDatabase(), empty() ) );
 
         assertFalse( response.isSuccess() );
         assertEquals( error, response.error() );
@@ -60,7 +60,7 @@ abstract class AbstractRoutingProcedureRunnerTest
         Exception error = new Exception( "Hi" );
         RoutingProcedureRunner runner = routingProcedureRunner( RoutingContext.EMPTY, failedFuture( error ) );
 
-        Exception e = assertThrows( Exception.class, () -> await( runner.run( connection(), ABSENT_DB_NAME, empty() ) ) );
+        Exception e = assertThrows( Exception.class, () -> await( runner.run( connection(), defaultDatabase(), empty() ) ) );
         assertEquals( error, e );
     }
 
@@ -70,7 +70,7 @@ abstract class AbstractRoutingProcedureRunnerTest
         RoutingProcedureRunner runner = routingProcedureRunner( RoutingContext.EMPTY );
 
         Connection connection = connection();
-        RoutingProcedureResponse response = await( runner.run( connection, ABSENT_DB_NAME, empty() ) );
+        RoutingProcedureResponse response = await( runner.run( connection, defaultDatabase(), empty() ) );
 
         assertTrue( response.isSuccess() );
         verify( connection ).release();
@@ -84,7 +84,7 @@ abstract class AbstractRoutingProcedureRunnerTest
         RuntimeException releaseError = new RuntimeException( "Release failed" );
         Connection connection = connection( failedFuture( releaseError ) );
 
-        RuntimeException e = assertThrows( RuntimeException.class, () -> await( runner.run( connection, ABSENT_DB_NAME, empty() ) ) );
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( runner.run( connection, defaultDatabase(), empty() ) ) );
         assertEquals( releaseError, e );
         verify( connection ).release();
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterRoutingTableTest.java
@@ -37,7 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.AccessMode.READ;
 import static org.neo4j.driver.AccessMode.WRITE;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.C;
@@ -129,7 +130,7 @@ class ClusterRoutingTableTest
         FakeClock clock = new FakeClock();
 
         // When
-        RoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, clock, A );
+        RoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), clock, A );
 
         // Then
         assertTrue( routingTable.isStaleFor( READ ) );
@@ -137,17 +138,17 @@ class ClusterRoutingTableTest
     }
 
     @ParameterizedTest
-    @ValueSource( strings = {"Molly", ABSENT_DB_NAME, "I AM A NAME"} )
+    @ValueSource( strings = {"Molly", "", "I AM A NAME"} )
     void shouldReturnDatabaseNameCorrectly( String db )
     {
         // Given
         FakeClock clock = new FakeClock();
 
         // When
-        RoutingTable routingTable = new ClusterRoutingTable( db, clock, A );
+        RoutingTable routingTable = new ClusterRoutingTable( database( db ), clock, A );
 
         // Then
-        assertEquals( db, routingTable.database() );
+        assertEquals( db, routingTable.database().description() );
     }
 
     @Test
@@ -157,7 +158,7 @@ class ClusterRoutingTableTest
         FakeClock clock = new FakeClock();
 
         // When
-        RoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, clock, A, B, C );
+        RoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), clock, A, B, C );
 
         // Then
         assertArrayEquals( new BoltServerAddress[]{A, B, C}, routingTable.routers().toArray() );
@@ -276,11 +277,11 @@ class ClusterRoutingTableTest
 
     private ClusterRoutingTable newRoutingTable()
     {
-        return new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock() );
+        return new ClusterRoutingTable( defaultDatabase(), new FakeClock() );
     }
 
     private ClusterRoutingTable newRoutingTable( Clock clock )
     {
-        return new ClusterRoutingTable( ABSENT_DB_NAME, clock );
+        return new ClusterRoutingTable( defaultDatabase(), clock );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -54,9 +55,9 @@ import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
 import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.C;
@@ -289,7 +290,7 @@ class RediscoveryTest
         ClusterCompositionProvider compositionProvider = compositionProviderMock( responsesByAddress );
         ServerAddressResolver resolver = resolverMock( initialRouter, initialRouter );
         Rediscovery rediscovery = newRediscovery( initialRouter, compositionProvider, resolver );
-        RoutingTable table = new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock() );
+        RoutingTable table = new ClusterRoutingTable( defaultDatabase(), new FakeClock() );
         table.update( noWritersComposition );
 
         ClusterComposition composition2 = await( rediscovery.lookupClusterComposition( table, pool, empty() ) );
@@ -412,7 +413,7 @@ class RediscoveryTest
             Map<BoltServerAddress,Object> responsesByAddress )
     {
         ClusterCompositionProvider provider = mock( ClusterCompositionProvider.class );
-        when( provider.getClusterComposition( any( Connection.class ), any( String.class ), any( InternalBookmark.class ) ) ).then( invocation ->
+        when( provider.getClusterComposition( any( Connection.class ), any( DatabaseName.class ), any( InternalBookmark.class ) ) ).then( invocation ->
         {
             Connection connection = invocation.getArgument( 0 );
             BoltServerAddress address = connection.serverAddress();
@@ -466,7 +467,7 @@ class RediscoveryTest
         AddressSet addressSet = new AddressSet();
         addressSet.update( asOrderedSet( routers ) );
         when( routingTable.routers() ).thenReturn( addressSet );
-        when( routingTable.database() ).thenReturn( ABSENT_DB_NAME );
+        when( routingTable.database() ).thenReturn( defaultDatabase() );
         when( routingTable.preferInitialRouter() ).thenReturn( preferInitialRouter );
         return routingTable;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryUtil.java
@@ -23,17 +23,18 @@ import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.ConnectionContext;
 import org.neo4j.driver.internal.async.ImmutableConnectionContext;
 
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 
-public class RediscoveryUtils
+public class RediscoveryUtil
 {
     public static ConnectionContext contextWithDatabase( String databaseName )
     {
-        return new ImmutableConnectionContext( databaseName, InternalBookmark.empty(), AccessMode.WRITE );
+        return new ImmutableConnectionContext( database( databaseName ), InternalBookmark.empty(), AccessMode.WRITE );
     }
 
     public static ConnectionContext contextWithMode( AccessMode mode )
     {
-        return new ImmutableConnectionContext( ABSENT_DB_NAME, InternalBookmark.empty(), mode );
+        return new ImmutableConnectionContext( defaultDatabase(), InternalBookmark.empty(), mode );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.spi.Connection;
@@ -50,8 +51,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.util.TestUtil.await;
@@ -68,12 +69,12 @@ class RoutingProcedureClusterCompositionProviderTest
                 newClusterCompositionProvider( mockedRunner, connection );
 
         RoutingProcedureResponse noRecordsResponse = newRoutingResponse();
-        when( mockedRunner.run( eq( connection ), any( String.class ), any( InternalBookmark.class ) ) )
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) )
                 .thenReturn( completedFuture( noRecordsResponse ) );
 
         // When & Then
         ProtocolException error = assertThrows( ProtocolException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( error.getMessage(), containsString( "records received '0' is too few or too many." ) );
     }
 
@@ -88,11 +89,11 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record aRecord = new InternalRecord( asList( "key1", "key2" ), new Value[]{ new StringValue( "a value" ) } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( aRecord, aRecord );
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
 
         // When
         ProtocolException error = assertThrows( ProtocolException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( error.getMessage(), containsString( "records received '2' is too few or too many." ) );
     }
 
@@ -107,11 +108,11 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record aRecord = new InternalRecord( asList( "key1", "key2" ), new Value[]{ new StringValue( "a value" ) } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( aRecord );
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
 
         // When
         ProtocolException error = assertThrows( ProtocolException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( error.getMessage(), containsString( "unparsable record received." ) );
     }
 
@@ -131,12 +132,12 @@ class RoutingProcedureClusterCompositionProviderTest
                 serverInfo( "WRITE", "one:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
         ProtocolException error = assertThrows( ProtocolException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( error.getMessage(), containsString( "no router or reader found in response." ) );
     }
 
@@ -156,12 +157,12 @@ class RoutingProcedureClusterCompositionProviderTest
                 serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
         ProtocolException error = assertThrows( ProtocolException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( error.getMessage(), containsString( "no router or reader found in response." ) );
     }
 
@@ -174,12 +175,12 @@ class RoutingProcedureClusterCompositionProviderTest
         ClusterCompositionProvider provider =
                 newClusterCompositionProvider( mockedRunner, connection );
 
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( failedFuture(
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( failedFuture(
                 new ServiceUnavailableException( "Connection breaks during cypher execution" ) ) );
 
         // When & Then
         ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertThat( e.getMessage(), containsString( "Connection breaks during cypher execution" ) );
     }
 
@@ -200,12 +201,12 @@ class RoutingProcedureClusterCompositionProviderTest
                 serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
-        when( mockedRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) )
+        when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) )
                 .thenReturn( completedFuture( routingResponse ) );
         when( mockedClock.millis() ).thenReturn( 12345L );
 
         // When
-        ClusterComposition cluster = await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) );
+        ClusterComposition cluster = await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) );
 
         // Then
         assertEquals( 12345 + 100_000, cluster.expirationTimestamp() );
@@ -221,14 +222,14 @@ class RoutingProcedureClusterCompositionProviderTest
         Connection connection = mock( Connection.class );
 
         RuntimeException error = new RuntimeException( "hi" );
-        when( procedureRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) )
+        when( procedureRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) )
                 .thenReturn( completedFuture( newRoutingResponse( error ) ) );
 
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider( procedureRunner, connection );
 
         RuntimeException e = assertThrows( RuntimeException.class,
-                () -> await( provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() ) ) );
+                () -> await( provider.getClusterComposition( connection, defaultDatabase(), empty() ) ) );
         assertEquals( error, e );
     }
 
@@ -241,10 +242,10 @@ class RoutingProcedureClusterCompositionProviderTest
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider( procedureRunner, connection );
 
-        when( procedureRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedWithNull() );
-        provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() );
+        when( procedureRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedWithNull() );
+        provider.getClusterComposition( connection, defaultDatabase(), empty() );
 
-        verify( procedureRunner ).run( eq( connection ), any( String.class ), any( InternalBookmark.class ) );
+        verify( procedureRunner ).run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) );
     }
 
     @Test
@@ -256,10 +257,10 @@ class RoutingProcedureClusterCompositionProviderTest
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider( procedureRunner, connection );
 
-        when( procedureRunner.run( eq( connection ), any( String.class ), any(InternalBookmark.class ) ) ).thenReturn( completedWithNull() );
-        provider.getClusterComposition( connection, ABSENT_DB_NAME, empty() );
+        when( procedureRunner.run( eq( connection ), any( DatabaseName.class ), any(InternalBookmark.class ) ) ).thenReturn( completedWithNull() );
+        provider.getClusterComposition( connection, defaultDatabase(), empty() );
 
-        verify( procedureRunner ).run( eq( connection ), any( String.class ), any( InternalBookmark.class ) );
+        verify( procedureRunner ).run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) );
     }
 
     private static Map<String,Object> serverInfo( String role, String... addresses )

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -46,11 +46,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.DatabaseNameUtil.SYSTEM_DATABASE_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.GET_ROUTING_TABLE;
 import static org.neo4j.driver.internal.cluster.RoutingProcedureRunner.ROUTING_CONTEXT;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.SYSTEM_DB_NAME;
 import static org.neo4j.driver.util.TestUtil.await;
 
 class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
@@ -59,13 +60,13 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
     void shouldCallGetRoutingTableWithEmptyMap()
     {
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY );
-        RoutingProcedureResponse response = await( runner.run( connection(), ABSENT_DB_NAME, empty() ) );
+        RoutingProcedureResponse response = await( runner.run( connection(), defaultDatabase(), empty() ) );
 
         assertTrue( response.isSuccess() );
         assertEquals( 1, response.records().size() );
 
         assertThat( runner.bookmarkHolder, equalTo( BookmarkHolder.NO_OP ) );
-        assertThat( runner.connection.databaseName(), equalTo( ABSENT_DB_NAME ) );
+        assertThat( runner.connection.databaseName(), equalTo( defaultDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.WRITE ) );
 
         Statement statement = generateRoutingStatement( EMPTY_MAP );
@@ -79,13 +80,13 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         RoutingContext context = new RoutingContext( uri );
 
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner( context );
-        RoutingProcedureResponse response = await( runner.run( connection(), ABSENT_DB_NAME, empty() ) );
+        RoutingProcedureResponse response = await( runner.run( connection(), defaultDatabase(), empty() ) );
 
         assertTrue( response.isSuccess() );
         assertEquals( 1, response.records().size() );
 
         assertThat( runner.bookmarkHolder, equalTo( BookmarkHolder.NO_OP ) );
-        assertThat( runner.connection.databaseName(), equalTo( ABSENT_DB_NAME ) );
+        assertThat( runner.connection.databaseName(), equalTo( defaultDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.WRITE ) );
 
         Statement statement = generateRoutingStatement( context.asMap() );
@@ -98,7 +99,7 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
     void shouldErrorWhenDatabaseIsNotAbsent( String db ) throws Throwable
     {
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner( RoutingContext.EMPTY );
-        assertThrows( FatalDiscoveryException.class, () -> await( runner.run( connection(), db, empty() ) ) );
+        assertThrows( FatalDiscoveryException.class, () -> await( runner.run( connection(), database( db ), empty() ) ) );
     }
 
     RoutingProcedureRunner routingProcedureRunner( RoutingContext context )
@@ -113,7 +114,7 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
 
     private static Stream<String> invalidDatabaseNames()
     {
-        return Stream.of( SYSTEM_DB_NAME, "This is a string", null );
+        return Stream.of( SYSTEM_DATABASE_NAME, "This is a string", "null" );
     }
 
     private static Statement generateRoutingStatement( Map context )

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.ConnectionContext;
 import org.neo4j.driver.internal.spi.Connection;
@@ -53,11 +54,11 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.READ;
 import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.internal.BoltServerAddress.LOCAL_DEFAULT;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.async.ImmutableConnectionContext.simple;
-import static org.neo4j.driver.internal.cluster.RediscoveryUtils.contextWithMode;
+import static org.neo4j.driver.internal.cluster.RediscoveryUtil.contextWithMode;
 import static org.neo4j.driver.internal.cluster.RoutingSettings.STALE_ROUTING_TABLE_PURGE_DELAY_MS;
 import static org.neo4j.driver.internal.logging.DevNullLogger.DEV_NULL_LOGGER;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.C;
@@ -72,7 +73,7 @@ class RoutingTableHandlerTest
     @Test
     void shouldRemoveAddressFromRoutingTableOnConnectionFailure()
     {
-        RoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock() );
+        RoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), new FakeClock() );
         routingTable.update( new ClusterComposition(
                 42, asOrderedSet( A, B, C ), asOrderedSet( A, C, E ), asOrderedSet( B, D, F ) ) );
 
@@ -102,7 +103,7 @@ class RoutingTableHandlerTest
         BoltServerAddress router1 = new BoltServerAddress( "router-1", 5 );
 
         ConnectionPool connectionPool = newConnectionPoolMock();
-        ClusterRoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock(), initialRouter );
+        ClusterRoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), new FakeClock(), initialRouter );
 
         Set<BoltServerAddress> readers = new LinkedHashSet<>( asList( reader1, reader2 ) );
         Set<BoltServerAddress> writers = new LinkedHashSet<>( singletonList( writer1 ) );
@@ -149,7 +150,7 @@ class RoutingTableHandlerTest
     @Test
     void shouldRetainAllFetchedAddressesInConnectionPoolAfterFetchingOfRoutingTable()
     {
-        RoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock() );
+        RoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), new FakeClock() );
         routingTable.update( new ClusterComposition(
                 42, asOrderedSet(), asOrderedSet( B, C ), asOrderedSet( D, E ) ) );
 
@@ -174,13 +175,13 @@ class RoutingTableHandlerTest
             }
 
             @Override
-            public void remove( String databaseName )
+            public void remove( DatabaseName databaseName )
             {
                 throw new UnsupportedOperationException();
             }
 
             @Override
-            public void purgeAged()
+            public void removeAged()
             {
             }
         };
@@ -197,7 +198,7 @@ class RoutingTableHandlerTest
     void shouldRemoveRoutingTableHandlerIfFailedToLookup() throws Throwable
     {
         // Given
-        RoutingTable routingTable = new ClusterRoutingTable( ABSENT_DB_NAME, new FakeClock() );
+        RoutingTable routingTable = new ClusterRoutingTable( defaultDatabase(), new FakeClock() );
 
         Rediscovery rediscovery = newRediscoveryMock();
         when( rediscovery.lookupClusterComposition( any(), any(), any() ) ).thenReturn( Futures.failedFuture( new RuntimeException( "Bang!" ) ) );
@@ -210,7 +211,7 @@ class RoutingTableHandlerTest
         assertThrows( RuntimeException.class, () -> await( handler.refreshRoutingTable( simple() ) ) );
 
         // Then
-        verify( registry ).remove( ABSENT_DB_NAME );
+        verify( registry ).remove( defaultDatabase() );
     }
 
     private void testRediscoveryWhenStale( AccessMode mode )
@@ -255,6 +256,7 @@ class RoutingTableHandlerTest
         addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ) );
         when( routingTable.readers() ).thenReturn( addresses );
         when( routingTable.writers() ).thenReturn( addresses );
+        when( routingTable.database() ).thenReturn( defaultDatabase() );
 
         return routingTable;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
@@ -68,10 +68,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.Logging.none;
-import static org.neo4j.driver.internal.cluster.RediscoveryUtils.contextWithDatabase;
+import static org.neo4j.driver.internal.DatabaseNameUtil.SYSTEM_DATABASE_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.cluster.RediscoveryUtil.contextWithDatabase;
 import static org.neo4j.driver.internal.cluster.RoutingSettings.STALE_ROUTING_TABLE_PURGE_DELAY_MS;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.SYSTEM_DB_NAME;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 import static org.neo4j.driver.util.TestUtil.await;
 
@@ -85,7 +85,7 @@ class RoutingTableAndConnectionPoolTest
     private static final BoltServerAddress F = new BoltServerAddress( "localhost:30005" );
     private static final List<BoltServerAddress> SERVERS = new LinkedList<>( Arrays.asList( null, A, B, C, D, E, F ) );
 
-    private static final String[] DATABASES = new String[]{"", ABSENT_DB_NAME, SYSTEM_DB_NAME, "my database"};
+    private static final String[] DATABASES = new String[]{"", SYSTEM_DATABASE_NAME, "my database"};
 
     private final Random random = new Random();
     private final Clock clock = Clock.SYSTEM;
@@ -107,7 +107,7 @@ class RoutingTableAndConnectionPoolTest
         // Then
         assertThat( routingTables.allServers().size(), equalTo( 1 ) );
         assertTrue( routingTables.allServers().contains( A ) );
-        assertTrue( routingTables.contains( "neo4j" ) );
+        assertTrue( routingTables.contains( database( "neo4j" ) ) );
         assertTrue( connectionPool.isOpen( A ) );
     }
 
@@ -126,7 +126,7 @@ class RoutingTableAndConnectionPoolTest
 
         // Then
         assertTrue( routingTables.allServers().isEmpty() );
-        assertFalse( routingTables.contains( "neo4j" ) );
+        assertFalse( routingTables.contains( database( "neo4j" ) ) );
         assertFalse( connectionPool.isOpen( A ) );
     }
 
@@ -145,7 +145,7 @@ class RoutingTableAndConnectionPoolTest
 
         // Then
         assertTrue( routingTables.allServers().isEmpty() );
-        assertFalse( routingTables.contains( "neo4j" ) );
+        assertFalse( routingTables.contains( database( "neo4j" ) ) );
         assertFalse( connectionPool.isOpen( A ) );
     }
 
@@ -164,7 +164,7 @@ class RoutingTableAndConnectionPoolTest
 
         // Then
         assertTrue( routingTables.allServers().isEmpty() );
-        assertFalse( routingTables.contains( "neo4j" ) );
+        assertFalse( routingTables.contains( database( "neo4j" ) ) );
         assertFalse( connectionPool.isOpen( A ) );
     }
 
@@ -183,7 +183,7 @@ class RoutingTableAndConnectionPoolTest
         await( connection.release() );
 
         // Then
-        assertTrue( routingTables.contains( "neo4j" ) );
+        assertTrue( routingTables.contains( database( "neo4j" ) ) );
 
         assertThat( routingTables.allServers().size(), equalTo( 1 ) );
         assertTrue( routingTables.allServers().contains( A ) );
@@ -207,8 +207,8 @@ class RoutingTableAndConnectionPoolTest
         await( loadBalancer.acquireConnection( contextWithDatabase( "foo"  ) ) );
 
         // Then
-        assertFalse( routingTables.contains( "neo4j" ) );
-        assertTrue( routingTables.contains( "foo" ) );
+        assertFalse( routingTables.contains( database( "neo4j" ) ) );
+        assertTrue( routingTables.contains( database( "foo" ) ) );
 
         assertThat( routingTables.allServers().size(), equalTo( 1 ) );
         assertTrue( routingTables.allServers().contains( B ) );
@@ -234,8 +234,8 @@ class RoutingTableAndConnectionPoolTest
         assertThat( routingTables.allServers().size(), equalTo( 1 ) );
         assertTrue( routingTables.allServers().contains( B ) );
         assertTrue( connectionPool.isOpen( B ) );
-        assertFalse( routingTables.contains( "neo4j" ) );
-        assertTrue( routingTables.contains( "foo" ) );
+        assertFalse( routingTables.contains( database( "neo4j" ) ) );
+        assertTrue( routingTables.contains( database( "foo" ) ) );
 
         // I still have A as A's connection is in use
         assertTrue( connectionPool.isOpen( A ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
@@ -27,19 +27,19 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.ValuePacker;
 import org.neo4j.driver.internal.messaging.request.BeginMessage;
-import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Value;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
-import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
-import static org.neo4j.driver.AccessMode.*;
+import static org.neo4j.driver.AccessMode.READ;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
+import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 
 class BeginMessageEncoderTest
 {
@@ -58,7 +58,7 @@ class BeginMessageEncoderTest
 
         Duration txTimeout = Duration.ofSeconds( 1 );
 
-        encoder.encode( new BeginMessage( bookmark, txTimeout, txMetadata, mode, ABSENT_DB_NAME ), packer );
+        encoder.encode( new BeginMessage( bookmark, txTimeout, txMetadata, mode, defaultDatabase() ), packer );
 
         InOrder order = inOrder( packer );
         order.verify( packer ).packStructHeader( 1, BeginMessage.SIGNATURE );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
@@ -40,8 +40,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.AccessMode.READ;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.messaging.request.DiscardAllMessage.DISCARD_ALL;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.autoCommitTxRunMessage;
 
 class RunWithMetadataMessageEncoderTest
@@ -65,7 +65,7 @@ class RunWithMetadataMessageEncoderTest
         Duration txTimeout = Duration.ofMillis( 42 );
 
         Statement statement = new Statement( "RETURN $answer", value( params ) );
-        encoder.encode( autoCommitTxRunMessage( statement, txTimeout, txMetadata, ABSENT_DB_NAME, mode, bookmark ), packer );
+        encoder.encode( autoCommitTxRunMessage( statement, txTimeout, txMetadata, defaultDatabase(), mode, bookmark ), packer );
 
         InOrder order = inOrder( packer );
         order.verify( packer ).packStructHeader( 3, RunWithMetadataMessage.SIGNATURE );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -77,7 +77,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.Values.value;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.messaging.v1.BoltProtocolV1.SingleBookmarkHelper.asBeginTransactionParameters;
 import static org.neo4j.driver.internal.util.Futures.blockingGet;
 import static org.neo4j.driver.util.TestUtil.await;
@@ -307,7 +307,7 @@ public class BoltProtocolV1Test
     private void testRunWithoutWaitingForRunResponse( boolean autoCommitTx ) throws Exception
     {
         Connection connection = mock( Connection.class );
-        when( connection.databaseName() ).thenReturn( ABSENT_DB_NAME );
+        when( connection.databaseName() ).thenReturn( defaultDatabase() );
 
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( autoCommitTx )
@@ -332,7 +332,7 @@ public class BoltProtocolV1Test
     private void testRunWithWaitingForResponse( boolean success, boolean session ) throws Exception
     {
         Connection connection = mock( Connection.class );
-        when( connection.databaseName() ).thenReturn( ABSENT_DB_NAME );
+        when( connection.databaseName() ).thenReturn( defaultDatabase() );
 
         CompletionStage<InternalStatementResultCursor> cursorStage;
         if ( session )

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -85,7 +85,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.Values.value;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.util.TestUtil.anyServerVersion;
 import static org.neo4j.driver.util.TestUtil.await;
 import static org.neo4j.driver.util.TestUtil.connectionMock;
@@ -190,7 +190,7 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), TransactionConfig.empty() );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), ABSENT_DB_NAME, WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
         assertNull( await( stage ) );
     }
 
@@ -202,7 +202,7 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmark, TransactionConfig.empty() );
 
-        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmark, TransactionConfig.empty(), ABSENT_DB_NAME, WRITE ) ), any( BeginTxResponseHandler.class ) );
+        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -213,7 +213,7 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), txConfig );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, ABSENT_DB_NAME, WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
         assertNull( await( stage ) );
     }
 
@@ -225,7 +225,7 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, bookmark, txConfig );
 
-        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmark, txConfig, ABSENT_DB_NAME, WRITE ) ), any( BeginTxResponseHandler.class ) );
+        verify( connection ).writeAndFlush( eq( new BeginMessage( bookmark, txConfig, defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -462,7 +462,7 @@ public class BoltProtocolV3Test
         RunWithMetadataMessage expectedMessage;
         if ( session )
         {
-            expectedMessage = RunWithMetadataMessage.autoCommitTxRunMessage( STATEMENT, config, ABSENT_DB_NAME, mode, bookmark );
+            expectedMessage = RunWithMetadataMessage.autoCommitTxRunMessage( STATEMENT, config, defaultDatabase(), mode, bookmark );
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -41,10 +41,10 @@ import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.AuthTokens.basic;
 import static org.neo4j.driver.Values.point;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.messaging.request.CommitMessage.COMMIT;
 import static org.neo4j.driver.internal.messaging.request.DiscardAllMessage.DISCARD_ALL;
 import static org.neo4j.driver.internal.messaging.request.GoodbyeMessage.GOODBYE;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_ALL;
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
@@ -66,13 +66,13 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
                 // Bolt V3 messages
                 new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap() ),
                 GOODBYE,
-                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, ABSENT_DB_NAME ),
-                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, ABSENT_DB_NAME ),
+                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, defaultDatabase() ),
+                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, defaultDatabase() ),
                 COMMIT,
                 ROLLBACK,
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), ABSENT_DB_NAME, READ,
+                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), ABSENT_DB_NAME, WRITE,
+                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
                 explicitTxRunMessage( new Statement( "RETURN 1" ) ),
                 PULL_ALL,
@@ -81,9 +81,9 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
 
                 // Bolt V3 messages with struct values
                 autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
-                        ABSENT_DB_NAME, READ, InternalBookmark.empty() ),
+                        defaultDatabase(), READ, InternalBookmark.empty() ),
                 autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
-                        ABSENT_DB_NAME, WRITE, InternalBookmark.empty() ),
+                        defaultDatabase(), WRITE, InternalBookmark.empty() ),
                 explicitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -43,10 +43,11 @@ import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.AuthTokens.basic;
 import static org.neo4j.driver.Values.point;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.messaging.request.CommitMessage.COMMIT;
 import static org.neo4j.driver.internal.messaging.request.DiscardAllMessage.DISCARD_ALL;
 import static org.neo4j.driver.internal.messaging.request.GoodbyeMessage.GOODBYE;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_ALL;
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
@@ -73,22 +74,22 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase
                 // Bolt V3 messages
                 new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap() ),
                 GOODBYE,
-                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, ABSENT_DB_NAME ),
-                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, "foo" ),
+                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, defaultDatabase() ),
+                new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, database( "foo" ) ),
                 COMMIT,
                 ROLLBACK,
 
                 RESET,
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), ABSENT_DB_NAME, READ,
+                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), "foo", WRITE,
+                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), database( "foo" ), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
                 explicitTxRunMessage( new Statement( "RETURN 1" ) ),
 
                 // Bolt V3 messages with struct values
                 autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
-                        ABSENT_DB_NAME, READ, InternalBookmark.empty() ),
-                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(), "foo",
+                        defaultDatabase(), READ, InternalBookmark.empty() ),
+                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(), database( "foo" ),
                         WRITE, InternalBookmark.empty() ),
                 explicitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
@@ -27,8 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.cluster.ClusterComposition;
 
-import static java.util.Arrays.asList;
-
 public final class ClusterCompositionUtil
 {
     private ClusterCompositionUtil() {}
@@ -43,12 +41,6 @@ public final class ClusterCompositionUtil
     public static final BoltServerAddress F = new BoltServerAddress( "6666:66" );
 
     public static final List<BoltServerAddress> EMPTY = new ArrayList<>();
-
-    public static final ClusterComposition VALID_CLUSTER_COMPOSITION =
-            createClusterComposition( asList( A, B ), asList( C ), asList( D, E ) );
-
-    public static final ClusterComposition INVALID_CLUSTER_COMPOSITION =
-            createClusterComposition( asList( A, B ), EMPTY, asList( D, E ) );
 
     @SafeVarargs
     public static ClusterComposition createClusterComposition( List<BoltServerAddress>... servers )

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
@@ -54,7 +54,7 @@ public class Neo4jRunner
 {
     private static Neo4jRunner globalInstance;
 
-    private static final String DEFAULT_NEOCTRL_ARGS = "-e 4.0";
+    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.5.11";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final Config DEFAULT_CONFIG = Config.builder().withLogging( console( INFO ) ).withoutEncryption().build();
 

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
@@ -54,7 +54,7 @@ public class Neo4jRunner
 {
     private static Neo4jRunner globalInstance;
 
-    private static final String DEFAULT_NEOCTRL_ARGS = "-e 3.5.3";
+    private static final String DEFAULT_NEOCTRL_ARGS = "-e 4.0";
     public static final String NEOCTRL_ARGS = System.getProperty( "neoctrl.args", DEFAULT_NEOCTRL_ARGS );
     public static final Config DEFAULT_CONFIG = Config.builder().withLogging( console( INFO ) ).withoutEncryption().build();
 

--- a/driver/src/test/java/org/neo4j/driver/util/StubServer.java
+++ b/driver/src/test/java/org/neo4j/driver/util/StubServer.java
@@ -44,7 +44,7 @@ public class StubServer
 {
     private static final int SOCKET_CONNECT_ATTEMPTS = 20;
 
-    public static final Config INSECURE_CONFIG = insecureBuilder().build();
+    public static final Config INSECURE_CONFIG = insecureBuilder().withLogging( none() ).build();
 
     private static final ExecutorService executor = newCachedThreadPool( daemon( "stub-server-output-reader-" ) );
 

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -44,12 +44,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.StatementResult;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.DefaultBookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.NetworkSession;
@@ -92,9 +92,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.SessionConfig.builder;
+import static org.neo4j.driver.internal.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 public final class TestUtil
@@ -266,7 +267,7 @@ public final class TestUtil
     public static NetworkSession newSession( ConnectionProvider connectionProvider, AccessMode mode,
             RetryLogic retryLogic, InternalBookmark bookmark )
     {
-        return new NetworkSession( connectionProvider, retryLogic, ABSENT_DB_NAME, mode, new DefaultBookmarkHolder( bookmark ), DEV_NULL_LOGGING );
+        return new NetworkSession( connectionProvider, retryLogic, defaultDatabase(), mode, new DefaultBookmarkHolder( bookmark ), DEV_NULL_LOGGING );
     }
 
     public static void verifyRun( Connection connection, String query )
@@ -441,7 +442,7 @@ public final class TestUtil
 
     public static Connection connectionMock( AccessMode mode, BoltProtocol protocol )
     {
-        return connectionMock( ABSENT_DB_NAME, mode, protocol );
+        return connectionMock( null, mode, protocol );
     }
 
     public static Connection connectionMock( String databaseName, BoltProtocol protocol )
@@ -456,7 +457,7 @@ public final class TestUtil
         when( connection.serverVersion() ).thenReturn( ServerVersion.vInDev );
         when( connection.protocol() ).thenReturn( protocol );
         when( connection.mode() ).thenReturn( mode );
-        when( connection.databaseName() ).thenReturn( databaseName );
+        when( connection.databaseName() ).thenReturn( database( databaseName ) );
         int version = protocol.version();
         if ( version == BoltProtocolV1.VERSION || version == BoltProtocolV2.VERSION )
         {

--- a/driver/src/test/resources/acquire_endpoints_v4_verify_connectivity.script
+++ b/driver/src/test/resources/acquire_endpoints_v4_verify_connectivity.script
@@ -3,7 +3,7 @@
 !: AUTO HELLO
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": null} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]

--- a/driver/src/test/resources/acquire_endpoints_v4_verify_connectivity.script
+++ b/driver/src/test/resources/acquire_endpoints_v4_verify_connectivity.script
@@ -3,7 +3,7 @@
 !: AUTO HELLO
 !: AUTO GOODBYE
 
-C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}, "database": null} {"mode": "r", "db": "system"}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {}} {"mode": "r", "db": "system"}
    PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007","127.0.0.1:9008"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]


### PR DESCRIPTION
Introduced `DatabaseName` which provides a `description` method to better describe the database name.
This avoids checking if database string is for "default database" everywhere in our code. It also simplifies internal logic to distinguish between database name not provided or default database name provided.