### PR TITLE
Fix duplicated fields on ProfiledPlan

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalPlan.java
@@ -21,11 +21,11 @@ package org.neo4j.driver.internal.summary;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.summary.Plan;
-import java.util.function.Function;
 
 import static java.lang.String.format;
 import static org.neo4j.driver.Values.ofString;
@@ -122,14 +122,8 @@ public class InternalPlan<T extends Plan> implements Plan
         return EXPLAIN_PLAN.create( operatorType, arguments, identifiers, children, null );
     }
 
-    public static final PlanCreator<Plan> EXPLAIN_PLAN = new PlanCreator<Plan>()
-    {
-        @Override
-        public Plan create( String operatorType, Map<String,Value> arguments, List<String> identifiers, List<Plan> children, Value originalPlanValue )
-        {
-            return new InternalPlan<>( operatorType, arguments, identifiers, children );
-        }
-    };
+    public static final PlanCreator<Plan> EXPLAIN_PLAN =
+            ( operatorType, arguments, identifiers, children, originalPlanValue ) -> new InternalPlan<>( operatorType, arguments, identifiers, children );
 
     /** Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` statement */
     public static final Function<Value, Plan> EXPLAIN_PLAN_FROM_VALUE = new Converter<>(EXPLAIN_PLAN);

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalProfiledPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalProfiledPlan.java
@@ -20,46 +20,20 @@ package org.neo4j.driver.internal.summary;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.summary.ProfiledPlan;
-import java.util.function.Function;
 
 public class InternalProfiledPlan extends InternalPlan<ProfiledPlan> implements ProfiledPlan
 {
-    private final long dbHits;
-    private final long records;
-
-    protected InternalProfiledPlan( String operatorType, Map<String, Value> arguments,
-                                    List<String> identifiers, List<ProfiledPlan> children, long dbHits, long records )
+    protected InternalProfiledPlan( String operatorType, Map<String,Value> arguments, List<String> identifiers, List<ProfiledPlan> children )
     {
         super( operatorType, arguments, identifiers, children );
-        this.dbHits = dbHits;
-        this.records = records;
     }
 
-    @Override
-    public long dbHits()
-    {
-        return dbHits;
-    }
-
-    @Override
-    public long records()
-    {
-        return records;
-    }
-
-    public static final PlanCreator<ProfiledPlan> PROFILED_PLAN = new PlanCreator<ProfiledPlan>()
-    {
-        @Override
-        public ProfiledPlan create( String operatorType, Map<String,Value> arguments, List<String> identifiers, List<ProfiledPlan> children, Value originalPlanValue )
-        {
-            return new InternalProfiledPlan( operatorType, arguments, identifiers, children,
-                    originalPlanValue.get( "dbHits" ).asLong(),
-                    originalPlanValue.get( "rows" ).asLong() );
-        }
-    };
+    public static final PlanCreator<ProfiledPlan> PROFILED_PLAN =
+            ( operatorType, arguments, identifiers, children, originalPlanValue ) -> new InternalProfiledPlan( operatorType, arguments, identifiers, children );
 
     /** Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` statement */
     public static final Function<Value, ProfiledPlan> PROFILED_PLAN_FROM_VALUE = new Converter<>(PROFILED_PLAN);

--- a/driver/src/main/java/org/neo4j/driver/summary/ProfiledPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/ProfiledPlan.java
@@ -27,16 +27,6 @@ import java.util.List;
  */
 public interface ProfiledPlan extends Plan
 {
-    /**
-     * @return the number of times this part of the plan touched the underlying data stores
-     */
-    long dbHits();
-
-    /**
-     * @return the number of records this part of the plan produced
-     */
-    long records();
-
     @Override
     List<ProfiledPlan> children();
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -144,6 +144,10 @@ class SummaryIT
             StatementResult result = session.run( "CREATE USER foo SET PASSWORD 'bar'" );
             assertThat( result.summary().counters().containsUpdates(), equalTo( false ) );
             assertThat( result.summary().counters().containsSystemUpdates(), equalTo( true ) );
+
+            StatementResult deleteResult = session.run( "DROP USER foo" );
+            assertThat( deleteResult.summary().counters().containsUpdates(), equalTo( false ) );
+            assertThat( deleteResult.summary().counters().containsSystemUpdates(), equalTo( true ) );
         }
     }
 
