### PR TITLE
Helpful error message when nesting transactions in the same session

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Statement.java
+++ b/driver/src/main/java/org/neo4j/driver/Statement.java
@@ -36,7 +36,7 @@ import static org.neo4j.driver.Values.value;
  * @see Session
  * @see Transaction
  * @see StatementResult
- * @see StatementResult#summary()
+ * @see StatementResult#consume()
  * @see ResultSummary
  * @since 1.0
  */

--- a/driver/src/main/java/org/neo4j/driver/StatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/StatementResult.java
@@ -147,5 +147,5 @@ public interface StatementResult extends Iterator<Record>
      *
      * @return a summary for the whole query result.
      */
-    ResultSummary summary();
+    ResultSummary consume();
 }

--- a/driver/src/main/java/org/neo4j/driver/StatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/StatementRunner.java
@@ -42,7 +42,7 @@ import java.util.Map;
  *
  * <ul>
  * <li>Read from or discard a result, for instance via
- * {@link StatementResult#next()} or {@link StatementResult#summary()} </li>
+ * {@link StatementResult#next()} or {@link StatementResult#consume()} </li>
  * <li>Explicitly commit/rollback a transaction using blocking {@link Transaction#close()} </li>
  * <li>Close a session using blocking {@link Session#close()}</li>
  * </ul>

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncStatementRunner.java
@@ -51,7 +51,7 @@ import org.neo4j.driver.Values;
  *
  * <ul>
  * <li>Read from or discard a result, for instance via
- * {@link StatementResultCursor#nextAsync()}, {@link StatementResultCursor#summaryAsync()}</li>
+ * {@link StatementResultCursor#nextAsync()}, {@link StatementResultCursor#consumeAsync()}</li>
  * <li>Explicitly commit/rollback a transaction using {@link AsyncTransaction#commitAsync()}, {@link AsyncTransaction#rollbackAsync()}</li>
  * <li>Close a session using {@link AsyncSession#closeAsync()}</li>
  * </ul>

--- a/driver/src/main/java/org/neo4j/driver/async/StatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/async/StatementResultCursor.java
@@ -80,7 +80,7 @@ public interface StatementResultCursor
      * @return a {@link CompletionStage} completed with a summary for the whole query result. Stage can also be
      * completed exceptionally if query execution fails.
      */
-    CompletionStage<ResultSummary> summaryAsync();
+    CompletionStage<ResultSummary> consumeAsync();
 
     /**
      * Asynchronously navigate to and retrieve the next {@link Record} in this result. Returned stage can contain

--- a/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
@@ -16,19 +16,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal;
+package org.neo4j.driver.exceptions;
 
-import java.util.concurrent.CompletionStage;
+import org.neo4j.driver.StatementRunner;
 
-public interface FailableCursor
+/**
+ * A user is trying to access resources that are no longer valid due to
+ * the resources have already been consumed or
+ * the {@link StatementRunner} where the resources are created has already been closed.
+ */
+public class ResultConsumedException extends ClientException
 {
-    /**
-     * Dispose this cursor by discarding all unconsumed records and returning failure if there is any to run and/or pulls.
-     */
-    CompletionStage<Throwable> consumeAsync();
-
-    /**
-     * Pulling all unconsumed records into memory and returning failure if there is any to run and/or pulls.
-     */
-    CompletionStage<Throwable> failureAsync();
+    public ResultConsumedException()
+    {
+        super( "Cannot access records on this result any more as the result has already been consumed " +
+                "or the statement runner where the result is created has already been closed." );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
@@ -27,9 +27,8 @@ import org.neo4j.driver.StatementRunner;
  */
 public class ResultConsumedException extends ClientException
 {
-    public ResultConsumedException()
+    public ResultConsumedException( String message )
     {
-        super( "Cannot access records on this result any more as the result has already been consumed " +
-                "or the statement runner where the result is created has already been closed." );
+        super( message );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
@@ -16,19 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal;
+package org.neo4j.driver.exceptions;
 
-import java.util.concurrent.CompletionStage;
-
-public interface FailableCursor
+/**
+ * This exception indicates a user is nesting new transaction with a on-going transaction (explicit and/or auto-commit).
+ */
+public class TransactionNestingException extends ClientException
 {
-    /**
-     * Dispose this cursor by discarding all unconsumed records and returning failure if there is any to run and/or pulls.
-     */
-    CompletionStage<Throwable> consumeAsync();
-
-    /**
-     * Pulling all unconsumed records into memory and returning failure if there is any to run and/or pulls.
-     */
-    CompletionStage<Throwable> failureAsync();
+    public TransactionNestingException( String message )
+    {
+        super( message );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
@@ -27,9 +27,4 @@ public class TransactionNestingException extends ClientException
     {
         super( message );
     }
-
-    public TransactionNestingException()
-    {
-        this( "You cannot run another query or begin a new transaction in the same session before you've fully consumed the previous run result." );
-    }
 }

--- a/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
@@ -27,4 +27,9 @@ public class TransactionNestingException extends ClientException
     {
         super( message );
     }
+
+    public TransactionNestingException()
+    {
+        this( "You cannot run another query or begin a new transaction in the same session before you've fully consumed the previous run result." );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/FailableCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/FailableCursor.java
@@ -23,12 +23,12 @@ import java.util.concurrent.CompletionStage;
 public interface FailableCursor
 {
     /**
-     * Dispose this cursor by discarding all unconsumed records and returning failure if there is any to run and/or pulls.
+     * Discarding all unconsumed records and returning failure if there is any to run and/or pulls.
      */
-    CompletionStage<Throwable> consumeAsync();
+    CompletionStage<Throwable> discardAllFailureAsync();
 
     /**
      * Pulling all unconsumed records into memory and returning failure if there is any to run and/or pulls.
      */
-    CompletionStage<Throwable> failureAsync();
+    CompletionStage<Throwable> pullAllFailureAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalStatementResult.java
@@ -112,9 +112,9 @@ public class InternalStatementResult implements StatementResult
     }
 
     @Override
-    public ResultSummary summary()
+    public ResultSummary consume()
     {
-        return blockingGet( cursor.summaryAsync() );
+        return blockingGet( cursor.consumeAsync() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -197,7 +197,7 @@ public class NetworkSession
                 if ( cursor != null )
                 {
                     // there exists a cursor with potentially unconsumed error, try to extract and propagate it
-                    return cursor.consumeAsync();
+                    return cursor.discardAllFailureAsync();
                 }
                 // no result cursor exists so no error exists
                 return completedWithNull();
@@ -255,7 +255,7 @@ public class NetworkSession
                 return completedWithNull();
             }
             // make sure previous result is fully consumed and connection is released back to the pool
-            return cursor.failureAsync();
+            return cursor.pullAllFailureAsync();
         } ).thenCompose( error ->
         {
             if ( error == null )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.internal.cursor.AsyncStatementResultCursor;
 import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
 import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
 import org.neo4j.driver.internal.logging.PrefixedLogger;
+import org.neo4j.driver.exceptions.TransactionNestingException;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -323,7 +324,7 @@ public class NetworkSession
         {
             if ( tx != null )
             {
-                throw new ClientException( errorMessage );
+                throw new TransactionNestingException( errorMessage );
             }
         } );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/ResultCursorsHolder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/ResultCursorsHolder.java
@@ -74,6 +74,6 @@ public class ResultCursorsHolder
     {
         return cursorStage
                 .exceptionally( cursor -> null )
-                .thenCompose( cursor -> cursor == null ? completedWithNull() : cursor.consumeAsync() );
+                .thenCompose( cursor -> cursor == null ? completedWithNull() : cursor.discardAllFailureAsync() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorImpl.java
@@ -49,9 +49,9 @@ public class AsyncStatementResultCursorImpl implements AsyncStatementResultCurso
     }
 
     @Override
-    public CompletionStage<ResultSummary> summaryAsync()
+    public CompletionStage<ResultSummary> consumeAsync()
     {
-        return pullAllHandler.summaryAsync();
+        return pullAllHandler.consumeAsync();
     }
 
     @Override
@@ -95,7 +95,7 @@ public class AsyncStatementResultCursorImpl implements AsyncStatementResultCurso
     {
         CompletableFuture<Void> resultFuture = new CompletableFuture<>();
         internalForEachAsync( action, resultFuture );
-        return resultFuture.thenCompose( ignore -> summaryAsync() );
+        return resultFuture.thenCompose( ignore -> consumeAsync() );
     }
 
     @Override
@@ -111,17 +111,16 @@ public class AsyncStatementResultCursorImpl implements AsyncStatementResultCurso
     }
 
     @Override
-    public CompletionStage<Throwable> consumeAsync()
+    public CompletionStage<Throwable> discardAllFailureAsync()
     {
-        return summaryAsync().handle( ( summary, error ) -> error );
+        return consumeAsync().handle( ( summary, error ) -> error );
     }
 
     @Override
-    public CompletionStage<Throwable> failureAsync()
+    public CompletionStage<Throwable> pullAllFailureAsync()
     {
-        return pullAllHandler.failureAsync();
+        return pullAllHandler.pullAllFailureAsync();
     }
-
 
     private void internalForEachAsync( Consumer<Record> action, CompletableFuture<Void> resultFuture )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorImpl.java
@@ -113,7 +113,7 @@ public class AsyncStatementResultCursorImpl implements AsyncStatementResultCurso
     @Override
     public CompletionStage<Throwable> consumeAsync()
     {
-        return pullAllHandler.summaryAsync().handle( ( summary, error ) -> error );
+        return summaryAsync().handle( ( summary, error ) -> error );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorOnlyFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorOnlyFactory.java
@@ -66,11 +66,12 @@ public class AsyncStatementResultCursorOnlyFactory implements StatementResultCur
         if ( waitForRunResponse )
         {
             // wait for response of RUN before proceeding
-            return runHandler.runFuture().thenApply( ignore -> new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) );
+            return runHandler.runFuture().thenApply( ignore ->
+                    new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
         else
         {
-            return completedFuture( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) );
+            return completedFuture( new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cursor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.exceptions.ResultConsumedException;
+import org.neo4j.driver.summary.ResultSummary;
+
+import static org.neo4j.driver.internal.util.Futures.completedWithNull;
+import static org.neo4j.driver.internal.util.Futures.failedFuture;
+
+public class DisposableAsyncStatementResultCursor implements AsyncStatementResultCursor
+{
+    private final AsyncStatementResultCursor delegate;
+    private boolean isDisposed;
+
+    public DisposableAsyncStatementResultCursor( AsyncStatementResultCursor delegate )
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<String> keys()
+    {
+        return delegate.keys();
+    }
+
+    @Override
+    public CompletionStage<ResultSummary> summaryAsync()
+    {
+        isDisposed = true;
+        return delegate.summaryAsync();
+    }
+
+    @Override
+    public CompletionStage<Record> nextAsync()
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.nextAsync() );
+    }
+
+    @Override
+    public CompletionStage<Record> peekAsync()
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.peekAsync() );
+    }
+
+    @Override
+    public CompletionStage<Record> singleAsync()
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.singleAsync() );
+    }
+
+    @Override
+    public CompletionStage<ResultSummary> forEachAsync( Consumer<Record> action )
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.forEachAsync( action ) );
+    }
+
+    @Override
+    public CompletionStage<List<Record>> listAsync()
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.listAsync() );
+    }
+
+    @Override
+    public <T> CompletionStage<List<T>> listAsync( Function<Record,T> mapFunction )
+    {
+        return assertNotDisposed().thenCompose( ignored -> delegate.listAsync( mapFunction ) );
+    }
+
+    @Override
+    public CompletionStage<Throwable> consumeAsync()
+    {
+        isDisposed = true;
+        return delegate.consumeAsync();
+    }
+
+    @Override
+    public CompletionStage<Throwable> failureAsync()
+    {
+        // This one does not dispose the result so that a user could still visit the buffered result after this method call.
+        // This also does not assert not disposed so that this method can be called after summary.
+        return delegate.failureAsync();
+    }
+
+    private <T> CompletableFuture<T> assertNotDisposed()
+    {
+        if ( isDisposed )
+        {
+            return failedFuture( new ResultConsumedException() );
+        }
+        return completedWithNull();
+    }
+
+    boolean isDisposed()
+    {
+        return this.isDisposed;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
@@ -48,10 +48,10 @@ public class DisposableAsyncStatementResultCursor implements AsyncStatementResul
     }
 
     @Override
-    public CompletionStage<ResultSummary> summaryAsync()
+    public CompletionStage<ResultSummary> consumeAsync()
     {
         isDisposed = true;
-        return delegate.summaryAsync();
+        return delegate.consumeAsync();
     }
 
     @Override
@@ -91,18 +91,18 @@ public class DisposableAsyncStatementResultCursor implements AsyncStatementResul
     }
 
     @Override
-    public CompletionStage<Throwable> consumeAsync()
+    public CompletionStage<Throwable> discardAllFailureAsync()
     {
         isDisposed = true;
-        return delegate.consumeAsync();
+        return delegate.discardAllFailureAsync();
     }
 
     @Override
-    public CompletionStage<Throwable> failureAsync()
+    public CompletionStage<Throwable> pullAllFailureAsync()
     {
         // This one does not dispose the result so that a user could still visit the buffered result after this method call.
         // This also does not assert not disposed so that this method can be called after summary.
-        return delegate.failureAsync();
+        return delegate.pullAllFailureAsync();
     }
 
     private <T> CompletableFuture<T> assertNotDisposed()

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursor.java
@@ -25,9 +25,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 
+import static org.neo4j.driver.internal.util.ErrorUtil.newResultConsumedError;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
@@ -109,7 +109,7 @@ public class DisposableAsyncStatementResultCursor implements AsyncStatementResul
     {
         if ( isDisposed )
         {
-            return failedFuture( new ResultConsumedException() );
+            return failedFuture( newResultConsumedError() );
         }
         return completedWithNull();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxStatementResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxStatementResultCursorImpl.java
@@ -98,22 +98,21 @@ public class RxStatementResultCursorImpl implements RxStatementResultCursor
     }
 
     @Override
-    public CompletionStage<Throwable> consumeAsync()
+    public CompletionStage<Throwable> discardAllFailureAsync()
     {
         // calling this method will enforce discarding record stream and finish running cypher query
         return summaryAsync().thenApply( summary -> (Throwable) null ).exceptionally( error -> error );
     }
 
     @Override
-    public CompletionStage<Throwable> failureAsync()
+    public CompletionStage<Throwable> pullAllFailureAsync()
     {
         if ( isRecordConsumerInstalled() && !isDone() )
         {
-            throw new TransactionNestingException(
-                    "You cannot run another query or begin a new transaction in the same session before you've fully consumed the previous run result." );
+            return CompletableFuture.completedFuture( new TransactionNestingException() );
         }
         // It is safe to discard records as either the streaming has not started at all, or the streaming is fully finished.
-        return consumeAsync();
+        return discardAllFailureAsync();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/StatementResultCursorFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/StatementResultCursorFactoryImpl.java
@@ -69,11 +69,12 @@ public class StatementResultCursorFactoryImpl implements StatementResultCursorFa
         if ( waitForRunResponse )
         {
             // wait for response of RUN before proceeding
-            return runHandler.runFuture().thenApply( ignore -> new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) );
+            return runHandler.runFuture().thenApply(
+                    ignore -> new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
         else
         {
-            return completedFuture( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) );
+            return completedFuture( new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandler.java
@@ -178,11 +178,11 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
         return peekAsync().thenApply( ignore -> dequeueRecord() );
     }
 
-    public synchronized CompletionStage<ResultSummary> summaryAsync()
+    public synchronized CompletionStage<ResultSummary> consumeAsync()
     {
         ignoreRecords = true;
         records.clear();
-        return failureAsync().thenApply( error ->
+        return pullAllFailureAsync().thenApply( error ->
         {
             if ( error != null )
             {
@@ -194,7 +194,7 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
 
     public synchronized <T> CompletionStage<List<T>> listAsync( Function<Record,T> mapFunction )
     {
-        return failureAsync().thenApply( error ->
+        return pullAllFailureAsync().thenApply( error ->
         {
             if ( error != null )
             {
@@ -210,7 +210,7 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
         connection.writeAndFlush( PullAllMessage.PULL_ALL, this );
     }
 
-    public synchronized CompletionStage<Throwable> failureAsync()
+    public synchronized CompletionStage<Throwable> pullAllFailureAsync()
     {
         if ( failure != null )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullAllResponseHandler.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.summary.ResultSummary;
 
 public interface PullAllResponseHandler extends ResponseHandler
 {
-    CompletionStage<ResultSummary> summaryAsync();
+    CompletionStage<ResultSummary> consumeAsync();
 
     CompletionStage<Record> nextAsync();
 
@@ -36,7 +36,7 @@ public interface PullAllResponseHandler extends ResponseHandler
 
     <T> CompletionStage<List<T>> listAsync( Function<Record, T> mapFunction );
 
-    CompletionStage<Throwable> failureAsync();
+    CompletionStage<Throwable> pullAllFailureAsync();
 
     void prePopulateRecords();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
@@ -139,15 +139,14 @@ public class AutoPullResponseHandler extends BasicPullResponseHandler implements
 
     public synchronized CompletionStage<ResultSummary> summaryAsync()
     {
+        records.clear();
         if ( isDone() )
         {
-            records.clear();
             return completedWithValueIfNoFailure( summary );
         }
         else
         {
             cancel();
-            records.clear();
             if ( summaryFuture == null )
             {
                 summaryFuture = new CompletableFuture<>();

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
@@ -137,7 +137,7 @@ public class AutoPullResponseHandler extends BasicPullResponseHandler implements
         return peekAsync().thenApply( ignore -> dequeueRecord() );
     }
 
-    public synchronized CompletionStage<ResultSummary> summaryAsync()
+    public synchronized CompletionStage<ResultSummary> consumeAsync()
     {
         records.clear();
         if ( isDone() )
@@ -162,7 +162,7 @@ public class AutoPullResponseHandler extends BasicPullResponseHandler implements
     }
 
     @Override
-    public synchronized CompletionStage<Throwable> failureAsync()
+    public synchronized CompletionStage<Throwable> pullAllFailureAsync()
     {
         return pullAllAsync().handle( ( ignore, error ) -> error );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxStatementResult.java
@@ -112,7 +112,7 @@ public class InternalRxStatementResult implements RxStatementResult
     }
 
     @Override
-    public Publisher<ResultSummary> summary()
+    public Publisher<ResultSummary> consume()
     {
         return Mono.create( sink -> getCursorFuture().whenComplete( ( cursor, completionError ) -> {
             if ( cursor != null )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -26,8 +26,9 @@ import java.util.stream.Stream;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.DatabaseException;
-import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
+import org.neo4j.driver.exceptions.Neo4jException;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.TransientException;
 
@@ -51,6 +52,12 @@ public final class ErrorUtil
         return new ServiceUnavailableException( "Connection to the database terminated. " +
                                                 "This can happen due to network instabilities, " +
                                                 "or due to restarts of the database" );
+    }
+
+    public static ResultConsumedException newResultConsumedError()
+    {
+        return new ResultConsumedException( "Cannot access records on this result any more as the result has already been consumed " +
+                "or the statement runner where the result is created has already been closed." );
     }
 
     public static Neo4jException newNeo4jError( String code, String message )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -64,7 +64,7 @@ public class ServerVersion
     {
         try ( Session session = driver.session() )
         {
-            String versionString = session.readTransaction( tx -> tx.run( "RETURN 1" ).summary().server().version() );
+            String versionString = session.readTransaction( tx -> tx.run( "RETURN 1" ).consume().server().version() );
             return version( versionString );
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
@@ -24,6 +24,7 @@ import org.reactivestreams.Subscription;
 
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 
 /**
@@ -83,8 +84,7 @@ public interface RxStatementResult
      * This publisher can only be subscribed by one {@link Subscriber} once.
      * <p>
      * If this publisher is subscribed after {@link #keys()}, then the publish of records is carried out after the arrival of keys.
-     * If this publisher is subscribed after {@link #consume()}, then the publish of records is already cancelled
-     * and an empty publisher of zero record will be return.
+     * If this publisher is subscribed after {@link #consume()}, then a {@link ResultConsumedException} will be thrown.
      * @return a cold unicast publisher of records.
      */
     Publisher<Record> records();
@@ -94,7 +94,7 @@ public interface RxStatementResult
      * <p>
      * {@linkplain Publisher#subscribe(Subscriber) Subscribing} the summary publisher results in the execution of the query followed by the result summary returned.
      * The summary publisher cancels record publishing if not yet subscribed and directly streams back the summary on query execution completion.
-     * As a result, the invocation of {@link #records()} after this method, would receive an empty publisher.
+     * As a result, the invocation of {@link #records()} after this method, would receive an {@link ResultConsumedException}.
      * <p>
      * If subscribed after {@link #keys()}, then the result summary will be published after the query execution without streaming any record to client.
      * If subscribed after {@link #records()}, then the result summary will be published after the query execution and the streaming of records.

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxStatementResult.java
@@ -45,9 +45,9 @@ public interface RxStatementResult
      * <p>
      * When this publisher is {@linkplain Publisher#subscribe(Subscriber) subscribed}, the query statement is sent to the server and executed.
      * This method does not start the record streaming nor publish query execution error.
-     * To retrieve the execution result, either {@link #records()} or {@link #summary()} can be used.
+     * To retrieve the execution result, either {@link #records()} or {@link #consume()} can be used.
      * {@link #records()} starts record streaming and reports query execution error.
-     * {@link #summary()} skips record streaming and directly reports query execution error.
+     * {@link #consume()} skips record streaming and directly reports query execution error.
      * <p>
      * Consuming of execution result ensures the resources (such as network connections) used by this result is freed correctly.
      * Consuming the keys without consuming the execution result will result in resource leak.
@@ -55,7 +55,7 @@ public interface RxStatementResult
      * and subscribed to enforce the result resources created in the {@link RxSession} (and/or {@link RxTransaction}) to be freed correctly.
      * <p>
      * This publisher can be subscribed many times. The keys published stays the same as the keys are buffered.
-     * If this publisher is subscribed after the publisher of {@link #records()} or {@link #summary()},
+     * If this publisher is subscribed after the publisher of {@link #records()} or {@link #consume()},
      * then the buffered keys will be returned.
      * @return a cold publisher of keys.
      */
@@ -83,7 +83,7 @@ public interface RxStatementResult
      * This publisher can only be subscribed by one {@link Subscriber} once.
      * <p>
      * If this publisher is subscribed after {@link #keys()}, then the publish of records is carried out after the arrival of keys.
-     * If this publisher is subscribed after {@link #summary()}, then the publish of records is already cancelled
+     * If this publisher is subscribed after {@link #consume()}, then the publish of records is already cancelled
      * and an empty publisher of zero record will be return.
      * @return a cold unicast publisher of records.
      */
@@ -104,5 +104,5 @@ public interface RxStatementResult
      * This method can be subscribed multiple times. When the {@linkplain ResultSummary summary} arrives, it will be buffered locally for all subsequent calls.
      * @return a cold publisher of result summary which only arrives after all records.
      */
-    Publisher<ResultSummary> summary();
+    Publisher<ResultSummary> consume();
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
@@ -166,7 +166,7 @@ class BookmarkIT
         Bookmark bookmark = session.lastBookmark();
         assertBookmarkContainsSingleValue( bookmark );
 
-        session.run( "RETURN 1" ).summary();
+        session.run( "RETURN 1" ).consume();
 
         assertEquals( bookmark, session.lastBookmark() );
     }
@@ -181,7 +181,7 @@ class BookmarkIT
         Bookmark bookmark = session.lastBookmark();
         assertBookmarkContainsSingleValue( bookmark );
 
-        assertThrows( ClientException.class, () -> session.run( "RETURN" ).summary() );
+        assertThrows( ClientException.class, () -> session.run( "RETURN" ).consume() );
         assertEquals( bookmark, session.lastBookmark() );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -116,7 +116,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        result.summary();
+        result.consume();
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
         assertSame( connection1, connection2 );
@@ -131,7 +131,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        ResultSummary summary = result.summary();
+        ResultSummary summary = result.consume();
 
         assertEquals( 5, summary.counters().nodesCreated() );
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
@@ -201,7 +201,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        assertThrows( ClientException.class, result::summary );
+        assertThrows( ClientException.class, result::consume );
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
         assertSame( connection1, connection2 );
@@ -355,7 +355,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         assertNull( connection1 );
 
-        StepVerifier.create( Mono.from( res.summary() ) ).expectNextCount( 1 ).verifyComplete();
+        StepVerifier.create( Mono.from( res.consume() ) ).expectNextCount( 1 ).verifyComplete();
 
         Connection connection2 = connectionPool.lastAcquiredConnectionSpy;
         assertNotSame( connection1, connection2 );

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
@@ -173,7 +173,7 @@ class ConnectionPoolIT
         {
             for ( StatementResult result : results )
             {
-                result.summary();
+                result.consume();
             }
             for ( Transaction tx : transactions )
             {

--- a/driver/src/test/java/org/neo4j/driver/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/CredentialsIT.java
@@ -76,7 +76,7 @@ class CredentialsIT
         try ( Driver driver = GraphDatabase.driver( neo4j.uri(), authToken );
               Session session = driver.session() )
         {
-            session.run( "RETURN 1" ).summary();
+            session.run( "RETURN 1" ).consume();
         }
 
         // verify old password does not work
@@ -87,7 +87,7 @@ class CredentialsIT
         try ( Driver driver = GraphDatabase.driver( CredentialsIT.neo4j.uri(), AuthTokens.basic( "neo4j", newPassword ) );
               Session session = driver.session() )
         {
-            session.run( "RETURN 2" ).summary();
+            session.run( "RETURN 2" ).consume();
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
@@ -81,7 +81,7 @@ class ErrorIT
         ClientException e = assertThrows( ClientException.class, () ->
         {
             StatementResult result = session.run( "invalid statement" );
-            result.summary();
+            result.consume();
         } );
 
         assertThat( e.getMessage(), startsWith( "Invalid input" ) );
@@ -94,7 +94,7 @@ class ErrorIT
         Transaction tx = session.beginTransaction();
 
         // And Given an error has occurred
-        try { tx.run( "invalid" ).summary(); } catch ( ClientException e ) {/*empty*/}
+        try { tx.run( "invalid" ).consume(); } catch ( ClientException e ) {/*empty*/}
 
         // Expect
         ClientException e = assertThrows( ClientException.class, () ->
@@ -109,7 +109,7 @@ class ErrorIT
     void shouldAllowNewStatementAfterRecoverableError()
     {
         // Given an error has occurred
-        try { session.run( "invalid" ).summary(); } catch ( ClientException e ) {/*empty*/}
+        try { session.run( "invalid" ).consume(); } catch ( ClientException e ) {/*empty*/}
 
         // When
         StatementResult cursor = session.run( "RETURN 1" );
@@ -125,7 +125,7 @@ class ErrorIT
         // Given an error has occurred in a prior transaction
         try ( Transaction tx = session.beginTransaction() )
         {
-            tx.run( "invalid" ).summary();
+            tx.run( "invalid" ).consume();
         }
         catch ( ClientException e ) {/*empty*/}
 
@@ -241,7 +241,7 @@ class ErrorIT
     @Test
     void shouldThrowErrorWithNiceStackTrace( TestInfo testInfo )
     {
-        ClientException error = assertThrows( ClientException.class, () -> session.run( "RETURN 10 / 0" ).summary() );
+        ClientException error = assertThrows( ClientException.class, () -> session.run( "RETURN 10 / 0" ).consume() );
 
         // thrown error should have this class & method in the stacktrace
         StackTraceElement[] stackTrace = error.getStackTrace();
@@ -273,7 +273,7 @@ class ErrorIT
 
                 try
                 {
-                    session.run( "RETURN 1" ).summary();
+                    session.run( "RETURN 1" ).consume();
                     fail( "Exception expected" );
                 }
                 catch ( Throwable error )

--- a/driver/src/test/java/org/neo4j/driver/integration/ExplicitTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ExplicitTransactionIT.java
@@ -190,7 +190,7 @@ class ExplicitTransactionIT
 
         await( session.beginTransactionAsync( TransactionConfig.empty() )
                 .thenCompose( tx -> tx.runAsync( new Statement( "CREATE (:Node {id: 42})" ), true )
-                        .thenCompose( StatementResultCursor::summaryAsync )
+                        .thenCompose( StatementResultCursor::consumeAsync )
                         .thenApply( ignore -> tx )
                 ).thenCompose( ExplicitTransaction::commitAsync ) );
 

--- a/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
@@ -495,7 +495,7 @@ class ParametersIT
 
     private static void expectIOExceptionWithMessage( Value value, String message )
     {
-        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> session.run( "RETURN {a}", value ).summary() );
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class, () -> session.run( "RETURN {a}", value ).consume() );
         Throwable cause = e.getCause();
         assertThat( cause, instanceOf( IOException.class ) );
         assertThat( cause.getMessage(), equalTo( message ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
@@ -175,40 +175,6 @@ class ResultStreamIT
     }
 
     @Test
-    void shouldNotBufferRecordsAfterSummary()
-    {
-        // Given
-        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
-
-        // When
-        ResultSummary summary = result.summary();
-
-        // Then
-        assertThat( summary, notNullValue() );
-        assertThat( summary.server().address(), equalTo( "localhost:" + session.boltPort() ) );
-        assertThat( summary.counters().nodesCreated(), equalTo( 0 ) );
-
-        assertFalse( result.hasNext() );
-    }
-
-    @Test
-    void shouldDiscardRecordsAfterConsume()
-    {
-        // Given
-        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
-
-        // When
-        ResultSummary summary = result.summary();
-
-        // Then
-        assertThat( summary, notNullValue() );
-        assertThat( summary.server().address(), equalTo( "localhost:" + session.boltPort() ) );
-        assertThat( summary.counters().nodesCreated(), equalTo( 0 ) );
-
-        assertThat( result.hasNext(), equalTo( false ) );
-    }
-
-    @Test
     void shouldHasNoElementsAfterFailure()
     {
         StatementResult result = session.run( "INVALID" );

--- a/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
@@ -126,7 +126,7 @@ class ResultStreamIT
     {
         // Given
         StatementResult res1 = session.run( "INVALID" );
-        assertThrows( Exception.class, res1::summary );
+        assertThrows( Exception.class, res1::consume );
 
         // When
         StatementResult res2 = session.run( "RETURN 1" );
@@ -144,8 +144,8 @@ class ResultStreamIT
         ResultSummary summary;
 
         // When
-        assertThrows( Exception.class, res1::summary );
-        summary = res1.summary();
+        assertThrows( Exception.class, res1::consume );
+        summary = res1.consume();
 
 
         // Then
@@ -171,7 +171,7 @@ class ResultStreamIT
 
         StatementResult result = resultRef.get();
         assertNotNull( result );
-        assertEquals( 0, result.summary().counters().nodesCreated() );
+        assertEquals( 0, result.consume().counters().nodesCreated() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -265,7 +265,7 @@ class RoutingDriverBoltKitTest
         try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
                 Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
         {
-            assertThrows( SessionExpiredException.class, () -> session.run( "CREATE (n {name:'Bob'})" ).summary() );
+            assertThrows( SessionExpiredException.class, () -> session.run( "CREATE (n {name:'Bob'})" ).consume() );
         }
         finally
         {
@@ -289,7 +289,7 @@ class RoutingDriverBoltKitTest
                 Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() );
                 Transaction tx = session.beginTransaction() )
         {
-            assertThrows( SessionExpiredException.class, () -> tx.run( "MATCH (n) RETURN n.name" ).summary() );
+            assertThrows( SessionExpiredException.class, () -> tx.run( "MATCH (n) RETURN n.name" ).consume() );
         }
         finally
         {
@@ -446,7 +446,7 @@ class RoutingDriverBoltKitTest
         boolean failed = false;
         try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
         {
-            session.run( "CREATE ()" ).summary();
+            session.run( "CREATE ()" ).consume();
         }
         catch ( SessionExpiredException e )
         {
@@ -500,7 +500,7 @@ class RoutingDriverBoltKitTest
         boolean failed = false;
         try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ); Transaction tx = session.beginTransaction() )
         {
-            tx.run( "CREATE ()" ).summary();
+            tx.run( "CREATE ()" ).consume();
         }
         catch ( SessionExpiredException e )
         {
@@ -902,7 +902,7 @@ class RoutingDriverBoltKitTest
         {
             assertEquals( asList( "Bob", "Alice", "Tina" ), readStrings( "MATCH (n) RETURN n.name", session ) );
 
-            assertThrows( SessionExpiredException.class, () -> session.run( "CREATE (n {name:'Bob'})" ).summary() );
+            assertThrows( SessionExpiredException.class, () -> session.run( "CREATE (n {name:'Bob'})" ).consume() );
         }
         finally
         {
@@ -961,11 +961,11 @@ class RoutingDriverBoltKitTest
 
             StatementResult readResult1 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult1.list().size() );
-            assertEquals( "127.0.0.1:9003", readResult1.summary().server().address() );
+            assertEquals( "127.0.0.1:9003", readResult1.consume().server().address() );
 
             StatementResult readResult2 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult2.list().size() );
-            assertEquals( "127.0.0.1:9004", readResult2.summary().server().address() );
+            assertEquals( "127.0.0.1:9004", readResult2.consume().server().address() );
         }
         finally
         {

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -118,21 +118,21 @@ class SessionBoltV3IT
     {
         // create a dummy node
         Session session = driver.session();
-        session.run( "CREATE (:Node)" ).summary();
+        session.run( "CREATE (:Node)" ).consume();
 
         try ( Session otherSession = driver.driver().session() )
         {
             try ( Transaction otherTx = otherSession.beginTransaction() )
             {
                 // lock dummy node but keep the transaction open
-                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).summary();
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
                     TransactionConfig config = TransactionConfig.builder().withTimeout( ofMillis( 1 ) ).build();
 
                     // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
                     TransientException error = assertThrows( TransientException.class,
-                            () -> session.run( "MATCH (n:Node) SET n.prop = 2", config ).summary() );
+                            () -> session.run( "MATCH (n:Node) SET n.prop = 2", config ).consume() );
                     assertThat( error.getMessage(), containsString( "terminated" ) );
                 } );
             }
@@ -144,14 +144,14 @@ class SessionBoltV3IT
     {
         // create a dummy node
         AsyncSession asyncSession = driver.asyncSession();
-        await( await( asyncSession.runAsync( "CREATE (:Node)" ) ).summaryAsync() );
+        await( await( asyncSession.runAsync( "CREATE (:Node)" ) ).consumeAsync() );
 
         try ( Session otherSession = driver.driver().session() )
         {
             try ( Transaction otherTx = otherSession.beginTransaction() )
             {
                 // lock dummy node but keep the transaction open
-                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).summary();
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
                     TransactionConfig config = TransactionConfig.builder()
@@ -160,7 +160,7 @@ class SessionBoltV3IT
 
                     // run a query in an auto-commit transaction with timeout and try to update the locked dummy node
                     CompletionStage<ResultSummary> resultFuture = asyncSession.runAsync( "MATCH (n:Node) SET n.prop = 2", config )
-                            .thenCompose( StatementResultCursor::summaryAsync );
+                            .thenCompose( StatementResultCursor::consumeAsync );
 
                     TransientException error = assertThrows( TransientException.class, () -> await( resultFuture ) );
 
@@ -200,18 +200,18 @@ class SessionBoltV3IT
         Session session = driver.session();
         Bookmark initialBookmark = session.lastBookmark();
 
-        session.run( "CREATE ()" ).summary();
+        session.run( "CREATE ()" ).consume();
         Bookmark bookmark1 = session.lastBookmark();
         assertNotNull( bookmark1 );
         assertNotEquals( initialBookmark, bookmark1 );
 
-        session.run( "CREATE ()" ).summary();
+        session.run( "CREATE ()" ).consume();
         Bookmark bookmark2 = session.lastBookmark();
         assertNotNull( bookmark2 );
         assertNotEquals( initialBookmark, bookmark2 );
         assertNotEquals( bookmark1, bookmark2 );
 
-        session.run( "CREATE ()" ).summary();
+        session.run( "CREATE ()" ).consume();
         Bookmark bookmark3 = session.lastBookmark();
         assertNotNull( bookmark3 );
         assertNotEquals( initialBookmark, bookmark3 );
@@ -234,7 +234,7 @@ class SessionBoltV3IT
         assertNotNull( bookmark1 );
         assertNotEquals( initialBookmark, bookmark1 );
 
-        session.run( "CREATE ()" ).summary();
+        session.run( "CREATE ()" ).consume();
         Bookmark bookmark2 = session.lastBookmark();
         assertNotNull( bookmark2 );
         assertNotEquals( initialBookmark, bookmark2 );
@@ -263,7 +263,7 @@ class SessionBoltV3IT
         assertNotNull( bookmark1 );
         assertNotEquals( initialBookmark, bookmark1 );
 
-        session.run( "CREATE ()" ).summary();
+        session.run( "CREATE ()" ).consume();
         Bookmark bookmark2 = session.lastBookmark();
         assertNotNull( bookmark2 );
         assertNotEquals( initialBookmark, bookmark2 );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
@@ -109,8 +109,8 @@ class SessionMixIT
                 // move execution to ForkJoinPool.commonPool()
                 .thenApplyAsync( tx ->
                 {
-                    session.run( "UNWIND [1,1,2] AS x CREATE (:Node {id: x})" ).summary();
-                    session.run( "CREATE (:Node {id: 42})" ).summary();
+                    session.run( "UNWIND [1,1,2] AS x CREATE (:Node {id: x})" ).consume();
+                    session.run( "CREATE (:Node {id: 42})" ).consume();
                     tx.commitAsync();
                     return tx;
                 } );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
@@ -191,7 +191,7 @@ class SessionResetIT
             assertThat( e2.getMessage(), containsString( "Cannot run more statements in this transaction" ) );
 
             // Make sure failure from the terminated long running statement is propagated
-            Neo4jException e3 = assertThrows( Neo4jException.class, result::summary );
+            Neo4jException e3 = assertThrows( Neo4jException.class, result::consume );
             assertThat( e3.getMessage(), containsString( "The transaction has been terminated" ) );
         }
     }
@@ -227,7 +227,7 @@ class SessionResetIT
             awaitActiveQueriesToContain( "CALL test.driver.longRunningStatement" );
             session.reset();
 
-            Neo4jException e = assertThrows( Neo4jException.class, procedureResult::summary );
+            Neo4jException e = assertThrows( Neo4jException.class, procedureResult::consume );
             assertThat( e.getMessage(), containsString( "The transaction has been terminated" ) );
             tx1.close();
 
@@ -264,7 +264,7 @@ class SessionResetIT
 
                 // When
                 startTime.set( System.currentTimeMillis() );
-                result.summary(); // blocking to run the statement
+                result.consume(); // blocking to run the statement
             }
         } );
 
@@ -338,13 +338,13 @@ class SessionResetIT
         try ( Session session = neo4j.driver().session() )
         {
 
-            session.run( "RETURN 1" ).summary();
+            session.run( "RETURN 1" ).consume();
 
             // When reset the state of this session
             session.reset();
 
             // Then can run successfully more statements without any error
-            session.run( "RETURN 2" ).summary();
+            session.run( "RETURN 2" ).consume();
         }
     }
 
@@ -427,7 +427,7 @@ class SessionResetIT
                     usedSessionRef.set( session );
                     latchToWait.await();
                     StatementResult result = updateNodeId( session, nodeId, newNodeId );
-                    result.summary();
+                    result.consume();
                 }
             }
         } );
@@ -448,7 +448,7 @@ class SessionResetIT
                     usedSessionRef.set( session );
                     latchToWait.await();
                     StatementResult result = updateNodeId( tx, nodeId, newNodeId );
-                    result.summary();
+                    result.consume();
                 }
             }
         } );
@@ -474,7 +474,7 @@ class SessionResetIT
                     {
                         invocationsOfWork.incrementAndGet();
                         StatementResult result = updateNodeId( tx, nodeId, newNodeId );
-                        result.summary();
+                        result.consume();
                         return null;
                     } );
                 }
@@ -585,7 +585,7 @@ class SessionResetIT
             Future<Void> txResult = nodeIdUpdater.update( nodeId, newNodeId1, otherSessionRef, nodeLocked );
 
             StatementResult result = updateNodeId( tx, nodeId, newNodeId2 );
-            result.summary();
+            result.consume();
 
             nodeLocked.countDown();
             // give separate thread some time to block on a lock
@@ -721,7 +721,7 @@ class SessionResetIT
     {
         if ( autoCommit )
         {
-            session.run( query ).summary();
+            session.run( query ).consume();
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
@@ -68,7 +68,7 @@ class StatementRunnerCloseIT
         StatementResult result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
 
         // When
-        result.summary();
+        result.consume();
 
         // Then
         assertThrows( ResultConsumedException.class, result::hasNext );
@@ -110,10 +110,10 @@ class StatementRunnerCloseIT
         List<String> keys = result.keys();
 
         // When
-        ResultSummary summary = result.summary();
+        ResultSummary summary = result.consume();
 
         // Then
-        ResultSummary summary1 = result.summary();
+        ResultSummary summary1 = result.consume();
         List<String> keys1 = result.keys();
 
         assertEquals( summary, summary1 );
@@ -127,13 +127,13 @@ class StatementRunnerCloseIT
         Session session = neo4j.driver().session();
         StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
         List<String> keys = result.keys();
-        ResultSummary summary = result.summary();
+        ResultSummary summary = result.consume();
 
         // When
         session.close();
 
         // Then
-        ResultSummary summary1 = result.summary();
+        ResultSummary summary1 = result.consume();
         List<String> keys1 = result.keys();
 
         assertEquals( summary, summary1 );
@@ -148,7 +148,7 @@ class StatementRunnerCloseIT
         StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
 
         // When
-        await( result.summaryAsync() );
+        await( result.consumeAsync() );
 
         // Then
         assertThrows( ResultConsumedException.class, () -> await( result.nextAsync() ) );
@@ -187,10 +187,10 @@ class StatementRunnerCloseIT
         List<String> keys = result.keys();
 
         // When
-        ResultSummary summary = await( result.summaryAsync() );
+        ResultSummary summary = await( result.consumeAsync() );
 
         // Then
-        ResultSummary summary1 = await( result.summaryAsync() );
+        ResultSummary summary1 = await( result.consumeAsync() );
         List<String> keys1 = result.keys();
 
         assertEquals( summary, summary1 );
@@ -204,14 +204,14 @@ class StatementRunnerCloseIT
         AsyncSession session = neo4j.driver().asyncSession();
         StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
         List<String> keys = result.keys();
-        ResultSummary summary = await( result.summaryAsync() );
+        ResultSummary summary = await( result.consumeAsync() );
 
         // When
         await( session.closeAsync() );
 
         // Then
         List<String> keys1 = result.keys();
-        ResultSummary summary1 = await( result.summaryAsync() );
+        ResultSummary summary1 = await( result.consumeAsync() );
 
         assertEquals( summary, summary1 );
         assertEquals( keys, keys1 );

--- a/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.async.AsyncSession;
+import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.exceptions.ResultConsumedException;
+import org.neo4j.driver.summary.ResultSummary;
+import org.neo4j.driver.util.DatabaseExtension;
+import org.neo4j.driver.util.ParallelizableIT;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.util.TestUtil.await;
+
+@ParallelizableIT
+class StatementRunnerCloseIT
+{
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    private Driver driver;
+    private ExecutorService executor;
+
+    @AfterEach
+    void tearDown()
+    {
+        if ( driver != null )
+        {
+            driver.close();
+        }
+        if ( executor != null )
+        {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldErrorToAccessRecordsAfterSummary()
+    {
+        // Given
+        StatementResult result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
+
+        // When
+        result.summary();
+
+        // Then
+        assertThrows( ResultConsumedException.class, result::hasNext );
+        assertThrows( ResultConsumedException.class, result::next );
+        assertThrows( ResultConsumedException.class, result::list );
+        assertThrows( ResultConsumedException.class, result::single );
+        assertThrows( ResultConsumedException.class, result::peek );
+        assertThrows( ResultConsumedException.class, ()-> result.stream().toArray() );
+        assertThrows( ResultConsumedException.class, () -> result.forEachRemaining( record -> {} ) );
+        assertThrows( ResultConsumedException.class, () -> result.list( record -> record ) );
+    }
+
+    @Test
+    void shouldErrorToAccessRecordsAfterClose()
+    {
+        // Given
+        Session session = neo4j.driver().session();
+        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
+
+        // When
+        session.close();
+
+        // Then
+        assertThrows( ResultConsumedException.class, result::hasNext );
+        assertThrows( ResultConsumedException.class, result::next );
+        assertThrows( ResultConsumedException.class, result::list );
+        assertThrows( ResultConsumedException.class, result::single );
+        assertThrows( ResultConsumedException.class, result::peek );
+        assertThrows( ResultConsumedException.class, ()-> result.stream().toArray() );
+        assertThrows( ResultConsumedException.class, () -> result.forEachRemaining( record -> {} ) );
+        assertThrows( ResultConsumedException.class, () -> result.list( record -> record ) );
+    }
+
+    @Test
+    void shouldAllowSummaryAndKeysAfterSummary()
+    {
+        // Given
+        StatementResult result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
+        List<String> keys = result.keys();
+
+        // When
+        ResultSummary summary = result.summary();
+
+        // Then
+        ResultSummary summary1 = result.summary();
+        List<String> keys1 = result.keys();
+
+        assertEquals( summary, summary1 );
+        assertEquals( keys, keys1 );
+    }
+
+    @Test
+    void shouldAllowSummaryAndKeysAfterClose()
+    {
+        // Given
+        Session session = neo4j.driver().session();
+        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
+        List<String> keys = result.keys();
+        ResultSummary summary = result.summary();
+
+        // When
+        session.close();
+
+        // Then
+        ResultSummary summary1 = result.summary();
+        List<String> keys1 = result.keys();
+
+        assertEquals( summary, summary1 );
+        assertEquals( keys, keys1 );
+    }
+
+    @Test
+    void shouldErrorToAccessRecordsAfterSummaryAsync()
+    {
+        // Given
+        AsyncSession session = neo4j.driver().asyncSession();
+        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+
+        // When
+        await( result.summaryAsync() );
+
+        // Then
+        assertThrows( ResultConsumedException.class, () -> await( result.nextAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.peekAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.singleAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.forEachAsync( record -> {} ) ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.listAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.listAsync( record -> record ) ) );
+    }
+
+    @Test
+    void shouldErrorToAccessRecordsAfterCloseAsync()
+    {
+        // Given
+        AsyncSession session = neo4j.driver().asyncSession();
+        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+
+        // When
+        await( session.closeAsync() );
+
+        // Then
+        assertThrows( ResultConsumedException.class, () -> await( result.nextAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.peekAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.singleAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.forEachAsync( record -> {} ) ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.listAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( result.listAsync( record -> record ) ) );    }
+
+    @Test
+    void shouldAllowSummaryAndKeysAfterSummaryAsync()
+    {
+        // Given
+        AsyncSession session = neo4j.driver().asyncSession();
+        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+
+        List<String> keys = result.keys();
+
+        // When
+        ResultSummary summary = await( result.summaryAsync() );
+
+        // Then
+        ResultSummary summary1 = await( result.summaryAsync() );
+        List<String> keys1 = result.keys();
+
+        assertEquals( summary, summary1 );
+        assertEquals( keys, keys1 );
+    }
+
+    @Test
+    void shouldAllowSummaryAndKeysAfterCloseAsync()
+    {
+        // Given
+        AsyncSession session = neo4j.driver().asyncSession();
+        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+        List<String> keys = result.keys();
+        ResultSummary summary = await( result.summaryAsync() );
+
+        // When
+        await( session.closeAsync() );
+
+        // Then
+        List<String> keys1 = result.keys();
+        ResultSummary summary1 = await( result.summaryAsync() );
+
+        assertEquals( summary, summary1 );
+        assertEquals( keys, keys1 );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -88,7 +88,7 @@ class SummaryIT
         assertTrue( result.hasNext() );
 
         // When
-        ResultSummary summary = result.summary();
+        ResultSummary summary = result.consume();
 
         // Then
         assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );
@@ -96,7 +96,7 @@ class SummaryIT
         assertThat( summary.statement().parameters(), equalTo( statementParameters ) );
         assertFalse( summary.hasPlan() );
         assertFalse( summary.hasProfile() );
-        assertThat( summary, equalTo( result.summary() ) );
+        assertThat( summary, equalTo( result.consume() ) );
 
     }
 
@@ -104,7 +104,7 @@ class SummaryIT
     void shouldContainTimeInformation()
     {
         // Given
-        ResultSummary summary = session.run( "UNWIND range(1,1000) AS n RETURN n AS number" ).summary();
+        ResultSummary summary = session.run( "UNWIND range(1,1000) AS n RETURN n AS number" ).consume();
 
         // Then
         assertThat( summary.resultAvailableAfter( TimeUnit.MILLISECONDS ), greaterThanOrEqualTo( 0L ) );
@@ -114,24 +114,24 @@ class SummaryIT
     @Test
     void shouldContainCorrectStatistics()
     {
-        assertThat( session.run( "CREATE (n)" ).summary().counters().nodesCreated(), equalTo( 1 ) );
-        assertThat( session.run( "MATCH (n) DELETE (n)" ).summary().counters().nodesDeleted(), equalTo( 1 ) );
+        assertThat( session.run( "CREATE (n)" ).consume().counters().nodesCreated(), equalTo( 1 ) );
+        assertThat( session.run( "MATCH (n) DELETE (n)" ).consume().counters().nodesDeleted(), equalTo( 1 ) );
 
-        assertThat( session.run( "CREATE ()-[:KNOWS]->()" ).summary().counters().relationshipsCreated(), equalTo( 1 ) );
-        assertThat( session.run( "MATCH ()-[r:KNOWS]->() DELETE r" ).summary().counters().relationshipsDeleted(), equalTo( 1 ) );
+        assertThat( session.run( "CREATE ()-[:KNOWS]->()" ).consume().counters().relationshipsCreated(), equalTo( 1 ) );
+        assertThat( session.run( "MATCH ()-[r:KNOWS]->() DELETE r" ).consume().counters().relationshipsDeleted(), equalTo( 1 ) );
 
-        assertThat( session.run( "CREATE (n:ALabel)" ).summary().counters().labelsAdded(), equalTo( 1 ) );
-        assertThat( session.run( "CREATE (n {magic: 42})" ).summary().counters().propertiesSet(), equalTo( 1 ) );
-        assertTrue( session.run( "CREATE (n {magic: 42})" ).summary().counters().containsUpdates() );
-        assertThat( session.run( "MATCH (n:ALabel) REMOVE n:ALabel " ).summary().counters().labelsRemoved(), equalTo( 1 ) );
+        assertThat( session.run( "CREATE (n:ALabel)" ).consume().counters().labelsAdded(), equalTo( 1 ) );
+        assertThat( session.run( "CREATE (n {magic: 42})" ).consume().counters().propertiesSet(), equalTo( 1 ) );
+        assertTrue( session.run( "CREATE (n {magic: 42})" ).consume().counters().containsUpdates() );
+        assertThat( session.run( "MATCH (n:ALabel) REMOVE n:ALabel " ).consume().counters().labelsRemoved(), equalTo( 1 ) );
 
-        assertThat( session.run( "CREATE INDEX ON :ALabel(prop)" ).summary().counters().indexesAdded(), equalTo( 1 ) );
-        assertThat( session.run( "DROP INDEX ON :ALabel(prop)" ).summary().counters().indexesRemoved(), equalTo( 1 ) );
+        assertThat( session.run( "CREATE INDEX ON :ALabel(prop)" ).consume().counters().indexesAdded(), equalTo( 1 ) );
+        assertThat( session.run( "DROP INDEX ON :ALabel(prop)" ).consume().counters().indexesRemoved(), equalTo( 1 ) );
 
         assertThat( session.run( "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE" )
-                .summary().counters().constraintsAdded(), equalTo( 1 ) );
+                .consume().counters().constraintsAdded(), equalTo( 1 ) );
         assertThat( session.run( "DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE" )
-                .summary().counters().constraintsRemoved(), equalTo( 1 ) );
+                .consume().counters().constraintsRemoved(), equalTo( 1 ) );
     }
 
     @Test
@@ -149,17 +149,17 @@ class SummaryIT
     @Test
     void shouldContainCorrectStatementType()
     {
-        assertThat( session.run("MATCH (n) RETURN 1").summary().statementType(), equalTo( StatementType.READ_ONLY ));
-        assertThat( session.run("CREATE (n)").summary().statementType(), equalTo( StatementType.WRITE_ONLY ));
-        assertThat( session.run("CREATE (n) RETURN (n)").summary().statementType(), equalTo( StatementType.READ_WRITE ));
-        assertThat( session.run("CREATE INDEX ON :User(p)").summary().statementType(), equalTo( StatementType.SCHEMA_WRITE ));
+        assertThat( session.run("MATCH (n) RETURN 1").consume().statementType(), equalTo( StatementType.READ_ONLY ));
+        assertThat( session.run("CREATE (n)").consume().statementType(), equalTo( StatementType.WRITE_ONLY ));
+        assertThat( session.run("CREATE (n) RETURN (n)").consume().statementType(), equalTo( StatementType.READ_WRITE ));
+        assertThat( session.run("CREATE INDEX ON :User(p)").consume().statementType(), equalTo( StatementType.SCHEMA_WRITE ));
     }
 
     @Test
     void shouldContainCorrectPlan()
     {
         // When
-        ResultSummary summary = session.run( "EXPLAIN MATCH (n) RETURN 1" ).summary();
+        ResultSummary summary = session.run( "EXPLAIN MATCH (n) RETURN 1" ).consume();
 
         // Then
         assertTrue( summary.hasPlan() );
@@ -175,7 +175,7 @@ class SummaryIT
     void shouldContainProfile()
     {
         // When
-        ResultSummary summary = session.run( "PROFILE RETURN 1" ).summary();
+        ResultSummary summary = session.run( "PROFILE RETURN 1" ).consume();
 
         // Then
         assertTrue( summary.hasProfile() );
@@ -192,7 +192,7 @@ class SummaryIT
     void shouldContainNotifications()
     {
         // When
-        ResultSummary summary = session.run( "EXPLAIN MATCH (n:ThisLabelDoesNotExist) RETURN n" ).summary();
+        ResultSummary summary = session.run( "EXPLAIN MATCH (n:ThisLabelDoesNotExist) RETURN n" ).consume();
 
         // Then
         List<Notification> notifications = summary.notifications();
@@ -210,7 +210,7 @@ class SummaryIT
     void shouldContainNoNotifications() throws Throwable
     {
         // When
-        ResultSummary summary = session.run( "RETURN 1" ).summary();
+        ResultSummary summary = session.run( "RETURN 1" ).consume();
 
         // Then
         assertThat( summary.notifications().size(), equalTo( 0 ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -91,7 +91,6 @@ class SummaryIT
         ResultSummary summary = result.summary();
 
         // Then
-        assertFalse( result.hasNext() );
         assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );
         assertThat( summary.statement().text(), equalTo( statementText ) );
         assertThat( summary.statement().parameters(), equalTo( statementParameters ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -141,8 +141,8 @@ class SummaryIT
         try ( Session session = neo4j.driver().session( forDatabase( "system" ) ) )
         {
             StatementResult result = session.run( "CREATE USER foo SET PASSWORD 'bar'" );
-            assertThat( result.summary().counters().containsUpdates(), equalTo( false ) );
-            assertThat( result.summary().counters().containsSystemUpdates(), equalTo( true ) );
+            assertThat( result.consume().counters().containsUpdates(), equalTo( false ) );
+            assertThat( result.consume().counters().containsSystemUpdates(), equalTo( true ) );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
@@ -70,7 +70,7 @@ class TransactionBoltV3IT
 
         try ( Transaction tx = driver.session().beginTransaction( config ) )
         {
-            tx.run( "RETURN 1" ).summary();
+            tx.run( "RETURN 1" ).consume();
 
             verifyTransactionMetadata( metadata );
         }
@@ -89,7 +89,7 @@ class TransactionBoltV3IT
 
         CompletionStage<AsyncTransaction> txFuture = driver.asyncSession().beginTransactionAsync( config )
                 .thenCompose( tx -> tx.runAsync( "RETURN 1" )
-                        .thenCompose( StatementResultCursor::summaryAsync )
+                        .thenCompose( StatementResultCursor::consumeAsync )
                         .thenApply( ignore -> tx ) );
 
         AsyncTransaction transaction = await( txFuture );
@@ -108,14 +108,14 @@ class TransactionBoltV3IT
     {
         // create a dummy node
         Session session = driver.session();
-        session.run( "CREATE (:Node)" ).summary();
+        session.run( "CREATE (:Node)" ).consume();
 
         try ( Session otherSession = driver.driver().session() )
         {
             try ( Transaction otherTx = otherSession.beginTransaction() )
             {
                 // lock dummy node but keep the transaction open
-                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).summary();
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
                     TransactionConfig config = TransactionConfig.builder()
@@ -145,14 +145,14 @@ class TransactionBoltV3IT
         Session session = driver.session();
         AsyncSession asyncSession = driver.asyncSession();
 
-        session.run( "CREATE (:Node)" ).summary();
+        session.run( "CREATE (:Node)" ).consume();
 
         try ( Session otherSession = driver.driver().session() )
         {
             try ( Transaction otherTx = otherSession.beginTransaction() )
             {
                 // lock dummy node but keep the transaction open
-                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).summary();
+                otherTx.run( "MATCH (n:Node) SET n.prop = 1" ).consume();
 
                 assertTimeoutPreemptively( TX_TIMEOUT_TEST_TIMEOUT, () -> {
                     TransactionConfig config = TransactionConfig.builder()

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
@@ -230,12 +230,12 @@ class TransactionIT
         // GIVEN a successful query in a transaction
         Transaction tx = session.beginTransaction();
         StatementResult result = tx.run( "CREATE (n) RETURN n" );
-        result.summary();
+        result.consume();
         tx.commit();
         tx.close();
 
         // WHEN when running a malformed query in the original session
-        assertThrows( ClientException.class, () -> session.run( "CREAT (n) RETURN n" ).summary() );
+        assertThrows( ClientException.class, () -> session.run( "CREAT (n) RETURN n" ).consume() );
     }
 
     @SuppressWarnings( "ConstantConditions" )
@@ -308,7 +308,7 @@ class TransactionIT
             try ( Transaction tx = session.beginTransaction() )
             {
                 StatementResult result = tx.run( "invalid" );
-                result.summary();
+                result.consume();
             }
         } );
 
@@ -327,9 +327,9 @@ class TransactionIT
         {
             StatementResult result = tx.run( "RETURN Wrong" );
 
-            ClientException e = assertThrows( ClientException.class, result::summary );
+            ClientException e = assertThrows( ClientException.class, result::consume );
             assertThat( e.code(), containsString( "SyntaxError" ) );
-            assertNotNull( result.summary() );
+            assertNotNull( result.consume() );
         }
     }
 
@@ -338,11 +338,11 @@ class TransactionIT
     {
         try ( Session otherSession = session.driver().session() )
         {
-            session.run( "CREATE (:Person {name: 'Beta Ray Bill'})" ).summary();
+            session.run( "CREATE (:Person {name: 'Beta Ray Bill'})" ).consume();
 
             Transaction tx1 = session.beginTransaction();
             Transaction tx2 = otherSession.beginTransaction();
-            tx1.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Mjolnir'" ).summary();
+            tx1.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Mjolnir'" ).consume();
 
             // now 'Beta Ray Bill' node is locked
 
@@ -352,7 +352,7 @@ class TransactionIT
             try
             {
                 ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class,
-                        () -> tx2.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Stormbreaker'" ).summary() );
+                        () -> tx2.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Stormbreaker'" ).consume() );
                 assertThat( e.getMessage(), containsString( "Connection to the database terminated" ) );
                 assertThat( e.getMessage(), containsString( "Thread interrupted while waiting for result to arrive" ) );
             }
@@ -369,11 +369,11 @@ class TransactionIT
     {
         try ( Session otherSession = session.driver().session() )
         {
-            session.run( "CREATE (:Person {name: 'Beta Ray Bill'})" ).summary();
+            session.run( "CREATE (:Person {name: 'Beta Ray Bill'})" ).consume();
 
             Transaction tx1 = session.beginTransaction();
             Transaction tx2 = otherSession.beginTransaction();
-            tx1.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Mjolnir'" ).summary();
+            tx1.run( "MATCH (n:Person {name: 'Beta Ray Bill'}) SET n.hammer = 'Mjolnir'" ).consume();
 
             // now 'Beta Ray Bill' node is locked
 
@@ -407,7 +407,7 @@ class TransactionIT
                 try ( Session session1 = driver.session();
                       Transaction tx = session1.beginTransaction() )
                 {
-                    tx.run( "CREATE (:MyNode {id: 1})" ).summary();
+                    tx.run( "CREATE (:MyNode {id: 1})" ).consume();
 
                     // kill all network channels
                     for ( Channel channel: factory.channels() )
@@ -415,7 +415,7 @@ class TransactionIT
                         channel.close().syncUninterruptibly();
                     }
 
-                    tx.run( "CREATE (:MyNode {id: 1})" ).summary();
+                    tx.run( "CREATE (:MyNode {id: 1})" ).consume();
                 }
             } );
 
@@ -433,7 +433,7 @@ class TransactionIT
             List<Integer> xs = tx.run( "UNWIND [1,2,3] AS x CREATE (:Node) RETURN x" ).list( record -> record.get( 0 ).asInt() );
             assertEquals( asList( 1, 2, 3 ), xs );
 
-            ClientException error1 = assertThrows( ClientException.class, () -> tx.run( "RETURN unknown" ).summary() );
+            ClientException error1 = assertThrows( ClientException.class, () -> tx.run( "RETURN unknown" ).consume() );
             assertThat( error1.code(), containsString( "SyntaxError" ) );
 
             ClientException error2 = assertThrows( ClientException.class, tx::commit );
@@ -449,13 +449,13 @@ class TransactionIT
             List<Integer> xs = tx.run( "UNWIND [1,2,3] AS x CREATE (:Node) RETURN x" ).list( record -> record.get( 0 ).asInt() );
             assertEquals( asList( 1, 2, 3 ), xs );
 
-            ClientException error1 = assertThrows( ClientException.class, () -> tx.run( "RETURN unknown" ).summary() );
+            ClientException error1 = assertThrows( ClientException.class, () -> tx.run( "RETURN unknown" ).consume() );
             assertThat( error1.code(), containsString( "SyntaxError" ) );
 
-            ClientException error2 = assertThrows( ClientException.class, () -> tx.run( "CREATE (:OtherNode)" ).summary() );
+            ClientException error2 = assertThrows( ClientException.class, () -> tx.run( "CREATE (:OtherNode)" ).consume() );
             assertThat( error2.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
 
-            ClientException error3 = assertThrows( ClientException.class, () -> tx.run( "RETURN 42" ).summary() );
+            ClientException error3 = assertThrows( ClientException.class, () -> tx.run( "RETURN 42" ).consume() );
             assertThat( error3.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
         }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
@@ -285,7 +285,7 @@ class AsyncSessionIT
         Value params = parameters( "id", 1, "name", "TheNode" );
 
         StatementResultCursor cursor = await( session.runAsync( query, params ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query, params ), summary.statement() );
         assertEquals( 1, summary.counters().nodesCreated() );
@@ -307,7 +307,7 @@ class AsyncSessionIT
         String query = "EXPLAIN CREATE (),() WITH * MATCH (n)-->(m) CREATE (n)-[:HI {id: 'id'}]->(m) RETURN n, m";
 
         StatementResultCursor cursor = await( session.runAsync( query ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query ), summary.statement() );
         assertEquals( 0, summary.counters().nodesCreated() );
@@ -333,7 +333,7 @@ class AsyncSessionIT
         String query = "PROFILE CREATE (:Node)-[:KNOWS]->(:Node) WITH * MATCH (n) RETURN n";
 
         StatementResultCursor cursor = await( session.runAsync( query ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query ), summary.statement() );
         assertEquals( 2, summary.counters().nodesCreated() );
@@ -639,7 +639,7 @@ class AsyncSessionIT
         assertThrows( ServiceUnavailableException.class, () ->
         {
             StatementResultCursor cursor = await( session.runAsync( "RETURN 42" ) );
-            await( cursor.summaryAsync() );
+            await( cursor.consumeAsync() );
         } );
 
         neo4j.startDb();
@@ -802,7 +802,7 @@ class AsyncSessionIT
     {
         StatementResultCursor cursor = await( session.runAsync( "SomeWrongQuery" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.getMessage(), startsWith( "Invalid input" ) );
         assertNull( await( session.closeAsync() ) );
     }
@@ -812,7 +812,7 @@ class AsyncSessionIT
     {
         StatementResultCursor cursor = await( session.runAsync( "UNWIND range(10, 0, -1) AS x RETURN 1 / x" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
         assertNull( await( session.closeAsync() ) );
     }
@@ -822,9 +822,9 @@ class AsyncSessionIT
     {
         StatementResultCursor cursor = await( session.runAsync( "RETURN Something" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
-        assertNotNull( await( cursor.summaryAsync() ) );
+        assertNotNull( await( cursor.consumeAsync() ) );
     }
 
     @Test
@@ -970,7 +970,7 @@ class AsyncSessionIT
     private void testConsume( String query )
     {
         StatementResultCursor cursor = await( session.runAsync( query ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertNotNull( summary );
         assertEquals( query, summary.statement().text() );

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -43,6 +43,7 @@ import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.StatementType;
 import org.neo4j.driver.types.Node;
@@ -873,6 +874,6 @@ class AsyncTransactionIT
         assertEquals( emptyMap(), summary.statement().parameters().asMap() );
 
         // no records should be available, they should all be consumed
-        assertNull( await( cursor.nextAsync() ) );
+        assertThrows( ResultConsumedException.class, () -> await( cursor.nextAsync() ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -221,7 +221,7 @@ class AsyncTransactionIT
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
 
-        Exception e = assertThrows( Exception.class, () -> await( cursor.summaryAsync() ) );
+        Exception e = assertThrows( Exception.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
 
         assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
@@ -256,7 +256,7 @@ class AsyncTransactionIT
 
         StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
 
-        Exception e = assertThrows( Exception.class, () -> await( cursor3.summaryAsync() ) );
+        Exception e = assertThrows( Exception.class, () -> await( cursor3.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
 
         assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
@@ -279,7 +279,7 @@ class AsyncTransactionIT
 
         StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
 
-        Exception e = assertThrows( Exception.class, () -> await( cursor3.summaryAsync() ) );
+        Exception e = assertThrows( Exception.class, () -> await( cursor3.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
         assertThat( await( tx.rollbackAsync() ), is( nullValue() ) );
     }
@@ -380,7 +380,7 @@ class AsyncTransactionIT
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( query, params ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query, params ), summary.statement() );
         assertEquals( 2, summary.counters().nodesCreated() );
@@ -403,7 +403,7 @@ class AsyncTransactionIT
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( query ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query ), summary.statement() );
         assertEquals( 0, summary.counters().nodesCreated() );
@@ -431,7 +431,7 @@ class AsyncTransactionIT
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( query, params ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query, params ), summary.statement() );
         assertEquals( 1, summary.counters().nodesCreated() );
@@ -774,7 +774,7 @@ class AsyncTransactionIT
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e1.code(), containsString( "SyntaxError" ) );
 
         ClientException e2 = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
@@ -788,7 +788,7 @@ class AsyncTransactionIT
         StatementResultCursor cursor = await( tx.runAsync(
                 "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" ) );
 
-        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e1.code(), containsString( "TypeError" ) );
 
         ClientException e2 = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
@@ -801,7 +801,7 @@ class AsyncTransactionIT
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
         assertNull( await( tx.rollbackAsync() ) );
     }
@@ -812,7 +812,7 @@ class AsyncTransactionIT
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 5 / x" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
         assertNull( await( tx.rollbackAsync() ) );
     }
@@ -824,9 +824,9 @@ class AsyncTransactionIT
 
         StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
-        ClientException e = assertThrows( ClientException.class, () -> await( cursor.summaryAsync() ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
-        assertNotNull( await( cursor.summaryAsync() ) );
+        assertNotNull( await( cursor.consumeAsync() ) );
     }
 
     private int countNodes( Object id )
@@ -867,7 +867,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
         StatementResultCursor cursor = await( tx.runAsync( query ) );
-        ResultSummary summary = await( cursor.summaryAsync() );
+        ResultSummary summary = await( cursor.consumeAsync() );
 
         assertNotNull( summary );
         assertEquals( query, summary.statement().text() );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxNestedQueriesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxNestedQueriesIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration.reactive;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import org.neo4j.driver.exceptions.TransactionNestingException;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxTransaction;
+import org.neo4j.driver.util.DatabaseExtension;
+import org.neo4j.driver.util.ParallelizableIT;
+
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
+
+@EnabledOnNeo4jWith( BOLT_V4 )
+@ParallelizableIT
+class RxNestedQueriesIT
+{
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    @Test
+    void shouldErrorForNestingQueriesAmongSessionRuns()
+    {
+        int size = 12555;
+
+        Flux<Integer> nodeIds = Flux.usingWhen(
+                Mono.fromSupplier( () -> neo4j.driver().rxSession() ),
+                session -> Flux.from( session.run( "UNWIND range(1, $size) AS x RETURN x", Collections.singletonMap( "size", size ) ).records() )
+                        .limitRate( 20 ).flatMap( record -> {
+                            int x = record.get( "x" ).asInt();
+                            RxStatementResult innerResult = session.run( "CREATE (n:Node {id: $x}) RETURN n.id", Collections.singletonMap( "x", x ) );
+                            return innerResult.records();
+                        } ).map( r -> r.get( 0 ).asInt() ),
+                RxSession::close );
+
+        StepVerifier.create( nodeIds ).expectError( TransactionNestingException.class ).verify();
+    }
+
+    @Test
+    void shouldErrorForNestingQueriesAmongTransactionFunctions()
+    {
+        int size = 12555;
+        Flux<Integer> nodeIds = Flux.usingWhen(
+                Mono.fromSupplier( () -> neo4j.driver().rxSession() ),
+                session -> Flux.from( session.readTransaction( tx ->
+                        tx.run( "UNWIND range(1, $size) AS x RETURN x",
+                                Collections.singletonMap( "size", size ) ).records() ) )
+                        .limitRate( 20 )
+                        .flatMap( record -> {
+                            int x = record.get( "x" ).asInt();
+                            return session.writeTransaction( tx ->
+                                    tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
+                                            Collections.singletonMap( "x", x ) ).records() );
+                        } ).map( r -> r.get( 0 ).asInt() ),
+                RxSession::close );
+
+        StepVerifier.create( nodeIds ).expectError( TransactionNestingException.class ).verify();
+    }
+
+    @Test
+    void shouldErrorForNestingQueriesAmongSessionRunAndTransactionFunction()
+    {
+        int size = 12555;
+        Flux<Integer> nodeIds = Flux.usingWhen(
+                Mono.fromSupplier( () -> neo4j.driver().rxSession() ),
+                session -> Flux.from( session.run( "UNWIND range(1, $size) AS x RETURN x",
+                        Collections.singletonMap( "size", size ) ).records() )
+                        .limitRate( 20 )
+                        .flatMap( record -> {
+                            int x = record.get( "x" ).asInt();
+                            return session.writeTransaction( tx ->
+                                    tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
+                                            Collections.singletonMap( "x", x ) ).records() );
+                        } ).map( r -> r.get( 0 ).asInt() ),
+                RxSession::close );
+
+        StepVerifier.create( nodeIds ).expectError( TransactionNestingException.class ).verify();
+    }
+
+    @Test
+    void shouldErrorForNestingQueriesAmongTransactionFunctionAndSessionRun()
+    {
+        int size = 12555;
+        Flux<Integer> nodeIds = Flux.usingWhen(
+                Mono.fromSupplier( () -> neo4j.driver().rxSession() ),
+                session -> Flux.from( session.readTransaction( tx ->
+                        tx.run( "UNWIND range(1, $size) AS x RETURN x",
+                                Collections.singletonMap( "size", size ) ).records() ) )
+                        .limitRate( 20 )
+                        .flatMap( record -> {
+                            int x = record.get( "x" ).asInt();
+                            return session.run( "CREATE (n:Node {id: $x}) RETURN n.id",
+                                    Collections.singletonMap( "x", x ) ).records();
+                        } ).map( r -> r.get( 0 ).asInt() ),
+                RxSession::close );
+
+        StepVerifier.create( nodeIds ).expectError( TransactionNestingException.class ).verify();
+    }
+
+    @Test
+    void shouldHandleNestedQueriesInTheSameTransaction() throws Throwable
+    {
+        int size = 12555;
+
+        RxSession session = neo4j.driver().rxSession();
+        Flux<Integer> nodeIds = Flux.usingWhen(
+                session.beginTransaction(),
+                tx -> {
+                    RxStatementResult result = tx.run( "UNWIND range(1, $size) AS x RETURN x",
+                            Collections.singletonMap( "size", size ) );
+                    return Flux.from( result.records() ).limitRate( 20 ).flatMap( record -> {
+                        int x = record.get( "x" ).asInt();
+                        RxStatementResult innerResult = tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
+                                Collections.singletonMap( "x", x ) );
+                        return innerResult.records();
+                    } ).map( record -> record.get( 0 ).asInt() );
+                }, RxTransaction::commit, ( tx, error ) -> tx.rollback(), null );
+
+        StepVerifier.create( nodeIds ).expectNextCount( size ).verifyComplete();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxSessionIT.java
@@ -26,7 +26,6 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -181,43 +180,6 @@ class RxSessionIT
         assertEquals( 2, work.invocationCount() );
         assertEquals( 0, countNodesByLabel( "Person" ) );
         assertNoParallelScheduler();
-    }
-
-    @Test
-    void shouldHandleNestedQueries() {
-        int size = 12555;
-
-        Flux<Integer> nodeIds = Flux.using( neo4j.driver()::rxSession,
-                session -> Flux.from( session.run( "UNWIND range(1, $size) AS x RETURN x",
-                        Collections.singletonMap( "size", size ) ).records() )
-                        .limitRate( 20 )
-                        .flatMap( record -> {
-                            int x = record.get( "x" ).asInt();
-                            RxStatementResult innerResult = session.run( "CREATE (n:Node {id: $x}) RETURN n.id",
-                                    Collections.singletonMap( "x", x ) );
-                            return innerResult.records();
-                        } ).map( r -> r.get( 0 ).asInt() ), RxSession::close );
-
-        StepVerifier.create( nodeIds ).expectNextCount( size ).verifyComplete();
-    }
-
-    @Test
-    void shouldGiveHelpfulErrorMessageWhenNestingTransactionFunctions() {
-
-        int size = 12555;
-        Flux<Integer> nodeIds = Flux.using( neo4j.driver()::rxSession,
-                session -> Flux.from( session.readTransaction( tx ->
-                        tx.run( "UNWIND range(1, $size) AS x RETURN x",
-                        Collections.singletonMap( "size", size ) ).records() ) )
-                        .limitRate( 20 )
-                        .flatMap( record -> {
-                            int x = record.get( "x" ).asInt();
-                            return session.writeTransaction( tx ->
-                                    tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
-                                    Collections.singletonMap( "x", x ) ).records() );
-                        } ).map( r -> r.get( 0 ).asInt() ), RxSession::close );
-
-        StepVerifier.create( nodeIds ).expectNextCount( size ).verifyComplete();
     }
 
     private void assertNoParallelScheduler()

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxStatementResultIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxStatementResultIT.java
@@ -211,7 +211,7 @@ class RxStatementResultIT
         // When
         Flux<String> keys = Flux.from( result.keys() );
         Flux<Record> records = Flux.from( result.records() );
-        Mono<ResultSummary> summaryMono = Mono.from( result.summary() );
+        Mono<ResultSummary> summaryMono = Mono.from( result.consume() );
 
         // Then
         StepVerifier.create( keys ).verifyComplete();
@@ -239,7 +239,7 @@ class RxStatementResultIT
 
         // When
         Flux<String> keys = Flux.from( result.keys() );
-        Mono<ResultSummary> summaryMono = Mono.from( result.summary() );
+        Mono<ResultSummary> summaryMono = Mono.from( result.consume() );
 
         // Then
         StepVerifier.create( keys ).verifyComplete();
@@ -272,7 +272,7 @@ class RxStatementResultIT
                 .thenCancel()
                 .verify();
 
-        StepVerifier.create( result.summary() ) // I shall be able to receive summary
+        StepVerifier.create( result.consume() ) // I shall be able to receive summary
                 .assertNext( summary -> {
                     // Then
                     assertThat( summary, notNullValue() );
@@ -300,7 +300,7 @@ class RxStatementResultIT
 
     private void verifyCanAccessSummary( RxStatementResult res )
     {
-        StepVerifier.create( res.summary() ).assertNext( summary -> {
+        StepVerifier.create( res.consume() ).assertNext( summary -> {
             assertThat( summary.statement().text(), equalTo( "UNWIND [1,2,3,4] AS a RETURN a" ) );
             assertThat( summary.counters().nodesCreated(), equalTo( 0 ) );
             assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
@@ -388,7 +388,7 @@ class RxTransactionIT
         RxStatementResult result = tx.run( query, params );
         await( result.records() ); // we run and stream
 
-        ResultSummary summary = await( Mono.from( result.summary() ) );
+        ResultSummary summary = await( Mono.from( result.consume() ) );
 
         assertEquals( new Statement( query, params ), summary.statement() );
         assertEquals( 2, summary.counters().nodesCreated() );
@@ -416,7 +416,7 @@ class RxTransactionIT
         RxStatementResult result = tx.run( query );
         await( result.records() ); // we run and stream
 
-        ResultSummary summary = await( Mono.from( result.summary() ) );
+        ResultSummary summary = await( Mono.from( result.consume() ) );
 
         assertEquals( new Statement( query ), summary.statement() );
         assertEquals( 0, summary.counters().nodesCreated() );
@@ -448,7 +448,7 @@ class RxTransactionIT
         RxStatementResult result = tx.run( query, params );
         await( result.records() ); // we run and stream
 
-        ResultSummary summary = await( Mono.from( result.summary() ) );
+        ResultSummary summary = await( Mono.from( result.consume() ) );
 
         assertEquals( new Statement( query, params ), summary.statement() );
         assertEquals( 1, summary.counters().nodesCreated() );
@@ -783,7 +783,7 @@ class RxTransactionIT
         ClientException e = assertThrows( ClientException.class, () -> await( result.records() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
 
-        await( result.summary() );
+        await( result.consume() );
         assertCanRollback( tx );
     }
 
@@ -801,7 +801,7 @@ class RxTransactionIT
             AtomicInteger recordsSeen = new AtomicInteger();
             return Flux.from( result.records() )
                     .doOnNext( record -> recordsSeen.incrementAndGet() )
-                    .then( Mono.from( result.summary() ) )
+                    .then( Mono.from( result.consume() ) )
                     .doOnSuccess( s -> {
                         assertNotNull( s );
                         assertEquals( query, s.statement().text() );
@@ -835,7 +835,7 @@ class RxTransactionIT
     private void testConsume( String query )
     {
         Flux<ResultSummary> summary = Flux.usingWhen( session.beginTransaction(), tx ->
-            tx.run( query ).summary(),
+            tx.run( query ).consume(),
             RxTransaction::commit,
             RxTransaction::rollback
         );

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.net.URI;
@@ -426,8 +427,8 @@ class DirectDriverBoltKitTest
 
         try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", INSECURE_CONFIG ) )
         {
-            Flux<String> keys = Flux.using(
-                    driver::rxSession,
+            Flux<String> keys = Flux.usingWhen(
+                    Mono.fromSupplier( driver::rxSession ),
                     session -> session.readTransaction( tx -> tx.run( "UNWIND [1,2,3,4] AS a RETURN a" ).keys() ),
                     RxSession::close );
             StepVerifier.create( keys ).expectNext( "a" ).verifyComplete();

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -356,7 +356,7 @@ class DirectDriverBoltKitTest
         {
             TransientException error = assertThrows( TransientException.class, () -> {
                 StatementResult result = transaction.run( "RETURN 1" );
-                result.summary();
+                result.consume();
             } );
             assertThat( error.code(), equalTo( "Neo.TransientError.General.DatabaseUnavailable" ) );
         }
@@ -376,7 +376,7 @@ class DirectDriverBoltKitTest
         {
             Transaction transaction = session.beginTransaction();
             StatementResult result = transaction.run( "CREATE (n {name:'Bob'})" );
-            result.summary();
+            result.consume();
 
             TransientException error = assertThrows( TransientException.class, transaction::commit );
             assertThat( error.code(), equalTo( "Neo.TransientError.General.DatabaseUnavailable" ) );
@@ -396,7 +396,7 @@ class DirectDriverBoltKitTest
                 Session session = driver.session( builder().withDatabase( "mydatabase" ).withDefaultAccessMode( AccessMode.READ ).build() ) )
         {
             final StatementResult result = session.run( "MATCH (n) RETURN n.name" );
-            result.summary();
+            result.consume();
         }
         finally
         {
@@ -412,7 +412,7 @@ class DirectDriverBoltKitTest
         try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", INSECURE_CONFIG );
                 Session session = driver.session( forDatabase( "mydatabase" ) ) )
         {
-            session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" ).summary() );
+            session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" ).consume() );
         }
         finally
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalStatementResultTest.java
@@ -185,7 +185,7 @@ class InternalStatementResultTest
         assertThrows( ResultConsumedException.class, () ->
         {
             StatementResult result = createResult( 2 );
-            result.summary();
+            result.consume();
             result.single();
         } );
     }
@@ -195,10 +195,10 @@ class InternalStatementResultTest
     {
         // GIVEN
         StatementResult result = createResult( 2 );
-        result.summary();
+        result.consume();
 
         // WHEN
-        result.summary();
+        result.consume();
 
         // THEN
         assertThrows( ResultConsumedException.class, result::hasNext );

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
@@ -93,7 +93,7 @@ class InternalTransactionTest
         setupSuccessfulRunAndPull( connection );
 
         StatementResult result = runReturnOne.apply( tx );
-        ResultSummary summary = result.summary();
+        ResultSummary summary = result.consume();
 
         verifyRunAndPull( connection, summary.statement().text() );
     }
@@ -131,7 +131,7 @@ class InternalTransactionTest
     void shouldRollbackWhenFailedRun() throws Throwable
     {
         setupFailingRun( connection, new RuntimeException( "Bang!" ) );
-        assertThrows( RuntimeException.class, () -> tx.run( "RETURN 1" ).summary() );
+        assertThrows( RuntimeException.class, () -> tx.run( "RETURN 1" ).consume() );
 
         tx.close();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncStatementResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncStatementResultCursorImplTest.java
@@ -90,11 +90,11 @@ class AsyncStatementResultCursorImplTest
                 new InternalServerInfo( BoltServerAddress.LOCAL_DEFAULT, anyServerVersion() ), DEFAULT_DATABASE_INFO, StatementType.SCHEMA_WRITE,
                 new InternalSummaryCounters( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 ),
                 null, null, emptyList(), 42, 42 );
-        when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
-        assertEquals( summary, await( cursor.summaryAsync() ) );
+        assertEquals( summary, await( cursor.consumeAsync() ) );
     }
 
     @Test
@@ -200,7 +200,7 @@ class AsyncStatementResultCursorImplTest
                 .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
-        when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
@@ -221,7 +221,7 @@ class AsyncStatementResultCursorImplTest
                 .thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
-        when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
@@ -239,7 +239,7 @@ class AsyncStatementResultCursorImplTest
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
         ResultSummary summary = mock( ResultSummary.class );
-        when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
@@ -292,22 +292,22 @@ class AsyncStatementResultCursorImplTest
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
         ServiceUnavailableException error = new ServiceUnavailableException( "Hi" );
-        when( pullAllHandler.failureAsync() ).thenReturn( completedFuture( error ) );
+        when( pullAllHandler.pullAllFailureAsync() ).thenReturn( completedFuture( error ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
-        assertEquals( error, await( cursor.failureAsync() ) );
+        assertEquals( error, await( cursor.pullAllFailureAsync() ) );
     }
 
     @Test
     void shouldReturnNullFailureWhenDoesNotExist()
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
-        when( pullAllHandler.failureAsync() ).thenReturn( completedWithNull() );
+        when( pullAllHandler.pullAllFailureAsync() ).thenReturn( completedWithNull() );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
-        assertNull( await( cursor.failureAsync() ) );
+        assertNull( await( cursor.pullAllFailureAsync() ) );
     }
 
     @Test
@@ -377,11 +377,11 @@ class AsyncStatementResultCursorImplTest
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         ResultSummary summary = mock( ResultSummary.class );
-        when( pullAllHandler.summaryAsync() ).thenReturn( completedFuture( summary ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
-        assertEquals( summary, await( cursor.summaryAsync() ) );
+        assertEquals( summary, await( cursor.consumeAsync() ) );
     }
 
     @Test
@@ -389,11 +389,11 @@ class AsyncStatementResultCursorImplTest
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         RuntimeException error = new RuntimeException( "Hi" );
-        when( pullAllHandler.summaryAsync() ).thenReturn( failedFuture( error ) );
+        when( pullAllHandler.consumeAsync() ).thenReturn( failedFuture( error ) );
 
         AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
 
-        RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.summaryAsync() ) );
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.consumeAsync() ) );
         assertEquals( error, e );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
@@ -138,7 +138,7 @@ class InternalAsyncSessionTest
 
         StatementResultCursor cursor = await( runReturnOne.apply( asyncSession ) );
 
-        verifyRunAndPull( connection, await( cursor.summaryAsync() ).statement().text() );
+        verifyRunAndPull( connection, await( cursor.consumeAsync() ).statement().text() );
     }
 
     @ParameterizedTest

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
@@ -96,7 +96,7 @@ class InternalAsyncTransactionTest
         setupSuccessfulRunAndPull( connection );
 
         StatementResultCursor result = await( runReturnOne.apply( tx ) );
-        ResultSummary summary = await( result.summaryAsync() );
+        ResultSummary summary = await( result.consumeAsync() );
 
         verifyRunAndPull( connection, summary.statement().text() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
@@ -149,7 +149,7 @@ class ResultCursorsHolderTest
     private static CompletionStage<AsyncStatementResultCursorImpl> cursorWithFailureFuture( CompletableFuture<Throwable> future )
     {
         AsyncStatementResultCursorImpl cursor = mock( AsyncStatementResultCursorImpl.class );
-        when( cursor.consumeAsync() ).thenReturn( future );
+        when( cursor.discardAllFailureAsync() ).thenReturn( future );
         return completedFuture( cursor );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorOnlyFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/AsyncStatementResultCursorOnlyFactoryTest.java
@@ -174,6 +174,6 @@ class AsyncStatementResultCursorOnlyFactoryTest
     private void verifyRunCompleted( Connection connection, CompletionStage<AsyncStatementResultCursor> cursorFuture )
     {
         verify( connection ).write( any( Message.class ), any( RunResponseHandler.class ) );
-        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursorImpl.class ) );
+        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursor.class ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cursor;
+
+import org.junit.jupiter.api.Test;
+
+import org.neo4j.driver.internal.util.Futures;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.util.TestUtil.await;
+
+class DisposableAsyncStatementResultCursorTest
+{
+    @Test
+    void summaryShouldDisposeCursor() throws Throwable
+    {
+        // Given
+        DisposableAsyncStatementResultCursor cursor = newCursor();
+
+        // When
+        await( cursor.summaryAsync() );
+
+        // Then
+        assertTrue( cursor.isDisposed() );
+    }
+
+    @Test
+    void consumeShouldDisposeCursor() throws Throwable
+    {
+        // Given
+        DisposableAsyncStatementResultCursor cursor = newCursor();
+
+        // When
+        await( cursor.consumeAsync() );
+
+        // Then
+        assertTrue( cursor.isDisposed() );
+    }
+
+    @Test
+    void shouldNotDisposeCursor() throws Throwable
+    {
+        // Given
+        DisposableAsyncStatementResultCursor cursor = newCursor();
+
+        // When
+        cursor.keys();
+        await( cursor.peekAsync() );
+        await( cursor.nextAsync() );
+        await( cursor.singleAsync() );
+        await( cursor.forEachAsync( record -> {} ) );
+        await( cursor.listAsync() );
+        await( cursor.listAsync( record -> record ) );
+        await( cursor.failureAsync() );
+
+        // Then
+        assertFalse( cursor.isDisposed() );
+    }
+
+    private static DisposableAsyncStatementResultCursor newCursor()
+    {
+        AsyncStatementResultCursor delegate = mock( AsyncStatementResultCursor.class );
+        when( delegate.summaryAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.consumeAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.peekAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.nextAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.singleAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.forEachAsync( any() ) ).thenReturn( Futures.completedWithNull() );
+        when( delegate.listAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.listAsync( any() ) ).thenReturn( Futures.completedWithNull() );
+        when( delegate.failureAsync() ).thenReturn( Futures.completedWithNull() );
+        return new DisposableAsyncStatementResultCursor( delegate );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncStatementResultCursorTest.java
@@ -38,7 +38,7 @@ class DisposableAsyncStatementResultCursorTest
         DisposableAsyncStatementResultCursor cursor = newCursor();
 
         // When
-        await( cursor.summaryAsync() );
+        await( cursor.consumeAsync() );
 
         // Then
         assertTrue( cursor.isDisposed() );
@@ -51,7 +51,7 @@ class DisposableAsyncStatementResultCursorTest
         DisposableAsyncStatementResultCursor cursor = newCursor();
 
         // When
-        await( cursor.consumeAsync() );
+        await( cursor.discardAllFailureAsync() );
 
         // Then
         assertTrue( cursor.isDisposed() );
@@ -71,7 +71,7 @@ class DisposableAsyncStatementResultCursorTest
         await( cursor.forEachAsync( record -> {} ) );
         await( cursor.listAsync() );
         await( cursor.listAsync( record -> record ) );
-        await( cursor.failureAsync() );
+        await( cursor.pullAllFailureAsync() );
 
         // Then
         assertFalse( cursor.isDisposed() );
@@ -80,15 +80,15 @@ class DisposableAsyncStatementResultCursorTest
     private static DisposableAsyncStatementResultCursor newCursor()
     {
         AsyncStatementResultCursor delegate = mock( AsyncStatementResultCursor.class );
-        when( delegate.summaryAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.consumeAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.discardAllFailureAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.peekAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.nextAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.singleAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.forEachAsync( any() ) ).thenReturn( Futures.completedWithNull() );
         when( delegate.listAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.listAsync( any() ) ).thenReturn( Futures.completedWithNull() );
-        when( delegate.failureAsync() ).thenReturn( Futures.completedWithNull() );
+        when( delegate.pullAllFailureAsync() ).thenReturn( Futures.completedWithNull() );
         return new DisposableAsyncStatementResultCursor( delegate );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/StatementResultCursorFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/StatementResultCursorFactoryImplTest.java
@@ -222,7 +222,7 @@ class StatementResultCursorFactoryImplTest
     private void verifyRunCompleted( Connection connection, CompletionStage<AsyncStatementResultCursor> cursorFuture )
     {
         verify( connection ).write( any( Message.class ), any( RunResponseHandler.class ) );
-        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursorImpl.class ) );
+        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursor.class ) );
     }
 
     private void verifyRxRunCompleted( Connection connection, CompletionStage<RxStatementResultCursor> cursorFuture )

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandlerTest.java
@@ -96,7 +96,7 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         List<String> keys = asList( "key1", "key2" );
         LegacyPullAllResponseHandler handler = newHandler( keys, connection );
 
-        CompletableFuture<ResultSummary> summaryFuture = handler.summaryAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture = handler.consumeAsync().toCompletableFuture();
         assertFalse( summaryFuture.isDone() );
 
         int recordCount = LegacyPullAllResponseHandler.RECORD_BUFFER_HIGH_WATERMARK + 10;
@@ -122,7 +122,7 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         List<String> keys = asList( "key1", "key2" );
         LegacyPullAllResponseHandler handler = newHandler( keys, connection );
 
-        CompletableFuture<Throwable> failureFuture = handler.failureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture = handler.pullAllFailureAsync().toCompletableFuture();
         assertFalse( failureFuture.isDone() );
 
         int recordCount = LegacyPullAllResponseHandler.RECORD_BUFFER_HIGH_WATERMARK + 5;
@@ -163,7 +163,7 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         verify( connection, never() ).enableAutoRead();
         verify( connection, never() ).disableAutoRead();
 
-        CompletableFuture<Throwable> failureFuture = handler.failureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture = handler.pullAllFailureAsync().toCompletableFuture();
         assertFalse( failureFuture.isDone() );
 
         verify( connection ).enableAutoRead();
@@ -203,7 +203,7 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         handler.onFailure( error );
 
         // consume the error
-        assertEquals( error, await( handler.failureAsync() ) );
+        assertEquals( error, await( handler.pullAllFailureAsync() ) );
         assertEquals( emptyList(), await( handler.listAsync( Function.identity() ) ) );
     }
 
@@ -220,7 +220,7 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         verify( connection, never() ).enableAutoRead();
         verify( connection, never() ).disableAutoRead();
 
-        CompletableFuture<ResultSummary> summaryFuture = handler.summaryAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture = handler.consumeAsync().toCompletableFuture();
         assertFalse( summaryFuture.isDone() );
 
         verify( connection ).enableAutoRead();

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
@@ -64,7 +64,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         PullAllResponseHandler handler = newHandler();
         handler.onSuccess( emptyMap() );
 
-        Throwable failure = await( handler.failureAsync() );
+        Throwable failure = await( handler.pullAllFailureAsync() );
 
         assertNull( failure );
     }
@@ -74,7 +74,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletableFuture<Throwable> failureFuture = handler.failureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture = handler.pullAllFailureAsync().toCompletableFuture();
         assertFalse( failureFuture.isDone() );
 
         handler.onSuccess( emptyMap() );
@@ -91,7 +91,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         RuntimeException failure = new RuntimeException( "Ops" );
         handler.onFailure( failure );
 
-        Throwable receivedFailure = await( handler.failureAsync() );
+        Throwable receivedFailure = await( handler.pullAllFailureAsync() );
         assertEquals( failure, receivedFailure );
     }
 
@@ -100,7 +100,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletableFuture<Throwable> failureFuture = handler.failureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture = handler.pullAllFailureAsync().toCompletableFuture();
         assertFalse( failureFuture.isDone() );
 
         IOException failure = new IOException( "Broken pipe" );
@@ -115,8 +115,8 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletableFuture<Throwable> failureFuture1 = handler.failureAsync().toCompletableFuture();
-        CompletableFuture<Throwable> failureFuture2 = handler.failureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture1 = handler.pullAllFailureAsync().toCompletableFuture();
+        CompletableFuture<Throwable> failureFuture2 = handler.pullAllFailureAsync().toCompletableFuture();
 
         assertFalse( failureFuture1.isDone() );
         assertFalse( failureFuture2.isDone() );
@@ -139,8 +139,8 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         ServiceUnavailableException failure = new ServiceUnavailableException( "Connection terminated" );
         handler.onFailure( failure );
 
-        assertEquals( failure, await( handler.failureAsync() ) );
-        assertNull( await( handler.failureAsync() ) );
+        assertEquals( failure, await( handler.pullAllFailureAsync() ) );
+        assertNull( await( handler.pullAllFailureAsync() ) );
     }
 
     @Test
@@ -148,13 +148,13 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletionStage<Throwable> failureFuture = handler.failureAsync();
+        CompletionStage<Throwable> failureFuture = handler.pullAllFailureAsync();
 
         SessionExpiredException failure = new SessionExpiredException( "Network unreachable" );
         handler.onFailure( failure );
         assertEquals( failure, await( failureFuture ) );
 
-        assertNull( await( handler.failureAsync() ) );
+        assertNull( await( handler.pullAllFailureAsync() ) );
     }
 
     @Test
@@ -166,9 +166,9 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         ServiceUnavailableException failure = new ServiceUnavailableException( "Neo4j unreachable" );
         handler.onFailure( failure );
 
-        assertEquals( failure, await( handler.failureAsync() ) );
+        assertEquals( failure, await( handler.pullAllFailureAsync() ) );
 
-        ResultSummary summary = await( handler.summaryAsync() );
+        ResultSummary summary = await( handler.consumeAsync() );
         assertNotNull( summary );
         assertEquals( statement, summary.statement() );
     }
@@ -180,7 +180,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         PullAllResponseHandler handler = newHandler( statement );
         handler.onSuccess( singletonMap( "type", value( "rw" ) ) );
 
-        ResultSummary summary = await( handler.summaryAsync() );
+        ResultSummary summary = await( handler.consumeAsync() );
 
         assertEquals( statement, summary.statement() );
         assertEquals( StatementType.READ_WRITE, summary.statementType() );
@@ -192,7 +192,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         Statement statement = new Statement( "RETURN 'Hi!" );
         PullAllResponseHandler handler = newHandler( statement );
 
-        CompletableFuture<ResultSummary> summaryFuture = handler.summaryAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture = handler.consumeAsync().toCompletableFuture();
         assertFalse( summaryFuture.isDone() );
 
         handler.onSuccess( singletonMap( "type", value( "r" ) ) );
@@ -212,7 +212,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         RuntimeException failure = new RuntimeException( "Computer is burning" );
         handler.onFailure( failure );
 
-        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.summaryAsync() ) );
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.consumeAsync() ) );
         assertEquals( failure, e );
     }
 
@@ -221,7 +221,7 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletableFuture<ResultSummary> summaryFuture = handler.summaryAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture = handler.consumeAsync().toCompletableFuture();
         assertFalse( summaryFuture.isDone() );
 
         IOException failure = new IOException( "FAILED to write" );
@@ -237,8 +237,8 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
     {
         PullAllResponseHandler handler = newHandler();
 
-        CompletableFuture<ResultSummary> summaryFuture1 = handler.summaryAsync().toCompletableFuture();
-        CompletableFuture<ResultSummary> summaryFuture2 = handler.summaryAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture1 = handler.consumeAsync().toCompletableFuture();
+        CompletableFuture<ResultSummary> summaryFuture2 = handler.consumeAsync().toCompletableFuture();
         assertFalse( summaryFuture1.isDone() );
         assertFalse( summaryFuture2.isDone() );
 
@@ -264,10 +264,10 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         IllegalStateException failure = new IllegalStateException( "Some state is illegal :(" );
         handler.onFailure( failure );
 
-        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.summaryAsync() ) );
+        RuntimeException e = assertThrows( RuntimeException.class, () -> await( handler.consumeAsync() ) );
         assertEquals( failure, e );
 
-        ResultSummary summary = await( handler.summaryAsync() );
+        ResultSummary summary = await( handler.consumeAsync() );
         assertNotNull( summary );
         assertEquals( statement, summary.statement() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxStatementResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxStatementResultTest.java
@@ -149,7 +149,7 @@ class InternalRxStatementResultTest
                 .expectNext( record2 )
                 .expectNext( record3 )
                 .verifyComplete();
-        StepVerifier.create( Mono.from( rxResult.summary() ) ).expectNextCount( 1 ).verifyComplete();
+        StepVerifier.create( Mono.from( rxResult.consume() ) ).expectNextCount( 1 ).verifyComplete();
     }
 
     @Test
@@ -167,7 +167,7 @@ class InternalRxStatementResultTest
         StepVerifier.create( Flux.from( rxResult.records() ).limitRate( 1 ).take( 1 ) )
                 .expectNext( record1 )
                 .verifyComplete();
-        StepVerifier.create( Mono.from( rxResult.summary() ) ).expectNextCount( 1 ).verifyComplete();
+        StepVerifier.create( Mono.from( rxResult.consume() ) ).expectNextCount( 1 ).verifyComplete();
     }
 
     @Test
@@ -179,7 +179,7 @@ class InternalRxStatementResultTest
 
         // When & Then
         StepVerifier.create( Flux.from( rxResult.records() ) ).expectErrorMatches( isEqual( error ) ).verify();
-        StepVerifier.create( Mono.from( rxResult.summary() ) ).expectErrorMatches( isEqual( error ) ).verify();
+        StepVerifier.create( Mono.from( rxResult.consume() ) ).expectErrorMatches( isEqual( error ) ).verify();
     }
 
     @Test
@@ -191,7 +191,7 @@ class InternalRxStatementResultTest
 
         // When & Then
         StepVerifier.create( Flux.from( rxResult.records() ) ).expectErrorMatches( isEqual( error ) ).verify();
-        StepVerifier.create( Mono.from( rxResult.summary() ) ).assertNext( summary -> {
+        StepVerifier.create( Mono.from( rxResult.consume() ) ).assertNext( summary -> {
             assertThat( summary, instanceOf( ResultSummary.class ) );
         } ).verifyComplete();
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -638,7 +638,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
     {
         return Flux.concat( Flux.range( 0, batchSize ).map( index -> batchIndex * batchSize + index ).map( nodeIndex -> {
             Statement statement = createNodeInTxStatement( nodeIndex );
-            return Flux.from( tx.run( statement ).summary() ).then(); // As long as there is no error
+            return Flux.from( tx.run( statement ).consume() ).then(); // As long as there is no error
         } ) );
     }
 
@@ -682,7 +682,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
     private static void createNodeInTx( Transaction tx, int nodeIndex )
     {
         Statement statement = createNodeInTxStatement( nodeIndex );
-        tx.run( statement ).summary();
+        tx.run( statement ).consume();
     }
 
     private static CompletionStage<Throwable> createNodesInTxAsync( AsyncTransaction tx, int batchIndex, int batchSize )
@@ -702,7 +702,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
     {
         Statement statement = createNodeInTxStatement( nodeIndex );
         return tx.runAsync( statement )
-                .thenCompose( StatementResultCursor::summaryAsync )
+                .thenCompose( StatementResultCursor::consumeAsync )
                 .thenApply( ignore -> (Void) null )
                 .toCompletableFuture();
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQuery.java
@@ -65,6 +65,6 @@ public class AsyncReadQuery<C extends AbstractContext> extends AbstractAsyncQuer
             Node node = record.get( 0 ).asNode();
             assertNotNull( node );
         }
-        return cursor.summaryAsync();
+        return cursor.consumeAsync();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQueryInTx.java
@@ -61,7 +61,7 @@ public class AsyncReadQueryInTx<C extends AbstractContext> extends AbstractAsync
             Node node = record.get( 0 ).asNode();
             assertNotNull( node );
         }
-        return cursor.summaryAsync();
+        return cursor.consumeAsync();
     }
 
     private CompletionStage<Void> processSummaryAndCommit( ResultSummary summary, AsyncTransaction tx, C context )

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
@@ -44,7 +44,7 @@ public class AsyncWriteQuery<C extends AbstractContext> extends AbstractAsyncQue
         AsyncSession session = newSession( AccessMode.WRITE, context );
 
         return session.runAsync( "CREATE ()" )
-                .thenCompose( StatementResultCursor::summaryAsync )
+                .thenCompose( StatementResultCursor::consumeAsync )
                 .handle( ( summary, error ) ->
                 {
                     session.closeAsync();

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQueryInTx.java
@@ -45,7 +45,7 @@ public class AsyncWriteQueryInTx<C extends AbstractContext> extends AbstractAsyn
 
         CompletionStage<ResultSummary> txCommitted = session.beginTransactionAsync().thenCompose( tx ->
                 tx.runAsync( "CREATE ()" ).thenCompose( cursor ->
-                        cursor.summaryAsync().thenCompose( summary ->
+                        cursor.consumeAsync().thenCompose( summary ->
                                 tx.commitAsync().thenApply( ignore -> summary ) ) ) );
 
         return txCommitted.handle( ( summary, error ) ->

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQuery.java
@@ -41,7 +41,7 @@ public class BlockingFailingQuery<C extends AbstractContext> extends AbstractBlo
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
             StatementResult result = session.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
-            Exception e = assertThrows( Exception.class, result::summary );
+            Exception e = assertThrows( Exception.class, result::consume );
             assertThat( e, is( arithmeticError() ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryInTx.java
@@ -45,7 +45,7 @@ public class BlockingFailingQueryInTx<C extends AbstractContext> extends Abstrac
             {
                 StatementResult result = tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
 
-                Exception e = assertThrows( Exception.class, result::summary );
+                Exception e = assertThrows( Exception.class, result::consume );
                 assertThat( e, is( arithmeticError() ) );
             }
         }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQuery.java
@@ -51,7 +51,7 @@ public class BlockingReadQuery<C extends AbstractContext> extends AbstractBlocki
                 assertNotNull( node );
             }
 
-            context.readCompleted( result.summary() );
+            context.readCompleted( result.consume() );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
@@ -53,7 +53,7 @@ public class BlockingReadQueryInTx<C extends AbstractContext> extends AbstractBl
                 assertNotNull( node );
             }
 
-            context.readCompleted( result.summary() );
+            context.readCompleted( result.consume() );
             tx.commit();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
@@ -56,7 +56,7 @@ public class BlockingWriteQuery<C extends AbstractContext> extends AbstractBlock
 
         if ( queryError == null && result != null )
         {
-            assertEquals( 1, result.summary().counters().nodesCreated() );
+            assertEquals( 1, result.consume().counters().nodesCreated() );
             context.nodeCreated();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
@@ -63,7 +63,7 @@ public class BlockingWriteQueryInTx<C extends AbstractContext> extends AbstractB
 
         if ( txError == null && result != null )
         {
-            assertEquals( 1, result.summary().counters().nodesCreated() );
+            assertEquals( 1, result.consume().counters().nodesCreated() );
             context.nodeCreated();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSession.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSession.java
@@ -50,6 +50,6 @@ public class BlockingWriteQueryUsingReadSession<C extends AbstractContext> exten
             }
         } );
         assertNotNull( resultRef.get() );
-        assertEquals( 0, resultRef.get().summary().counters().nodesCreated() );
+        assertEquals( 0, resultRef.get().consume().counters().nodesCreated() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
@@ -53,6 +53,6 @@ public class BlockingWriteQueryUsingReadSessionInTx<C extends AbstractContext> e
             }
         } );
         assertNotNull( resultRef.get() );
-        assertEquals( 0, resultRef.get().summary().counters().nodesCreated() );
+        assertEquals( 0, resultRef.get().consume().counters().nodesCreated() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWrongQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWrongQuery.java
@@ -39,7 +39,7 @@ public class BlockingWrongQuery<C extends AbstractContext> extends AbstractBlock
     {
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
-            Exception e = assertThrows( Exception.class, () -> session.run( "RETURN" ).summary() );
+            Exception e = assertThrows( Exception.class, () -> session.run( "RETURN" ).consume() );
             assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWrongQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWrongQueryInTx.java
@@ -42,7 +42,7 @@ public class BlockingWrongQueryInTx<C extends AbstractContext> extends AbstractB
         {
             try ( Transaction tx = beginTransaction( session, context ) )
             {
-                Exception e = assertThrows( Exception.class, () -> tx.run( "RETURN" ).summary() );
+                Exception e = assertThrows( Exception.class, () -> tx.run( "RETURN" ).consume() );
                 assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
             }
         }

--- a/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
@@ -388,7 +388,7 @@ public class CausalClusteringIT implements NestedQueries
                 {
                     try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
                     {
-                        session.run( "CREATE (p:Person {name: 'Gamora'})" ).summary();
+                        session.run( "CREATE (p:Person {name: 'Gamora'})" ).consume();
                     }
                 } );
             }
@@ -430,7 +430,7 @@ public class CausalClusteringIT implements NestedQueries
             {
                 try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
                 {
-                    session.run( "CREATE (p:Person {name: 'Gamora'})" ).summary();
+                    session.run( "CREATE (p:Person {name: 'Gamora'})" ).consume();
                 }
             } );
 
@@ -569,11 +569,11 @@ public class CausalClusteringIT implements NestedQueries
         {
             Session session1 = driver.session();
             Transaction tx1 = session1.beginTransaction();
-            tx1.run( "CREATE (n:Node1 {name: 'Node1'})" ).summary();
+            tx1.run( "CREATE (n:Node1 {name: 'Node1'})" ).consume();
 
             Session session2 = driver.session();
             Transaction tx2 = session2.beginTransaction();
-            tx2.run( "CREATE (n:Node2 {name: 'Node2'})" ).summary();
+            tx2.run( "CREATE (n:Node2 {name: 'Node2'})" ).consume();
 
             ServiceUnavailableException error = new ServiceUnavailableException( "Connection broke!" );
             driverFactory.setNextRunFailure( error );
@@ -628,7 +628,7 @@ public class CausalClusteringIT implements NestedQueries
             try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
             {
                 SessionExpiredException e = assertThrows( SessionExpiredException.class,
-                        () -> runCreateNode( session, "Person", "name", "Vision" ).summary() );
+                        () -> runCreateNode( session, "Person", "name", "Vision" ).consume() );
                 assertEquals( "Disconnected", e.getCause().getMessage() );
             }
 
@@ -708,7 +708,7 @@ public class CausalClusteringIT implements NestedQueries
 
     private static void assertUnableToRunMoreStatementsInTx( Transaction tx, ServiceUnavailableException cause )
     {
-        SessionExpiredException e = assertThrows( SessionExpiredException.class, () -> tx.run( "CREATE (n:Node3 {name: 'Node3'})" ).summary() );
+        SessionExpiredException e = assertThrows( SessionExpiredException.class, () -> tx.run( "CREATE (n:Node3 {name: 'Node3'})" ).consume() );
         assertEquals( cause, e.getCause() );
     }
 
@@ -722,7 +722,7 @@ public class CausalClusteringIT implements NestedQueries
     private CompletionStage<RecordAndSummary> buildRecordAndSummary( StatementResultCursor cursor )
     {
         return cursor.singleAsync().thenCompose( record ->
-                cursor.summaryAsync().thenApply( summary -> new RecordAndSummary( record, summary ) ) );
+                cursor.consumeAsync().thenApply( summary -> new RecordAndSummary( record, summary ) ) );
     }
 
     private int executeWriteAndReadThroughBolt( ClusterMember member ) throws TimeoutException, InterruptedException
@@ -755,7 +755,7 @@ public class CausalClusteringIT implements NestedQueries
     {
         return session ->
         {
-            session.run( "MERGE (n:Person {name: 'Jim'})" ).summary();
+            session.run( "MERGE (n:Person {name: 'Jim'})" ).consume();
             Record record = session.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
             return record.get( "count" ).asInt();
         };

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQuery.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.stress;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -45,7 +46,7 @@ public class RxFailingQuery<C extends AbstractContext> extends AbstractRxQuery<C
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.READ, context ),
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ),
                 session -> session.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" ).records(),
                 RxSession::close )
                 .subscribe( record -> {

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryInTx.java
@@ -49,7 +49,7 @@ public class RxFailingQueryInTx<C extends AbstractContext> extends AbstractRxQue
         RxSession session = newSession( AccessMode.READ, context );
         Flux.usingWhen( session.beginTransaction(),
                 tx -> tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" ).records(),
-                RxTransaction::commit, RxTransaction::rollback )
+                RxTransaction::commit, ( tx, error ) -> tx.rollback(), null )
                 .subscribe( record -> {
                     assertThat( record.get( 0 ).asInt(), either( equalTo( 1 ) ).or( equalTo( 2 ) ) );
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryWithRetries.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.stress;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -45,7 +46,7 @@ public class RxFailingQueryWithRetries<C extends AbstractContext> extends Abstra
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.READ, context ),
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ),
                 session -> session.readTransaction( tx -> tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" ).records() ),
                 RxSession::close )
                 .subscribe( record -> {

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
@@ -43,7 +43,7 @@ public class RxReadQuery<C extends AbstractContext> extends AbstractRxQuery<C>
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.READ, context ), this::processAndGetSummary, RxSession::close )
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ), this::processAndGetSummary, RxSession::close )
                 .subscribe( summary -> {
                     context.readCompleted( summary );
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
@@ -58,7 +58,7 @@ public class RxReadQuery<C extends AbstractContext> extends AbstractRxQuery<C>
     {
         RxStatementResult result = session.run( "MATCH (n) RETURN n LIMIT 1" );
         Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
-        Mono<ResultSummary> summaryMono = Mono.from( result.summary() ).single();
+        Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
         return records.then( summaryMono );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
@@ -45,7 +45,8 @@ public class RxReadQueryInTx<C extends AbstractContext> extends AbstractRxQuery<
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
         RxSession session = newSession( AccessMode.READ, context );
-        Flux.usingWhen( session.beginTransaction(), this::processAndGetSummary, RxTransaction::commit, RxTransaction::rollback )
+        Flux.usingWhen( session.beginTransaction(), this::processAndGetSummary,
+                RxTransaction::commit, ( tx, error ) -> tx.rollback(), null )
                 .subscribe( summary -> {
                     context.readCompleted( summary );
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
@@ -60,7 +60,7 @@ public class RxReadQueryInTx<C extends AbstractContext> extends AbstractRxQuery<
     {
         RxStatementResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
         Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
-        Mono<ResultSummary> summaryMono = Mono.from( result.summary() ).single();
+        Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
         return records.then( summaryMono );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
@@ -59,7 +59,7 @@ public class RxReadQueryWithRetries<C extends AbstractContext> extends AbstractR
         return session.readTransaction( tx -> {
             RxStatementResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
             Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
-            Mono<ResultSummary> summaryMono = Mono.from( result.summary() ).single();
+            Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
             return records.then( summaryMono );
         } );
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
@@ -43,7 +43,7 @@ public class RxReadQueryWithRetries<C extends AbstractContext> extends AbstractR
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.READ, context ), this::processAndGetSummary, RxSession::close )
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ), this::processAndGetSummary, RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );
                     context.readCompleted( summary );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.stress;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -44,7 +45,7 @@ public class RxWriteQuery<C extends AbstractContext> extends AbstractRxQuery<C>
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.WRITE, context ),
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.WRITE, context ) ),
                 session -> session.run( "CREATE ()" ).summary(), RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
@@ -46,7 +46,7 @@ public class RxWriteQuery<C extends AbstractContext> extends AbstractRxQuery<C>
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
         Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.WRITE, context ) ),
-                session -> session.run( "CREATE ()" ).summary(), RxSession::close )
+                session -> session.run( "CREATE ()" ).consume(), RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );
                     assertEquals( 1, summary.counters().nodesCreated() );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
@@ -46,7 +46,8 @@ public class RxWriteQueryInTx<C extends AbstractContext> extends AbstractRxQuery
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
         RxSession session = newSession( AccessMode.WRITE, context );
-        Flux.usingWhen( session.beginTransaction(), tx -> tx.run( "CREATE ()" ).consume(), RxTransaction::commit, RxTransaction::rollback ).subscribe(
+        Flux.usingWhen( session.beginTransaction(), tx -> tx.run( "CREATE ()" ).consume(),
+                RxTransaction::commit, ( tx, error ) -> tx.rollback(), null ).subscribe(
                 summary -> {
                     assertEquals( 1, summary.counters().nodesCreated() );
                     context.nodeCreated();

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
@@ -46,7 +46,7 @@ public class RxWriteQueryInTx<C extends AbstractContext> extends AbstractRxQuery
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
         RxSession session = newSession( AccessMode.WRITE, context );
-        Flux.usingWhen( session.beginTransaction(), tx -> tx.run( "CREATE ()" ).summary(), RxTransaction::commit, RxTransaction::rollback ).subscribe(
+        Flux.usingWhen( session.beginTransaction(), tx -> tx.run( "CREATE ()" ).consume(), RxTransaction::commit, RxTransaction::rollback ).subscribe(
                 summary -> {
                     assertEquals( 1, summary.counters().nodesCreated() );
                     context.nodeCreated();

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
@@ -46,7 +46,7 @@ public class RxWriteQueryWithRetries<C extends AbstractContext> extends Abstract
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
         Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ),
-                session -> session.writeTransaction( tx -> tx.run( "CREATE ()" ).summary() ), RxSession::close )
+                session -> session.writeTransaction( tx -> tx.run( "CREATE ()" ).consume() ), RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );
                     assertEquals( 1, summary.counters().nodesCreated() );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.stress;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -44,7 +45,7 @@ public class RxWriteQueryWithRetries<C extends AbstractContext> extends Abstract
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.using( () -> newSession( AccessMode.READ, context ),
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ),
                 session -> session.writeTransaction( tx -> tx.run( "CREATE ()" ).summary() ), RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/SessionPoolingStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/SessionPoolingStressIT.java
@@ -160,7 +160,7 @@ class SessionPoolingStressIT
             {
                 StatementResult run = session.run( query );
                 Thread.sleep( random.nextInt( 100 ) );
-                run.summary();
+                run.consume();
                 Thread.sleep( random.nextInt( 100 ) );
             }
         }

--- a/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
@@ -46,7 +46,7 @@ public class RxTransactionFunctionExample extends BaseApplication
                 session -> session.readTransaction( tx -> {
                     RxStatementResult result = tx.run( query, parameters );
                     return Flux.from( result.records() )
-                            .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).then( Mono.from( result.summary() ) );
+                            .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).then( Mono.from( result.consume() ) );
                 }
              ), RxSession::close );
         // end::reactor-transaction-function[]
@@ -62,7 +62,7 @@ public class RxTransactionFunctionExample extends BaseApplication
         return Flowable.fromPublisher( session.readTransaction( tx -> {
                     RxStatementResult result = tx.run( query, parameters );
                     return Flowable.fromPublisher( result.records() )
-                            .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).ignoreElements().andThen( result.summary() );
+                            .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).ignoreElements().andThen( result.consume() );
                 } ) ).onErrorResumeNext( error -> {
                     // We rollback and rethrow the error. For a real application, you may want to handle the error directly here
                     return Flowable.<ResultSummary>fromPublisher( session.close() ).concatWith( Flowable.error( error ) );

--- a/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
@@ -42,8 +42,8 @@ public class RxTransactionFunctionExample extends BaseApplication
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String,Object> parameters = Collections.singletonMap( "id", 0 );
 
-
-        return Flux.using( driver::rxSession, session -> session.readTransaction( tx -> {
+        return Flux.usingWhen( Mono.fromSupplier( driver::rxSession ),
+                session -> session.readTransaction( tx -> {
                     RxStatementResult result = tx.run( query, parameters );
                     return Flux.from( result.records() )
                             .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).then( Mono.from( result.summary() ) );
@@ -58,13 +58,15 @@ public class RxTransactionFunctionExample extends BaseApplication
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String,Object> parameters = Collections.singletonMap( "id", 0 );
 
-
-        return Flowable.using( driver::rxSession, session -> session.readTransaction( tx -> {
+        RxSession session = driver.rxSession();
+        return Flowable.fromPublisher( session.readTransaction( tx -> {
                     RxStatementResult result = tx.run( query, parameters );
                     return Flowable.fromPublisher( result.records() )
                             .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).ignoreElements().andThen( result.summary() );
-                }
-        ), RxSession::close );
+                } ) ).onErrorResumeNext( error -> {
+                    // We rollback and rethrow the error. For a real application, you may want to handle the error directly here
+                    return Flowable.<ResultSummary>fromPublisher( session.close() ).concatWith( Flowable.error( error ) );
+                } );
         // end::RxJava-transaction-function[]
     }
 }


### PR DESCRIPTION
Give helpful error message when nesting transactions in the same session.
Give helpful error message when accessing records on a result which has already been consumed with `Result#consume` or `StatementRunner#close`.

Updated some reactive example code to ensure the close is always closed.