@@ -184,9 +188,8 @@ class SummaryIT
         assertEquals( summary.plan(), summary.profile() );
 
         ProfiledPlan profile = summary.profile();
-
-        assertEquals( 0, profile.dbHits() );
-        assertEquals( 1, profile.records() );
+        assertEquals( 0, profile.arguments().get( "dbHits" ).asInt() );
+        assertEquals( 1, profile.arguments().get( "rows" ).asInt() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalProfiledPlanTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalProfiledPlanTest.java
@@ -49,8 +49,6 @@ class InternalProfiledPlanTest
         ProfiledPlan plan = InternalProfiledPlan.PROFILED_PLAN_FROM_VALUE.apply( value );
 
         // THEN
-        assertThat( plan.dbHits(), equalTo( 42L ) );
-        assertThat( plan.records(), equalTo( 1337L ) );
         assertThat( plan.operatorType(), equalTo( "AwesomeOperator" ) );
         assertThat( plan.identifiers(), equalTo( asList( "n1", "n2" ) ) );
         assertThat( plan.arguments().values(), hasItem( new StringValue( "CYPHER 1337" ) ) );
@@ -71,8 +69,6 @@ class InternalProfiledPlanTest
         // THEN
         for ( ProfiledPlan child : plan.children() )
         {
-            assertThat( child.dbHits(), equalTo( 42L ) );
-            assertThat( child.records(), equalTo( 1337L ) );
             assertThat( child.operatorType(), equalTo( "AwesomeOperator" ) );
             assertThat( child.identifiers(), equalTo( asList( "n1", "n2" ) ) );
             assertThat( child.arguments().values(), hasItem( new StringValue( "CYPHER 1337" ) ) );
@@ -84,8 +80,6 @@ class InternalProfiledPlanTest
     {
         Map<String,Value> map = new HashMap<>();
         map.put( "operatorType", new StringValue( "AwesomeOperator" ) );
-        map.put( "rows", new IntegerValue( 1337L ) );
-        map.put( "dbHits", new IntegerValue( 42 ) );
         map.put( "identifiers", new ListValue( new StringValue( "n1" ), new StringValue( "n2" ) ) );
         Map<String,Value> args = new HashMap<>();
         args.put( "version", new StringValue( "CYPHER 1337" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
@@ -226,15 +226,11 @@ class MetadataExtractorTest
                 "operatorType", "ProduceResult",
                 "args", parameters( "a", 42 ),
                 "identifiers", values( "a", "b" ),
-                "rows", value( 424242 ),
-                "dbHits", value( 242424 ),
                 "children", values(
                         parameters(
                                 "operatorType", "LabelScan",
                                 "args", parameters( "x", 1 ),
-                                "identifiers", values( "y", "z" ),
-                                "rows", value( 2 ),
-                                "dbHits", value( 4 )
+                                "identifiers", values( "y", "z" )
                         )
                 )
         ) );
@@ -247,8 +243,6 @@ class MetadataExtractorTest
         assertEquals( "ProduceResult", summary.profile().operatorType() );
         assertEquals( singletonMap( "a", value( 42 ) ), summary.profile().arguments() );
         assertEquals( asList( "a", "b" ), summary.profile().identifiers() );
-        assertEquals( 424242, summary.profile().records() );
-        assertEquals( 242424, summary.profile().dbHits() );
 
         List<ProfiledPlan> children = summary.profile().children();
         assertEquals( 1, children.size() );
@@ -257,8 +251,6 @@ class MetadataExtractorTest
         assertEquals( "LabelScan", child.operatorType() );
         assertEquals( singletonMap( "x", value( 1 ) ), child.arguments() );
         assertEquals( asList( "y", "z" ), child.identifiers() );
-        assertEquals( 2, child.records() );
-        assertEquals( 4, child.dbHits() );
     }
 
     @Test


### PR DESCRIPTION
The current PR removes duplicated keys from fields in `ProfiledPlan`.

If we want to remove duplicated keys from `argument` map instead, then we shall add missing fields `pageCacheHits`, `pageCacheMisses`, `pageCacheHitRatio`, `time`.