### PR TITLE
4.0 renames

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -121,7 +121,7 @@
           that such additional attribution notices cannot be construed
           as modifying the License.
 
-      You may add Your own copyright statement to Your modifications and
+      You may add Your own copyright query to Your modifications and
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -121,7 +121,7 @@
           that such additional attribution notices cannot be construed
           as modifying the License.
 
-      You may add Your own copyright query to Your modifications and
+      You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run a simple query, the following can be used:
 ```java
 Driver driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "PasSW0rd"));
 try (Session session = driver.session()) {
-    StatementResult rs = session.run("CREATE (n) RETURN n");
+    Result result = session.run("CREATE (n) RETURN n");
 }
 driver.close();
 ```

--- a/driver/src/main/java/org/neo4j/driver/Bookmark.java
+++ b/driver/src/main/java/org/neo4j/driver/Bookmark.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.internal.InternalBookmark;
  * the database is as up-to-date as the latest transaction referenced by the supplied bookmarks.
  *
  * Within a session, bookmark propagation is carried out automatically.
- * Thus all transactions in a session including explicit and implicit transactions are ensured to be carried out one after another.
+ * Thus all transactions in a session (both managed and unmanaged) are guaranteed to be carried out one after another.
  *
  * To opt out of this mechanism for unrelated units of work, applications can use multiple sessions.
  */

--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -167,7 +167,7 @@ public interface Driver extends AutoCloseable
      * This will return the type system supported by the driver.
      * The types supported on a particular server a session is connected against might not contain all of the types defined here.
      *
-     * @return type system used by this statement runner for classifying values
+     * @return type system used by this query runner for classifying values
      */
     @Experimental
     TypeSystem defaultTypeSystem();

--- a/driver/src/main/java/org/neo4j/driver/Query.java
+++ b/driver/src/main/java/org/neo4j/driver/Query.java
@@ -31,7 +31,7 @@ import static org.neo4j.driver.Values.ofValue;
 import static org.neo4j.driver.Values.value;
 
 /**
- * An executable statement, i.e. the statements' text and its parameters.
+ * The components of a Cypher query, containing the query text and parameter map.
  *
  * @see Session
  * @see Transaction
@@ -41,19 +41,19 @@ import static org.neo4j.driver.Values.value;
  * @since 1.0
  */
 @Immutable
-public class Statement
+public class Query
 {
     private final String text;
     private final Value parameters;
 
     /**
-     * Create a new statement.
-     * @param text the statement text
-     * @param parameters the statement parameters
+     * Create a new query.
+     * @param text the query text
+     * @param parameters the parameter map
      */
-    public Statement( String text, Value parameters )
+    public Query(String text, Value parameters )
     {
-        this.text = validateQuery( text );
+        this.text = validateQueryText( text );
         if( parameters == null )
         {
             this.parameters = Values.EmptyMap;
@@ -69,26 +69,26 @@ public class Statement
     }
 
     /**
-     * Create a new statement.
-     * @param text the statement text
-     * @param parameters the statement parameters
+     * Create a new query.
+     * @param text the query text
+     * @param parameters the parameter map
      */
-    public Statement( String text, Map<String, Object> parameters )
+    public Query(String text, Map<String, Object> parameters )
     {
         this( text, Values.value( parameters ) );
     }
 
     /**
-     * Create a new statement.
-     * @param text the statement text
+     * Create a new query.
+     * @param text the query text
      */
-    public Statement( String text )
+    public Query(String text )
     {
         this( text, Values.EmptyMap );
     }
 
     /**
-     * @return the statement's text
+     * @return the query text
      */
     public String text()
     {
@@ -96,7 +96,7 @@ public class Statement
     }
 
     /**
-     * @return the statement's parameters
+     * @return the parameter map
      */
     public Value parameters()
     {
@@ -104,44 +104,44 @@ public class Statement
     }
 
     /**
-     * @param newText the new statement's text
-     * @return a new statement with updated text
+     * @param newText the new query text
+     * @return a new Query object with updated text
      */
-    public Statement withText( String newText )
+    public Query withText(String newText )
     {
-        return new Statement( newText, parameters );
+        return new Query( newText, parameters );
     }
 
     /**
-     * @param newParameters the new statement's parameters
-     * @return a new statement with updated parameters
+     * @param newParameters the new parameter map
+     * @return a new Query object with updated parameters
      */
-    public Statement withParameters( Value newParameters )
+    public Query withParameters(Value newParameters )
     {
-        return new Statement( text, newParameters );
+        return new Query( text, newParameters );
     }
 
     /**
-     * @param newParameters the new statement's parameters
-     * @return a new statement with updated parameters
+     * @param newParameters the new parameter map
+     * @return a new Query object with updated parameters
      */
-    public Statement withParameters( Map<String, Object> newParameters )
+    public Query withParameters(Map<String, Object> newParameters )
     {
-        return new Statement( text, newParameters );
+        return new Query( text, newParameters );
     }
 
     /**
-     * Create a new statement with new parameters derived by updating this'
-     * statement's parameters using the given updates.
+     * Create a new query with new parameters derived by updating this'
+     * query's parameters using the given updates.
      *
      * Every update key that points to a null value will be removed from
-     * the new statement's parameters. All other entries will just replace
-     * any existing parameter in the new statement.
+     * the new query's parameters. All other entries will just replace
+     * any existing parameter in the new query.
      *
      * @param updates describing how to update the parameters
-     * @return a new statement with updated parameters
+     * @return a new query with updated parameters
      */
-    public Statement withUpdatedParameters( Value updates )
+    public Query withUpdatedParameters(Value updates )
     {
         if ( updates == null || updates.isEmpty() )
         {
@@ -179,8 +179,8 @@ public class Statement
             return false;
         }
 
-        Statement statement = (Statement) o;
-        return text.equals( statement.text ) && parameters.equals( statement.parameters );
+        Query query = (Query) o;
+        return text.equals( query.text ) && parameters.equals( query.parameters );
 
     }
 
@@ -195,13 +195,13 @@ public class Statement
     @Override
     public String toString()
     {
-        return format( "Statement{text='%s', parameters=%s}", text, parameters );
+        return format( "Query{text='%s', parameters=%s}", text, parameters );
     }
 
-    private static String validateQuery( String query )
+    private static String validateQueryText(String query )
     {
-        checkArgument( query != null, "Cypher query should not be null" );
-        checkArgument( !query.isEmpty(), "Cypher query should not be an empty string" );
+        checkArgument( query != null, "Cypher query text should not be null" );
+        checkArgument( !query.isEmpty(), "Cypher query text should not be an empty string" );
         return query;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/QueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/QueryRunner.java
@@ -21,23 +21,23 @@ package org.neo4j.driver;
 import java.util.Map;
 
 /**
- * Common interface for components that can execute Neo4j statements.
+ * Common interface for components that can execute Neo4j queries.
  *
  * <h2>Important notes on semantics</h2>
  * <p>
- * Statements run in the same {@link StatementRunner} are guaranteed
- * to execute in order, meaning changes made by one statement will be seen
- * by all subsequent statements in the same {@link StatementRunner}.
+ * queries run in the same {@link QueryRunner} are guaranteed
+ * to execute in order, meaning changes made by one query will be seen
+ * by all subsequent queries in the same {@link QueryRunner}.
  * <p>
  * However, to allow handling very large results, and to improve performance,
  * result streams are retrieved lazily from the network.
- * This means that when any of {@link #run(Statement)}
- * methods return a result, the statement has only started executing - it may not
+ * This means that when any of {@link #run(Query)}
+ * methods return a result, the query has only started executing - it may not
  * have completed yet. Most of the time, you will not notice this, because the
- * driver automatically waits for statements to complete at specific points to
+ * driver automatically waits for queries to complete at specific points to
  * fulfill its contracts.
  * <p>
- * Specifically, the driver will ensure all outstanding statements are completed
+ * Specifically, the driver will ensure all outstanding queries are completed
  * whenever you:
  *
  * <ul>
@@ -59,13 +59,13 @@ import java.util.Map;
  * @see Transaction
  * @since 1.0
  */
-public interface StatementRunner
+public interface QueryRunner
 {
     /**
-     * Run a statement and return a result stream.
+     * Run a query and return a result stream.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -77,7 +77,7 @@ public interface StatementRunner
      * might be more helpful, it converts your map to a {@link Value} for you.
      *
      * <h2>Example</h2>
-     * <pre class="doctest:StatementRunnerDocIT#parameterTest">
+     * <pre class="doctest:QueryRunnerDocIT#parameterTest">
      * {@code
      *
      * Result result = session.run( "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
@@ -85,17 +85,17 @@ public interface StatementRunner
      * }
      * </pre>
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
      * @return a stream of result values and associated metadata
      */
-    Result run(String statementTemplate, Value parameters );
+    Result run(String query, Value parameters );
 
     /**
-     * Run a statement and return a result stream.
+     * Run a query and return a result stream.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -104,7 +104,7 @@ public interface StatementRunner
      * a list of allowed types.
      *
      * <h2>Example</h2>
-     * <pre class="doctest:StatementRunnerDocIT#parameterTest">
+     * <pre class="doctest:QueryRunnerDocIT#parameterTest">
      * {@code
      *
      * Map<String, Object> parameters = new HashMap<String, Object>();
@@ -115,50 +115,50 @@ public interface StatementRunner
      * }
      * </pre>
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return a stream of result values and associated metadata
      */
-    Result run(String statementTemplate, Map<String,Object> statementParameters );
+    Result run(String query, Map<String,Object> parameters );
 
     /**
-     * Run a statement and return a result stream.
+     * Run a query and return a result stream.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
      * This version of run takes a {@link Record} of parameters, which can be useful
-     * if you want to use the output of one statement as input for another.
+     * if you want to use the output of one query as input for another.
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return a stream of result values and associated metadata
      */
-    Result run(String statementTemplate, Record statementParameters );
+    Result run(String query, Record parameters );
 
     /**
-     * Run a statement and return a result stream.
+     * Run a query and return a result stream.
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @return a stream of result values and associated metadata
      */
-    Result run(String statementTemplate );
+    Result run(String query );
 
     /**
-     * Run a statement and return a result stream.
+     * Run a query and return a result stream.
      * <h2>Example</h2>
-     * <pre class="doctest:StatementRunnerDocIT#statementObjectTest">
+     * <pre class="doctest:QueryRunnerDocIT#queryObjectTest">
      * {@code
      *
-     * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * Result result = session.run( statement.withParameters( Values.parameters( "myNameParam", "Bob" )  ) );
+     * Query query = new Query( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
+     * Result result = session.run( query.withParameters( Values.parameters( "myNameParam", "Bob" )  ) );
      * }
      * </pre>
      *
-     * @param statement a Neo4j statement
+     * @param query a Neo4j query
      * @return a stream of result values and associated metadata
      */
-    Result run(Statement statement );
+    Result run(Query query);
 }

--- a/driver/src/main/java/org/neo4j/driver/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/Record.java
@@ -32,7 +32,7 @@ import org.neo4j.driver.util.Pair;
 /**
  * Container for Cypher result values.
  * <p>
- * Streams of records are returned from Cypher statement execution, contained
+ * Streams of records are returned from Cypher query execution, contained
  * within a {@link Result}.
  * <p>
  * A record is a form of ordered map and, as such, contained values can be

--- a/driver/src/main/java/org/neo4j/driver/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/Record.java
@@ -33,7 +33,7 @@ import org.neo4j.driver.util.Pair;
  * Container for Cypher result values.
  * <p>
  * Streams of records are returned from Cypher statement execution, contained
- * within a {@link StatementResult}.
+ * within a {@link Result}.
  * <p>
  * A record is a form of ordered map and, as such, contained values can be
  * accessed by either positional {@link #get(int) index} or textual

--- a/driver/src/main/java/org/neo4j/driver/Records.java
+++ b/driver/src/main/java/org/neo4j/driver/Records.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 /**
  * Static utility methods for retaining records
  *
- * @see StatementResult#list()
+ * @see Result#list()
  * @since 1.0
  */
 public abstract class Records

--- a/driver/src/main/java/org/neo4j/driver/Result.java
+++ b/driver/src/main/java/org/neo4j/driver/Result.java
@@ -29,22 +29,22 @@ import org.neo4j.driver.util.Resource;
 
 
 /**
- * The result of running a Cypher statement, conceptually a stream of {@link Record records}.
+ * The result of running a Cypher query, conceptually a stream of {@link Record records}.
  *
  * The standard way of navigating through the result returned by the database is to
  * {@link #next() iterate} over it.
  *
- * Results are valid until the next statement is run or until the end of the current transaction,
- * whichever comes first. To keep a result around while further statements are run, or to use a result outside the scope
+ * Results are valid until the next query is run or until the end of the current transaction,
+ * whichever comes first. To keep a result around while further queries are run, or to use a result outside the scope
  * of the current transaction, see {@link #list()}.
  *
  * <h2>Important note on semantics</h2>
  *
  * In order to handle very large results, and to minimize memory overhead and maximize
- * performance, results are retrieved lazily. Please see {@link StatementRunner} for
+ * performance, results are retrieved lazily. Please see {@link QueryRunner} for
  * important details on the effects of this.
  *
- * The short version is that, if you want a hard guarantee that the underlying statement
+ * The short version is that, if you want a hard guarantee that the underlying query
  * has completed, you need to either call {@link Resource#close()} on the {@link Transaction}
  * or {@link Session} that created this result, or you need to use the result.
  *
@@ -109,8 +109,8 @@ public interface Result extends Iterator<Record>
      * This can be used if you want to iterate over the stream multiple times or to store the
      * whole result for later use.
      *
-     * Note that this method can only be used if you know that the statement that
-     * yielded this result returns a finite stream. Some statements can yield
+     * Note that this method can only be used if you know that the query that
+     * yielded this result returns a finite stream. Some queries can yield
      * infinite results, in which case calling this method will lead to running
      * out of memory.
      *
@@ -125,8 +125,8 @@ public interface Result extends Iterator<Record>
      * This can be used if you want to iterate over the stream multiple times or to store the
      * whole result for later use.
      *
-     * Note that this method can only be used if you know that the statement that
-     * yielded this result returns a finite stream. Some statements can yield
+     * Note that this method can only be used if you know that the query that
+     * yielded this result returns a finite stream. Some queries can yield
      * infinite results, in which case calling this method will lead to running
      * out of memory.
      *

--- a/driver/src/main/java/org/neo4j/driver/Result.java
+++ b/driver/src/main/java/org/neo4j/driver/Result.java
@@ -53,7 +53,7 @@ import org.neo4j.driver.util.Resource;
  *
  * @since 1.0
  */
-public interface StatementResult extends Iterator<Record>
+public interface Result extends Iterator<Record>
 {
     /**
      * Retrieve the keys of the records this result contains.
@@ -143,7 +143,7 @@ public interface StatementResult extends Iterator<Record>
      *
      * If the records in the result is not fully consumed, then calling this method will exhausts the result.
      *
-     * If you want to access unconsumed records after summary, you shall use {@link StatementResult#list()} to buffer all records into memory before summary.
+     * If you want to access unconsumed records after summary, you shall use {@link Result#list()} to buffer all records into memory before summary.
      *
      * @return a summary for the whole query result.
      */

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -27,15 +27,15 @@ import org.neo4j.driver.util.Resource;
  * Provides a context of work for database interactions.
  * <p>
  * A <em>Session</em> hosts a series of {@linkplain Transaction transactions}
- * carried out against a database. Within the database, all statements are
+ * carried out against a database. Within the database, all queries are
  * carried out within a transaction. Within application code, however, it is
  * not always necessary to explicitly {@link #beginTransaction() begin a
- * transaction}. If a statement is {@link #run} directly against a {@link
+ * transaction}. If a query is {@link #run} directly against a {@link
  * Session}, the server will automatically <code>BEGIN</code> and
- * <code>COMMIT</code> that statement within its own transaction. This type
+ * <code>COMMIT</code> that query within its own transaction. This type
  * of transaction is known as an <em>autocommit transaction</em>.
  * <p>
- * Explicit transactions allow multiple statements to be committed as part of
+ * Explicit transactions allow multiple queries to be committed as part of
  * a single atomic operation and can be rolled back if necessary. They can also
  * be used to ensure <em>causal consistency</em>, meaning that an application
  * can run a series of queries on different members of a cluster, while
@@ -61,7 +61,7 @@ import org.neo4j.driver.util.Resource;
  *
  * @since 1.0 (Removed async API to {@link AsyncSession} in 2.0)
  */
-public interface Session extends Resource, StatementRunner
+public interface Session extends Resource, QueryRunner
 {
     /**
      * Begin a new <em>explicit {@linkplain Transaction transaction}</em>. At
@@ -135,19 +135,19 @@ public interface Session extends Resource, StatementRunner
     <T> T writeTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
-     * Run a statement in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a result stream.
      *
-     * @param statement text of a Neo4j statement.
+     * @param query text of a Neo4j query.
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    Result run(String statement, TransactionConfig config );
+    Result run(String query, TransactionConfig config );
 
     /**
-     * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query with parameters in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -173,15 +173,15 @@ public interface Session extends Resource, StatementRunner
      * }
      * </pre>
      *
-     * @param statement text of a Neo4j statement.
-     * @param parameters input data for the statement.
+     * @param query text of a Neo4j query.
+     * @param parameters input data for the query.
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    Result run(String statement, Map<String,Object> parameters, TransactionConfig config );
+    Result run(String query, Map<String,Object> parameters, TransactionConfig config );
 
     /**
-     * Run a statement in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
      * <h2>Example</h2>
      * <pre>
      * {@code
@@ -193,16 +193,16 @@ public interface Session extends Resource, StatementRunner
      *                 .withMetadata(metadata)
      *                 .build();
      *
-     * Statement statement = new Statement("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
-     * Result result = session.run(statement.withParameters(Values.parameters("myNameParam", "Bob")));
+     * Query query = new Query("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
+     * Result result = session.run(query.withParameters(Values.parameters("myNameParam", "Bob")));
      * }
      * </pre>
      *
-     * @param statement a Neo4j statement.
+     * @param query a Neo4j query.
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    Result run(Statement statement, TransactionConfig config );
+    Result run(Query query, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed
@@ -216,7 +216,7 @@ public interface Session extends Resource, StatementRunner
 
     /**
      * Reset the current session. This sends an immediate RESET signal to the server which both interrupts
-     * any statement that is currently executing and ignores any subsequently queued statements. Following
+     * any query that is currently executing and ignores any subsequently queued queries. Following
      * the reset, the current transaction will have been rolled back and any outstanding failures will
      * have been acknowledged.
      *

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -141,7 +141,7 @@ public interface Session extends Resource, StatementRunner
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    StatementResult run( String statement, TransactionConfig config );
+    Result run(String statement, TransactionConfig config );
 
     /**
      * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
@@ -169,7 +169,7 @@ public interface Session extends Resource, StatementRunner
      * Map<String, Object> parameters = new HashMap<>();
      * parameters.put("myNameParam", "Bob");
      *
-     * StatementResult cursor = session.run("MATCH (n) WHERE n.name = {myNameParam} RETURN (n)", parameters, config);
+     * Result result = session.run("MATCH (n) WHERE n.name = {myNameParam} RETURN (n)", parameters, config);
      * }
      * </pre>
      *
@@ -178,7 +178,7 @@ public interface Session extends Resource, StatementRunner
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config );
+    Result run(String statement, Map<String,Object> parameters, TransactionConfig config );
 
     /**
      * Run a statement in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
@@ -194,7 +194,7 @@ public interface Session extends Resource, StatementRunner
      *                 .build();
      *
      * Statement statement = new Statement("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
-     * StatementResult cursor = session.run(statement.withParameters(Values.parameters("myNameParam", "Bob")));
+     * Result result = session.run(statement.withParameters(Values.parameters("myNameParam", "Bob")));
      * }
      * </pre>
      *
@@ -202,7 +202,7 @@ public interface Session extends Resource, StatementRunner
      * @param config configuration for the new transaction.
      * @return a stream of result values and associated metadata.
      */
-    StatementResult run( Statement statement, TransactionConfig config );
+    Result run(Statement statement, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -26,38 +26,29 @@ import org.neo4j.driver.util.Resource;
 /**
  * Provides a context of work for database interactions.
  * <p>
- * A <em>Session</em> hosts a series of {@linkplain Transaction transactions}
- * carried out against a database. Within the database, all queries are
- * carried out within a transaction. Within application code, however, it is
- * not always necessary to explicitly {@link #beginTransaction() begin a
- * transaction}. If a query is {@link #run} directly against a {@link
- * Session}, the server will automatically <code>BEGIN</code> and
- * <code>COMMIT</code> that query within its own transaction. This type
- * of transaction is known as an <em>autocommit transaction</em>.
+ * A <em>Session</em> is a logical container for a causally chained series of
+ * {@linkplain Transaction transactions}. Client applications typically work
+ * with <em>managed transactions</em>, which come in two flavours: transaction
+ * functions and auto-commit transactions. Managed transactions automatically
+ * handle the transaction boundaries (<code>BEGIN</code> and
+ * <code>COMMIT</code>/<code>ROLLBACK</code>) and can also provide other
+ * supporting features; transaction functions offer retry capabilities, for
+ * example.
  * <p>
- * Unmanaged transactions allow multiple queries to be committed as part of
- * a single atomic operation and can be rolled back if necessary. They can also
- * be used to ensure <em>causal consistency</em>, meaning that an application
- * can run a series of queries on different members of a cluster, while
- * ensuring that each query sees the state of graph at least as up-to-date as
- * the graph seen by the previous query. For more on causal consistency, see
- * the Neo4j clustering manual.
+ * Unmanaged transactions are also available but tend to be used by libraries
+ * or tooling that require more fine-grained control.
  * <p>
- * Typically, a session will acquire a TCP connection to execute query or
- * transaction. Such a connection will be acquired from a connection pool
- * and released back there when query result is consumed or transaction is
- * committed or rolled back. One connection can therefore be adopted by many
- * sessions, although by only one at a time. Application code should never need
- * to deal directly with connection management.
+ * Typically, a session will acquire a TCP connection from a connection pool
+ * in order to carry out a transaction. Once the transaction has completed,
+ * and the entire result has been consumed, this connection will be released
+ * back into the pool. One connection can therefore be adopted by several
+ * sessions over its lifetime, although it will only be owned by one at a
+ * time. Client applications should never need to deal directly with
+ * connection management.
  * <p>
- * A session inherits its destination address and permissions from its
- * underlying connection. This means that for a single query/transaction one
- * session may only ever target one machine within a cluster and does not
- * support re-authentication. To achieve otherwise requires creation of a
- * separate session.
- * <p>
- * Similarly, multiple sessions should be used when working with concurrency;
- * session implementations are not thread safe.
+ * Session implementations are not generally thread-safe. Therefore, multiple
+ * sessions should be used when an application requires multiple concurrent
+ * threads of database work to be carried out.
  *
  * @since 1.0 (Removed async API to {@link AsyncSession} in 2.0)
  */
@@ -74,10 +65,10 @@ public interface Session extends Resource, QueryRunner
     Transaction beginTransaction();
 
     /**
-     * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em> with the specified {@link TransactionConfig configuration}.
-     * At most one transaction may exist in a session at any point in time. To
-     * maintain multiple concurrent transactions, use multiple concurrent
-     * sessions.
+     * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em> with
+     * the specified {@link TransactionConfig configuration}. At most one
+     * transaction may exist in a session at any point in time. To maintain
+     * multiple concurrent transactions, use multiple concurrent sessions.
      *
      * @param config configuration for the new transaction.
      * @return a new {@link Transaction}
@@ -85,10 +76,13 @@ public interface Session extends Resource, QueryRunner
     Transaction beginTransaction( TransactionConfig config );
 
     /**
-     * Execute given unit of work in a  {@link AccessMode#READ read} transaction.
+     * Execute a unit of work in a managed {@link AccessMode#READ read} transaction.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
-     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
+     * This transaction will automatically be committed unless an exception is
+     * thrown during query execution or by the user code.
+     * <p>
+     * Managed transactions should not generally be explicitly committed (via
+     * {@link Transaction#commit()}).
      *
      * @param work the {@link TransactionWork} to be applied to a new read transaction.
      * @param <T> the return type of the given unit of work.
@@ -97,10 +91,14 @@ public interface Session extends Resource, QueryRunner
     <T> T readTransaction( TransactionWork<T> work );
 
     /**
-     * Execute given unit of work in a  {@link AccessMode#READ read} transaction with the specified {@link TransactionConfig configuration}.
+     * Execute a unit of work in a managed {@link AccessMode#READ read} transaction
+     * with the specified {@link TransactionConfig configuration}.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
-     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
+     * This transaction will automatically be committed unless an exception is
+     * thrown during query execution or by the user code.
+     * <p>
+     * Managed transactions should not generally be explicitly committed (via
+     * {@link Transaction#commit()}).
      *
      * @param work the {@link TransactionWork} to be applied to a new read transaction.
      * @param config configuration for all transactions started to execute the unit of work.
@@ -110,10 +108,13 @@ public interface Session extends Resource, QueryRunner
     <T> T readTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
-     * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction.
+     * Execute a unit of work in a managed {@link AccessMode#WRITE write} transaction.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
-     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
+     * This transaction will automatically be committed unless an exception is
+     * thrown during query execution or by the user code.
+     * <p>
+     * Managed transactions should not generally be explicitly committed (via
+     * {@link Transaction#commit()}).
      *
      * @param work the {@link TransactionWork} to be applied to a new write transaction.
      * @param <T> the return type of the given unit of work.
@@ -122,10 +123,14 @@ public interface Session extends Resource, QueryRunner
     <T> T writeTransaction( TransactionWork<T> work );
 
     /**
-     * Execute given unit of work in a  {@link AccessMode#WRITE write} transaction with the specified {@link TransactionConfig configuration}.
+     * Execute a unit of work in a managed {@link AccessMode#WRITE write} transaction
+     * with the specified {@link TransactionConfig configuration}.
      * <p>
-     * Transaction will automatically be committed unless exception is thrown from the unit of work itself or during committing,
-     * or transaction is explicitly committed via {@link Transaction#commit()} or rolled back via {@link Transaction#rollback()}.
+     * This transaction will automatically be committed unless an exception is
+     * thrown during query execution or by the user code.
+     * <p>
+     * Managed transactions should not generally be explicitly committed (via
+     * {@link Transaction#commit()}).
      *
      * @param work the {@link TransactionWork} to be applied to a new write transaction.
      * @param config configuration for all transactions started to execute the unit of work.
@@ -135,7 +140,8 @@ public interface Session extends Resource, QueryRunner
     <T> T writeTransaction( TransactionWork<T> work, TransactionConfig config );
 
     /**
-     * Run a query in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query in a managed auto-commit transaction with the specified
+     * {@link TransactionConfig configuration}, and return a result stream.
      *
      * @param query text of a Neo4j query.
      * @param config configuration for the new transaction.
@@ -144,7 +150,8 @@ public interface Session extends Resource, QueryRunner
     Result run(String query, TransactionConfig config );
 
     /**
-     * Run a query with parameters in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query with parameters in a managed auto-commit transaction with the
+     * specified {@link TransactionConfig configuration}, and return a result stream.
      * <p>
      * This method takes a set of parameters that will be injected into the
      * query by Neo4j. Using parameters is highly encouraged, it helps avoid
@@ -181,7 +188,8 @@ public interface Session extends Resource, QueryRunner
     Result run(String query, Map<String,Object> parameters, TransactionConfig config );
 
     /**
-     * Run a query in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a result stream.
+     * Run a query in a managed auto-commit transaction with the specified
+     * {@link TransactionConfig configuration}, and return a result stream.
      * <h2>Example</h2>
      * <pre>
      * {@code

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -35,7 +35,7 @@ import org.neo4j.driver.util.Resource;
  * <code>COMMIT</code> that query within its own transaction. This type
  * of transaction is known as an <em>autocommit transaction</em>.
  * <p>
- * Explicit transactions allow multiple queries to be committed as part of
+ * Unmanaged transactions allow multiple queries to be committed as part of
  * a single atomic operation and can be rolled back if necessary. They can also
  * be used to ensure <em>causal consistency</em>, meaning that an application
  * can run a series of queries on different members of a cluster, while
@@ -64,7 +64,7 @@ import org.neo4j.driver.util.Resource;
 public interface Session extends Resource, QueryRunner
 {
     /**
-     * Begin a new <em>explicit {@linkplain Transaction transaction}</em>. At
+     * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em>. At
      * most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent
      * sessions.
@@ -74,7 +74,7 @@ public interface Session extends Resource, QueryRunner
     Transaction beginTransaction();
 
     /**
-     * Begin a new <em>explicit {@linkplain Transaction transaction}</em> with the specified {@link TransactionConfig configuration}.
+     * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em> with the specified {@link TransactionConfig configuration}.
      * At most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent
      * sessions.

--- a/driver/src/main/java/org/neo4j/driver/Statement.java
+++ b/driver/src/main/java/org/neo4j/driver/Statement.java
@@ -35,8 +35,8 @@ import static org.neo4j.driver.Values.value;
  *
  * @see Session
  * @see Transaction
- * @see StatementResult
- * @see StatementResult#consume()
+ * @see Result
+ * @see Result#consume()
  * @see ResultSummary
  * @since 1.0
  */

--- a/driver/src/main/java/org/neo4j/driver/StatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/StatementRunner.java
@@ -42,7 +42,7 @@ import java.util.Map;
  *
  * <ul>
  * <li>Read from or discard a result, for instance via
- * {@link StatementResult#next()} or {@link StatementResult#consume()} </li>
+ * {@link Result#next()} or {@link Result#consume()} </li>
  * <li>Explicitly commit/rollback a transaction using blocking {@link Transaction#close()} </li>
  * <li>Close a session using blocking {@link Session#close()}</li>
  * </ul>
@@ -80,7 +80,7 @@ public interface StatementRunner
      * <pre class="doctest:StatementRunnerDocIT#parameterTest">
      * {@code
      *
-     * StatementResult cursor = session.run( "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
+     * Result result = session.run( "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
      *                                       Values.parameters( "myNameParam", "Bob" ) );
      * }
      * </pre>
@@ -89,7 +89,7 @@ public interface StatementRunner
      * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
      * @return a stream of result values and associated metadata
      */
-    StatementResult run( String statementTemplate, Value parameters );
+    Result run(String statementTemplate, Value parameters );
 
     /**
      * Run a statement and return a result stream.
@@ -110,7 +110,7 @@ public interface StatementRunner
      * Map<String, Object> parameters = new HashMap<String, Object>();
      * parameters.put("myNameParam", "Bob");
      *
-     * StatementResult cursor = session.run( "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
+     * Result result = session.run( "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
      *                                       parameters );
      * }
      * </pre>
@@ -119,7 +119,7 @@ public interface StatementRunner
      * @param statementParameters input data for the statement
      * @return a stream of result values and associated metadata
      */
-    StatementResult run( String statementTemplate, Map<String,Object> statementParameters );
+    Result run(String statementTemplate, Map<String,Object> statementParameters );
 
     /**
      * Run a statement and return a result stream.
@@ -136,7 +136,7 @@ public interface StatementRunner
      * @param statementParameters input data for the statement
      * @return a stream of result values and associated metadata
      */
-    StatementResult run( String statementTemplate, Record statementParameters );
+    Result run(String statementTemplate, Record statementParameters );
 
     /**
      * Run a statement and return a result stream.
@@ -144,7 +144,7 @@ public interface StatementRunner
      * @param statementTemplate text of a Neo4j statement
      * @return a stream of result values and associated metadata
      */
-    StatementResult run( String statementTemplate );
+    Result run(String statementTemplate );
 
     /**
      * Run a statement and return a result stream.
@@ -153,12 +153,12 @@ public interface StatementRunner
      * {@code
      *
      * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * StatementResult cursor = session.run( statement.withParameters( Values.parameters( "myNameParam", "Bob" )  ) );
+     * Result result = session.run( statement.withParameters( Values.parameters( "myNameParam", "Bob" )  ) );
      * }
      * </pre>
      *
      * @param statement a Neo4j statement
      * @return a stream of result values and associated metadata
      */
-    StatementResult run( Statement statement );
+    Result run(Statement statement );
 }

--- a/driver/src/main/java/org/neo4j/driver/Transaction.java
+++ b/driver/src/main/java/org/neo4j/driver/Transaction.java
@@ -36,19 +36,19 @@ import org.neo4j.driver.util.Resource;
  * }
  * }
  * Blocking calls are: {@link #commit()}, {@link #rollback()}, {@link #close()}
- * and various overloads of {@link #run(Statement)}.
+ * and various overloads of {@link #run(Query)}.
  *
  * @see Session#run
- * @see StatementRunner
+ * @see QueryRunner
  * @since 1.0
  */
-public interface Transaction extends Resource, StatementRunner
+public interface Transaction extends Resource, QueryRunner
 {
     /**
      * Commit this current transaction.
-     * When this method returns, all outstanding statements in the transaction are guaranteed to
+     * When this method returns, all outstanding queries in the transaction are guaranteed to
      * have completed, meaning any writes you performed are guaranteed to be durably stored.
-     * No more statement can be executed inside this transaction once this transaction is committed.
+     * No more queries can be executed inside this transaction once this transaction is committed.
      * After this method is called, the transaction cannot be committed or rolled back again.
      * You must call this method before calling {@link #close()} to have your transaction committed.
      * If a transaction is not committed or rolled back before close,
@@ -68,7 +68,7 @@ public interface Transaction extends Resource, StatementRunner
 
     /**
      * Roll back this current transaction.
-     * No more statement can be executed inside this transaction once this transaction is committed.
+     * No more queries can be executed inside this transaction once this transaction is committed.
      * After this method has been called, the transaction cannot be committed or rolled back again.
      * If a transaction is not committed or rolled back before close,
      * the transaction will be rolled back by default in {@link #close}.

--- a/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
 
 /**
- * Configuration object containing settings for explicit and auto-commit transactions.
+ * Configuration object containing settings for transactions.
  * Instances are immutable and can be reused for multiple transactions.
  * <p>
  * Configuration is supported for:
@@ -42,7 +42,7 @@ import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
  * <li>transactions started by transaction functions - using {@link Session#readTransaction(TransactionWork, TransactionConfig)},
  * {@link Session#writeTransaction(TransactionWork, TransactionConfig)}, {@link AsyncSession#readTransactionAsync(AsyncTransactionWork, TransactionConfig)} and
  * {@link AsyncSession#writeTransactionAsync(AsyncTransactionWork, TransactionConfig)}</li>
- * <li>explicit transactions - using {@link Session#beginTransaction(TransactionConfig)} and {@link AsyncSession#beginTransactionAsync(TransactionConfig)}</li>
+ * <li>unmanaged transactions - using {@link Session#beginTransaction(TransactionConfig)} and {@link AsyncSession#beginTransactionAsync(TransactionConfig)}</li>
  * </ul>
  * <p>
  * Creation of configuration objects can be done using the builder API:

--- a/driver/src/main/java/org/neo4j/driver/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/Values.java
@@ -366,7 +366,7 @@ public abstract class Values
 
     /**
      * Helper function for creating a map of parameters, this can be used when you {@link
-     * StatementRunner#run(String, Value) run} statements.
+     * QueryRunner#run(String, Value) run} queries.
      * <p>
      * Allowed parameter types are:
      * <ul>
@@ -382,7 +382,7 @@ public abstract class Values
      *
      * @param keysAndValues alternating sequence of keys and values
      * @return Map containing all parameters specified
-     * @see StatementRunner#run(String, Value)
+     * @see QueryRunner#run(String, Value)
      */
     public static Value parameters( Object... keysAndValues )
     {

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncQueryRunner.java
@@ -24,29 +24,29 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 
 /**
- * Asynchronous interface for components that can execute Neo4j statements.
+ * Asynchronous interface for components that can execute Neo4j queries.
  *
  * <h2>Important notes on semantics</h2>
  * <p>
- * Statements run in the same {@link AsyncStatementRunner} are guaranteed
- * to execute in order, meaning changes made by one statement will be seen
- * by all subsequent statements in the same {@link AsyncStatementRunner}.
+ * Queries run in the same {@link AsyncQueryRunner} are guaranteed
+ * to execute in order, meaning changes made by one query will be seen
+ * by all subsequent queries in the same {@link AsyncQueryRunner}.
  * <p>
  * However, to allow handling very large results, and to improve performance,
  * result streams are retrieved lazily from the network. This means that when
- * async {@link #runAsync(Statement)}
- * methods return a result, the statement has only started executing - it may not
+ * async {@link #runAsync(Query)}
+ * methods return a result, the query has only started executing - it may not
  * have completed yet. Most of the time, you will not notice this, because the
- * driver automatically waits for statements to complete at specific points to
+ * driver automatically waits for queries to complete at specific points to
  * fulfill its contracts.
  * <p>
- * Specifically, the driver will ensure all outstanding statements are completed
+ * Specifically, the driver will ensure all outstanding queries are completed
  * whenever you:
  *
  * <ul>
@@ -66,7 +66,7 @@ import org.neo4j.driver.Values;
  *
  * <h2>Asynchronous API</h2>
  * <p>
- * All overloads of {@link #runAsync(Statement)} execute queries in async fashion and return {@link CompletionStage} of
+ * All overloads of {@link #runAsync(Query)} execute queries in async fashion and return {@link CompletionStage} of
  * a new {@link ResultCursor}. Stage can be completed exceptionally when error happens, e.g. connection can't
  * be acquired from the pool.
  * <p>
@@ -80,14 +80,14 @@ import org.neo4j.driver.Values;
  * @see AsyncTransaction
  * @since 2.0
  */
-public interface AsyncStatementRunner
+public interface AsyncQueryRunner
 {
     /**
-     * Run a statement asynchronously and return a {@link CompletionStage} with a
+     * Run a query asynchronously and return a {@link CompletionStage} with a
      * result cursor.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -109,19 +109,19 @@ public interface AsyncStatementRunner
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
      * more information.
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statementTemplate, Value parameters );
+    CompletionStage<ResultCursor> runAsync(String query, Value parameters );
 
     /**
-     * Run a statement asynchronously and return a {@link CompletionStage} with a
+     * Run a query asynchronously and return a {@link CompletionStage} with a
      * result cursor.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -143,64 +143,64 @@ public interface AsyncStatementRunner
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
      * more information.
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statementTemplate, Map<String,Object> statementParameters );
+    CompletionStage<ResultCursor> runAsync(String query, Map<String,Object> parameters );
 
     /**
-     * Run a statement asynchronously and return a {@link CompletionStage} with a
+     * Run a query asynchronously and return a {@link CompletionStage} with a
      * result cursor.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
      * This version of runAsync takes a {@link Record} of parameters, which can be useful
-     * if you want to use the output of one statement as input for another.
+     * if you want to use the output of one query as input for another.
      * <p>
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
      * more information.
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statementTemplate, Record statementParameters );
+    CompletionStage<ResultCursor> runAsync(String query, Record parameters );
 
     /**
-     * Run a statement asynchronously and return a {@link CompletionStage} with a
+     * Run a query asynchronously and return a {@link CompletionStage} with a
      * result cursor.
      * <p>
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
      * more information.
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statementTemplate );
+    CompletionStage<ResultCursor> runAsync(String query );
 
     /**
-     * Run a statement asynchronously and return a {@link CompletionStage} with a
+     * Run a query asynchronously and return a {@link CompletionStage} with a
      * result cursor.
      * <h2>Example</h2>
      * <pre>
      * {@code
-     * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * CompletionStage<ResultCursor> cursorStage = session.runAsync(statement);
+     * Query query = new Query( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(query);
      * }
      * </pre>
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
      * more information.
      *
-     * @param statement a Neo4j statement
+     * @param query a Neo4j query
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(Statement statement );
+    CompletionStage<ResultCursor> runAsync(Query query);
 }

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
@@ -43,7 +43,7 @@ import org.neo4j.driver.Bookmark;
  * <code>COMMIT</code> that query within its own transaction. This type
  * of transaction is known as an <em>autocommit transaction</em>.
  * <p>
- * Explicit transactions allow multiple queries to be committed as part of
+ * Unmanaged transactions allow multiple queries to be committed as part of
  * a single atomic operation and can be rolled back if necessary. They can also
  * be used to ensure <em>causal consistency</em>, meaning that an application
  * can run a series of queries on different members of a cluster, while
@@ -72,7 +72,7 @@ import org.neo4j.driver.Bookmark;
 public interface AsyncSession extends AsyncQueryRunner
 {
     /**
-     * Begin a new <em>explicit {@linkplain Transaction transaction}</em>. At
+     * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em>. At
      * most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent
      * sessions.
@@ -93,7 +93,7 @@ public interface AsyncSession extends AsyncQueryRunner
     CompletionStage<AsyncTransaction> beginTransactionAsync();
 
     /**
-     * Begin a new <em>explicit {@linkplain AsyncTransaction transaction}</em> with the specified {@link TransactionConfig configuration}.
+     * Begin a new <em>unmanaged {@linkplain AsyncTransaction transaction}</em> with the specified {@link TransactionConfig configuration}.
      * At most one transaction may exist in a session at any point in time.
      * To maintain multiple concurrent transactions, use multiple concurrent sessions.
      * <p>

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Values;
@@ -35,15 +35,15 @@ import org.neo4j.driver.Bookmark;
  * Provides a context of work for database interactions.
  * <p>
  * A <em>AsyncSession</em> hosts a series of {@linkplain AsyncTransaction transactions}
- * carried out against a database. Within the database, all statements are
+ * carried out against a database. Within the database, all queries are
  * carried out within a transaction. Within application code, however, it is
  * not always necessary to explicitly {@link #beginTransactionAsync() begin a
- * transaction}. If a statement is {@link #runAsync} directly against a {@link
+ * transaction}. If a query is {@link #runAsync} directly against a {@link
  * AsyncSession}, the server will automatically <code>BEGIN</code> and
- * <code>COMMIT</code> that statement within its own transaction. This type
+ * <code>COMMIT</code> that query within its own transaction. This type
  * of transaction is known as an <em>autocommit transaction</em>.
  * <p>
- * Explicit transactions allow multiple statements to be committed as part of
+ * Explicit transactions allow multiple queries to be committed as part of
  * a single atomic operation and can be rolled back if necessary. They can also
  * be used to ensure <em>causal consistency</em>, meaning that an application
  * can run a series of queries on different members of a cluster, while
@@ -69,7 +69,7 @@ import org.neo4j.driver.Bookmark;
  *
  * @since 2.0
  */
-public interface AsyncSession extends AsyncStatementRunner
+public interface AsyncSession extends AsyncQueryRunner
 {
     /**
      * Begin a new <em>explicit {@linkplain Transaction transaction}</em>. At
@@ -210,25 +210,25 @@ public interface AsyncSession extends AsyncStatementRunner
     <T> CompletionStage<T> writeTransactionAsync( AsyncTransactionWork<CompletionStage<T>> work, TransactionConfig config );
 
     /**
-     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * Run a query asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
      * {@link CompletionStage} with a result cursor.
      * <p>
-     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncStatementRunner} for
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncQueryRunner} for
      * more information.
      *
-     * @param statement text of a Neo4j statement.
+     * @param query text of a Neo4j query.
      * @param config configuration for the new transaction.
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statement, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(String query, TransactionConfig config );
 
     /**
-     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * Run a query asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
      * {@link CompletionStage} with a result cursor.
      * <p>
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      * <p>
@@ -255,19 +255,19 @@ public interface AsyncSession extends AsyncStatementRunner
      *             config);
      * }
      * </pre>
-     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncStatementRunner} for
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncQueryRunner} for
      * more information.
      *
-     * @param statement text of a Neo4j statement.
-     * @param parameters input data for the statement.
+     * @param query text of a Neo4j query.
+     * @param parameters input data for the query.
      * @param config configuration for the new transaction.
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(String statement, Map<String,Object> parameters, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(String query, Map<String,Object> parameters, TransactionConfig config );
 
     /**
-     * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
+     * Run a query asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
      * {@link CompletionStage} with a result cursor.
      * <h2>Example</h2>
      * <pre>
@@ -280,19 +280,19 @@ public interface AsyncSession extends AsyncStatementRunner
      *                 .withMetadata(metadata)
      *                 .build();
      *
-     * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * CompletionStage<ResultCursor> cursorStage = session.runAsync(statement, config);
+     * Query query = new Query( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(query, config);
      * }
      * </pre>
-     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncStatementRunner} for
+     * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncQueryRunner} for
      * more information.
      *
-     * @param statement a Neo4j statement.
+     * @param query a Neo4j query.
      * @param config configuration for the new transaction.
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<ResultCursor> runAsync(Statement statement, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(Query query, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed
@@ -309,8 +309,8 @@ public interface AsyncSession extends AsyncStatementRunner
      * very low cost.
      * <p>
      * This operation is asynchronous and returns a {@link CompletionStage}. Stage is completed when all outstanding
-     * statements in the session have completed, meaning any writes you performed are guaranteed to be durably stored.
-     * It might be completed exceptionally when there are unconsumed errors from previous statements or transactions.
+     * queries in the session have completed, meaning any writes you performed are guaranteed to be durably stored.
+     * It might be completed exceptionally when there are unconsumed errors from previous queries or transactions.
      *
      * @return a {@link CompletionStage completion stage} that represents the asynchronous close.
      */

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
@@ -221,7 +221,7 @@ public interface AsyncSession extends AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statement, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(String statement, TransactionConfig config );
 
     /**
      * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
@@ -249,7 +249,7 @@ public interface AsyncSession extends AsyncStatementRunner
      * Map<String, Object> parameters = new HashMap<String, Object>();
      * parameters.put("myNameParam", "Bob");
      *
-     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(
      *             "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
      *             parameters,
      *             config);
@@ -264,7 +264,7 @@ public interface AsyncSession extends AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statement, Map<String,Object> parameters, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(String statement, Map<String,Object> parameters, TransactionConfig config );
 
     /**
      * Run a statement asynchronously in an auto-commit transaction with the specified {@link TransactionConfig configuration} and return a
@@ -281,7 +281,7 @@ public interface AsyncSession extends AsyncStatementRunner
      *                 .build();
      *
      * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(statement, config);
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(statement, config);
      * }
      * </pre>
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc in {@link AsyncStatementRunner} for
@@ -292,7 +292,7 @@ public interface AsyncSession extends AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config );
+    CompletionStage<ResultCursor> runAsync(Statement statement, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncStatementRunner.java
@@ -51,7 +51,7 @@ import org.neo4j.driver.Values;
  *
  * <ul>
  * <li>Read from or discard a result, for instance via
- * {@link StatementResultCursor#nextAsync()}, {@link StatementResultCursor#consumeAsync()}</li>
+ * {@link ResultCursor#nextAsync()}, {@link ResultCursor#consumeAsync()}</li>
  * <li>Explicitly commit/rollback a transaction using {@link AsyncTransaction#commitAsync()}, {@link AsyncTransaction#rollbackAsync()}</li>
  * <li>Close a session using {@link AsyncSession#closeAsync()}</li>
  * </ul>
@@ -67,7 +67,7 @@ import org.neo4j.driver.Values;
  * <h2>Asynchronous API</h2>
  * <p>
  * All overloads of {@link #runAsync(Statement)} execute queries in async fashion and return {@link CompletionStage} of
- * a new {@link StatementResultCursor}. Stage can be completed exceptionally when error happens, e.g. connection can't
+ * a new {@link ResultCursor}. Stage can be completed exceptionally when error happens, e.g. connection can't
  * be acquired from the pool.
  * <p>
  * <b>Note:</b> Returned stage can be completed by an IO thread which should never block. Otherwise IO operations on
@@ -101,7 +101,7 @@ public interface AsyncStatementRunner
      * <pre>
      * {@code
      *
-     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(
      *             "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
      *             Values.parameters("myNameParam", "Bob"));
      * }
@@ -114,7 +114,7 @@ public interface AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Value parameters );
+    CompletionStage<ResultCursor> runAsync(String statementTemplate, Value parameters );
 
     /**
      * Run a statement asynchronously and return a {@link CompletionStage} with a
@@ -135,7 +135,7 @@ public interface AsyncStatementRunner
      * Map<String, Object> parameters = new HashMap<String, Object>();
      * parameters.put("myNameParam", "Bob");
      *
-     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(
      *             "MATCH (n) WHERE n.name = {myNameParam} RETURN (n)",
      *             parameters);
      * }
@@ -148,7 +148,7 @@ public interface AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Map<String,Object> statementParameters );
+    CompletionStage<ResultCursor> runAsync(String statementTemplate, Map<String,Object> statementParameters );
 
     /**
      * Run a statement asynchronously and return a {@link CompletionStage} with a
@@ -170,7 +170,7 @@ public interface AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Record statementParameters );
+    CompletionStage<ResultCursor> runAsync(String statementTemplate, Record statementParameters );
 
     /**
      * Run a statement asynchronously and return a {@link CompletionStage} with a
@@ -183,7 +183,7 @@ public interface AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( String statementTemplate );
+    CompletionStage<ResultCursor> runAsync(String statementTemplate );
 
     /**
      * Run a statement asynchronously and return a {@link CompletionStage} with a
@@ -192,7 +192,7 @@ public interface AsyncStatementRunner
      * <pre>
      * {@code
      * Statement statement = new Statement( "MATCH (n) WHERE n.name=$myNameParam RETURN n.age" );
-     * CompletionStage<StatementResultCursor> cursorStage = session.runAsync(statement);
+     * CompletionStage<ResultCursor> cursorStage = session.runAsync(statement);
      * }
      * </pre>
      * It is not allowed to chain blocking operations on the returned {@link CompletionStage}. See class javadoc for
@@ -202,5 +202,5 @@ public interface AsyncStatementRunner
      * @return new {@link CompletionStage} that gets completed with a result cursor when query execution is successful.
      * Stage can be completed exceptionally when error happens, e.g. connection can't be acquired from the pool.
      */
-    CompletionStage<StatementResultCursor> runAsync( Statement statement );
+    CompletionStage<ResultCursor> runAsync(Statement statement );
 }

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncTransaction.java
@@ -24,8 +24,8 @@ import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.QueryRunner;
 
 /**
  * Logical container for an atomic unit of work.
@@ -49,13 +49,13 @@ import org.neo4j.driver.StatementRunner;
  * }
  * </pre>
  * Async calls are: {@link #commitAsync()}, {@link #rollbackAsync()} and various overloads of
- * {@link #runAsync(Statement)}.
+ * {@link #runAsync(Query)}.
  *
  * @see Session#run
- * @see StatementRunner
+ * @see QueryRunner
  * @since 2.0
  */
-public interface AsyncTransaction extends AsyncStatementRunner
+public interface AsyncTransaction extends AsyncQueryRunner
 {
     /**
      * Commit this transaction in asynchronous fashion. This operation is typically executed as part of the

--- a/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Records;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.summary.ResultSummary;
 
@@ -61,7 +61,7 @@ import org.neo4j.driver.summary.ResultSummary;
  *
  * @since 1.5
  */
-public interface StatementResultCursor
+public interface ResultCursor
 {
     /**
      * Retrieve the keys of the records this result cursor contains.
@@ -75,7 +75,7 @@ public interface StatementResultCursor
      * <p>
      * If the records in the result is not fully consumed, then calling this method will exhausts the result.
      * <p>
-     * If you want to access unconsumed records after summary, you shall use {@link StatementResult#list()} to buffer all records into memory before summary.
+     * If you want to access unconsumed records after summary, you shall use {@link Result#list()} to buffer all records into memory before summary.
      *
      * @return a {@link CompletionStage} completed with a summary for the whole query result. Stage can also be
      * completed exceptionally if query execution fails.

--- a/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
@@ -32,22 +32,22 @@ import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.summary.ResultSummary;
 
 /**
- * The result of asynchronous execution of a Cypher statement, conceptually an asynchronous stream of
+ * The result of asynchronous execution of a Cypher query, conceptually an asynchronous stream of
  * {@link Record records}.
  * <p>
  * Result can be eagerly fetched in a list using {@link #listAsync()} or navigated lazily using
  * {@link #forEachAsync(Consumer)} or {@link #nextAsync()}.
  * <p>
- * Results are valid until the next statement is run or until the end of the current transaction,
- * whichever comes first. To keep a result around while further statements are run, or to use a result outside the scope
+ * Results are valid until the next query is run or until the end of the current transaction,
+ * whichever comes first. To keep a result around while further queries are run, or to use a result outside the scope
  * of the current transaction, see {@link #listAsync()}.
  * <h2>Important note on semantics</h2>
  * <p>
  * In order to handle very large results, and to minimize memory overhead and maximize
- * performance, results are retrieved lazily. Please see {@link AsyncStatementRunner} for
+ * performance, results are retrieved lazily. Please see {@link AsyncQueryRunner} for
  * important details on the effects of this.
  * <p>
- * The short version is that, if you want a hard guarantee that the underlying statement
+ * The short version is that, if you want a hard guarantee that the underlying query
  * has completed, you need to either call {@link AsyncTransaction#commitAsync()} on the {@link AsyncTransaction transaction}
  * or {@link AsyncSession#closeAsync()} on the {@link AsyncSession session} that created this result, or you need to use
  * the result.
@@ -124,8 +124,8 @@ public interface ResultCursor
      * This can be used if you want to iterate over the stream multiple times or to store the
      * whole result for later use.
      * <p>
-     * Note that this method can only be used if you know that the statement that
-     * yielded this result returns a finite stream. Some statements can yield
+     * Note that this method can only be used if you know that the query that
+     * yielded this result returns a finite stream. Some queries can yield
      * infinite results, in which case calling this method will lead to running
      * out of memory.
      * <p>
@@ -141,8 +141,8 @@ public interface ResultCursor
      * This can be used if you want to iterate over the stream multiple times or to store the
      * whole result for later use.
      * <p>
-     * Note that this method can only be used if you know that the statement that
-     * yielded this result returns a finite stream. Some statements can yield
+     * Note that this method can only be used if you know that the query that
+     * yielded this result returns a finite stream. Some queries can yield
      * infinite results, in which case calling this method will lead to running
      * out of memory.
      * <p>

--- a/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/ResultConsumedException.java
@@ -18,12 +18,12 @@
  */
 package org.neo4j.driver.exceptions;
 
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 
 /**
  * A user is trying to access resources that are no longer valid due to
  * the resources have already been consumed or
- * the {@link StatementRunner} where the resources are created has already been closed.
+ * the {@link QueryRunner} where the resources are created has already been closed.
  */
 public class ResultConsumedException extends ClientException
 {

--- a/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/TransactionNestingException.java
@@ -19,7 +19,7 @@
 package org.neo4j.driver.exceptions;
 
 /**
- * This exception indicates a user is nesting new transaction with an on-going transaction (explicit and/or auto-commit).
+ * This exception indicates a user is nesting new transaction with an on-going transaction (unmanaged and/or auto-commit).
  */
 public class TransactionNestingException extends ClientException
 {

--- a/driver/src/main/java/org/neo4j/driver/internal/AbstractQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/AbstractQueryRunner.java
@@ -21,38 +21,38 @@ package org.neo4j.driver.internal;
 import java.util.Map;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.value.MapValue;
 
-public abstract class AbstractStatementRunner implements StatementRunner
+public abstract class AbstractQueryRunner implements QueryRunner
 {
     @Override
-    public final Result run(String statementTemplate, Value parameters )
+    public final Result run(String query, Value parameters )
     {
-        return run( new Statement( statementTemplate, parameters ) );
+        return run( new Query( query, parameters ) );
     }
 
     @Override
-    public final Result run(String statementTemplate, Map<String,Object> statementParameters )
+    public final Result run(String query, Map<String,Object> parameters)
     {
-        return run( statementTemplate, parameters( statementParameters ) );
+        return run(query, parameters(parameters) );
     }
 
     @Override
-    public final Result run(String statementTemplate, Record statementParameters )
+    public final Result run(String query, Record parameters)
     {
-        return run( statementTemplate, parameters( statementParameters ) );
+        return run(query, parameters(parameters) );
     }
 
     @Override
-    public final Result run(String statementText )
+    public final Result run(String query)
     {
-        return run( statementText, Values.EmptyMap );
+        return run(query, Values.EmptyMap );
     }
 
     public static Value parameters( Record record )

--- a/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/AbstractStatementRunner.java
@@ -22,37 +22,35 @@ import java.util.Map;
 
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.StatementRunner;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.value.MapValue;
-import org.neo4j.driver.types.TypeSystem;
 
 public abstract class AbstractStatementRunner implements StatementRunner
 {
     @Override
-    public final StatementResult run( String statementTemplate, Value parameters )
+    public final Result run(String statementTemplate, Value parameters )
     {
         return run( new Statement( statementTemplate, parameters ) );
     }
 
     @Override
-    public final StatementResult run( String statementTemplate, Map<String,Object> statementParameters )
+    public final Result run(String statementTemplate, Map<String,Object> statementParameters )
     {
         return run( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final StatementResult run( String statementTemplate, Record statementParameters )
+    public final Result run(String statementTemplate, Record statementParameters )
     {
         return run( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final StatementResult run( String statementText )
+    public final Result run(String statementText )
     {
         return run( statementText, Values.EmptyMap );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalResult.java
@@ -27,21 +27,21 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.StatementResult;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.summary.ResultSummary;
 
-public class InternalStatementResult implements StatementResult
+public class InternalResult implements Result
 {
     private final Connection connection;
-    private final StatementResultCursor cursor;
+    private final ResultCursor cursor;
     private List<String> keys;
 
-    public InternalStatementResult( Connection connection, StatementResultCursor cursor )
+    public InternalResult(Connection connection, ResultCursor cursor )
     {
         this.connection = connection;
         this.cursor = cursor;

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
@@ -22,8 +22,8 @@ import java.util.Map;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
@@ -36,7 +36,7 @@ import org.neo4j.driver.internal.util.Futures;
 
 import static java.util.Collections.emptyMap;
 
-public class InternalSession extends AbstractStatementRunner implements Session
+public class InternalSession extends AbstractQueryRunner implements Session
 {
     private final NetworkSession session;
 
@@ -46,27 +46,27 @@ public class InternalSession extends AbstractStatementRunner implements Session
     }
 
     @Override
-    public Result run(Statement statement )
+    public Result run(Query query)
     {
-        return run( statement, TransactionConfig.empty() );
+        return run(query, TransactionConfig.empty() );
     }
 
     @Override
-    public Result run(String statement, TransactionConfig config )
+    public Result run(String query, TransactionConfig config )
     {
-        return run( statement, emptyMap(), config );
+        return run(query, emptyMap(), config );
     }
 
     @Override
-    public Result run(String statement, Map<String,Object> parameters, TransactionConfig config )
+    public Result run(String query, Map<String,Object> parameters, TransactionConfig config )
     {
-        return run( new Statement( statement, parameters ), config );
+        return run( new Query(query, parameters ), config );
     }
 
     @Override
-    public Result run(Statement statement, TransactionConfig config )
+    public Result run(Query query, TransactionConfig config )
     {
-        ResultCursor cursor = Futures.blockingGet( session.runAsync( statement, config, false ),
+        ResultCursor cursor = Futures.blockingGet( session.runAsync(query, config, false ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while running query in session" ) );
 
         // query executed, it is safe to obtain a connection in a blocking way

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
@@ -24,12 +24,12 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.TransactionWork;
-import org.neo4j.driver.async.StatementResultCursor;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.async.ResultCursor;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
@@ -46,32 +46,32 @@ public class InternalSession extends AbstractStatementRunner implements Session
     }
 
     @Override
-    public StatementResult run( Statement statement )
+    public Result run(Statement statement )
     {
         return run( statement, TransactionConfig.empty() );
     }
 
     @Override
-    public StatementResult run( String statement, TransactionConfig config )
+    public Result run(String statement, TransactionConfig config )
     {
         return run( statement, emptyMap(), config );
     }
 
     @Override
-    public StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config )
+    public Result run(String statement, Map<String,Object> parameters, TransactionConfig config )
     {
         return run( new Statement( statement, parameters ), config );
     }
 
     @Override
-    public StatementResult run( Statement statement, TransactionConfig config )
+    public Result run(Statement statement, TransactionConfig config )
     {
-        StatementResultCursor cursor = Futures.blockingGet( session.runAsync( statement, config, false ),
+        ResultCursor cursor = Futures.blockingGet( session.runAsync( statement, config, false ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while running query in session" ) );
 
         // query executed, it is safe to obtain a connection in a blocking way
         Connection connection = Futures.getNow( session.connectionAsync() );
-        return new InternalStatementResult( connection, cursor );
+        return new InternalResult( connection, cursor );
     }
 
     @Override
@@ -95,7 +95,7 @@ public class InternalSession extends AbstractStatementRunner implements Session
     @Override
     public Transaction beginTransaction( TransactionConfig config )
     {
-        ExplicitTransaction tx = Futures.blockingGet( session.beginTransactionAsync( config ),
+        UnmanagedTransaction tx = Futures.blockingGet( session.beginTransactionAsync( config ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while starting a transaction" ) );
         return new InternalTransaction( tx );
     }
@@ -160,7 +160,7 @@ public class InternalSession extends AbstractStatementRunner implements Session
 
     private Transaction beginTransaction( AccessMode mode, TransactionConfig config )
     {
-        ExplicitTransaction tx = Futures.blockingGet( session.beginTransactionAsync( mode, config ),
+        UnmanagedTransaction tx = Futures.blockingGet( session.beginTransactionAsync( mode, config ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while starting a transaction" ) );
         return new InternalTransaction( tx );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
@@ -19,16 +19,16 @@
 package org.neo4j.driver.internal;
 
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
-import org.neo4j.driver.async.StatementResultCursor;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.async.ResultCursor;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.util.Futures;
 
 public class InternalTransaction extends AbstractStatementRunner implements Transaction
 {
-    private final ExplicitTransaction tx;
-    public InternalTransaction( ExplicitTransaction tx )
+    private final UnmanagedTransaction tx;
+    public InternalTransaction( UnmanagedTransaction tx )
     {
         this.tx = tx;
     }
@@ -55,11 +55,11 @@ public class InternalTransaction extends AbstractStatementRunner implements Tran
     }
 
     @Override
-    public StatementResult run( Statement statement )
+    public Result run(Statement statement )
     {
-        StatementResultCursor cursor = Futures.blockingGet( tx.runAsync( statement, false ),
+        ResultCursor cursor = Futures.blockingGet( tx.runAsync( statement, false ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while running query in transaction" ) );
-        return new InternalStatementResult( tx.connection(), cursor );
+        return new InternalResult( tx.connection(), cursor );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
@@ -18,14 +18,14 @@
  */
 package org.neo4j.driver.internal;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.util.Futures;
 
-public class InternalTransaction extends AbstractStatementRunner implements Transaction
+public class InternalTransaction extends AbstractQueryRunner implements Transaction
 {
     private final UnmanagedTransaction tx;
     public InternalTransaction( UnmanagedTransaction tx )
@@ -55,9 +55,9 @@ public class InternalTransaction extends AbstractStatementRunner implements Tran
     }
 
     @Override
-    public Result run(Statement statement )
+    public Result run(Query query)
     {
-        ResultCursor cursor = Futures.blockingGet( tx.runAsync( statement, false ),
+        ResultCursor cursor = Futures.blockingGet( tx.runAsync(query, false ),
                 () -> terminateConnectionOnThreadInterrupt( "Thread interrupted while running query in transaction" ) );
         return new InternalResult( tx.connection(), cursor );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/AsyncAbstractQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/AsyncAbstractQueryRunner.java
@@ -22,37 +22,37 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.neo4j.driver.async.AsyncStatementRunner;
+import org.neo4j.driver.async.AsyncQueryRunner;
 import org.neo4j.driver.async.ResultCursor;
 
-import static org.neo4j.driver.internal.AbstractStatementRunner.parameters;
+import static org.neo4j.driver.internal.AbstractQueryRunner.parameters;
 
-public abstract class AsyncAbstractStatementRunner implements AsyncStatementRunner
+public abstract class AsyncAbstractQueryRunner implements AsyncQueryRunner
 {
     @Override
-    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Value parameters )
+    public final CompletionStage<ResultCursor> runAsync(String query, Value parameters )
     {
-        return runAsync( new Statement( statementTemplate, parameters ) );
+        return runAsync( new Query(query, parameters ) );
     }
 
     @Override
-    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Map<String,Object> statementParameters )
+    public final CompletionStage<ResultCursor> runAsync(String query, Map<String,Object> parameters)
     {
-        return runAsync( statementTemplate, parameters( statementParameters ) );
+        return runAsync(query, parameters(parameters) );
     }
 
     @Override
-    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Record statementParameters )
+    public final CompletionStage<ResultCursor> runAsync(String query, Record parameters)
     {
-        return runAsync( statementTemplate, parameters( statementParameters ) );
+        return runAsync(query, parameters(parameters) );
     }
 
     @Override
-    public final CompletionStage<ResultCursor> runAsync(String statementText )
+    public final CompletionStage<ResultCursor> runAsync(String query)
     {
-        return runAsync( statementText, Values.EmptyMap );
+        return runAsync(query, Values.EmptyMap );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/AsyncAbstractStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/AsyncAbstractStatementRunner.java
@@ -26,32 +26,32 @@ import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.async.AsyncStatementRunner;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 
 import static org.neo4j.driver.internal.AbstractStatementRunner.parameters;
 
 public abstract class AsyncAbstractStatementRunner implements AsyncStatementRunner
 {
     @Override
-    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Value parameters )
+    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Value parameters )
     {
         return runAsync( new Statement( statementTemplate, parameters ) );
     }
 
     @Override
-    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Map<String,Object> statementParameters )
+    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Map<String,Object> statementParameters )
     {
         return runAsync( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final CompletionStage<StatementResultCursor> runAsync( String statementTemplate, Record statementParameters )
+    public final CompletionStage<ResultCursor> runAsync(String statementTemplate, Record statementParameters )
     {
         return runAsync( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final CompletionStage<StatementResultCursor> runAsync( String statementText )
+    public final CompletionStage<ResultCursor> runAsync(String statementText )
     {
         return runAsync( statementText, Values.EmptyMap );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
@@ -36,7 +36,7 @@ import static java.util.Collections.emptyMap;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
-public class InternalAsyncSession extends AsyncAbstractStatementRunner implements AsyncSession
+public class InternalAsyncSession extends AsyncAbstractQueryRunner implements AsyncSession
 {
     private final NetworkSession session;
 
@@ -46,27 +46,27 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
     }
 
     @Override
-    public CompletionStage<ResultCursor> runAsync(Statement statement )
+    public CompletionStage<ResultCursor> runAsync(Query query)
     {
-        return runAsync( statement, TransactionConfig.empty() );
+        return runAsync(query, TransactionConfig.empty() );
     }
 
     @Override
-    public CompletionStage<ResultCursor> runAsync(String statement, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(String query, TransactionConfig config )
     {
-        return runAsync( statement, emptyMap(), config );
+        return runAsync(query, emptyMap(), config );
     }
 
     @Override
-    public CompletionStage<ResultCursor> runAsync(String statement, Map<String,Object> parameters, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(String query, Map<String,Object> parameters, TransactionConfig config )
     {
-        return runAsync( new Statement( statement, parameters ), config );
+        return runAsync( new Query(query, parameters ), config );
     }
 
     @Override
-    public CompletionStage<ResultCursor> runAsync(Statement statement, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(Query query, TransactionConfig config )
     {
-        return session.runAsync( statement, config, true );
+        return session.runAsync(query, config, true );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.AsyncTransactionWork;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.util.Futures;
 
@@ -46,25 +46,25 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
     }
 
     @Override
-    public CompletionStage<StatementResultCursor> runAsync( Statement statement )
+    public CompletionStage<ResultCursor> runAsync(Statement statement )
     {
         return runAsync( statement, TransactionConfig.empty() );
     }
 
     @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statement, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(String statement, TransactionConfig config )
     {
         return runAsync( statement, emptyMap(), config );
     }
 
     @Override
-    public CompletionStage<StatementResultCursor> runAsync( String statement, Map<String,Object> parameters, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(String statement, Map<String,Object> parameters, TransactionConfig config )
     {
         return runAsync( new Statement( statement, parameters ), config );
     }
 
     @Override
-    public CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config )
+    public CompletionStage<ResultCursor> runAsync(Statement statement, TransactionConfig config )
     {
         return session.runAsync( statement, config, true );
     }
@@ -121,7 +121,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
     {
         return session.retryLogic().retryAsync( () -> {
             CompletableFuture<T> resultFuture = new CompletableFuture<>();
-            CompletionStage<ExplicitTransaction> txFuture = session.beginTransactionAsync( mode, config );
+            CompletionStage<UnmanagedTransaction> txFuture = session.beginTransactionAsync( mode, config );
 
             txFuture.whenComplete( ( tx, completionError ) -> {
                 Throwable error = Futures.completionExceptionCause( completionError );
@@ -139,7 +139,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
         } );
     }
 
-    private <T> void executeWork( CompletableFuture<T> resultFuture, ExplicitTransaction tx, AsyncTransactionWork<CompletionStage<T>> work )
+    private <T> void executeWork(CompletableFuture<T> resultFuture, UnmanagedTransaction tx, AsyncTransactionWork<CompletionStage<T>> work )
     {
         CompletionStage<T> workFuture = safeExecuteWork( tx, work );
         workFuture.whenComplete( ( result, completionError ) -> {
@@ -155,7 +155,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
         } );
     }
 
-    private <T> CompletionStage<T> safeExecuteWork( ExplicitTransaction tx, AsyncTransactionWork<CompletionStage<T>> work )
+    private <T> CompletionStage<T> safeExecuteWork(UnmanagedTransaction tx, AsyncTransactionWork<CompletionStage<T>> work )
     {
         // given work might fail in both async and sync way
         // async failure will result in a failed future being returned
@@ -174,7 +174,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
         }
     }
 
-    private <T> void rollbackTxAfterFailedTransactionWork( ExplicitTransaction tx, CompletableFuture<T> resultFuture, Throwable error )
+    private <T> void rollbackTxAfterFailedTransactionWork(UnmanagedTransaction tx, CompletableFuture<T> resultFuture, Throwable error )
     {
         if ( tx.isOpen() )
         {
@@ -192,7 +192,7 @@ public class InternalAsyncSession extends AsyncAbstractStatementRunner implement
         }
     }
 
-    private <T> void closeTxAfterSucceededTransactionWork( ExplicitTransaction tx, CompletableFuture<T> resultFuture, T result )
+    private <T> void closeTxAfterSucceededTransactionWork(UnmanagedTransaction tx, CompletableFuture<T> resultFuture, T result )
     {
         if ( tx.isOpen() )
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
@@ -20,11 +20,11 @@ package org.neo4j.driver.internal.async;
 
 import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.ResultCursor;
 
-public class InternalAsyncTransaction extends AsyncAbstractStatementRunner implements AsyncTransaction
+public class InternalAsyncTransaction extends AsyncAbstractQueryRunner implements AsyncTransaction
 {
     private final UnmanagedTransaction tx;
     public InternalAsyncTransaction( UnmanagedTransaction tx )
@@ -45,9 +45,9 @@ public class InternalAsyncTransaction extends AsyncAbstractStatementRunner imple
     }
 
     @Override
-    public CompletionStage<ResultCursor> runAsync(Statement statement )
+    public CompletionStage<ResultCursor> runAsync(Query query)
     {
-        return tx.runAsync( statement, true );
+        return tx.runAsync(query, true );
     }
 
     public void markTerminated()

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
@@ -22,12 +22,12 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 
 public class InternalAsyncTransaction extends AsyncAbstractStatementRunner implements AsyncTransaction
 {
-    private final ExplicitTransaction tx;
-    public InternalAsyncTransaction( ExplicitTransaction tx )
+    private final UnmanagedTransaction tx;
+    public InternalAsyncTransaction( UnmanagedTransaction tx )
     {
         this.tx = tx;
     }
@@ -45,7 +45,7 @@ public class InternalAsyncTransaction extends AsyncAbstractStatementRunner imple
     }
 
     @Override
-    public CompletionStage<StatementResultCursor> runAsync( Statement statement )
+    public CompletionStage<ResultCursor> runAsync(Statement statement )
     {
         return tx.runAsync( statement, true );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -28,15 +28,15 @@ import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.TransactionNestingException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.FailableCursor;
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursor;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
-import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
+import org.neo4j.driver.internal.cursor.AsyncResultCursor;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
+import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.logging.PrefixedLogger;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
@@ -58,7 +58,7 @@ public class NetworkSession
 
     private final BookmarkHolder bookmarkHolder;
     private final long fetchSize;
-    private volatile CompletionStage<ExplicitTransaction> transactionStage = completedWithNull();
+    private volatile CompletionStage<UnmanagedTransaction> transactionStage = completedWithNull();
     private volatile CompletionStage<Connection> connectionStage = completedWithNull();
     private volatile CompletionStage<? extends FailableCursor> resultCursorStage = completedWithNull();
 
@@ -76,44 +76,44 @@ public class NetworkSession
         this.fetchSize = fetchSize;
     }
 
-    public CompletionStage<StatementResultCursor> runAsync( Statement statement, TransactionConfig config, boolean waitForRunResponse )
+    public CompletionStage<ResultCursor> runAsync(Statement statement, TransactionConfig config, boolean waitForRunResponse )
     {
-        CompletionStage<AsyncStatementResultCursor> newResultCursorStage =
-                buildResultCursorFactory( statement, config, waitForRunResponse ).thenCompose( StatementResultCursorFactory::asyncResult );
+        CompletionStage<AsyncResultCursor> newResultCursorStage =
+                buildResultCursorFactory( statement, config, waitForRunResponse ).thenCompose( ResultCursorFactory::asyncResult );
 
         resultCursorStage = newResultCursorStage.exceptionally( error -> null );
         return newResultCursorStage.thenApply( cursor -> cursor ); // convert the return type
     }
 
-    public CompletionStage<RxStatementResultCursor> runRx( Statement statement, TransactionConfig config )
+    public CompletionStage<RxResultCursor> runRx(Statement statement, TransactionConfig config )
     {
-        CompletionStage<RxStatementResultCursor> newResultCursorStage =
-                buildResultCursorFactory( statement, config, true ).thenCompose( StatementResultCursorFactory::rxResult );
+        CompletionStage<RxResultCursor> newResultCursorStage =
+                buildResultCursorFactory( statement, config, true ).thenCompose( ResultCursorFactory::rxResult );
 
         resultCursorStage = newResultCursorStage.exceptionally( error -> null );
         return newResultCursorStage;
     }
 
-    public CompletionStage<ExplicitTransaction> beginTransactionAsync( TransactionConfig config )
+    public CompletionStage<UnmanagedTransaction> beginTransactionAsync( TransactionConfig config )
     {
         return this.beginTransactionAsync( mode, config );
     }
 
-    public CompletionStage<ExplicitTransaction> beginTransactionAsync( AccessMode mode, TransactionConfig config )
+    public CompletionStage<UnmanagedTransaction> beginTransactionAsync( AccessMode mode, TransactionConfig config )
     {
         ensureSessionIsOpen();
 
         // create a chain that acquires connection and starts a transaction
-        CompletionStage<ExplicitTransaction> newTransactionStage = ensureNoOpenTxBeforeStartingTx()
+        CompletionStage<UnmanagedTransaction> newTransactionStage = ensureNoOpenTxBeforeStartingTx()
                 .thenCompose( ignore -> acquireConnection( mode ) )
                 .thenCompose( connection ->
                 {
-                    ExplicitTransaction tx = new ExplicitTransaction( connection, bookmarkHolder, fetchSize );
+                    UnmanagedTransaction tx = new UnmanagedTransaction( connection, bookmarkHolder, fetchSize );
                     return tx.beginAsync( bookmarkHolder.getBookmark(), config );
                 } );
 
         // update the reference to the only known transaction
-        CompletionStage<ExplicitTransaction> currentTransactionStage = transactionStage;
+        CompletionStage<UnmanagedTransaction> currentTransactionStage = transactionStage;
 
         transactionStage = newTransactionStage
                 .exceptionally( error -> null ) // ignore errors from starting new transaction
@@ -223,7 +223,7 @@ public class NetworkSession
                 connection.isOpen() ); // and it's still open
     }
 
-    private CompletionStage<StatementResultCursorFactory> buildResultCursorFactory( Statement statement, TransactionConfig config, boolean waitForRunResponse )
+    private CompletionStage<ResultCursorFactory> buildResultCursorFactory(Statement statement, TransactionConfig config, boolean waitForRunResponse )
     {
         ensureSessionIsOpen();
 
@@ -232,7 +232,7 @@ public class NetworkSession
                 .thenCompose( connection -> {
                     try
                     {
-                        StatementResultCursorFactory factory = connection.protocol()
+                        ResultCursorFactory factory = connection.protocol()
                                 .runInAutoCommitTransaction( connection, statement, bookmarkHolder, config, waitForRunResponse, fetchSize );
                         return completedFuture( factory );
                     }
@@ -328,7 +328,7 @@ public class NetworkSession
         } );
     }
 
-    private CompletionStage<ExplicitTransaction> existingTransactionOrNull()
+    private CompletionStage<UnmanagedTransaction> existingTransactionOrNull()
     {
         return transactionStage
                 .exceptionally( error -> null ) // handle previous connection acquisition and tx begin failures

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -23,8 +23,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
@@ -138,20 +138,20 @@ public class UnmanagedTransaction
         }
     }
 
-    public CompletionStage<ResultCursor> runAsync(Statement statement, boolean waitForRunResponse )
+    public CompletionStage<ResultCursor> runAsync(Query query, boolean waitForRunResponse )
     {
         ensureCanRunQueries();
         CompletionStage<AsyncResultCursor> cursorStage =
-                protocol.runInExplicitTransaction( connection, statement, this, waitForRunResponse, fetchSize ).asyncResult();
+                protocol.runInExplicitTransaction( connection, query, this, waitForRunResponse, fetchSize ).asyncResult();
         resultCursors.add( cursorStage );
         return cursorStage.thenApply( cursor -> cursor );
     }
 
-    public CompletionStage<RxResultCursor> runRx(Statement statement )
+    public CompletionStage<RxResultCursor> runRx(Query query)
     {
         ensureCanRunQueries();
         CompletionStage<RxResultCursor> cursorStage =
-                protocol.runInExplicitTransaction( connection, statement, this, false, fetchSize ).rxResult();
+                protocol.runInExplicitTransaction( connection, query, this, false, fetchSize ).rxResult();
         resultCursors.add( cursorStage );
         return cursorStage;
     }
@@ -175,15 +175,15 @@ public class UnmanagedTransaction
     {
         if ( state == State.COMMITTED )
         {
-            throw new ClientException( "Cannot run more statements in this transaction, it has been committed" );
+            throw new ClientException( "Cannot run more queries in this transaction, it has been committed" );
         }
         else if ( state == State.ROLLED_BACK )
         {
-            throw new ClientException( "Cannot run more statements in this transaction, it has been rolled back" );
+            throw new ClientException( "Cannot run more queries in this transaction, it has been rolled back" );
         }
         else if ( state == State.TERMINATED )
         {
-            throw new ClientException( "Cannot run more statements in this transaction, " +
+            throw new ClientException( "Cannot run more queries in this transaction, " +
                     "it has either experienced an fatal error or was explicitly terminated" );
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -142,7 +142,7 @@ public class UnmanagedTransaction
     {
         ensureCanRunQueries();
         CompletionStage<AsyncResultCursor> cursorStage =
-                protocol.runInExplicitTransaction( connection, query, this, waitForRunResponse, fetchSize ).asyncResult();
+                protocol.runInUnmanagedTransaction( connection, query, this, waitForRunResponse, fetchSize ).asyncResult();
         resultCursors.add( cursorStage );
         return cursorStage.thenApply( cursor -> cursor );
     }
@@ -151,7 +151,7 @@ public class UnmanagedTransaction
     {
         ensureCanRunQueries();
         CompletionStage<RxResultCursor> cursorStage =
-                protocol.runInExplicitTransaction( connection, query, this, false, fetchSize ).rxResult();
+                protocol.runInUnmanagedTransaction( connection, query, this, false, fetchSize ).rxResult();
         resultCursors.add( cursorStage );
         return cursorStage;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
@@ -51,12 +51,12 @@ public class MultiDatabasesRoutingProcedureRunner extends RoutingProcedureRunner
     }
 
     @Override
-    Statement procedureStatement( ServerVersion serverVersion, DatabaseName databaseName )
+    Query procedureQuery(ServerVersion serverVersion, DatabaseName databaseName )
     {
         HashMap<String,Value> map = new HashMap<>();
         map.put( ROUTING_CONTEXT, value( context.asMap() ) );
         map.put( DATABASE_NAME, value( (Object) databaseName.databaseName().orElse( null ) ) );
-        return new Statement( MULTI_DB_GET_ROUTING_TABLE, value( map ) );
+        return new Query( MULTI_DB_GET_ROUTING_TABLE, value( map ) );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.value.ValueException;
 import org.neo4j.driver.internal.DatabaseName;
@@ -120,7 +120,7 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
 
     private static String invokedProcedureString( RoutingProcedureResponse response )
     {
-        Statement statement = response.procedure();
-        return statement.text() + " " + statement.parameters();
+        Query query = response.procedure();
+        return query.text() + " " + query.parameters();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponse.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponse.java
@@ -20,26 +20,26 @@ package org.neo4j.driver.internal.cluster;
 
 import java.util.List;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 
 public class RoutingProcedureResponse
 {
-    private final Statement procedure;
+    private final Query procedure;
     private final List<Record> records;
     private final Throwable error;
 
-    public RoutingProcedureResponse( Statement procedure, List<Record> records )
+    public RoutingProcedureResponse(Query procedure, List<Record> records )
     {
         this( procedure, records, null );
     }
 
-    public RoutingProcedureResponse( Statement procedure, Throwable error )
+    public RoutingProcedureResponse(Query procedure, Throwable error )
     {
         this( procedure, null, error );
     }
 
-    private RoutingProcedureResponse( Statement procedure, List<Record> records, Throwable error )
+    private RoutingProcedureResponse(Query procedure, List<Record> records, Throwable error )
     {
         this.procedure = procedure;
         this.records = records;
@@ -51,7 +51,7 @@ public class RoutingProcedureResponse
         return records != null;
     }
 
-    public Statement procedure()
+    public Query procedure()
     {
         return procedure;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
 import org.neo4j.driver.internal.BookmarkHolder;
@@ -88,7 +88,7 @@ public class RoutingProcedureRunner
     {
         return connection.protocol()
                 .runInAutoCommitTransaction( connection, procedure, bookmarkHolder, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE )
-                .asyncResult().thenCompose( StatementResultCursor::listAsync );
+                .asyncResult().thenCompose( ResultCursor::listAsync );
     }
 
     private CompletionStage<List<Record>> releaseConnection( Connection connection, List<Record> records )

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursor.java
@@ -19,8 +19,8 @@
 package org.neo4j.driver.internal.cursor;
 
 import org.neo4j.driver.internal.FailableCursor;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 
-public interface AsyncStatementResultCursor extends StatementResultCursor, FailableCursor
+public interface AsyncResultCursor extends ResultCursor, FailableCursor
 {
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
@@ -31,12 +31,12 @@ import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.summary.ResultSummary;
 
-public class AsyncStatementResultCursorImpl implements AsyncStatementResultCursor
+public class AsyncResultCursorImpl implements AsyncResultCursor
 {
     private final RunResponseHandler runHandler;
     private final PullAllResponseHandler pullAllHandler;
 
-    public AsyncStatementResultCursorImpl( RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
+    public AsyncResultCursorImpl(RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
     {
         this.runHandler = runHandler;
         this.pullAllHandler = pullAllHandler;

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
@@ -45,7 +45,7 @@ public class AsyncResultCursorImpl implements AsyncResultCursor
     @Override
     public List<String> keys()
     {
-        return runHandler.statementKeys();
+        return runHandler.queryKeys();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorOnlyFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorOnlyFactory.java
@@ -33,7 +33,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 /**
  * Used by Bolt V1, V2, V3
  */
-public class AsyncStatementResultCursorOnlyFactory implements StatementResultCursorFactory
+public class AsyncResultCursorOnlyFactory implements ResultCursorFactory
 {
     protected final Connection connection;
     protected final Message runMessage;
@@ -41,8 +41,8 @@ public class AsyncStatementResultCursorOnlyFactory implements StatementResultCur
     protected final PullAllResponseHandler pullAllHandler;
     private final boolean waitForRunResponse;
 
-    public AsyncStatementResultCursorOnlyFactory( Connection connection, Message runMessage, RunResponseHandler runHandler,
-            PullAllResponseHandler pullHandler, boolean waitForRunResponse )
+    public AsyncResultCursorOnlyFactory(Connection connection, Message runMessage, RunResponseHandler runHandler,
+                                        PullAllResponseHandler pullHandler, boolean waitForRunResponse )
     {
         requireNonNull( connection );
         requireNonNull( runMessage );
@@ -57,7 +57,7 @@ public class AsyncStatementResultCursorOnlyFactory implements StatementResultCur
         this.waitForRunResponse = waitForRunResponse;
     }
 
-    public CompletionStage<AsyncStatementResultCursor> asyncResult()
+    public CompletionStage<AsyncResultCursor> asyncResult()
     {
         // only write and flush messages when async result is wanted.
         connection.write( runMessage, runHandler ); // queues the run message, will be flushed with pull message together
@@ -67,15 +67,15 @@ public class AsyncStatementResultCursorOnlyFactory implements StatementResultCur
         {
             // wait for response of RUN before proceeding
             return runHandler.runFuture().thenApply( ignore ->
-                    new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
+                    new DisposableAsyncResultCursor( new AsyncResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
         else
         {
-            return completedFuture( new DisposableAsyncStatementResultCursor( new AsyncStatementResultCursorImpl( runHandler, pullAllHandler ) ) );
+            return completedFuture( new DisposableAsyncResultCursor( new AsyncResultCursorImpl( runHandler, pullAllHandler ) ) );
         }
     }
 
-    public CompletionStage<RxStatementResultCursor> rxResult()
+    public CompletionStage<RxResultCursor> rxResult()
     {
         return Futures.failedFuture( new ClientException( "Driver is connected to the database that does not support driver reactive API. " +
                 "In order to use the driver reactive API, please upgrade to neo4j 4.0.0 or later." ) );

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursor.java
@@ -31,12 +31,12 @@ import static org.neo4j.driver.internal.util.ErrorUtil.newResultConsumedError;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
-public class DisposableAsyncStatementResultCursor implements AsyncStatementResultCursor
+public class DisposableAsyncResultCursor implements AsyncResultCursor
 {
-    private final AsyncStatementResultCursor delegate;
+    private final AsyncResultCursor delegate;
     private boolean isDisposed;
 
-    public DisposableAsyncStatementResultCursor( AsyncStatementResultCursor delegate )
+    public DisposableAsyncResultCursor(AsyncResultCursor delegate )
     {
         this.delegate = delegate;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/ResultCursorFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/ResultCursorFactory.java
@@ -20,9 +20,9 @@ package org.neo4j.driver.internal.cursor;
 
 import java.util.concurrent.CompletionStage;
 
-public interface StatementResultCursorFactory
+public interface ResultCursorFactory
 {
-    CompletionStage<AsyncStatementResultCursor> asyncResult();
+    CompletionStage<AsyncResultCursor> asyncResult();
 
-    CompletionStage<RxStatementResultCursor> rxResult();
+    CompletionStage<RxResultCursor> rxResult();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.internal.FailableCursor;
 import org.neo4j.driver.summary.ResultSummary;
 
-public interface RxStatementResultCursor extends Subscription, FailableCursor
+public interface RxResultCursor extends Subscription, FailableCursor
 {
     List<String> keys();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
@@ -30,12 +30,12 @@ import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler;
 import org.neo4j.driver.summary.ResultSummary;
 
-import static org.neo4j.driver.internal.cursor.RxStatementResultCursorImpl.RecordConsumerStatus.DISCARD_INSTALLED;
-import static org.neo4j.driver.internal.cursor.RxStatementResultCursorImpl.RecordConsumerStatus.INSTALLED;
-import static org.neo4j.driver.internal.cursor.RxStatementResultCursorImpl.RecordConsumerStatus.NOT_INSTALLED;
+import static org.neo4j.driver.internal.cursor.RxResultCursorImpl.RecordConsumerStatus.DISCARD_INSTALLED;
+import static org.neo4j.driver.internal.cursor.RxResultCursorImpl.RecordConsumerStatus.INSTALLED;
+import static org.neo4j.driver.internal.cursor.RxResultCursorImpl.RecordConsumerStatus.NOT_INSTALLED;
 import static org.neo4j.driver.internal.util.ErrorUtil.newResultConsumedError;
 
-public class RxStatementResultCursorImpl implements RxStatementResultCursor
+public class RxResultCursorImpl implements RxResultCursor
 {
     static final BiConsumer<Record,Throwable> DISCARD_RECORD_CONSUMER = ( record, throwable ) -> {/*do nothing*/};
     private final RunResponseHandler runHandler;
@@ -45,12 +45,12 @@ public class RxStatementResultCursorImpl implements RxStatementResultCursor
     private boolean resultConsumed;
     private RecordConsumerStatus consumerStatus = NOT_INSTALLED;
 
-    public RxStatementResultCursorImpl( RunResponseHandler runHandler, PullResponseHandler pullHandler )
+    public RxResultCursorImpl(RunResponseHandler runHandler, PullResponseHandler pullHandler )
     {
         this( null, runHandler, pullHandler );
     }
 
-    public RxStatementResultCursorImpl( Throwable runError, RunResponseHandler runHandler, PullResponseHandler pullHandler )
+    public RxResultCursorImpl(Throwable runError, RunResponseHandler runHandler, PullResponseHandler pullHandler )
     {
         Objects.requireNonNull( runHandler );
         Objects.requireNonNull( pullHandler );

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
@@ -65,7 +65,7 @@ public class RxResultCursorImpl implements RxResultCursor
     @Override
     public List<String> keys()
     {
-        return runHandler.statementKeys();
+        return runHandler.queryKeys();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandler.java
@@ -27,8 +27,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
@@ -54,7 +54,7 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
     static final int RECORD_BUFFER_LOW_WATERMARK = Integer.getInteger( "recordBufferLowWatermark", 300 );
     static final int RECORD_BUFFER_HIGH_WATERMARK = Integer.getInteger( "recordBufferHighWatermark", 1000 );
 
-    private final Statement statement;
+    private final Query query;
     private final RunResponseHandler runResponseHandler;
     protected final MetadataExtractor metadataExtractor;
     protected final Connection connection;
@@ -72,10 +72,10 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
     private CompletableFuture<Record> recordFuture;
     private CompletableFuture<Throwable> failureFuture;
 
-    public LegacyPullAllResponseHandler( Statement statement, RunResponseHandler runResponseHandler, Connection connection, MetadataExtractor metadataExtractor,
-            PullResponseCompletionListener completionListener )
+    public LegacyPullAllResponseHandler(Query query, RunResponseHandler runResponseHandler, Connection connection, MetadataExtractor metadataExtractor,
+                                        PullResponseCompletionListener completionListener )
     {
-        this.statement = requireNonNull( statement );
+        this.query = requireNonNull(query);
         this.runResponseHandler = requireNonNull( runResponseHandler );
         this.metadataExtractor = requireNonNull( metadataExtractor );
         this.connection = requireNonNull( connection );
@@ -134,7 +134,7 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
         }
         else
         {
-            Record record = new InternalRecord( runResponseHandler.statementKeys(), fields );
+            Record record = new InternalRecord( runResponseHandler.queryKeys(), fields );
             enqueueRecord( record );
             completeRecordFuture( record );
         }
@@ -335,7 +335,7 @@ public class LegacyPullAllResponseHandler implements PullAllResponseHandler
     private ResultSummary extractResultSummary( Map<String,Value> metadata )
     {
         long resultAvailableAfter = runResponseHandler.resultAvailableAfter();
-        return metadataExtractor.extractSummary( statement, connection, resultAvailableAfter, metadata );
+        return metadataExtractor.extractSummary(query, connection, resultAvailableAfter, metadata );
     }
 
     private void enableAutoRead()

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullHandlers.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullHandlers.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal.handlers;
 
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.BookmarkHolder;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.pulln.AutoPullResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.BasicPullResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler;
@@ -31,7 +31,7 @@ import org.neo4j.driver.internal.spi.Connection;
 public class PullHandlers
 {
     public static PullAllResponseHandler newBoltV1PullAllHandler( Statement statement, RunResponseHandler runHandler,
-            Connection connection, ExplicitTransaction tx )
+            Connection connection, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, BookmarkHolder.NO_OP, tx );
 
@@ -39,15 +39,15 @@ public class PullHandlers
     }
 
     public static PullAllResponseHandler newBoltV3PullAllHandler( Statement statement, RunResponseHandler runHandler, Connection connection,
-            BookmarkHolder bookmarkHolder, ExplicitTransaction tx )
+            BookmarkHolder bookmarkHolder, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
         return new LegacyPullAllResponseHandler( statement, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener );
     }
 
-    public static PullAllResponseHandler newBoltV4AutoPullHandler( Statement statement, RunResponseHandler runHandler, Connection connection,
-            BookmarkHolder bookmarkHolder, ExplicitTransaction tx, long fetchSize )
+    public static PullAllResponseHandler newBoltV4AutoPullHandler(Statement statement, RunResponseHandler runHandler, Connection connection,
+                                                                  BookmarkHolder bookmarkHolder, UnmanagedTransaction tx, long fetchSize )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
@@ -56,7 +56,7 @@ public class PullHandlers
 
 
     public static PullResponseHandler newBoltV4BasicPullHandler( Statement statement, RunResponseHandler runHandler, Connection connection,
-            BookmarkHolder bookmarkHolder, ExplicitTransaction tx )
+            BookmarkHolder bookmarkHolder, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
@@ -64,7 +64,7 @@ public class PullHandlers
     }
 
     private static PullResponseCompletionListener createPullResponseCompletionListener( Connection connection, BookmarkHolder bookmarkHolder,
-            ExplicitTransaction tx )
+            UnmanagedTransaction tx )
     {
         return tx != null ? new TransactionPullResponseCompletionListener( tx ) : new SessionPullResponseCompletionListener( connection, bookmarkHolder );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/PullHandlers.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/PullHandlers.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.handlers;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.pulln.AutoPullResponseHandler;
@@ -30,37 +30,37 @@ import org.neo4j.driver.internal.spi.Connection;
 
 public class PullHandlers
 {
-    public static PullAllResponseHandler newBoltV1PullAllHandler( Statement statement, RunResponseHandler runHandler,
+    public static PullAllResponseHandler newBoltV1PullAllHandler(Query query, RunResponseHandler runHandler,
             Connection connection, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, BookmarkHolder.NO_OP, tx );
 
-        return new LegacyPullAllResponseHandler( statement, runHandler, connection, BoltProtocolV1.METADATA_EXTRACTOR, completionListener );
+        return new LegacyPullAllResponseHandler(query, runHandler, connection, BoltProtocolV1.METADATA_EXTRACTOR, completionListener );
     }
 
-    public static PullAllResponseHandler newBoltV3PullAllHandler( Statement statement, RunResponseHandler runHandler, Connection connection,
+    public static PullAllResponseHandler newBoltV3PullAllHandler(Query query, RunResponseHandler runHandler, Connection connection,
             BookmarkHolder bookmarkHolder, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
-        return new LegacyPullAllResponseHandler( statement, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener );
+        return new LegacyPullAllResponseHandler(query, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener );
     }
 
-    public static PullAllResponseHandler newBoltV4AutoPullHandler(Statement statement, RunResponseHandler runHandler, Connection connection,
+    public static PullAllResponseHandler newBoltV4AutoPullHandler(Query query, RunResponseHandler runHandler, Connection connection,
                                                                   BookmarkHolder bookmarkHolder, UnmanagedTransaction tx, long fetchSize )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
-        return new AutoPullResponseHandler( statement, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener, fetchSize );
+        return new AutoPullResponseHandler(query, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener, fetchSize );
     }
 
 
-    public static PullResponseHandler newBoltV4BasicPullHandler( Statement statement, RunResponseHandler runHandler, Connection connection,
+    public static PullResponseHandler newBoltV4BasicPullHandler(Query query, RunResponseHandler runHandler, Connection connection,
             BookmarkHolder bookmarkHolder, UnmanagedTransaction tx )
     {
         PullResponseCompletionListener completionListener = createPullResponseCompletionListener( connection, bookmarkHolder, tx );
 
-        return new BasicPullResponseHandler( statement, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener );
+        return new BasicPullResponseHandler(query, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR, completionListener );
     }
 
     private static PullResponseCompletionListener createPullResponseCompletionListener( Connection connection, BookmarkHolder bookmarkHolder,

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
@@ -32,9 +32,9 @@ public class RunResponseHandler implements ResponseHandler
 {
     private final CompletableFuture<Throwable> runCompletedFuture;
     private final MetadataExtractor metadataExtractor;
-    private long statementId = MetadataExtractor.ABSENT_QUERY_ID;
+    private long queryId = MetadataExtractor.ABSENT_QUERY_ID;
 
-    private List<String> statementKeys = emptyList();
+    private List<String> queryKeys = emptyList();
     private long resultAvailableAfter = -1;
 
     public RunResponseHandler( MetadataExtractor metadataExtractor )
@@ -51,9 +51,9 @@ public class RunResponseHandler implements ResponseHandler
     @Override
     public void onSuccess( Map<String,Value> metadata )
     {
-        statementKeys = metadataExtractor.extractStatementKeys( metadata );
+        queryKeys = metadataExtractor.extractQueryKeys( metadata );
         resultAvailableAfter = metadataExtractor.extractResultAvailableAfter( metadata );
-        statementId = metadataExtractor.extractQueryId( metadata );
+        queryId = metadataExtractor.extractQueryId( metadata );
 
         completeRunFuture( null );
     }
@@ -70,9 +70,9 @@ public class RunResponseHandler implements ResponseHandler
         throw new UnsupportedOperationException();
     }
 
-    public List<String> statementKeys()
+    public List<String> queryKeys()
     {
-        return statementKeys;
+        return queryKeys;
     }
 
     public long resultAvailableAfter()
@@ -80,15 +80,15 @@ public class RunResponseHandler implements ResponseHandler
         return resultAvailableAfter;
     }
 
-    public long statementId()
+    public long queryId()
     {
-        return statementId;
+        return queryId;
     }
 
     /**
      * Complete the given future with error if the future was failed.
      * Future is never completed exceptionally.
-     * Async API needs to wait for RUN because it needs to access statement keys.
+     * Async API needs to wait for RUN because it needs to access query keys.
      * Reactive API needs to know if RUN failed by checking the error.
      */
     private void completeRunFuture( Throwable error )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
@@ -21,15 +21,15 @@ package org.neo4j.driver.internal.handlers;
 import java.util.Map;
 
 import org.neo4j.driver.Value;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 
 import static java.util.Objects.requireNonNull;
 
 public class TransactionPullResponseCompletionListener implements PullResponseCompletionListener
 {
-    private final ExplicitTransaction tx;
+    private final UnmanagedTransaction tx;
 
-    public TransactionPullResponseCompletionListener( ExplicitTransaction tx )
+    public TransactionPullResponseCompletionListener( UnmanagedTransaction tx )
     {
         this.tx = requireNonNull( tx );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
@@ -26,8 +26,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -59,10 +59,10 @@ public class AutoPullResponseHandler extends BasicPullResponseHandler implements
     private CompletableFuture<Record> recordFuture;
     private CompletableFuture<ResultSummary> summaryFuture;
 
-    public AutoPullResponseHandler( Statement statement, RunResponseHandler runResponseHandler, Connection connection, MetadataExtractor metadataExtractor,
-            PullResponseCompletionListener completionListener, long fetchSize )
+    public AutoPullResponseHandler(Query query, RunResponseHandler runResponseHandler, Connection connection, MetadataExtractor metadataExtractor,
+                                   PullResponseCompletionListener completionListener, long fetchSize )
     {
-        super( statement, runResponseHandler, connection, metadataExtractor, completionListener );
+        super(query, runResponseHandler, connection, metadataExtractor, completionListener );
         this.fetchSize = fetchSize;
         installRecordAndSummaryConsumers();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -33,8 +33,8 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
-import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.messaging.v1.BoltProtocolV1;
 import org.neo4j.driver.internal.messaging.v2.BoltProtocolV2;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
@@ -106,8 +106,8 @@ public interface BoltProtocol
      * @param fetchSize the record fetch size for PULL message.
      * @return stage with cursor.
      */
-    StatementResultCursorFactory runInAutoCommitTransaction( Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
-            TransactionConfig config, boolean waitForRunResponse, long fetchSize );
+    ResultCursorFactory runInAutoCommitTransaction(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+                                                   TransactionConfig config, boolean waitForRunResponse, long fetchSize );
 
     /**
      * Execute the given statement in a running explicit transaction, i.e. {@link Transaction#run(Statement)}.
@@ -121,8 +121,8 @@ public interface BoltProtocol
      * @param fetchSize the record fetch size for PULL message.
      * @return stage with cursor.
      */
-    StatementResultCursorFactory runInExplicitTransaction( Connection connection, Statement statement, ExplicitTransaction tx, boolean waitForRunResponse,
-            long fetchSize );
+    ResultCursorFactory runInExplicitTransaction(Connection connection, Statement statement, UnmanagedTransaction tx, boolean waitForRunResponse,
+                                                 long fetchSize );
 
     /**
      * Returns the protocol version. It can be used for version specific error messages.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -68,7 +68,7 @@ public interface BoltProtocol
     void prepareToCloseChannel( Channel channel );
 
     /**
-     * Begin an explicit transaction.
+     * Begin an unmanaged transaction.
      *
      * @param connection the connection to use.
      * @param bookmark the bookmarks. Never null, should be {@link InternalBookmark#empty()} when absent.
@@ -78,7 +78,7 @@ public interface BoltProtocol
     CompletionStage<Void> beginTransaction( Connection connection, Bookmark bookmark, TransactionConfig config );
 
     /**
-     * Commit the explicit transaction.
+     * Commit the unmanaged transaction.
      *
      * @param connection the connection to use.
      * @return a completion stage completed with a bookmark when transaction is committed or completed exceptionally when there was a failure.
@@ -86,7 +86,7 @@ public interface BoltProtocol
     CompletionStage<Bookmark> commitTransaction( Connection connection );
 
     /**
-     * Rollback the explicit transaction.
+     * Rollback the unmanaged transaction.
      *
      * @param connection the connection to use.
      * @return a completion stage completed when transaction is rolled back or completed exceptionally when there was a failure.
@@ -110,7 +110,7 @@ public interface BoltProtocol
                                                    TransactionConfig config, boolean waitForRunResponse, long fetchSize );
 
     /**
-     * Execute the given query in a running explicit transaction, i.e. {@link Transaction#run(Query)}.
+     * Execute the given query in a running unmanaged transaction, i.e. {@link Transaction#run(Query)}.
      *
      * @param connection the network connection to use.
      * @param query the cypher to execute.
@@ -121,7 +121,7 @@ public interface BoltProtocol
      * @param fetchSize the record fetch size for PULL message.
      * @return stage with cursor.
      */
-    ResultCursorFactory runInExplicitTransaction(Connection connection, Query query, UnmanagedTransaction tx, boolean waitForRunResponse,
+    ResultCursorFactory runInUnmanagedTransaction(Connection connection, Query query, UnmanagedTransaction tx, boolean waitForRunResponse,
                                                  long fetchSize );
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
@@ -94,34 +94,34 @@ public interface BoltProtocol
     CompletionStage<Void> rollbackTransaction( Connection connection );
 
     /**
-     * Execute the given statement in an aut-commit transaction, i.e. {@link Session#run(Statement)}.
+     * Execute the given query in an auto-commit transaction, i.e. {@link Session#run(Query)}.
      *
      * @param connection the network connection to use.
-     * @param statement the cypher to execute.
+     * @param query the cypher to execute.
      * @param bookmarkHolder the bookmarksHolder that keeps track of the current bookmark and can be updated with a new bookmark.
      * @param config the transaction config for the implicitly started auto-commit transaction.
      * @param waitForRunResponse {@code true} for async query execution and {@code false} for blocking query
-     * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have statement
+     * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have query
      * keys populated.
      * @param fetchSize the record fetch size for PULL message.
      * @return stage with cursor.
      */
-    ResultCursorFactory runInAutoCommitTransaction(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+    ResultCursorFactory runInAutoCommitTransaction(Connection connection, Query query, BookmarkHolder bookmarkHolder,
                                                    TransactionConfig config, boolean waitForRunResponse, long fetchSize );
 
     /**
-     * Execute the given statement in a running explicit transaction, i.e. {@link Transaction#run(Statement)}.
+     * Execute the given query in a running explicit transaction, i.e. {@link Transaction#run(Query)}.
      *
      * @param connection the network connection to use.
-     * @param statement the cypher to execute.
+     * @param query the cypher to execute.
      * @param tx the transaction which executes the query.
      * @param waitForRunResponse {@code true} for async query execution and {@code false} for blocking query
-     * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have statement
+     * execution. Makes returned cursor stage be chained after the RUN response arrives. Needed to have query
      * keys populated.
      * @param fetchSize the record fetch size for PULL message.
      * @return stage with cursor.
      */
-    ResultCursorFactory runInExplicitTransaction(Connection connection, Statement statement, UnmanagedTransaction tx, boolean waitForRunResponse,
+    ResultCursorFactory runInExplicitTransaction(Connection connection, Query query, UnmanagedTransaction tx, boolean waitForRunResponse,
                                                  long fetchSize );
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RunMessageEncoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RunMessageEncoder.java
@@ -35,7 +35,7 @@ public class RunMessageEncoder implements MessageEncoder
         checkArgument( message, RunMessage.class );
         RunMessage runMessage = (RunMessage) message;
         packer.packStructHeader( 2, runMessage.signature() );
-        packer.pack( runMessage.statement() );
+        packer.pack( runMessage.query() );
         packer.pack( runMessage.parameters() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoder.java
@@ -35,7 +35,7 @@ public class RunWithMetadataMessageEncoder implements MessageEncoder
         checkArgument( message, RunWithMetadataMessage.class );
         RunWithMetadataMessage runMessage = (RunWithMetadataMessage) message;
         packer.packStructHeader( 3, runMessage.signature() );
-        packer.pack( runMessage.statement() );
+        packer.pack( runMessage.query() );
         packer.pack( runMessage.parameters() );
         packer.pack( runMessage.metadata() );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunMessage.java
@@ -29,30 +29,30 @@ import static java.lang.String.format;
 /**
  * RUN request message
  * <p>
- * Sent by clients to start a new Tank job for a given statement and
+ * Sent by clients to start a new Tank job for a given query and
  * parameter set.
  */
 public class RunMessage implements Message
 {
     public final static byte SIGNATURE = 0x10;
 
-    private final String statement;
+    private final String query;
     private final Map<String,Value> parameters;
 
-    public RunMessage( String statement )
+    public RunMessage( String query)
     {
-        this( statement, Collections.emptyMap() );
+        this(query, Collections.emptyMap() );
     }
 
-    public RunMessage( String statement, Map<String,Value> parameters )
+    public RunMessage(String query, Map<String,Value> parameters )
     {
-        this.statement = statement;
+        this.query = query;
         this.parameters = parameters;
     }
 
-    public String statement()
+    public String query()
     {
-        return statement;
+        return query;
     }
 
     public Map<String,Value> parameters()
@@ -69,7 +69,7 @@ public class RunMessage implements Message
     @Override
     public String toString()
     {
-        return format( "RUN \"%s\" %s", statement, parameters );
+        return format( "RUN \"%s\" %s", query, parameters );
     }
 
     @Override
@@ -87,14 +87,14 @@ public class RunMessage implements Message
         RunMessage that = (RunMessage) o;
 
         return !(parameters != null ? !parameters.equals( that.parameters ) : that.parameters != null) &&
-               !(statement != null ? !statement.equals( that.statement ) : that.statement != null);
+               !(query != null ? !query.equals( that.query) : that.query != null);
 
     }
 
     @Override
     public int hashCode()
     {
-        int result = statement != null ? statement.hashCode() : 0;
+        int result = query != null ? query.hashCode() : 0;
         result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
         return result;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.DatabaseName;
@@ -37,37 +37,37 @@ public class RunWithMetadataMessage extends MessageWithMetadata
 {
     public final static byte SIGNATURE = 0x10;
 
-    private final String statement;
+    private final String query;
     private final Map<String,Value> parameters;
 
-    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, TransactionConfig config, DatabaseName databaseName, AccessMode mode,
+    public static RunWithMetadataMessage autoCommitTxRunMessage(Query query, TransactionConfig config, DatabaseName databaseName, AccessMode mode,
             Bookmark bookmark )
     {
-        return autoCommitTxRunMessage( statement, config.timeout(), config.metadata(), databaseName, mode, bookmark );
+        return autoCommitTxRunMessage(query, config.timeout(), config.metadata(), databaseName, mode, bookmark );
     }
 
-    public static RunWithMetadataMessage autoCommitTxRunMessage( Statement statement, Duration txTimeout, Map<String,Value> txMetadata, DatabaseName databaseName,
+    public static RunWithMetadataMessage autoCommitTxRunMessage(Query query, Duration txTimeout, Map<String,Value> txMetadata, DatabaseName databaseName,
             AccessMode mode, Bookmark bookmark )
     {
         Map<String,Value> metadata = buildMetadata( txTimeout, txMetadata, databaseName, mode, bookmark );
-        return new RunWithMetadataMessage( statement.text(), statement.parameters().asMap( ofValue() ), metadata );
+        return new RunWithMetadataMessage( query.text(), query.parameters().asMap( ofValue() ), metadata );
     }
 
-    public static RunWithMetadataMessage explicitTxRunMessage( Statement statement )
+    public static RunWithMetadataMessage explicitTxRunMessage( Query query)
     {
-        return new RunWithMetadataMessage( statement.text(), statement.parameters().asMap( ofValue() ), emptyMap() );
+        return new RunWithMetadataMessage( query.text(), query.parameters().asMap( ofValue() ), emptyMap() );
     }
 
-    private RunWithMetadataMessage( String statement, Map<String,Value> parameters, Map<String,Value> metadata )
+    private RunWithMetadataMessage(String query, Map<String,Value> parameters, Map<String,Value> metadata )
     {
         super( metadata );
-        this.statement = statement;
+        this.query = query;
         this.parameters = parameters;
     }
 
-    public String statement()
+    public String query()
     {
-        return statement;
+        return query;
     }
 
     public Map<String,Value> parameters()
@@ -93,18 +93,18 @@ public class RunWithMetadataMessage extends MessageWithMetadata
             return false;
         }
         RunWithMetadataMessage that = (RunWithMetadataMessage) o;
-        return Objects.equals( statement, that.statement ) && Objects.equals( parameters, that.parameters ) && Objects.equals( metadata(), that.metadata() );
+        return Objects.equals(query, that.query) && Objects.equals( parameters, that.parameters ) && Objects.equals( metadata(), that.metadata() );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( statement, parameters, metadata() );
+        return Objects.hash(query, parameters, metadata() );
     }
 
     @Override
     public String toString()
     {
-        return "RUN \"" + statement + "\" " + parameters + " " + metadata();
+        return "RUN \"" + query + "\" " + parameters + " " + metadata();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -53,7 +53,7 @@ public class RunWithMetadataMessage extends MessageWithMetadata
         return new RunWithMetadataMessage( query.text(), query.parameters().asMap( ofValue() ), metadata );
     }
 
-    public static RunWithMetadataMessage explicitTxRunMessage( Query query)
+    public static RunWithMetadataMessage unmanagedTxRunMessage(Query query)
     {
         return new RunWithMetadataMessage( query.text(), query.parameters().asMap( ofValue() ), emptyMap() );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -33,9 +33,9 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursorOnlyFactory;
-import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
+import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
 import org.neo4j.driver.internal.handlers.InitResponseHandler;
@@ -159,8 +159,8 @@ public class BoltProtocolV1 implements BoltProtocol
     }
 
     @Override
-    public StatementResultCursorFactory runInAutoCommitTransaction( Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
-            TransactionConfig config, boolean waitForRunResponse, long ignored )
+    public ResultCursorFactory runInAutoCommitTransaction(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+                                                          TransactionConfig config, boolean waitForRunResponse, long ignored )
     {
         // bookmarks are ignored for auto-commit transactions in this version of the protocol
         verifyBeforeTransaction( config, connection.databaseName() );
@@ -168,8 +168,8 @@ public class BoltProtocolV1 implements BoltProtocol
     }
 
     @Override
-    public StatementResultCursorFactory runInExplicitTransaction( Connection connection, Statement statement, ExplicitTransaction tx,
-            boolean waitForRunResponse, long ignored )
+    public ResultCursorFactory runInExplicitTransaction(Connection connection, Statement statement, UnmanagedTransaction tx,
+                                                        boolean waitForRunResponse, long ignored )
     {
         return buildResultCursorFactory( connection, statement, tx, waitForRunResponse );
     }
@@ -180,8 +180,8 @@ public class BoltProtocolV1 implements BoltProtocol
         return VERSION;
     }
 
-    private static StatementResultCursorFactory buildResultCursorFactory( Connection connection, Statement statement,
-            ExplicitTransaction tx, boolean waitForRunResponse )
+    private static ResultCursorFactory buildResultCursorFactory(Connection connection, Statement statement,
+                                                                UnmanagedTransaction tx, boolean waitForRunResponse )
     {
         String query = statement.text();
         Map<String,Value> params = statement.parameters().asMap( ofValue() );
@@ -190,7 +190,7 @@ public class BoltProtocolV1 implements BoltProtocol
         RunResponseHandler runHandler = new RunResponseHandler( METADATA_EXTRACTOR );
         PullAllResponseHandler pullAllHandler = PullHandlers.newBoltV1PullAllHandler( statement, runHandler, connection, tx );
 
-        return new AsyncStatementResultCursorOnlyFactory( connection, runMessage, runHandler, pullAllHandler, waitForRunResponse );
+        return new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullAllHandler, waitForRunResponse );
     }
 
     private void verifyBeforeTransaction( TransactionConfig config, DatabaseName databaseName )

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
+import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
@@ -168,8 +169,8 @@ public class BoltProtocolV1 implements BoltProtocol
     }
 
     @Override
-    public ResultCursorFactory runInExplicitTransaction(Connection connection, Query query, UnmanagedTransaction tx,
-                                                        boolean waitForRunResponse, long ignored )
+    public ResultCursorFactory runInUnmanagedTransaction(Connection connection, Query query, UnmanagedTransaction tx,
+                                                         boolean waitForRunResponse, long ignored )
     {
         return buildResultCursorFactory( connection, query, tx, waitForRunResponse );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
+import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
@@ -57,7 +58,7 @@ import static org.neo4j.driver.internal.messaging.request.CommitMessage.COMMIT;
 import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.assertEmptyDatabaseName;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
 import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.autoCommitTxRunMessage;
-import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.explicitTxRunMessage;
+import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.unmanagedTxRunMessage;
 
 public class BoltProtocolV3 implements BoltProtocol
 {
@@ -147,10 +148,10 @@ public class BoltProtocolV3 implements BoltProtocol
     }
 
     @Override
-    public ResultCursorFactory runInExplicitTransaction(Connection connection, Query query, UnmanagedTransaction tx,
-                                                        boolean waitForRunResponse, long fetchSize )
+    public ResultCursorFactory runInUnmanagedTransaction(Connection connection, Query query, UnmanagedTransaction tx,
+                                                         boolean waitForRunResponse, long fetchSize )
     {
-        RunWithMetadataMessage runMessage = explicitTxRunMessage(query);
+        RunWithMetadataMessage runMessage = unmanagedTxRunMessage(query);
         return buildResultCursorFactory( connection, query, BookmarkHolder.NO_OP, tx, runMessage, waitForRunResponse, fetchSize );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
@@ -137,28 +137,28 @@ public class BoltProtocolV3 implements BoltProtocol
     }
 
     @Override
-    public ResultCursorFactory runInAutoCommitTransaction(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+    public ResultCursorFactory runInAutoCommitTransaction(Connection connection, Query query, BookmarkHolder bookmarkHolder,
                                                           TransactionConfig config, boolean waitForRunResponse, long fetchSize )
     {
         verifyDatabaseNameBeforeTransaction( connection.databaseName() );
         RunWithMetadataMessage runMessage =
-                autoCommitTxRunMessage( statement, config, connection.databaseName(), connection.mode(), bookmarkHolder.getBookmark() );
-        return buildResultCursorFactory( connection, statement, bookmarkHolder, null, runMessage, waitForRunResponse, fetchSize );
+                autoCommitTxRunMessage(query, config, connection.databaseName(), connection.mode(), bookmarkHolder.getBookmark() );
+        return buildResultCursorFactory( connection, query, bookmarkHolder, null, runMessage, waitForRunResponse, fetchSize );
     }
 
     @Override
-    public ResultCursorFactory runInExplicitTransaction(Connection connection, Statement statement, UnmanagedTransaction tx,
+    public ResultCursorFactory runInExplicitTransaction(Connection connection, Query query, UnmanagedTransaction tx,
                                                         boolean waitForRunResponse, long fetchSize )
     {
-        RunWithMetadataMessage runMessage = explicitTxRunMessage( statement );
-        return buildResultCursorFactory( connection, statement, BookmarkHolder.NO_OP, tx, runMessage, waitForRunResponse, fetchSize );
+        RunWithMetadataMessage runMessage = explicitTxRunMessage(query);
+        return buildResultCursorFactory( connection, query, BookmarkHolder.NO_OP, tx, runMessage, waitForRunResponse, fetchSize );
     }
 
-    protected ResultCursorFactory buildResultCursorFactory(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+    protected ResultCursorFactory buildResultCursorFactory(Connection connection, Query query, BookmarkHolder bookmarkHolder,
                                                            UnmanagedTransaction tx, RunWithMetadataMessage runMessage, boolean waitForRunResponse, long ignored )
     {
         RunResponseHandler runHandler = new RunResponseHandler( METADATA_EXTRACTOR );
-        PullAllResponseHandler pullHandler = newBoltV3PullAllHandler( statement, runHandler, connection, bookmarkHolder, tx );
+        PullAllResponseHandler pullHandler = newBoltV3PullAllHandler(query, runHandler, connection, bookmarkHolder, tx );
 
         return new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullHandler, waitForRunResponse );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.driver.internal.messaging.v4;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
@@ -48,13 +48,13 @@ public class BoltProtocolV4 extends BoltProtocolV3
     }
 
     @Override
-    protected ResultCursorFactory buildResultCursorFactory(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+    protected ResultCursorFactory buildResultCursorFactory(Connection connection, Query query, BookmarkHolder bookmarkHolder,
                                                            UnmanagedTransaction tx, RunWithMetadataMessage runMessage, boolean waitForRunResponse, long fetchSize )
     {
         RunResponseHandler runHandler = new RunResponseHandler( METADATA_EXTRACTOR );
 
-        PullAllResponseHandler pullAllHandler = newBoltV4AutoPullHandler( statement, runHandler, connection, bookmarkHolder, tx, fetchSize );
-        PullResponseHandler pullHandler = newBoltV4BasicPullHandler( statement, runHandler, connection, bookmarkHolder, tx );
+        PullAllResponseHandler pullAllHandler = newBoltV4AutoPullHandler(query, runHandler, connection, bookmarkHolder, tx, fetchSize );
+        PullResponseHandler pullHandler = newBoltV4BasicPullHandler(query, runHandler, connection, bookmarkHolder, tx );
 
         return new ResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRunResponse );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4.java
@@ -21,9 +21,9 @@ package org.neo4j.driver.internal.messaging.v4;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
-import org.neo4j.driver.internal.cursor.StatementResultCursorFactoryImpl;
-import org.neo4j.driver.internal.cursor.StatementResultCursorFactory;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cursor.ResultCursorFactoryImpl;
+import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler;
@@ -48,15 +48,15 @@ public class BoltProtocolV4 extends BoltProtocolV3
     }
 
     @Override
-    protected StatementResultCursorFactory buildResultCursorFactory( Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
-            ExplicitTransaction tx, RunWithMetadataMessage runMessage, boolean waitForRunResponse, long fetchSize )
+    protected ResultCursorFactory buildResultCursorFactory(Connection connection, Statement statement, BookmarkHolder bookmarkHolder,
+                                                           UnmanagedTransaction tx, RunWithMetadataMessage runMessage, boolean waitForRunResponse, long fetchSize )
     {
         RunResponseHandler runHandler = new RunResponseHandler( METADATA_EXTRACTOR );
 
         PullAllResponseHandler pullAllHandler = newBoltV4AutoPullHandler( statement, runHandler, connection, bookmarkHolder, tx, fetchSize );
         PullResponseHandler pullHandler = newBoltV4BasicPullHandler( statement, runHandler, connection, bookmarkHolder, tx );
 
-        return new StatementResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRunResponse );
+        return new ResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRunResponse );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractRxQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractRxQueryRunner.java
@@ -20,37 +20,37 @@ package org.neo4j.driver.internal.reactive;
 
 import java.util.Map;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.reactive.RxResult;
-import org.neo4j.driver.reactive.RxStatementRunner;
+import org.neo4j.driver.reactive.RxQueryRunner;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 
-import static org.neo4j.driver.internal.AbstractStatementRunner.parameters;
+import static org.neo4j.driver.internal.AbstractQueryRunner.parameters;
 
-public abstract class AbstractRxStatementRunner implements RxStatementRunner
+public abstract class AbstractRxQueryRunner implements RxQueryRunner
 {
     @Override
-    public final RxResult run(String statementTemplate, Value parameters )
+    public final RxResult run(String query, Value parameters )
     {
-        return run( new Statement( statementTemplate, parameters ) );
+        return run( new Query( query, parameters ) );
     }
 
     @Override
-    public final RxResult run(String statementTemplate, Map<String,Object> statementParameters )
+    public final RxResult run(String query, Map<String,Object> parameters )
     {
-        return run( statementTemplate, parameters( statementParameters ) );
+        return run( query, parameters( parameters ) );
     }
 
     @Override
-    public final RxResult run(String statementTemplate, Record statementParameters )
+    public final RxResult run(String query, Record parameters )
     {
-        return run( statementTemplate, parameters( statementParameters ) );
+        return run( query, parameters( parameters ) );
     }
 
     @Override
-    public final RxResult run(String statementTemplate )
+    public final RxResult run(String query )
     {
-        return run( new Statement( statementTemplate ) );
+        return run( new Query( query ) );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractRxStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractRxStatementRunner.java
@@ -20,7 +20,7 @@ package org.neo4j.driver.internal.reactive;
 
 import java.util.Map;
 
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxStatementRunner;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
@@ -31,25 +31,25 @@ import static org.neo4j.driver.internal.AbstractStatementRunner.parameters;
 public abstract class AbstractRxStatementRunner implements RxStatementRunner
 {
     @Override
-    public final RxStatementResult run( String statementTemplate, Value parameters )
+    public final RxResult run(String statementTemplate, Value parameters )
     {
         return run( new Statement( statementTemplate, parameters ) );
     }
 
     @Override
-    public final RxStatementResult run( String statementTemplate, Map<String,Object> statementParameters )
+    public final RxResult run(String statementTemplate, Map<String,Object> statementParameters )
     {
         return run( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final RxStatementResult run( String statementTemplate, Record statementParameters )
+    public final RxResult run(String statementTemplate, Record statementParameters )
     {
         return run( statementTemplate, parameters( statementParameters ) );
     }
 
     @Override
-    public final RxStatementResult run( String statementTemplate )
+    public final RxResult run(String statementTemplate )
     {
         return run( new Statement( statementTemplate ) );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
@@ -29,20 +29,20 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.util.Futures;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.summary.ResultSummary;
 
 import static org.neo4j.driver.internal.util.ErrorUtil.newResultConsumedError;
 import static reactor.core.publisher.FluxSink.OverflowStrategy.IGNORE;
 
-public class InternalRxStatementResult implements RxStatementResult
+public class InternalRxResult implements RxResult
 {
-    private Supplier<CompletionStage<RxStatementResultCursor>> cursorFutureSupplier;
-    private volatile CompletionStage<RxStatementResultCursor> cursorFuture;
+    private Supplier<CompletionStage<RxResultCursor>> cursorFutureSupplier;
+    private volatile CompletionStage<RxResultCursor> cursorFuture;
 
-    public InternalRxStatementResult( Supplier<CompletionStage<RxStatementResultCursor>> cursorFuture )
+    public InternalRxResult(Supplier<CompletionStage<RxResultCursor>> cursorFuture )
     {
         this.cursorFutureSupplier = cursorFuture;
     }
@@ -50,7 +50,7 @@ public class InternalRxStatementResult implements RxStatementResult
     @Override
     public Publisher<List<String>> keys()
     {
-        return Mono.defer( () -> Mono.fromCompletionStage( getCursorFuture() ).map( RxStatementResultCursor::keys )
+        return Mono.defer( () -> Mono.fromCompletionStage( getCursorFuture() ).map( RxResultCursor::keys )
                 .onErrorMap( Futures::completionExceptionCause ) );
     }
 
@@ -105,7 +105,7 @@ public class InternalRxStatementResult implements RxStatementResult
         };
     }
 
-    private CompletionStage<RxStatementResultCursor> getCursorFuture()
+    private CompletionStage<RxResultCursor> getCursorFuture()
     {
         if ( cursorFuture != null )
         {
@@ -114,7 +114,7 @@ public class InternalRxStatementResult implements RxStatementResult
         return initCursorFuture();
     }
 
-    synchronized CompletionStage<RxStatementResultCursor> initCursorFuture()
+    synchronized CompletionStage<RxResultCursor> initCursorFuture()
     {
         // A quick path to return
         if ( cursorFuture != null )
@@ -155,7 +155,7 @@ public class InternalRxStatementResult implements RxStatementResult
     }
 
     // For testing purpose
-    Supplier<CompletionStage<RxStatementResultCursor>> cursorFutureSupplier()
+    Supplier<CompletionStage<RxResultCursor>> cursorFutureSupplier()
     {
         return this.cursorFutureSupplier;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
@@ -30,9 +30,9 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.exceptions.TransactionNestingException;
 import org.neo4j.driver.internal.async.NetworkSession;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.util.Futures;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.reactive.RxTransactionWork;
@@ -129,28 +129,28 @@ public class InternalRxSession extends AbstractRxStatementRunner implements RxSe
     }
 
     @Override
-    public RxStatementResult run( String statement, TransactionConfig config )
+    public RxResult run(String statement, TransactionConfig config )
     {
         return run( new Statement( statement ), config );
     }
 
     @Override
-    public RxStatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config )
+    public RxResult run(String statement, Map<String,Object> parameters, TransactionConfig config )
     {
         return run( new Statement( statement, parameters ), config );
     }
 
     @Override
-    public RxStatementResult run( Statement statement )
+    public RxResult run(Statement statement )
     {
         return run( statement, TransactionConfig.empty() );
     }
 
     @Override
-    public RxStatementResult run( Statement statement, TransactionConfig config )
+    public RxResult run(Statement statement, TransactionConfig config )
     {
-        return new InternalRxStatementResult( () -> {
-            CompletableFuture<RxStatementResultCursor> resultCursorFuture = new CompletableFuture<>();
+        return new InternalRxResult( () -> {
+            CompletableFuture<RxResultCursor> resultCursorFuture = new CompletableFuture<>();
             session.runRx( statement, config ).whenComplete( ( cursor, completionError ) -> {
                 if ( cursor != null )
                 {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.reactive;
 
+import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -25,7 +26,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.exceptions.TransactionNestingException;
@@ -40,7 +40,7 @@ import org.neo4j.driver.reactive.RxTransactionWork;
 import static org.neo4j.driver.internal.reactive.RxUtils.createEmptyPublisher;
 import static org.neo4j.driver.internal.reactive.RxUtils.createMono;
 
-public class InternalRxSession extends AbstractRxStatementRunner implements RxSession
+public class InternalRxSession extends AbstractRxQueryRunner implements RxSession
 {
     private final NetworkSession session;
 
@@ -129,29 +129,29 @@ public class InternalRxSession extends AbstractRxStatementRunner implements RxSe
     }
 
     @Override
-    public RxResult run(String statement, TransactionConfig config )
+    public RxResult run(String query, TransactionConfig config )
     {
-        return run( new Statement( statement ), config );
+        return run( new Query( query ), config );
     }
 
     @Override
-    public RxResult run(String statement, Map<String,Object> parameters, TransactionConfig config )
+    public RxResult run(String query, Map<String,Object> parameters, TransactionConfig config )
     {
-        return run( new Statement( statement, parameters ), config );
+        return run( new Query( query, parameters ), config );
     }
 
     @Override
-    public RxResult run(Statement statement )
+    public RxResult run(Query query)
     {
-        return run( statement, TransactionConfig.empty() );
+        return run(query, TransactionConfig.empty() );
     }
 
     @Override
-    public RxResult run(Statement statement, TransactionConfig config )
+    public RxResult run(Query query, TransactionConfig config )
     {
         return new InternalRxResult( () -> {
             CompletableFuture<RxResultCursor> resultCursorFuture = new CompletableFuture<>();
-            session.runRx( statement, config ).whenComplete( ( cursor, completionError ) -> {
+            session.runRx(query, config ).whenComplete( (cursor, completionError ) -> {
                 if ( cursor != null )
                 {
                     resultCursorFuture.complete( cursor );

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -23,28 +23,28 @@ import org.reactivestreams.Publisher;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.util.Futures;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 
 import static org.neo4j.driver.internal.reactive.RxUtils.createEmptyPublisher;
 
 public class InternalRxTransaction extends AbstractRxStatementRunner implements RxTransaction
 {
-    private final ExplicitTransaction tx;
+    private final UnmanagedTransaction tx;
 
-    public InternalRxTransaction( ExplicitTransaction tx )
+    public InternalRxTransaction( UnmanagedTransaction tx )
     {
         this.tx = tx;
     }
 
     @Override
-    public RxStatementResult run( Statement statement )
+    public RxResult run(Statement statement )
     {
-        return new InternalRxStatementResult( () -> {
-            CompletableFuture<RxStatementResultCursor> cursorFuture = new CompletableFuture<>();
+        return new InternalRxResult( () -> {
+            CompletableFuture<RxResultCursor> cursorFuture = new CompletableFuture<>();
             tx.runRx( statement ).whenComplete( ( cursor, completionError ) -> {
                 if ( cursor != null )
                 {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -18,11 +18,11 @@
  */
 package org.neo4j.driver.internal.reactive;
 
+import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.util.Futures;
@@ -31,7 +31,7 @@ import org.neo4j.driver.reactive.RxTransaction;
 
 import static org.neo4j.driver.internal.reactive.RxUtils.createEmptyPublisher;
 
-public class InternalRxTransaction extends AbstractRxStatementRunner implements RxTransaction
+public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTransaction
 {
     private final UnmanagedTransaction tx;
 
@@ -41,11 +41,11 @@ public class InternalRxTransaction extends AbstractRxStatementRunner implements 
     }
 
     @Override
-    public RxResult run(Statement statement )
+    public RxResult run(Query query)
     {
         return new InternalRxResult( () -> {
             CompletableFuture<RxResultCursor> cursorFuture = new CompletableFuture<>();
-            tx.runRx( statement ).whenComplete( ( cursor, completionError ) -> {
+            tx.runRx(query).whenComplete( (cursor, completionError ) -> {
                 if ( cursor != null )
                 {
                     cursorFuture.complete( cursor );

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalPlan.java
@@ -131,7 +131,7 @@ public class InternalPlan<T extends Plan> implements Plan
         }
     };
 
-    /** Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` statement */
+    /** Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` query */
     public static final Function<Value, Plan> EXPLAIN_PLAN_FROM_VALUE = new Converter<>(EXPLAIN_PLAN);
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalProfiledPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalProfiledPlan.java
@@ -102,7 +102,7 @@ public class InternalProfiledPlan extends InternalPlan<ProfiledPlan> implements 
     };
 
     /**
-     * Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` statement
+     * Builds a regular plan without profiling information - eg. a plan that came as a result of an `EXPLAIN` query
      */
     public static final Function<Value,ProfiledPlan> PROFILED_PLAN_FROM_VALUE = new Converter<>( PROFILED_PLAN );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalResultSummary.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalResultSummary.java
@@ -23,21 +23,21 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.summary.DatabaseInfo;
 import org.neo4j.driver.summary.Notification;
 import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ProfiledPlan;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.ServerInfo;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 import org.neo4j.driver.summary.SummaryCounters;
 
 public class InternalResultSummary implements ResultSummary
 {
-    private final Statement statement;
+    private final Query query;
     private final ServerInfo serverInfo;
-    private final StatementType statementType;
+    private final QueryType queryType;
     private final SummaryCounters counters;
     private final Plan plan;
     private final ProfiledPlan profile;
@@ -46,13 +46,13 @@ public class InternalResultSummary implements ResultSummary
     private final long resultConsumedAfter;
     private final DatabaseInfo databaseInfo;
 
-    public InternalResultSummary( Statement statement, ServerInfo serverInfo, DatabaseInfo databaseInfo, StatementType statementType,
-            SummaryCounters counters, Plan plan, ProfiledPlan profile, List<Notification> notifications, long resultAvailableAfter, long resultConsumedAfter )
+    public InternalResultSummary(Query query, ServerInfo serverInfo, DatabaseInfo databaseInfo, QueryType queryType,
+                                 SummaryCounters counters, Plan plan, ProfiledPlan profile, List<Notification> notifications, long resultAvailableAfter, long resultConsumedAfter )
     {
-        this.statement = statement;
+        this.query = query;
         this.serverInfo = serverInfo;
         this.databaseInfo = databaseInfo;
-        this.statementType = statementType;
+        this.queryType = queryType;
         this.counters = counters;
         this.plan = resolvePlan( plan, profile );
         this.profile = profile;
@@ -62,9 +62,9 @@ public class InternalResultSummary implements ResultSummary
     }
 
     @Override
-    public Statement statement()
+    public Query query()
     {
-        return statement;
+        return query;
     }
 
     @Override
@@ -74,9 +74,9 @@ public class InternalResultSummary implements ResultSummary
     }
 
     @Override
-    public StatementType statementType()
+    public QueryType queryType()
     {
-        return statementType;
+        return queryType;
     }
 
     @Override
@@ -149,9 +149,9 @@ public class InternalResultSummary implements ResultSummary
         InternalResultSummary that = (InternalResultSummary) o;
         return resultAvailableAfter == that.resultAvailableAfter &&
                resultConsumedAfter == that.resultConsumedAfter &&
-               Objects.equals( statement, that.statement ) &&
+               Objects.equals(query, that.query) &&
                Objects.equals( serverInfo, that.serverInfo ) &&
-               statementType == that.statementType &&
+               queryType == that.queryType &&
                Objects.equals( counters, that.counters ) &&
                Objects.equals( plan, that.plan ) &&
                Objects.equals( profile, that.profile ) &&
@@ -161,7 +161,7 @@ public class InternalResultSummary implements ResultSummary
     @Override
     public int hashCode()
     {
-        return Objects.hash( statement, serverInfo, statementType, counters, plan, profile, notifications,
+        return Objects.hash(query, serverInfo, queryType, counters, plan, profile, notifications,
                 resultAvailableAfter, resultConsumedAfter );
     }
 
@@ -169,10 +169,10 @@ public class InternalResultSummary implements ResultSummary
     public String toString()
     {
         return "InternalResultSummary{" +
-               "statement=" + statement +
+               "query=" + query +
                ", serverInfo=" + serverInfo +
                ", databaseInfo=" + databaseInfo +
-               ", statementType=" + statementType +
+               ", queryType=" + queryType +
                ", counters=" + counters +
                ", plan=" + plan +
                ", profile=" + profile +

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -57,7 +57,7 @@ public final class ErrorUtil
     public static ResultConsumedException newResultConsumedError()
     {
         return new ResultConsumedException( "Cannot access records on this result any more as the result has already been consumed " +
-                "or the statement runner where the result is created has already been closed." );
+                "or the query runner where the result is created has already been closed." );
     }
 
     public static Neo4jException newNeo4jError( String code, String message )

--- a/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.UntrustedServerException;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -42,7 +42,7 @@ import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ProfiledPlan;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.ServerInfo;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 
 import static java.util.Collections.emptyList;
 import static org.neo4j.driver.internal.summary.InternalDatabaseInfo.DEFAULT_DATABASE_INFO;
@@ -60,7 +60,7 @@ public class MetadataExtractor
         this.resultConsumedAfterMetadataKey = resultConsumedAfterMetadataKey;
     }
 
-    public List<String> extractStatementKeys( Map<String,Value> metadata )
+    public List<String> extractQueryKeys(Map<String,Value> metadata )
     {
         Value keysValue = metadata.get( "fields" );
         if ( keysValue != null )
@@ -81,10 +81,10 @@ public class MetadataExtractor
 
     public long extractQueryId( Map<String,Value> metadata )
     {
-        Value statementId = metadata.get( "qid" );
-        if ( statementId != null )
+        Value queryId = metadata.get( "qid" );
+        if ( queryId != null )
         {
-            return statementId.asLong();
+            return queryId.asLong();
         }
         return ABSENT_QUERY_ID;
     }
@@ -100,11 +100,11 @@ public class MetadataExtractor
         return -1;
     }
 
-    public ResultSummary extractSummary( Statement statement, Connection connection, long resultAvailableAfter, Map<String,Value> metadata )
+    public ResultSummary extractSummary(Query query, Connection connection, long resultAvailableAfter, Map<String,Value> metadata )
     {
         ServerInfo serverInfo = new InternalServerInfo( connection.serverAddress(), connection.serverVersion() );
         DatabaseInfo dbInfo = extractDatabaseInfo( metadata );
-        return new InternalResultSummary( statement, serverInfo, dbInfo, extractStatementType( metadata ), extractCounters( metadata ), extractPlan( metadata ),
+        return new InternalResultSummary(query, serverInfo, dbInfo, extractQueryType( metadata ), extractCounters( metadata ), extractPlan( metadata ),
                 extractProfiledPlan( metadata ), extractNotifications( metadata ), resultAvailableAfter,
                 extractResultConsumedAfter( metadata, resultConsumedAfterMetadataKey ) );
     }
@@ -153,12 +153,12 @@ public class MetadataExtractor
         }
     }
 
-    private static StatementType extractStatementType( Map<String,Value> metadata )
+    private static QueryType extractQueryType(Map<String,Value> metadata )
     {
         Value typeValue = metadata.get( "type" );
         if ( typeValue != null )
         {
-            return StatementType.fromCode( typeValue.asString() );
+            return QueryType.fromCode( typeValue.asString() );
         }
         return null;
     }

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxQueryRunner.java
@@ -20,26 +20,26 @@ package org.neo4j.driver.reactive;
 
 import java.util.Map;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 
 /**
- * Common interface for components that can execute Neo4j statements using Reactive API.
+ * Common interface for components that can execute Neo4j queries using Reactive API.
  * @see RxSession
  * @see RxTransaction
  * @since 2.0
  */
-public interface RxStatementRunner
+public interface RxQueryRunner
 {
     /**
-     * Register running of a statement and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Register running of a query and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      *
@@ -50,19 +50,19 @@ public interface RxStatementRunner
      * If you are creating parameters programmatically, {@link #run(String, Map)}
      * might be more helpful, it converts your map to a {@link Value} for you.
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
      * @return a reactive result.
      */
-    RxResult run(String statementTemplate, Value parameters );
+    RxResult run(String query, Value parameters );
 
     /**
-     * Register running of a statement and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Register running of a query and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      *
@@ -70,48 +70,48 @@ public interface RxStatementRunner
      * must be values that can be converted to Neo4j types. See {@link Values#parameters(Object...)} for
      * a list of allowed types.
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return a reactive result.
      */
-    RxResult run(String statementTemplate, Map<String,Object> statementParameters );
+    RxResult run(String query, Map<String,Object> parameters );
 
     /**
-     * Register running of a statement and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Register running of a query and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
      * This method takes a set of parameters that will be injected into the
-     * statement by Neo4j. Using parameters is highly encouraged, it helps avoid
+     * query by Neo4j. Using parameters is highly encouraged, it helps avoid
      * dangerous cypher injection attacks and improves database performance as
      * Neo4j can re-use query plans more often.
      *
      * This version of run takes a {@link Record} of parameters, which can be useful
-     * if you want to use the output of one statement as input for another.
+     * if you want to use the output of one query as input for another.
      *
-     * @param statementTemplate text of a Neo4j statement
-     * @param statementParameters input data for the statement
+     * @param query text of a Neo4j query
+     * @param parameters input data for the query
      * @return a reactive result.
      */
-    RxResult run(String statementTemplate, Record statementParameters );
+    RxResult run(String query, Record parameters );
 
     /**
-     * Register running of a statement and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Register running of a query and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
-     * @param statementTemplate text of a Neo4j statement
+     * @param query text of a Neo4j query
      * @return a reactive result.
      */
-    RxResult run(String statementTemplate );
+    RxResult run(String query );
 
     /**
-     * Register running of a statement and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Register running of a query and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
-     * @param statement a Neo4j statement
+     * @param query a Neo4j query
      * @return a reactive result.
      */
-    RxResult run(Statement statement );
+    RxResult run(Query query);
 }

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
@@ -41,7 +41,7 @@ import org.neo4j.driver.summary.ResultSummary;
  * @see Subscription
  * @since 2.0
  */
-public interface RxStatementResult
+public interface RxResult
 {
     /**
      * Returns a cold publisher of keys.
@@ -69,7 +69,7 @@ public interface RxStatementResult
      * Returns a cold unicast publisher of records.
      * <p>
      * When the record publisher is {@linkplain Publisher#subscribe(Subscriber) subscribed},
-     * the query statement is executed and the statement result is streamed back as a record stream followed by a result summary.
+     * the query statement is executed and the result is streamed back as a record stream followed by a result summary.
      * This record publisher publishes all records in the result and signals the completion.
      * However before completion or error reporting if any, a cleanup of result resources such as network connection will be carried out automatically.
      * <p>

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
@@ -33,7 +33,7 @@ import org.neo4j.driver.Bookmark;
 /**
  * A reactive session is the same as {@link Session} except it provides a reactive API.
  * @see Session
- * @see RxStatementResult
+ * @see RxResult
  * @see RxTransaction
  * @see Publisher
  * @since 2.0
@@ -161,7 +161,7 @@ public interface RxSession extends RxStatementRunner
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxStatementResult run( String statement, TransactionConfig config );
+    RxResult run(String statement, TransactionConfig config );
 
     /**
      * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig} and return a reactive result stream.
@@ -199,7 +199,7 @@ public interface RxSession extends RxStatementRunner
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxStatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config );
+    RxResult run(String statement, Map<String,Object> parameters, TransactionConfig config );
 
     /**
      * Run a statement in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a reactive result stream.
@@ -225,7 +225,7 @@ public interface RxSession extends RxStatementRunner
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxStatementResult run( Statement statement, TransactionConfig config );
+    RxResult run(Statement statement, TransactionConfig config );
 
     /**
      * Return the bookmark received following the last completed statement within this session.

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
@@ -41,7 +41,7 @@ import org.neo4j.driver.Bookmark;
 public interface RxSession extends RxQueryRunner
 {
     /**
-     * Begin a new <em>explicit {@linkplain RxTransaction transaction}</em>. At
+     * Begin a new <em>unmanaged {@linkplain RxTransaction transaction}</em>. At
      * most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent
      * sessions.
@@ -53,7 +53,7 @@ public interface RxSession extends RxQueryRunner
     Publisher<RxTransaction> beginTransaction();
 
     /**
-     * Begin a new <em>explicit {@linkplain RxTransaction transaction}</em> with the specified {@link TransactionConfig configuration}.
+     * Begin a new <em>unmanaged {@linkplain RxTransaction transaction}</em> with the specified {@link TransactionConfig configuration}.
      * At most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent sessions.
      * <p>

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.reactive;
 
+import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 
 import java.util.Map;
@@ -25,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.Bookmark;
@@ -38,7 +38,7 @@ import org.neo4j.driver.Bookmark;
  * @see Publisher
  * @since 2.0
  */
-public interface RxSession extends RxStatementRunner
+public interface RxSession extends RxQueryRunner
 {
     /**
      * Begin a new <em>explicit {@linkplain RxTransaction transaction}</em>. At
@@ -153,22 +153,22 @@ public interface RxSession extends RxStatementRunner
     <T> Publisher<T> writeTransaction( RxTransactionWork<? extends Publisher<T>> work, TransactionConfig config );
 
     /**
-     * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig} and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Run a query with parameters in an auto-commit transaction with specified {@link TransactionConfig} and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      *
-     * @param statement text of a Neo4j statement.
+     * @param query text of a Neo4j query.
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxResult run(String statement, TransactionConfig config );
+    RxResult run(String query, TransactionConfig config );
 
     /**
-     * Run a statement with parameters in an auto-commit transaction with specified {@link TransactionConfig} and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Run a query with parameters in an auto-commit transaction with specified {@link TransactionConfig} and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      * <p>
-     * This method takes a set of parameters that will be injected into the statement by Neo4j.
+     * This method takes a set of parameters that will be injected into the query by Neo4j.
      * Using parameters is highly encouraged, it helps avoid dangerous cypher injection attacks
      * and improves database performance as Neo4j can re-use query plans more often.
      * <p>
@@ -194,17 +194,17 @@ public interface RxSession extends RxStatementRunner
      * }
      * </pre>
      *
-     * @param statement text of a Neo4j statement.
-     * @param parameters input data for the statement.
+     * @param query text of a Neo4j query.
+     * @param parameters input data for the query.
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxResult run(String statement, Map<String,Object> parameters, TransactionConfig config );
+    RxResult run(String query, Map<String,Object> parameters, TransactionConfig config );
 
     /**
-     * Run a statement in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a reactive result stream.
-     * The statement is not executed when the reactive result is returned.
-     * Instead, the publishers in the result will actually start the execution of the statement.
+     * Run a query in an auto-commit transaction with specified {@link TransactionConfig configuration} and return a reactive result stream.
+     * The query is not executed when the reactive result is returned.
+     * Instead, the publishers in the result will actually start the execution of the query.
      * <h2>Example</h2>
      * <pre>
      * {@code
@@ -216,21 +216,21 @@ public interface RxSession extends RxStatementRunner
      *                 .withMetadata(metadata)
      *                 .build();
      *
-     * Statement statement = new Statement("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
-     * RxResult result = rxSession.run(statement.withParameters(Values.parameters("myNameParam", "Bob")));
+     * Query query = new Query("MATCH (n) WHERE n.name=$myNameParam RETURN n.age");
+     * RxResult result = rxSession.run(query.withParameters(Values.parameters("myNameParam", "Bob")));
      * }
      * </pre>
      *
-     * @param statement a Neo4j statement.
+     * @param query a Neo4j query.
      * @param config configuration for the new transaction.
      * @return a reactive result.
      */
-    RxResult run(Statement statement, TransactionConfig config );
+    RxResult run(Query query, TransactionConfig config );
 
     /**
-     * Return the bookmark received following the last completed statement within this session.
-     * The last completed statement can be run in a {@linkplain RxTransaction transaction}
-     * started using {@linkplain #beginTransaction() beginTransaction} or directly via {@link #run(Statement) run}.
+     * Return the bookmark received following the last completed query within this session.
+     * The last completed query can be run in a {@linkplain RxTransaction transaction}
+     * started using {@linkplain #beginTransaction() beginTransaction} or directly via {@link #run(Query) run}.
      *
      * @return a reference to a previous transaction.
      */
@@ -244,9 +244,9 @@ public interface RxSession extends RxStatementRunner
      * 2) all transactions opened by this session have been either committed or rolled back.
      * <p>
      * This method is a fallback if you failed to fulfill the two requirements above.
-     * This publisher is completed when all outstanding statements in the session have completed,
+     * This publisher is completed when all outstanding queries in the session have completed,
      * meaning any writes you performed are guaranteed to be durably stored.
-     * It might be completed exceptionally when there are unconsumed errors from previous statements or transactions.
+     * It might be completed exceptionally when there are unconsumed errors from previous queries or transactions.
      *
      * @param <T> makes it easier to be chained.
      * @return an empty publisher that represents the reactive close.

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxStatementRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxStatementRunner.java
@@ -54,7 +54,7 @@ public interface RxStatementRunner
      * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
      * @return a reactive result.
      */
-    RxStatementResult run( String statementTemplate, Value parameters );
+    RxResult run(String statementTemplate, Value parameters );
 
     /**
      * Register running of a statement and return a reactive result stream.
@@ -74,7 +74,7 @@ public interface RxStatementRunner
      * @param statementParameters input data for the statement
      * @return a reactive result.
      */
-    RxStatementResult run( String statementTemplate, Map<String,Object> statementParameters );
+    RxResult run(String statementTemplate, Map<String,Object> statementParameters );
 
     /**
      * Register running of a statement and return a reactive result stream.
@@ -93,7 +93,7 @@ public interface RxStatementRunner
      * @param statementParameters input data for the statement
      * @return a reactive result.
      */
-    RxStatementResult run( String statementTemplate, Record statementParameters );
+    RxResult run(String statementTemplate, Record statementParameters );
 
     /**
      * Register running of a statement and return a reactive result stream.
@@ -103,7 +103,7 @@ public interface RxStatementRunner
      * @param statementTemplate text of a Neo4j statement
      * @return a reactive result.
      */
-    RxStatementResult run( String statementTemplate );
+    RxResult run(String statementTemplate );
 
     /**
      * Register running of a statement and return a reactive result stream.
@@ -113,5 +113,5 @@ public interface RxStatementRunner
      * @param statement a Neo4j statement
      * @return a reactive result.
      */
-    RxStatementResult run( Statement statement );
+    RxResult run(Statement statement );
 }

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxTransaction.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.Transaction;
  * @see Publisher
  * @since 2.0
  */
-public interface RxTransaction extends RxStatementRunner
+public interface RxTransaction extends RxQueryRunner
 {
     /**
      * Commits the transaction.

--- a/driver/src/main/java/org/neo4j/driver/summary/InputPosition.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/InputPosition.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.summary;
 import org.neo4j.driver.util.Immutable;
 
 /**
- * An input position refers to a specific character in a statement.
+ * An input position refers to a specific character in a query.
  * @since 1.0
  */
 @Immutable

--- a/driver/src/main/java/org/neo4j/driver/summary/Notification.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Notification.java
@@ -21,9 +21,9 @@ package org.neo4j.driver.summary;
 import org.neo4j.driver.util.Immutable;
 
 /**
- * Representation for notifications found when executing a statement.
+ * Representation for notifications found when executing a query.
  *
- * A notification can be visualized in a client pinpointing problems or other information about the statement.
+ * A notification can be visualized in a client pinpointing problems or other information about the query.
  * @since 1.0
  */
 @Immutable
@@ -48,10 +48,10 @@ public interface Notification
     String description();
 
     /**
-     * The position in the statement where this notification points to.
+     * The position in the query where this notification points to.
      * Not all notifications have a unique position to point to and in that case the position would be set to null.
      *
-     * @return the position in the statement where the issue was found, or null if no position is associated with this
+     * @return the position in the query where the issue was found, or null if no position is associated with this
      * notification.
      */
     InputPosition position();

--- a/driver/src/main/java/org/neo4j/driver/summary/Plan.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Plan.java
@@ -25,11 +25,11 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.util.Immutable;
 
 /**
- * This describes the plan that the database planner produced and used (or will use) to execute your statement.
- * This can be extremely helpful in understanding what a statement is doing, and how to optimize it. For more
+ * This describes the plan that the database planner produced and used (or will use) to execute your query.
+ * This can be extremely helpful in understanding what a query is doing, and how to optimize it. For more
  * details, see the Neo4j Manual.
  *
- * The plan for the statement is a tree of plans - each sub-tree containing zero or more child plans. The statement
+ * The plan for the query is a tree of plans - each sub-tree containing zero or more child plans. The query
  * starts with the root plan. Each sub-plan is of a specific {@link #operatorType() operator type}, which describes
  * what that part of the plan does - for instance, perform an index lookup or filter results. The Neo4j Manual contains
  * a reference of the available operator types, and these may differ across Neo4j versions.

--- a/driver/src/main/java/org/neo4j/driver/summary/QueryType.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/QueryType.java
@@ -21,30 +21,30 @@ package org.neo4j.driver.summary;
 import org.neo4j.driver.exceptions.ClientException;
 
 /**
- * The type of statement executed.
+ * The type of query executed.
  * @since 1.0
  */
-public enum StatementType
+public enum QueryType
 {
     READ_ONLY,
     READ_WRITE,
     WRITE_ONLY,
     SCHEMA_WRITE;
 
-    public static StatementType fromCode( String type )
+    public static QueryType fromCode(String type )
     {
         switch ( type )
         {
         case "r":
-            return StatementType.READ_ONLY;
+            return QueryType.READ_ONLY;
         case "rw":
-            return StatementType.READ_WRITE;
+            return QueryType.READ_WRITE;
         case "w":
-            return StatementType.WRITE_ONLY;
+            return QueryType.WRITE_ONLY;
         case "s":
-            return StatementType.SCHEMA_WRITE;
+            return QueryType.SCHEMA_WRITE;
         default:
-            throw new ClientException( "Unknown statement type: `" + type + "`." );
+            throw new ClientException( "Unknown query type: `" + type + "`." );
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/summary/ResultSummary.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/ResultSummary.java
@@ -21,11 +21,11 @@ package org.neo4j.driver.summary;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.util.Immutable;
 
 /**
- * The result summary of running a statement. The result summary interface can be used to investigate
+ * The result summary of running a query. The result summary interface can be used to investigate
  * details about the result, like the type of query run, how many and which kinds of updates have been executed,
  * and query plan and profiling information if available.
  *
@@ -38,57 +38,57 @@ import org.neo4j.driver.util.Immutable;
 public interface ResultSummary
 {
     /**
-     * @return statement that has been executed
+     * @return query that has been executed
      */
-    Statement statement();
+    Query query();
 
     /**
-     * @return counters for operations the statement triggered
+     * @return counters for operations the query triggered
      */
     SummaryCounters counters();
 
     /**
-     * @return type of statement that has been executed
+     * @return type of query that has been executed
      */
-    StatementType statementType();
+    QueryType queryType();
 
     /**
-     * @return true if the result contained a statement plan, i.e. is the summary of a Cypher "PROFILE" or "EXPLAIN" statement
+     * @return true if the result contained a query plan, i.e. is the summary of a Cypher "PROFILE" or "EXPLAIN" query
      */
     boolean hasPlan();
 
     /**
-     * @return true if the result contained profiling information, i.e. is the summary of a Cypher "PROFILE" statement
+     * @return true if the result contained profiling information, i.e. is the summary of a Cypher "PROFILE" query
      */
     boolean hasProfile();
 
     /**
-     * This describes how the database will execute your statement.
+     * This describes how the database will execute your query.
      *
-     * @return statement plan for the executed statement if available, otherwise null
+     * @return query plan for the executed query if available, otherwise null
      */
     Plan plan();
 
     /**
-     * This describes how the database did execute your statement.
+     * This describes how the database did execute your query.
      *
-     * If the statement you executed {@link #hasProfile() was profiled}, the statement plan will contain detailed
-     * information about what each step of the plan did. That more in-depth version of the statement plan becomes
+     * If the query you executed {@link #hasProfile() was profiled}, the query plan will contain detailed
+     * information about what each step of the plan did. That more in-depth version of the query plan becomes
      * available here.
      *
-     * @return profiled statement plan for the executed statement if available, otherwise null
+     * @return profiled query plan for the executed query if available, otherwise null
      */
     ProfiledPlan profile();
 
     /**
-     * A list of notifications that might arise when executing the statement.
-     * Notifications can be warnings about problematic statements or other valuable information that can be presented
+     * A list of notifications that might arise when executing the query.
+     * Notifications can be warnings about problematic queries or other valuable information that can be presented
      * in a client.
      *
-     * Unlike failures or errors, notifications do not affect the execution of a statement.
+     * Unlike failures or errors, notifications do not affect the execution of a query.
      *
-     * @return a list of notifications produced while executing the statement. The list will be empty if no
-     * notifications produced while executing the statement.
+     * @return a list of notifications produced while executing the query. The list will be empty if no
+     * notifications produced while executing the query.
      */
     List<Notification> notifications();
 

--- a/driver/src/main/java/org/neo4j/driver/summary/SummaryCounters.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/SummaryCounters.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.summary;
 import org.neo4j.driver.util.Immutable;
 
 /**
- * Contains counters for various operations that a statement triggered.
+ * Contains counters for various operations that a query triggered.
  * @since 1.0
  */
 @Immutable
@@ -29,7 +29,7 @@ public interface SummaryCounters
 {
     /**
      * Whether there were any updates at all, eg. any of the counters are greater than 0.
-     * @return true if the statement made any updates
+     * @return true if the query made any updates
      */
     boolean containsUpdates();
 

--- a/driver/src/main/javadoc/overview.html
+++ b/driver/src/main/javadoc/overview.html
@@ -43,7 +43,7 @@ public class SmallExample
         try (Session session = driver.session())
         {
             // Auto-commit transactions are a quick and easy way to wrap a read.
-            StatementResult result = session.run(
+            Result result = session.run(
                     "MATCH (a:Person) WHERE a.name STARTS WITH $x RETURN a.name AS name",
                     parameters("x", initial));
             // Each Cypher execution returns a stream of records.

--- a/driver/src/main/javadoc/overview.html
+++ b/driver/src/main/javadoc/overview.html
@@ -28,7 +28,7 @@ public class SmallExample
         // Sessions are lightweight and disposable connection wrappers.
         try (Session session = driver.session())
         {
-            // Wrapping Cypher in an explicit transaction provides atomicity
+            // Wrapping Cypher in an unmanaged transaction provides atomicity
             // and makes handling errors much easier.
             try (Transaction tx = session.beginTransaction())
             {

--- a/driver/src/test/java/org/neo4j/driver/QueryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/QueryTest.java
@@ -23,70 +23,66 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.neo4j.driver.Statement;
-import org.neo4j.driver.Value;
-import org.neo4j.driver.Values;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
 
-class StatementTest
+class QueryTest
 {
     @Test
-    void shouldConstructStatementWithParameters()
+    void shouldConstructQueryWithParameters()
     {
         // given
         String text = "MATCH (n) RETURN n";
 
         // when
-        Statement statement = new Statement( text, Values.EmptyMap );
+        Query query = new Query( text, Values.EmptyMap );
 
         // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( Values.EmptyMap ) );
+        assertThat( query.text(), equalTo( text ) );
+        assertThat( query.parameters(), equalTo( Values.EmptyMap ) );
     }
 
     @Test
-    void shouldConstructStatementWithNoParameters()
+    void shouldConstructQueryWithNoParameters()
     {
         // given
         String text = "MATCH (n) RETURN n";
 
         // when
-        Statement statement = new Statement( text );
+        Query query = new Query( text );
 
         // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( Values.EmptyMap ) );
+        assertThat( query.text(), equalTo( text ) );
+        assertThat( query.parameters(), equalTo( Values.EmptyMap ) );
     }
 
     @Test
-    void shouldUpdateStatementText()
+    void shouldUpdateQueryText()
     {
         // when
-        Statement statement =
-                new Statement( "MATCH (n) RETURN n" )
+        Query query =
+                new Query( "MATCH (n) RETURN n" )
                 .withText( "BOO" );
 
         // then
-        assertThat( statement.text(), equalTo( "BOO" ) );
-        assertThat( statement.parameters(), equalTo( Values.EmptyMap ) );
+        assertThat( query.text(), equalTo( "BOO" ) );
+        assertThat( query.parameters(), equalTo( Values.EmptyMap ) );
     }
 
 
     @Test
-    void shouldReplaceStatementParameters()
+    void shouldReplaceQueryParameters()
     {
         // when
         String text = "MATCH (n) RETURN n";
         Value initialParameters = parameters( "a", 1, "b", 2 );
-        Statement statement = new Statement( "MATCH (n) RETURN n" ).withParameters( initialParameters );
+        Query query = new Query( "MATCH (n) RETURN n" ).withParameters( initialParameters );
 
         // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( initialParameters ) );
+        assertThat( query.text(), equalTo( text ) );
+        assertThat( query.parameters(), equalTo( initialParameters ) );
     }
 
     @Test
@@ -96,37 +92,37 @@ class StatementTest
         String text = "MATCH (n) RETURN n";
         Map<String, Object> parameters = new HashMap<>();
         parameters.put( "a", 1 );
-        Statement statement = new Statement( "MATCH (n) RETURN n" ).withParameters( parameters );
+        Query query = new Query( "MATCH (n) RETURN n" ).withParameters( parameters );
 
         // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( Values.value( parameters ) ) );
+        assertThat( query.text(), equalTo( text ) );
+        assertThat( query.parameters(), equalTo( Values.value( parameters ) ) );
     }
 
     @Test
-    void shouldUpdateStatementParameters()
+    void shouldUpdateQueryParameters()
     {
         // when
         String text = "MATCH (n) RETURN n";
         Value initialParameters = parameters( "a", 1, "b", 2, "c", 3 );
-        Statement statement =
-                new Statement( "MATCH (n) RETURN n", initialParameters )
+        Query query =
+                new Query( "MATCH (n) RETURN n", initialParameters )
                 .withUpdatedParameters( parameters( "a", 0, "b", Values.NULL ) );
 
         // then
-        assertThat( statement.text(), equalTo( text ) );
-        assertThat( statement.parameters(), equalTo( parameters( "a", 0, "c", 3 ) ) );
+        assertThat( query.text(), equalTo( text ) );
+        assertThat( query.parameters(), equalTo( parameters( "a", 0, "c", 3 ) ) );
     }
 
     @Test
     void shouldProhibitNullQuery()
     {
-        assertThrows( IllegalArgumentException.class, () -> new Statement( null ) );
+        assertThrows( IllegalArgumentException.class, () -> new Query( null ) );
     }
 
     @Test
     void shouldProhibitEmptyQuery()
     {
-        assertThrows( IllegalArgumentException.class, () -> new Statement( "" ) );
+        assertThrows( IllegalArgumentException.class, () -> new Query( "" ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -40,7 +40,7 @@ import org.neo4j.driver.Logging;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BoltServerAddress;
@@ -432,9 +432,9 @@ class ConnectionHandlingIT
         return createNodes( nodesToCreate, driver.session() );
     }
 
-    private Result createNodes(int nodesToCreate, StatementRunner statementRunner )
+    private Result createNodes(int nodesToCreate, QueryRunner queryRunner)
     {
-        return statementRunner.run( "UNWIND range(1, $nodesToCreate) AS i CREATE (n {index: i}) RETURN n",
+        return queryRunner.run( "UNWIND range(1, $nodesToCreate) AS i CREATE (n {index: i}) RETURN n",
                 parameters( "nodesToCreate", nodesToCreate ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -39,7 +39,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.StatementRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
@@ -58,7 +58,7 @@ import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -112,7 +112,7 @@ class ConnectionHandlingIT
     @Test
     void connectionUsedForSessionRunReturnedToThePoolWhenResultConsumed()
     {
-        StatementResult result = createNodesInNewSession( 12 );
+        Result result = createNodesInNewSession( 12 );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -127,7 +127,7 @@ class ConnectionHandlingIT
     @Test
     void connectionUsedForSessionRunReturnedToThePoolWhenResultSummaryObtained()
     {
-        StatementResult result = createNodesInNewSession( 5 );
+        Result result = createNodesInNewSession( 5 );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -143,7 +143,7 @@ class ConnectionHandlingIT
     @Test
     void connectionUsedForSessionRunReturnedToThePoolWhenResultFetchedInList()
     {
-        StatementResult result = createNodesInNewSession( 2 );
+        Result result = createNodesInNewSession( 2 );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -159,7 +159,7 @@ class ConnectionHandlingIT
     @Test
     void connectionUsedForSessionRunReturnedToThePoolWhenSingleRecordFetched()
     {
-        StatementResult result = createNodesInNewSession( 1 );
+        Result result = createNodesInNewSession( 1 );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -174,7 +174,7 @@ class ConnectionHandlingIT
     @Test
     void connectionUsedForSessionRunReturnedToThePoolWhenResultFetchedAsIterator()
     {
-        StatementResult result = createNodesInNewSession( 6 );
+        Result result = createNodesInNewSession( 6 );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -197,7 +197,7 @@ class ConnectionHandlingIT
     {
         Session session = driver.session();
         // provoke division by zero
-        StatementResult result = session.run( "UNWIND range(10, 0, -1) AS i CREATE (n {index: 10/i}) RETURN n" );
+        Result result = session.run( "UNWIND range(10, 0, -1) AS i CREATE (n {index: 10/i}) RETURN n" );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -219,7 +219,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        StatementResult result = createNodes( 5, tx );
+        Result result = createNodes( 5, tx );
         int size = result.list().size();
         tx.commit();
         tx.close();
@@ -241,7 +241,7 @@ class ConnectionHandlingIT
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
 
-        StatementResult result = createNodes( 8, tx );
+        Result result = createNodes( 8, tx );
         int size = result.list().size();
         tx.rollback();
         tx.close();
@@ -282,7 +282,7 @@ class ConnectionHandlingIT
     void connectionUsedForSessionRunReturnedToThePoolWhenSessionClose()
     {
         Session session = driver.session();
-        StatementResult result = createNodes( 12, session );
+        Result result = createNodes( 12, session );
 
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         verify( connection1, never() ).release();
@@ -315,7 +315,7 @@ class ConnectionHandlingIT
     void sessionCloseShouldReleaseConnectionUsedBySessionRun() throws Throwable
     {
         RxSession session = driver.rxSession();
-        RxStatementResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        RxResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
 
         // When we only run but not pull
         StepVerifier.create( Flux.from( res.keys() ) ).expectNext( singletonList( "a" ) ).verifyComplete();
@@ -334,7 +334,7 @@ class ConnectionHandlingIT
     void resultRecordsShouldReleaseConnectionUsedBySessionRun() throws Throwable
     {
         RxSession session = driver.rxSession();
-        RxStatementResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        RxResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         assertNull( connection1 );
 
@@ -352,7 +352,7 @@ class ConnectionHandlingIT
     void resultSummaryShouldReleaseConnectionUsedBySessionRun() throws Throwable
     {
         RxSession session = driver.rxSession();
-        RxStatementResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        RxResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
         Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
         assertNull( connection1 );
 
@@ -373,7 +373,7 @@ class ConnectionHandlingIT
             Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
             verify( connection1, never() ).release();
 
-            RxStatementResult result = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+            RxResult result = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
             StepVerifier.create( Flux.from( result.records() ).map( record -> record.get( "a" ).asInt() ) )
                     .expectNext( 1, 2, 3, 4 ).verifyComplete();
 
@@ -395,7 +395,7 @@ class ConnectionHandlingIT
             Connection connection1 = connectionPool.lastAcquiredConnectionSpy;
             verify( connection1, never() ).release();
 
-            RxStatementResult result = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+            RxResult result = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
             StepVerifier.create( Flux.from( result.records() ).map( record -> record.get( "a" ).asInt() ) )
                     .expectNext( 1, 2, 3, 4 ).verifyComplete();
 
@@ -427,12 +427,12 @@ class ConnectionHandlingIT
         verify( connection1, times( 2 ) ).release();
     }
 
-    private StatementResult createNodesInNewSession( int nodesToCreate )
+    private Result createNodesInNewSession(int nodesToCreate )
     {
         return createNodes( nodesToCreate, driver.session() );
     }
 
-    private StatementResult createNodes( int nodesToCreate, StatementRunner statementRunner )
+    private Result createNodes(int nodesToCreate, StatementRunner statementRunner )
     {
         return statementRunner.run( "UNWIND range(1, $nodesToCreate) AS i CREATE (n {index: i}) RETURN n",
                 parameters( "nodesToCreate", nodesToCreate ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionPoolIT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -154,7 +154,7 @@ class ConnectionPoolIT
     {
         List<Session> sessions = new ArrayList<>( txCount );
         List<Transaction> transactions = new ArrayList<>( txCount );
-        List<StatementResult> results = new ArrayList<>( txCount );
+        List<Result> results = new ArrayList<>( txCount );
         try
         {
             for ( int i = 0; i < txCount; i++ )
@@ -165,13 +165,13 @@ class ConnectionPoolIT
                 Transaction tx = session.beginTransaction();
                 transactions.add( tx );
 
-                StatementResult result = tx.run( "RETURN 1" );
+                Result result = tx.run( "RETURN 1" );
                 results.add( result );
             }
         }
         finally
         {
-            for ( StatementResult result : results )
+            for ( Result result : results )
             {
                 result.consume();
             }

--- a/driver/src/test/java/org/neo4j/driver/integration/DirectDriverIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/DirectDriverIT.java
@@ -28,7 +28,7 @@ import java.net.URI;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -103,7 +103,7 @@ class DirectDriverIT
               Session session = driver.session() )
         {
             // When
-            StatementResult result = session.run( "RETURN 1" );
+            Result result = session.run( "RETURN 1" );
 
             // Then
             assertThat( result.single().get( 0 ).asInt(), CoreMatchers.equalTo( 1 ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/EncryptionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/EncryptionIT.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.Neo4jSettings;
@@ -93,7 +93,7 @@ class EncryptionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "RETURN 1" );
+                Result result = session.run( "RETURN 1" );
 
                 Record record = result.next();
                 int value = record.get( 0 ).asInt();

--- a/driver/src/test/java/org/neo4j/driver/integration/EntityTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/EntityTypeIT.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.integration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
@@ -41,7 +41,7 @@ class EntityTypeIT
     void shouldReturnIdentitiesOfNodes()
     {
         // When
-        StatementResult cursor = session.run( "CREATE (n) RETURN n" );
+        Result cursor = session.run( "CREATE (n) RETURN n" );
         Node node = cursor.single().get( "n" ).asNode();
 
         // Then
@@ -52,7 +52,7 @@ class EntityTypeIT
     void shouldReturnIdentitiesOfRelationships()
     {
         // When
-        StatementResult cursor = session.run( "CREATE ()-[r:T]->() RETURN r" );
+        Result cursor = session.run( "CREATE ()-[r:T]->() RETURN r" );
         Relationship rel = cursor.single().get( "r" ).asRelationship();
 
         // Then
@@ -65,7 +65,7 @@ class EntityTypeIT
     void shouldReturnIdentitiesOfPaths()
     {
         // When
-        StatementResult cursor = session.run( "CREATE p=()-[r:T]->() RETURN p" );
+        Result cursor = session.run( "CREATE p=()-[r:T]->() RETURN p" );
         Path path = cursor.single().get( "p" ).asPath();
 
         // Then

--- a/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
@@ -38,7 +38,7 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -80,7 +80,7 @@ class ErrorIT
     {
         ClientException e = assertThrows( ClientException.class, () ->
         {
-            StatementResult result = session.run( "invalid statement" );
+            Result result = session.run( "invalid statement" );
             result.consume();
         } );
 
@@ -99,7 +99,7 @@ class ErrorIT
         // Expect
         ClientException e = assertThrows( ClientException.class, () ->
         {
-            StatementResult cursor = tx.run( "RETURN 1" );
+            Result cursor = tx.run( "RETURN 1" );
             cursor.single().get( "1" ).asInt();
         } );
         assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
@@ -112,7 +112,7 @@ class ErrorIT
         try { session.run( "invalid" ).consume(); } catch ( ClientException e ) {/*empty*/}
 
         // When
-        StatementResult cursor = session.run( "RETURN 1" );
+        Result cursor = session.run( "RETURN 1" );
         int val = cursor.single().get( "1" ).asInt();
 
         // Then
@@ -132,7 +132,7 @@ class ErrorIT
         // When
         try ( Transaction tx = session.beginTransaction() )
         {
-            StatementResult cursor = tx.run( "RETURN 1" );
+            Result cursor = tx.run( "RETURN 1" );
             int val = cursor.single().get( "1" ).asInt();
 
             // Then

--- a/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ErrorIT.java
@@ -80,7 +80,7 @@ class ErrorIT
     {
         ClientException e = assertThrows( ClientException.class, () ->
         {
-            Result result = session.run( "invalid statement" );
+            Result result = session.run( "invalid query" );
             result.consume();
         } );
 
@@ -102,11 +102,11 @@ class ErrorIT
             Result cursor = tx.run( "RETURN 1" );
             cursor.single().get( "1" ).asInt();
         } );
-        assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
+        assertThat( e.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
     }
 
     @Test
-    void shouldAllowNewStatementAfterRecoverableError()
+    void shouldAllowNewQueryAfterRecoverableError()
     {
         // Given an error has occurred
         try { session.run( "invalid" ).consume(); } catch ( ClientException e ) {/*empty*/}

--- a/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.Neo4jSettings;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -51,7 +51,7 @@ class LoadCSVIT
             String csvFileUrl = createLocalIrisData( session );
 
             // When
-            StatementResult result = session.run(
+            Result result = session.run(
                     "USING PERIODIC COMMIT 40\n" +
                     "LOAD CSV WITH HEADERS FROM $csvFileUrl AS l\n" +
                     "MATCH (c:Class {name: l.class_name})\n" +

--- a/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.StatementRunner;
 import org.neo4j.driver.Transaction;
 
@@ -101,7 +101,7 @@ public interface NestedQueries
     {
         int recordsSeen = 0;
 
-        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = statementRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         while ( result1.hasNext() )
@@ -110,7 +110,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            StatementResult result2 = statementRunner.run( INNER_QUERY );
+            Result result2 = statementRunner.run( INNER_QUERY );
             while ( result2.hasNext() )
             {
                 Record record2 = result2.next();
@@ -126,7 +126,7 @@ public interface NestedQueries
     {
         int recordsSeen = 0;
 
-        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = statementRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         List<Record> records1 = result1.list();
@@ -135,7 +135,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            StatementResult result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            Result result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
             List<Record> records2 = result2.list();
             for ( Record record2 : records2 )
             {
@@ -151,7 +151,7 @@ public interface NestedQueries
     {
         int recordsSeen = 0;
 
-        StatementResult result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = statementRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         while ( result1.hasNext() )
@@ -160,7 +160,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            StatementResult result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            Result result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
             List<Record> records2 = result2.list();
             for ( Record record2 : records2 )
             {

--- a/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/NestedQueries.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Transaction;
 
 import static org.junit.Assert.assertEquals;
@@ -97,11 +97,11 @@ public interface NestedQueries
         }
     }
 
-    default void testNestedQueriesConsumedAsIterators( StatementRunner statementRunner ) throws Exception
+    default void testNestedQueriesConsumedAsIterators( QueryRunner queryRunner) throws Exception
     {
         int recordsSeen = 0;
 
-        Result result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = queryRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         while ( result1.hasNext() )
@@ -110,7 +110,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            Result result2 = statementRunner.run( INNER_QUERY );
+            Result result2 = queryRunner.run( INNER_QUERY );
             while ( result2.hasNext() )
             {
                 Record record2 = result2.next();
@@ -122,11 +122,11 @@ public interface NestedQueries
         assertEquals( EXPECTED_RECORDS, recordsSeen );
     }
 
-    default void testNestedQueriesConsumedAsLists( StatementRunner statementRunner ) throws Exception
+    default void testNestedQueriesConsumedAsLists( QueryRunner queryRunner) throws Exception
     {
         int recordsSeen = 0;
 
-        Result result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = queryRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         List<Record> records1 = result1.list();
@@ -135,7 +135,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            Result result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            Result result2 = queryRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
             List<Record> records2 = result2.list();
             for ( Record record2 : records2 )
             {
@@ -147,11 +147,11 @@ public interface NestedQueries
         assertEquals( EXPECTED_RECORDS, recordsSeen );
     }
 
-    default void testNestedQueriesConsumedAsIteratorAndList( StatementRunner statementRunner ) throws Exception
+    default void testNestedQueriesConsumedAsIteratorAndList( QueryRunner queryRunner) throws Exception
     {
         int recordsSeen = 0;
 
-        Result result1 = statementRunner.run( OUTER_QUERY );
+        Result result1 = queryRunner.run( OUTER_QUERY );
         Thread.sleep( 1000 ); // allow some result records to arrive and be buffered
 
         while ( result1.hasNext() )
@@ -160,7 +160,7 @@ public interface NestedQueries
             assertFalse( record1.get( "x" ).isNull() );
             recordsSeen++;
 
-            Result result2 = statementRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
+            Result result2 = queryRunner.run( "UNWIND range(1, 10) AS y RETURN y" );
             List<Record> records2 = result2.list();
             for ( Record record2 : records2 )
             {

--- a/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -66,7 +66,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnBooleanProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", true ) );
 
         // Then
@@ -82,7 +82,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnByteProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", (byte) 1 ) );
 
         // Then
@@ -98,7 +98,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnShortProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", (short) 1 ) );
 
         // Then
@@ -114,7 +114,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnIntegerProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 1 ) );
 
         // Then
@@ -131,7 +131,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnLongProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 1L ) );
 
         // Then
@@ -148,7 +148,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnDoubleProperty()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", 6.28 ) );
 
         // Then
@@ -186,7 +186,7 @@ class ParametersIT
     {
         // When
         boolean[] arrayValue = new boolean[]{true, true, true};
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
@@ -209,7 +209,7 @@ class ParametersIT
     {
         // When
         int[] arrayValue = new int[]{42, 42, 42};
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
@@ -232,7 +232,7 @@ class ParametersIT
     {
         // When
         double[] arrayValue = new double[]{6.28, 6.28, 6.28};
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
@@ -260,7 +260,7 @@ class ParametersIT
     {
         String[] arrayValue = new String[]{str, str, str};
 
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", arrayValue ) );
 
         // Then
@@ -303,7 +303,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnBooleanPropertyWithinMap()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", true ) ) );
 
@@ -321,7 +321,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnIntegerPropertyWithinMap()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", 42 ) ) );
 
@@ -339,7 +339,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnDoublePropertyWithinMap()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", 6.28 ) ) );
 
@@ -357,7 +357,7 @@ class ParametersIT
     void shouldBeAbleToSetAndReturnStringPropertyWithinMap()
     {
         // When
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value.v}) RETURN a.value",
                 parameters( "value", parameters( "v", "Mjölnir" ) ) );
 
@@ -455,7 +455,7 @@ class ParametersIT
     {
         Stream<Integer> stream = Stream.of( 1, 2, 3, 4, 5, 42 );
 
-        StatementResult result = session.run( "RETURN $value", singletonMap( "value", stream ) );
+        Result result = session.run( "RETURN $value", singletonMap( "value", stream ) );
         Value receivedValue = result.single().get( 0 );
 
         assertEquals( asList( 1, 2, 3, 4, 5, 42 ), receivedValue.asList( ofInteger() ) );
@@ -463,7 +463,7 @@ class ParametersIT
 
     private static void testBytesProperty( byte[] array )
     {
-        StatementResult result = session.run( "CREATE (a {value:$value}) RETURN a.value", parameters( "value", array ) );
+        Result result = session.run( "CREATE (a {value:$value}) RETURN a.value", parameters( "value", array ) );
 
         for ( Record record : result.list() )
         {
@@ -475,7 +475,7 @@ class ParametersIT
 
     private static void testStringProperty( String string )
     {
-        StatementResult result = session.run(
+        Result result = session.run(
                 "CREATE (a {value:$value}) RETURN a.value", parameters( "value", string ) );
 
         for ( Record record : result.list() )
@@ -503,7 +503,7 @@ class ParametersIT
 
     private static void testSendAndReceiveValue( Object value )
     {
-        StatementResult result = session.run( "RETURN $value", singletonMap( "value", value ) );
+        Result result = session.run( "RETURN $value", singletonMap( "value", value ) );
         Object receivedValue = result.single().get( 0 ).asObject();
         assertArrayEquals( new Object[]{value}, new Object[]{receivedValue} );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
 
 @ParallelizableIT
-class StatementIT
+class QueryIT
 {
     @RegisterExtension
     static final SessionExtension session = new SessionExtension();
@@ -48,7 +48,7 @@ class StatementIT
     @Test
     void shouldRunWithResult()
     {
-        // When I execute a statement that yields a result
+        // When I execute a query that yields a result
         List<Record> result = session.run( "UNWIND [1,2,3] AS k RETURN k" ).list();
 
         // Then the result object should contain the returned values
@@ -156,14 +156,14 @@ class StatementIT
         assertThat( result.size(), equalTo( 3 ) );
     }
 
-    @SuppressWarnings({"StatementWithEmptyBody", "ConstantConditions"})
+    @SuppressWarnings({"QueryWithEmptyBody", "ConstantConditions"})
     @Test
-    void shouldRunSimpleStatement()
+    void shouldRunSimpleQuery()
     {
-        // When I run a simple write statement
+        // When I run a simple write query
         session.run( "CREATE (a {name:'Adam'})" );
 
-        // And I run a read statement
+        // And I run a read query
         Result result2 = session.run( "MATCH (a) RETURN a.name" );
 
         // Then I expect to get the name back

--- a/driver/src/test/java/org/neo4j/driver/integration/QueryRunnerCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/QueryRunnerCloseIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.util.TestUtil.await;
 
 @ParallelizableIT
-class StatementRunnerCloseIT
+class QueryRunnerCloseIT
 {
     @RegisterExtension
     static final DatabaseExtension neo4j = new DatabaseExtension();

--- a/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResultStreamIT.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
@@ -61,7 +61,7 @@ class ResultStreamIT
     void shouldAllowIteratingOverResultStream()
     {
         // When
-        StatementResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        Result res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
 
         // Then I should be able to iterate over the result
         int idx = 1;
@@ -75,7 +75,7 @@ class ResultStreamIT
     void shouldHaveFieldNamesInResult()
     {
         // When
-        StatementResult res = session.run( "CREATE (n:TestNode {name:'test'}) RETURN n" );
+        Result res = session.run( "CREATE (n:TestNode {name:'test'}) RETURN n" );
 
         // Then
         assertEquals( "[n]", res.keys().toString() );
@@ -87,7 +87,7 @@ class ResultStreamIT
     void shouldGiveHelpfulFailureMessageWhenAccessNonExistingField()
     {
         // Given
-        StatementResult rs =
+        Result rs =
                 session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
@@ -101,7 +101,7 @@ class ResultStreamIT
     void shouldGiveHelpfulFailureMessageWhenAccessNonExistingPropertyOnNode()
     {
         // Given
-        StatementResult rs =
+        Result rs =
                 session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
@@ -115,7 +115,7 @@ class ResultStreamIT
     void shouldNotReturnNullKeysOnEmptyResult()
     {
         // Given
-        StatementResult rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
+        Result rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
 
         // THEN
         assertNotNull( rs.keys() );
@@ -125,11 +125,11 @@ class ResultStreamIT
     void shouldBeAbleToReuseSessionAfterFailure()
     {
         // Given
-        StatementResult res1 = session.run( "INVALID" );
+        Result res1 = session.run( "INVALID" );
         assertThrows( Exception.class, res1::consume );
 
         // When
-        StatementResult res2 = session.run( "RETURN 1" );
+        Result res2 = session.run( "RETURN 1" );
 
         // Then
         assertTrue( res2.hasNext() );
@@ -140,7 +140,7 @@ class ResultStreamIT
     void shouldBeAbleToAccessSummaryAfterFailure()
     {
         // Given
-        StatementResult res1 = session.run( "INVALID" );
+        Result res1 = session.run( "INVALID" );
         ResultSummary summary;
 
         // When
@@ -157,19 +157,19 @@ class ResultStreamIT
     @Test
     void shouldBeAbleToAccessSummaryAfterTransactionFailure()
     {
-        AtomicReference<StatementResult> resultRef = new AtomicReference<>();
+        AtomicReference<Result> resultRef = new AtomicReference<>();
 
         assertThrows( ClientException.class, () ->
         {
             try ( Transaction tx = session.beginTransaction() )
             {
-                StatementResult result = tx.run( "UNWIND [1,2,0] AS x RETURN 10/x" );
+                Result result = tx.run( "UNWIND [1,2,0] AS x RETURN 10/x" );
                 resultRef.set( result );
                 tx.commit();
             }
         } );
 
-        StatementResult result = resultRef.get();
+        Result result = resultRef.get();
         assertNotNull( result );
         assertEquals( 0, result.consume().counters().nodesCreated() );
     }
@@ -177,7 +177,7 @@ class ResultStreamIT
     @Test
     void shouldHasNoElementsAfterFailure()
     {
-        StatementResult result = session.run( "INVALID" );
+        Result result = session.run( "INVALID" );
 
         assertThrows( ClientException.class, result::hasNext );
         assertFalse( result.hasNext() );
@@ -186,14 +186,14 @@ class ResultStreamIT
     @Test
     void shouldBeAnEmptyLitAfterFailure()
     {
-        StatementResult result = session.run( "UNWIND (0, 1) as i RETURN 10 / i" );
+        Result result = session.run( "UNWIND (0, 1) as i RETURN 10 / i" );
 
         assertThrows( ClientException.class, result::list );
         assertTrue( result.list().isEmpty() );
     }
 
     @Test
-    void shouldConvertEmptyStatementResultToStream()
+    void shouldConvertEmptyResultToStream()
     {
         long count = session.run( "MATCH (n:WrongLabel) RETURN n" )
                 .stream()
@@ -209,7 +209,7 @@ class ResultStreamIT
     }
 
     @Test
-    void shouldConvertStatementResultToStream()
+    void shouldConvertResultToStream()
     {
         List<Integer> receivedList = session.run( "UNWIND range(1, 10) AS x RETURN x" )
                 .stream()
@@ -221,7 +221,7 @@ class ResultStreamIT
     }
 
     @Test
-    void shouldConvertImmediatelyFailingStatementResultToStream()
+    void shouldConvertImmediatelyFailingResultToStream()
     {
         List<Integer> seen = new ArrayList<>();
 
@@ -236,7 +236,7 @@ class ResultStreamIT
     }
 
     @Test
-    void shouldConvertEventuallyFailingStatementResultToStream()
+    void shouldConvertEventuallyFailingResultToStream()
     {
         List<Integer> seen = new ArrayList<>();
 
@@ -254,7 +254,7 @@ class ResultStreamIT
     @Test
     void shouldEmptyResultWhenConvertedToStream()
     {
-        StatementResult result = session.run( "UNWIND range(1, 10) AS x RETURN x" );
+        Result result = session.run( "UNWIND range(1, 10) AS x RETURN x" );
 
         assertTrue( result.hasNext() );
         assertEquals( 1, result.next().get( 0 ).asInt() );

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -40,7 +40,7 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -933,7 +933,7 @@ class RoutingDriverBoltKitTest
 
                 assertEquals( asList( "Bob", "Alice", "Tina" ), readStrings( "MATCH (n) RETURN n.name", session ) );
 
-                StatementResult createResult = session.run( "CREATE (n {name:'Bob'})" );
+                Result createResult = session.run( "CREATE (n {name:'Bob'})" );
                 assertFalse( createResult.hasNext() );
             }
         }
@@ -960,11 +960,11 @@ class RoutingDriverBoltKitTest
             // returned routing table contains only one router, this should be fine and we should be able to
             // read multiple times without additional rediscovery
 
-            StatementResult readResult1 = session.run( "MATCH (n) RETURN n.name" );
+            Result readResult1 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult1.list().size() );
             assertEquals( "127.0.0.1:9003", readResult1.consume().server().address() );
 
-            StatementResult readResult2 = session.run( "MATCH (n) RETURN n.name" );
+            Result readResult2 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult2.list().size() );
             assertEquals( "127.0.0.1:9004", readResult2.consume().server().address() );
         }

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverIT.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.Neo4jFeature;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -55,7 +55,7 @@ class RoutingDriverIT
         {
             assertThat( driver, is( clusterDriver() ) );
 
-            StatementResult result = session.run( "RETURN 1" );
+            Result result = session.run( "RETURN 1" );
             assertThat( result.single().get( 0 ).asInt(), CoreMatchers.equalTo( 1 ) );
         }
     }
@@ -69,7 +69,7 @@ class RoutingDriverIT
         {
             assertThat( driver, is( clusterDriver() ) );
 
-            StatementResult result = session.run( "RETURN 1" );
+            Result result = session.run( "RETURN 1" );
             assertThat( result.single().get( 0 ).asInt(), CoreMatchers.equalTo( 1 ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
@@ -71,10 +71,10 @@ class ScalarTypeIT
 
     @ParameterizedTest
     @MethodSource( "typesToTest" )
-    void shouldHandleType( String statement, Value expectedValue )
+    void shouldHandleType( String query, Value expectedValue )
     {
         // When
-        Result cursor = session.run( statement );
+        Result cursor = session.run( query );
 
         // Then
         assertThat( cursor.single().get( "v" ), equalTo( expectedValue ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ScalarTypeIT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.internal.value.ListValue;
 import org.neo4j.driver.internal.value.MapValue;
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.internal.value.StringValue;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -74,7 +74,7 @@ class ScalarTypeIT
     void shouldHandleType( String statement, Value expectedValue )
     {
         // When
-        StatementResult cursor = session.run( statement );
+        Result cursor = session.run( statement );
 
         // Then
         assertThat( cursor.single().get( "v" ), equalTo( expectedValue ) );
@@ -245,7 +245,7 @@ class ScalarTypeIT
     private void verifyCanEncodeAndDecode( Value input )
     {
         // When
-        StatementResult cursor = session.run( "RETURN $x as y", parameters( "x", input ) );
+        Result cursor = session.run( "RETURN $x as y", parameters( "x", input ) );
 
         // Then
         assertThat( cursor.single().get( "y" ), equalTo( input ) );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -220,7 +220,7 @@ class SessionBoltV3IT
     }
 
     @Test
-    void shouldUseBookmarksForAutoCommitAndExplicitTransactions()
+    void shouldUseBookmarksForAutoCommitAndUnmanagedTransactions()
     {
         Session session = driver.session();
         Bookmark initialBookmark = session.lastBookmark();

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -43,7 +43,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.StatementRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
@@ -60,7 +60,7 @@ import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.StatementType;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -276,7 +276,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Ronan'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Ronan'}) RETURN count(p)" );
                 assertEquals( 0, result.single().get( 0 ).asInt() );
             }
 
@@ -300,7 +300,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Ronan'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Ronan'}) RETURN count(p)" );
                 assertEquals( 0, result.single().get( 0 ).asInt() );
             }
 
@@ -356,7 +356,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Thor Odinson'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Thor Odinson'}) RETURN count(p)" );
                 assertEquals( 1, result.single().get( 0 ).asInt() );
             }
         }
@@ -372,7 +372,7 @@ class SessionIT
 
             long answer = session.readTransaction( tx ->
             {
-                StatementResult result = tx.run( "RETURN 42" );
+                Result result = tx.run( "RETURN 42" );
                 long single = result.single().get( 0 ).asLong();
                 tx.rollback();
                 return single;
@@ -403,7 +403,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
                 assertEquals( 0, result.single().get( 0 ).asInt() );
             }
         }
@@ -420,7 +420,7 @@ class SessionIT
             assertThrows( IllegalStateException.class, () ->
                     session.readTransaction( tx ->
                     {
-                        StatementResult result = tx.run( "RETURN 42" );
+                        Result result = tx.run( "RETURN 42" );
                         if ( result.single().get( 0 ).asLong() == 42 )
                         {
                             throw new IllegalStateException();
@@ -450,7 +450,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
                 assertEquals( 0, result.single().get( 0 ).asInt() );
             }
         }
@@ -463,7 +463,7 @@ class SessionIT
               Session session = driver.session() )
         {
             ClientException error = assertThrows( ClientException.class, () -> session.readTransaction( tx -> {
-                StatementResult result = tx.run( "RETURN 42" );
+                Result result = tx.run( "RETURN 42" );
                 tx.commit();
                 tx.rollback();
                 return result.single().get( 0 ).asLong();
@@ -530,7 +530,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
                 assertEquals( 1, result.single().get( 0 ).asInt() );
             }
         }
@@ -575,7 +575,7 @@ class SessionIT
 
             try ( Session session = driver.session() )
             {
-                StatementResult result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
+                Result result = session.run( "MATCH (p:Person {name: 'Natasha Romanoff'}) RETURN count(p)" );
                 assertEquals( 0, result.single().get( 0 ).asInt() );
             }
         }
@@ -788,7 +788,7 @@ class SessionIT
     @Test
     void shouldNotBePossibleToConsumeResultAfterSessionIsClosed()
     {
-        StatementResult result;
+        Result result;
         try ( Session session = neo4j.driver().session() )
         {
             result = session.run( "UNWIND range(1, 20000) AS x RETURN x" );
@@ -802,7 +802,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "RETURN Wrong" );
+            Result result = session.run( "RETURN Wrong" );
 
             ClientException e = assertThrows( ClientException.class, result::consume );
             assertThat( e.code(), containsString( "SyntaxError" ) );
@@ -902,7 +902,7 @@ class SessionIT
     {
         Session session = neo4j.driver().session();
 
-        StatementResult result = session.run( "CYPHER runtime=interpreted UNWIND [2, 4, 8, 0] AS x RETURN 32 / x" );
+        Result result = session.run( "CYPHER runtime=interpreted UNWIND [2, 4, 8, 0] AS x RETURN 32 / x" );
 
         ClientException e = assertThrows( ClientException.class, session::close );
         assertThat( e, is( arithmeticError() ) );
@@ -916,7 +916,7 @@ class SessionIT
 
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( query );
+            Result result = session.run( query );
 
             ResultSummary summary = result.consume();
             assertEquals( query, summary.statement().text() );
@@ -932,7 +932,7 @@ class SessionIT
         int recordCount = 11_333;
         String query = "UNWIND range(1, " + recordCount + ") AS x RETURN 'Result-' + x";
 
-        StatementResult result;
+        Result result;
         try ( Session session = neo4j.driver().session() )
         {
             result = session.run( query );
@@ -946,7 +946,7 @@ class SessionIT
     {
         Session session = neo4j.driver().session();
 
-        StatementResult result = session.run( "UNWIND range(10000, 0, -1) AS x RETURN 10 / x" );
+        Result result = session.run( "UNWIND range(10000, 0, -1) AS x RETURN 10 / x" );
 
         // summary couple records slowly with a sleep in-between
         for ( int i = 0; i < 10; i++ )
@@ -965,7 +965,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "UNWIND range(8000, 1, -1) AS x RETURN 42 / x" );
+            Result result = session.run( "UNWIND range(8000, 1, -1) AS x RETURN 42 / x" );
 
             // summary couple records slowly with a sleep in-between
             for ( int i = 0; i < 12; i++ )
@@ -1068,7 +1068,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "UNWIND [] AS x RETURN x" );
+            Result result = session.run( "UNWIND [] AS x RETURN x" );
             assertFalse( result.hasNext() );
 
             assertThrows( NoSuchElementException.class, result::next );
@@ -1080,7 +1080,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "UNWIND [] AS x RETURN x" );
+            Result result = session.run( "UNWIND [] AS x RETURN x" );
             ResultSummary summary = result.consume();
             assertNotNull( summary );
             assertEquals( StatementType.READ_ONLY, summary.statementType() );
@@ -1092,7 +1092,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "UNWIND [] AS x RETURN x" );
+            Result result = session.run( "UNWIND [] AS x RETURN x" );
             assertEquals( emptyList(), result.list() );
         }
     }
@@ -1103,7 +1103,7 @@ class SessionIT
         try ( Session session = neo4j.driver().session() )
         {
             String query = "UNWIND [1, 2, 3, 4, 0] AS x RETURN 10 / x";
-            StatementResult result = session.run( query );
+            Result result = session.run( query );
 
             ClientException e = assertThrows( ClientException.class, result::consume );
             assertThat( e, is( arithmeticError() ) );
@@ -1179,13 +1179,13 @@ class SessionIT
             int seenResources = 0;
 
             // read properties and resources using a single session
-            StatementResult properties = session.run( "MATCH (p:Property) RETURN p" );
+            Result properties = session.run( "MATCH (p:Property) RETURN p" );
             while ( properties.hasNext() )
             {
                 assertNotNull( properties.next() );
                 seenProperties++;
 
-                StatementResult resources = session.run( "MATCH (r:Resource) RETURN r" );
+                Result resources = session.run( "MATCH (r:Resource) RETURN r" );
                 while ( resources.hasNext() )
                 {
                     assertNotNull( resources.next() );
@@ -1204,7 +1204,7 @@ class SessionIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "RETURN 1" );
+        RxResult result = session.run( "RETURN 1" );
 
         // When trying to run the query on a server that is using a protocol that is lower than V4
         StepVerifier.create( result.records() ).expectErrorSatisfies( error -> {
@@ -1247,7 +1247,7 @@ class SessionIT
         // Given
         try( Session session = neo4j.driver().session( forDatabase( "neo4j" ) ) )
         {
-            StatementResult result = session.run( "RETURN 1" );
+            Result result = session.run( "RETURN 1" );
             assertThat( result.single().get( 0 ).asInt(), equalTo( 1 ) );
         }
     }
@@ -1259,7 +1259,7 @@ class SessionIT
         try ( Session session = neo4j.driver().session( forDatabase( "neo4j" ) );
               Transaction transaction = session.beginTransaction() )
         {
-            StatementResult result = transaction.run( "RETURN 1" );
+            Result result = transaction.run( "RETURN 1" );
             assertThat( result.single().get( 0 ).asInt(), equalTo( 1 ) );
         }
     }
@@ -1282,7 +1282,7 @@ class SessionIT
         Session session = neo4j.driver().session( forDatabase( "foo" ) );
 
         ClientException error = assertThrows( ClientException.class, () -> {
-            StatementResult result = session.run( "RETURN 1" );
+            Result result = session.run( "RETURN 1" );
             result.consume();
         } );
 
@@ -1300,7 +1300,7 @@ class SessionIT
         // When trying to run the query on a server that is using a protocol that is lower than V4
         ClientException error = assertThrows( ClientException.class, () -> {
             Transaction transaction = session.beginTransaction();
-            StatementResult result = transaction.run( "RETURN 1" );
+            Result result = transaction.run( "RETURN 1" );
             result.consume();
         });
         assertThat( error.getMessage(), containsString( "Database does not exist. Database name: 'foo'" ) );
@@ -1360,7 +1360,7 @@ class SessionIT
         {
             String material = session.writeTransaction( tx ->
             {
-                StatementResult result = tx.run( "CREATE (s:Shield {material: 'Vibranium'}) RETURN s" );
+                Result result = tx.run( "CREATE (s:Shield {material: 'Vibranium'}) RETURN s" );
                 Record record = result.single();
                 tx.commit();
                 return record.get( 0 ).asNode().get( "material" ).asString();
@@ -1438,7 +1438,7 @@ class SessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "MATCH (n {id: $id}) RETURN count(n)", parameters( "id", id ) );
+            Result result = session.run( "MATCH (n {id: $id}) RETURN count(n)", parameters( "id", id ) );
             return result.single().get( 0 ).asInt();
         }
     }
@@ -1451,7 +1451,7 @@ class SessionIT
         }
     }
 
-    private static StatementResult updateNodeId( StatementRunner statementRunner, int currentId, int newId )
+    private static Result updateNodeId(StatementRunner statementRunner, int currentId, int newId )
     {
         return statementRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
                 parameters( "currentId", currentId, "newId", newId ) );
@@ -1528,7 +1528,7 @@ class SessionIT
         @Override
         public Record execute( Transaction tx )
         {
-            StatementResult result = tx.run( query );
+            Result result = tx.run( query );
             if ( invoked++ < failures )
             {
                 throw new ServiceUnavailableException( "" );

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -44,7 +44,7 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.exceptions.AuthenticationException;
@@ -62,7 +62,7 @@ import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.TestUtil;
@@ -919,8 +919,8 @@ class SessionIT
             Result result = session.run( query );
 
             ResultSummary summary = result.consume();
-            assertEquals( query, summary.statement().text() );
-            assertEquals( StatementType.READ_ONLY, summary.statementType() );
+            assertEquals( query, summary.query().text() );
+            assertEquals( QueryType.READ_ONLY, summary.queryType() );
 
             assertThrows( ResultConsumedException.class, result::list );
         }
@@ -1083,7 +1083,7 @@ class SessionIT
             Result result = session.run( "UNWIND [] AS x RETURN x" );
             ResultSummary summary = result.consume();
             assertNotNull( summary );
-            assertEquals( StatementType.READ_ONLY, summary.statementType() );
+            assertEquals( QueryType.READ_ONLY, summary.queryType() );
         }
     }
 
@@ -1109,7 +1109,7 @@ class SessionIT
             assertThat( e, is( arithmeticError() ) );
 
             ResultSummary summary = result.consume();
-            assertEquals( query, summary.statement().text() );
+            assertEquals( query, summary.query().text() );
         }
     }
 
@@ -1451,9 +1451,9 @@ class SessionIT
         }
     }
 
-    private static Result updateNodeId(StatementRunner statementRunner, int currentId, int newId )
+    private static Result updateNodeId(QueryRunner queryRunner, int currentId, int newId )
     {
-        return statementRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
+        return queryRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
                 parameters( "currentId", currentId, "newId", newId ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.AsyncSession;
@@ -229,8 +229,8 @@ class SessionMixIT
 
     private int countNodes( Object id )
     {
-        Statement statement = new Statement( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) );
-        Record record = session.run( statement ).single();
+        Query query = new Query( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) );
+        Record record = session.run(query).single();
         return record.get( 0 ).asInt();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
@@ -135,7 +135,7 @@ class SessionResetIT
     }
 
     @Test
-    void shouldTerminateQueryInExplicitTransaction()
+    void shouldTerminateQueryInUnmanagedTransaction()
     {
         testQueryTermination( LONG_QUERY, false );
     }
@@ -165,7 +165,7 @@ class SessionResetIT
     }
 
     @Test
-    void shouldTerminateQueriesInExplicitTransactionsRandomly() throws Exception
+    void shouldTerminateQueriesInUnmanagedTransactionsRandomly() throws Exception
     {
         testRandomQueryTermination( false );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionResetIT.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.StatementRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
@@ -179,7 +179,7 @@ class SessionResetIT
         {
             Transaction tx1 = session.beginTransaction();
 
-            StatementResult result = tx1.run( "CALL test.driver.longRunningStatement({seconds})", parameters( "seconds", 10 ) );
+            Result result = tx1.run( "CALL test.driver.longRunningStatement({seconds})", parameters( "seconds", 10 ) );
 
             awaitActiveQueriesToContain( "CALL test.driver.longRunningStatement" );
             session.reset();
@@ -221,7 +221,7 @@ class SessionResetIT
         {
             Transaction tx1 = session.beginTransaction();
 
-            StatementResult procedureResult = tx1.run( "CALL test.driver.longRunningStatement({seconds})",
+            Result procedureResult = tx1.run( "CALL test.driver.longRunningStatement({seconds})",
                     parameters( "seconds", 10 ) );
 
             awaitActiveQueriesToContain( "CALL test.driver.longRunningStatement" );
@@ -237,7 +237,7 @@ class SessionResetIT
                 tx2.commit();
             }
 
-            StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+            Result result = session.run( "MATCH (n) RETURN count(n)" );
             long nodes = result.single().get( "count(n)" ).asLong();
             MatcherAssert.assertThat( nodes, equalTo( 1L ) );
         }
@@ -257,7 +257,7 @@ class SessionResetIT
         {
             try ( Session session = neo4j.driver().session() )
             {
-                StatementResult result = session.run( "CALL test.driver.longRunningStatement({seconds})",
+                Result result = session.run( "CALL test.driver.longRunningStatement({seconds})",
                         parameters( "seconds", executionTimeout ) );
 
                 resetSessionAfterTimeout( session, killTimeout );
@@ -289,7 +289,7 @@ class SessionResetIT
         {
             try ( Session session = neo4j.driver().session() )
             {
-                StatementResult result = session.run( "CALL test.driver.longStreamingResult({seconds})",
+                Result result = session.run( "CALL test.driver.longStreamingResult({seconds})",
                         parameters( "seconds", executionTimeout ) );
 
                 resetSessionAfterTimeout( session, killTimeout );
@@ -426,7 +426,7 @@ class SessionResetIT
                 {
                     usedSessionRef.set( session );
                     latchToWait.await();
-                    StatementResult result = updateNodeId( session, nodeId, newNodeId );
+                    Result result = updateNodeId( session, nodeId, newNodeId );
                     result.consume();
                 }
             }
@@ -447,7 +447,7 @@ class SessionResetIT
                 {
                     usedSessionRef.set( session );
                     latchToWait.await();
-                    StatementResult result = updateNodeId( tx, nodeId, newNodeId );
+                    Result result = updateNodeId( tx, nodeId, newNodeId );
                     result.consume();
                 }
             }
@@ -473,7 +473,7 @@ class SessionResetIT
                     session.writeTransaction( tx ->
                     {
                         invocationsOfWork.incrementAndGet();
-                        StatementResult result = updateNodeId( tx, nodeId, newNodeId );
+                        Result result = updateNodeId( tx, nodeId, newNodeId );
                         result.consume();
                         return null;
                     } );
@@ -498,7 +498,7 @@ class SessionResetIT
             tx.commit();
 
             // Then the outcome of both statements should be visible
-            StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+            Result result = session.run( "MATCH (n) RETURN count(n)" );
             long nodes = result.single().get( "count(n)" ).asLong();
             assertThat( nodes, equalTo( 1L ) );
         }
@@ -584,7 +584,7 @@ class SessionResetIT
         {
             Future<Void> txResult = nodeIdUpdater.update( nodeId, newNodeId1, otherSessionRef, nodeLocked );
 
-            StatementResult result = updateNodeId( tx, nodeId, newNodeId2 );
+            Result result = updateNodeId( tx, nodeId, newNodeId2 );
             result.consume();
 
             nodeLocked.countDown();
@@ -598,7 +598,7 @@ class SessionResetIT
 
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "MATCH (n) RETURN n.id AS id" );
+            Result result = session.run( "MATCH (n) RETURN n.id AS id" );
             int value = result.single().get( "id" ).asInt();
             assertEquals( newNodeId2, value );
         }
@@ -612,7 +612,7 @@ class SessionResetIT
         }
     }
 
-    private static StatementResult updateNodeId( StatementRunner statementRunner, int currentId, int newId )
+    private static Result updateNodeId(StatementRunner statementRunner, int currentId, int newId )
     {
         return statementRunner.run( "MATCH (n {id: $currentId}) SET n.id = $newId",
                 parameters( "currentId", currentId, "newId", newId ) );
@@ -753,7 +753,7 @@ class SessionResetIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "MATCH (n" + (label == null ? "" : ":" + label) + ") RETURN count(n) AS result" );
+            Result result = session.run( "MATCH (n" + (label == null ? "" : ":" + label) + ") RETURN count(n) AS result" );
             return result.single().get( 0 ).asLong();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/StatementIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/StatementIT.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -164,7 +164,7 @@ class StatementIT
         session.run( "CREATE (a {name:'Adam'})" );
 
         // And I run a read statement
-        StatementResult result2 = session.run( "MATCH (a) RETURN a.name" );
+        Result result2 = session.run( "MATCH (a) RETURN a.name" );
 
         // Then I expect to get the name back
         Value name = null;

--- a/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/StatementRunnerCloseIT.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ExecutorService;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -65,7 +65,7 @@ class StatementRunnerCloseIT
     void shouldErrorToAccessRecordsAfterConsume()
     {
         // Given
-        StatementResult result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
+        Result result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
 
         // When
         result.consume();
@@ -86,7 +86,7 @@ class StatementRunnerCloseIT
     {
         // Given
         Session session = neo4j.driver().session();
-        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
+        Result result = session.run("UNWIND [1,2] AS a RETURN a");
 
         // When
         session.close();
@@ -106,7 +106,7 @@ class StatementRunnerCloseIT
     void shouldAllowConsumeAndKeysAfterConsume()
     {
         // Given
-        StatementResult result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
+        Result result = neo4j.driver().session().run("UNWIND [1,2] AS a RETURN a");
         List<String> keys = result.keys();
 
         // When
@@ -125,7 +125,7 @@ class StatementRunnerCloseIT
     {
         // Given
         Session session = neo4j.driver().session();
-        StatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
+        Result result = session.run("UNWIND [1,2] AS a RETURN a");
         List<String> keys = result.keys();
         ResultSummary summary = result.consume();
 
@@ -145,7 +145,7 @@ class StatementRunnerCloseIT
     {
         // Given
         AsyncSession session = neo4j.driver().asyncSession();
-        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+        ResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
 
         // When
         await( result.consumeAsync() );
@@ -164,7 +164,7 @@ class StatementRunnerCloseIT
     {
         // Given
         AsyncSession session = neo4j.driver().asyncSession();
-        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+        ResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
 
         // When
         await( session.closeAsync() );
@@ -182,7 +182,7 @@ class StatementRunnerCloseIT
     {
         // Given
         AsyncSession session = neo4j.driver().asyncSession();
-        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+        ResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
 
         List<String> keys = result.keys();
 
@@ -202,7 +202,7 @@ class StatementRunnerCloseIT
     {
         // Given
         AsyncSession session = neo4j.driver().asyncSession();
-        StatementResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
+        ResultCursor result = await( session.runAsync( "UNWIND [1,2] AS a RETURN a" ) );
         List<String> keys = result.keys();
         ResultSummary summary = await( result.consumeAsync() );
 

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.summary.Notification;
 import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ProfiledPlan;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 
@@ -78,11 +78,11 @@ class SummaryIT
     void shouldContainBasicMetadata()
     {
         // Given
-        Value statementParameters = Values.parameters( "limit", 10 );
-        String statementText = "UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT $limit";
+        Value parameters = Values.parameters( "limit", 10 );
+        String query = "UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT $limit";
 
         // When
-        Result result = session.run( statementText, statementParameters );
+        Result result = session.run( query, parameters );
 
         // Then
         assertTrue( result.hasNext() );
@@ -91,9 +91,9 @@ class SummaryIT
         ResultSummary summary = result.consume();
 
         // Then
-        assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );
-        assertThat( summary.statement().text(), equalTo( statementText ) );
-        assertThat( summary.statement().parameters(), equalTo( statementParameters ) );
+        assertThat( summary.queryType(), equalTo( QueryType.READ_ONLY ) );
+        assertThat( summary.query().text(), equalTo( query ) );
+        assertThat( summary.query().parameters(), equalTo( parameters ) );
         assertFalse( summary.hasPlan() );
         assertFalse( summary.hasProfile() );
         assertThat( summary, equalTo( result.consume() ) );
@@ -147,12 +147,12 @@ class SummaryIT
     }
 
     @Test
-    void shouldContainCorrectStatementType()
+    void shouldContainCorrectQueryType()
     {
-        assertThat( session.run("MATCH (n) RETURN 1").consume().statementType(), equalTo( StatementType.READ_ONLY ));
-        assertThat( session.run("CREATE (n)").consume().statementType(), equalTo( StatementType.WRITE_ONLY ));
-        assertThat( session.run("CREATE (n) RETURN (n)").consume().statementType(), equalTo( StatementType.READ_WRITE ));
-        assertThat( session.run("CREATE INDEX ON :User(p)").consume().statementType(), equalTo( StatementType.SCHEMA_WRITE ));
+        assertThat( session.run("MATCH (n) RETURN 1").consume().queryType(), equalTo( QueryType.READ_ONLY ));
+        assertThat( session.run("CREATE (n)").consume().queryType(), equalTo( QueryType.WRITE_ONLY ));
+        assertThat( session.run("CREATE (n) RETURN (n)").consume().queryType(), equalTo( QueryType.READ_WRITE ));
+        assertThat( session.run("CREATE INDEX ON :User(p)").consume().queryType(), equalTo( QueryType.SCHEMA_WRITE ));
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
@@ -82,7 +82,7 @@ class SummaryIT
         String statementText = "UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT $limit";
 
         // When
-        StatementResult result = session.run( statementText, statementParameters );
+        Result result = session.run( statementText, statementParameters );
 
         // Then
         assertTrue( result.hasNext() );
@@ -140,7 +140,7 @@ class SummaryIT
     {
         try ( Session session = neo4j.driver().session( forDatabase( "system" ) ) )
         {
-            StatementResult result = session.run( "CREATE USER foo SET PASSWORD 'bar'" );
+            Result result = session.run( "CREATE USER foo SET PASSWORD 'bar'" );
             assertThat( result.consume().counters().containsUpdates(), equalTo( false ) );
             assertThat( result.consume().counters().containsSystemUpdates(), equalTo( true ) );
         }

--- a/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.types.IsoDuration;
 import java.util.function.Function;
@@ -410,7 +410,7 @@ class TemporalTypesIT
 
     private static void testDurationToString( long seconds, int nanoseconds, String expectedValue )
     {
-        StatementResult result = session.run( "RETURN duration({seconds: $s, nanoseconds: $n})", parameters( "s", seconds, "n", nanoseconds ) );
+        Result result = session.run( "RETURN duration({seconds: $s, nanoseconds: $n})", parameters( "s", seconds, "n", nanoseconds ) );
         IsoDuration duration = result.single().get( 0 ).asIsoDuration();
         assertEquals( expectedValue, duration.toString() );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionBoltV3IT.java
@@ -27,13 +27,13 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.TransientException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.util.DriverExtension;
@@ -89,7 +89,7 @@ class TransactionBoltV3IT
 
         CompletionStage<AsyncTransaction> txFuture = driver.asyncSession().beginTransactionAsync( config )
                 .thenCompose( tx -> tx.runAsync( "RETURN 1" )
-                        .thenCompose( StatementResultCursor::consumeAsync )
+                        .thenCompose( ResultCursor::consumeAsync )
                         .thenApply( ignore -> tx ) );
 
         AsyncTransaction transaction = await( txFuture );
@@ -175,7 +175,7 @@ class TransactionBoltV3IT
     {
         try ( Session session = driver.driver().session() )
         {
-            StatementResult result = session.run( "CALL dbms.listTransactions()" );
+            Result result = session.run( "CALL dbms.listTransactions()" );
 
             Map<String,Object> receivedMetadata = result.list()
                     .stream()

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
@@ -30,7 +30,7 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
@@ -92,7 +92,7 @@ class TransactionIT
         }
 
         // Then there should be no visible effect of the transaction
-        StatementResult cursor = session.run( "MATCH (n) RETURN count(n)" );
+        Result cursor = session.run( "MATCH (n) RETURN count(n)" );
         long nodes = cursor.single().get( "count(n)" ).asLong();
         assertThat( nodes, equalTo( 0L ) );
     }
@@ -106,7 +106,7 @@ class TransactionIT
         // When
         try ( Transaction tx = session.beginTransaction() )
         {
-            StatementResult res = tx.run( "MATCH (n) RETURN n.name" );
+            Result res = tx.run( "MATCH (n) RETURN n.name" );
 
             // Then
             assertThat( res.single().get( "n.name" ).asString(), equalTo( "Steve Brook" ) );
@@ -229,7 +229,7 @@ class TransactionIT
     {
         // GIVEN a successful query in a transaction
         Transaction tx = session.beginTransaction();
-        StatementResult result = tx.run( "CREATE (n) RETURN n" );
+        Result result = tx.run( "CREATE (n) RETURN n" );
         result.consume();
         tx.commit();
         tx.close();
@@ -294,7 +294,7 @@ class TransactionIT
 
         try ( Transaction anotherTx = session.beginTransaction() )
         {
-            StatementResult cursor = anotherTx.run( "RETURN 1" );
+            Result cursor = anotherTx.run( "RETURN 1" );
             int val = cursor.single().get( "1" ).asInt();
             assertThat( val, equalTo( 1 ) );
         }
@@ -307,14 +307,14 @@ class TransactionIT
         {
             try ( Transaction tx = session.beginTransaction() )
             {
-                StatementResult result = tx.run( "invalid" );
+                Result result = tx.run( "invalid" );
                 result.consume();
             }
         } );
 
         try ( Transaction tx = session.beginTransaction() )
         {
-            StatementResult cursor = tx.run( "RETURN 1" );
+            Result cursor = tx.run( "RETURN 1" );
             int val = cursor.single().get( "1" ).asInt();
             assertThat( val, equalTo( 1 ) );
         }
@@ -325,7 +325,7 @@ class TransactionIT
     {
         try ( Transaction tx = session.beginTransaction() )
         {
-            StatementResult result = tx.run( "RETURN Wrong" );
+            Result result = tx.run( "RETURN Wrong" );
 
             ClientException e = assertThrows( ClientException.class, result::consume );
             assertThat( e.code(), containsString( "SyntaxError" ) );
@@ -503,7 +503,7 @@ class TransactionIT
         }
 
         // Then the outcome of both statements should be visible
-        StatementResult result = session.run( "MATCH (n) RETURN count(n)" );
+        Result result = session.run( "MATCH (n) RETURN count(n)" );
         long nodes = result.single().get( "count(n)" ).asLong();
         if (isCommit)
         {

--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
@@ -114,7 +114,7 @@ class TransactionIT
     }
 
     @Test
-    void shouldNotAllowSessionLevelStatementsWhenThereIsATransaction()
+    void shouldNotAllowSessionLevelQueriesWhenThereIsATransaction()
     {
         session.beginTransaction();
 
@@ -453,10 +453,10 @@ class TransactionIT
             assertThat( error1.code(), containsString( "SyntaxError" ) );
 
             ClientException error2 = assertThrows( ClientException.class, () -> tx.run( "CREATE (:OtherNode)" ).consume() );
-            assertThat( error2.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
+            assertThat( error2.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
 
             ClientException error3 = assertThrows( ClientException.class, () -> tx.run( "RETURN 42" ).consume() );
-            assertThat( error3.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
+            assertThat( error3.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
         }
 
         assertEquals( 0, countNodesByLabel( "Node" ) );
@@ -464,7 +464,7 @@ class TransactionIT
     }
 
     @Test
-    void shouldRollbackWhenMarkedSuccessfulButOneStatementFails()
+    void shouldRollbackWhenMarkedSuccessfulButOneQueryFails()
     {
         ClientException error = assertThrows( ClientException.class, () ->
         {
@@ -502,7 +502,7 @@ class TransactionIT
             txConsumer.accept( tx );
         }
 
-        // Then the outcome of both statements should be visible
+        // Then the outcome of both queries should be visible
         Result result = session.run( "MATCH (n) RETURN count(n)" );
         long nodes = result.single().get( "count(n)" ).asLong();
         if (isCommit)
@@ -532,7 +532,7 @@ class TransactionIT
         txConsumer.accept( tx );
 
         ClientException e = assertThrows( ClientException.class, () -> tx.run( "CREATE (:MyOtherLabel)" ) );
-        assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
+        assertThat( e.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
     }
 
     private static int countNodesByLabel( String label )

--- a/driver/src/test/java/org/neo4j/driver/integration/TrustCustomCertificateIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TrustCustomCertificateIT.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.SecurityException;
 import org.neo4j.driver.util.CertificateExtension;
 import org.neo4j.driver.util.CertificateUtil.CertificateKeyPair;
@@ -83,7 +83,7 @@ class TrustCustomCertificateIT
     {
         try ( Driver driver = driverSupplier.get(); Session session = driver.session() )
         {
-            StatementResult result = session.run( "RETURN 1 as n" );
+            Result result = session.run( "RETURN 1 as n" );
             assertThat( result.single().get( "n" ).asInt(), equalTo( 1 ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/UnsupportedBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/UnsupportedBoltV3IT.java
@@ -75,13 +75,13 @@ class UnsupportedBoltV3IT
     }
 
     @Test
-    void shouldNotSupportExplicitTransactionsWithTransactionConfig()
+    void shouldNotSupportUnmanagedTransactionsWithTransactionConfig()
     {
         assertTxConfigNotSupported( () -> driver.session().beginTransaction( txConfig ) );
     }
 
     @Test
-    void shouldNotSupportAsyncExplicitTransactionsWithTransactionConfig()
+    void shouldNotSupportAsyncUnmanagedTransactionsWithTransactionConfig()
     {
         assertTxConfigNotSupported( driver.asyncSession().beginTransactionAsync( txConfig ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -38,7 +38,7 @@ import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -122,7 +122,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "CREATE (n:Node {id: 42}) RETURN n" ) );
+        ResultCursor cursor = await( tx.runAsync( "CREATE (n:Node {id: 42}) RETURN n" ) );
 
         Record record = await( cursor.nextAsync() );
         assertNotNull( record );
@@ -140,7 +140,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "CREATE (n:Node {id: 4242}) RETURN n" ) );
+        ResultCursor cursor = await( tx.runAsync( "CREATE (n:Node {id: 4242}) RETURN n" ) );
         Record record = await( cursor.nextAsync() );
         assertNotNull( record );
         Node node = record.get( 0 ).asNode();
@@ -157,13 +157,13 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node {id: 1})" ) );
+        ResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node {id: 1})" ) );
         assertNull( await( cursor1.nextAsync() ) );
 
-        StatementResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node {id: 2})" ) );
+        ResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node {id: 2})" ) );
         assertNull( await( cursor2.nextAsync() ) );
 
-        StatementResultCursor cursor3 = await( tx.runAsync( "CREATE (n:Node {id: 2})" ) );
+        ResultCursor cursor3 = await( tx.runAsync( "CREATE (n:Node {id: 2})" ) );
         assertNull( await( cursor3.nextAsync() ) );
 
         assertNull( await( tx.commitAsync() ) );
@@ -190,10 +190,10 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node {id: 1})" ) );
+        ResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node {id: 1})" ) );
         assertNull( await( cursor1.nextAsync() ) );
 
-        StatementResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node {id: 42})" ) );
+        ResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node {id: 42})" ) );
         assertNull( await( cursor2.nextAsync() ) );
 
         assertNull( await( tx.rollbackAsync() ) );
@@ -219,7 +219,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN" ) );
 
         Exception e = assertThrows( Exception.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
@@ -232,7 +232,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN" ) );
 
         Exception e = assertThrows( Exception.class, () -> await( cursor.nextAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
@@ -244,17 +244,17 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node) RETURN n" ) );
+        ResultCursor cursor1 = await( tx.runAsync( "CREATE (n:Node) RETURN n" ) );
         Record record1 = await( cursor1.nextAsync() );
         assertNotNull( record1 );
         assertTrue( record1.get( 0 ).asNode().hasLabel( "Node" ) );
 
-        StatementResultCursor cursor2 = await( tx.runAsync( "RETURN 42" ) );
+        ResultCursor cursor2 = await( tx.runAsync( "RETURN 42" ) );
         Record record2 = await( cursor2.nextAsync() );
         assertNotNull( record2 );
         assertEquals( 42, record2.get( 0 ).asInt() );
 
-        StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
+        ResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
 
         Exception e = assertThrows( Exception.class, () -> await( cursor3.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
@@ -267,17 +267,17 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor1 = await( tx.runAsync( "RETURN 4242" ) );
+        ResultCursor cursor1 = await( tx.runAsync( "RETURN 4242" ) );
         Record record1 = await( cursor1.nextAsync() );
         assertNotNull( record1 );
         assertEquals( 4242, record1.get( 0 ).asInt() );
 
-        StatementResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node) DELETE n RETURN 42" ) );
+        ResultCursor cursor2 = await( tx.runAsync( "CREATE (n:Node) DELETE n RETURN 42" ) );
         Record record2 = await( cursor2.nextAsync() );
         assertNotNull( record2 );
         assertEquals( 42, record2.get( 0 ).asInt() );
 
-        StatementResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
+        ResultCursor cursor3 = await( tx.runAsync( "RETURN" ) );
 
         Exception e = assertThrows( Exception.class, () -> await( cursor3.consumeAsync() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
@@ -289,7 +289,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN" ) );
 
         Exception e1 = assertThrows( Exception.class, () -> await( cursor.nextAsync() ) );
         assertThat( e1, is( syntaxError( "Unexpected end of input" ) ) );
@@ -358,7 +358,7 @@ class AsyncTransactionIT
     void shouldExposeStatementKeysForColumnsWithAliases()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN 1 AS one, 2 AS two, 3 AS three, 4 AS five" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN 1 AS one, 2 AS two, 3 AS three, 4 AS five" ) );
 
         assertEquals( Arrays.asList( "one", "two", "three", "five" ), cursor.keys() );
     }
@@ -367,7 +367,7 @@ class AsyncTransactionIT
     void shouldExposeStatementKeysForColumnsWithoutAliases()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN 1, 2, 3, 5" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN 1, 2, 3, 5" ) );
 
         assertEquals( Arrays.asList( "1", "2", "3", "5" ), cursor.keys() );
     }
@@ -379,7 +379,7 @@ class AsyncTransactionIT
         Value params = parameters( "name1", "Bob", "name2", "John" );
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query, params ) );
+        ResultCursor cursor = await( tx.runAsync( query, params ) );
         ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query, params ), summary.statement() );
@@ -402,7 +402,7 @@ class AsyncTransactionIT
         String query = "EXPLAIN MATCH (n) RETURN n";
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query ) );
+        ResultCursor cursor = await( tx.runAsync( query ) );
         ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query ), summary.statement() );
@@ -430,7 +430,7 @@ class AsyncTransactionIT
         Value params = parameters( "name", "Bob" );
 
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query, params ) );
+        ResultCursor cursor = await( tx.runAsync( query, params ) );
         ResultSummary summary = await( cursor.consumeAsync() );
 
         assertEquals( new Statement( query, params ), summary.statement() );
@@ -454,7 +454,7 @@ class AsyncTransactionIT
     void shouldPeekRecordFromCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
 
         assertEquals( "a", await( cursor.peekAsync() ).get( 0 ).asString() );
         assertEquals( "a", await( cursor.peekAsync() ).get( 0 ).asString() );
@@ -490,7 +490,7 @@ class AsyncTransactionIT
     void shouldFailForEachWhenActionFails()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hi!'" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN 'Hi!'" ) );
         RuntimeException error = new RuntimeException();
 
         RuntimeException e = assertThrows( RuntimeException.class, () ->
@@ -519,7 +519,7 @@ class AsyncTransactionIT
     void shouldConvertToTransformedListWithEmptyCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "CREATE ()" ) );
+        ResultCursor cursor = await( tx.runAsync( "CREATE ()" ) );
         List<Map<String,Object>> maps = await( cursor.listAsync( record -> record.get( 0 ).asMap() ) );
         assertEquals( 0, maps.size() );
     }
@@ -528,7 +528,7 @@ class AsyncTransactionIT
     void shouldConvertToTransformedListWithNonEmptyCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b', 'c'] AS x RETURN x" ) );
         List<String> strings = await( cursor.listAsync( record -> record.get( 0 ).asString() + "!" ) );
         assertEquals( Arrays.asList( "a!", "b!", "c!" ), strings );
     }
@@ -537,7 +537,7 @@ class AsyncTransactionIT
     void shouldFailWhenListTransformationFunctionFails()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hello'" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN 'Hello'" ) );
         IOException error = new IOException( "World" );
 
         Exception e = assertThrows( Exception.class, () ->
@@ -564,7 +564,7 @@ class AsyncTransactionIT
     void shouldFailSingleWithEmptyCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "MATCH (n:NoSuchLabel) RETURN n" ) );
+        ResultCursor cursor = await( tx.runAsync( "MATCH (n:NoSuchLabel) RETURN n" ) );
 
         NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), containsString( "result is empty" ) );
@@ -574,7 +574,7 @@ class AsyncTransactionIT
     void shouldFailSingleWithMultiRecordCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b'] AS x RETURN x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND ['a', 'b'] AS x RETURN x" ) );
 
         NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), startsWith( "Expected a result with a single record" ) );
@@ -584,7 +584,7 @@ class AsyncTransactionIT
     void shouldReturnSingleWithSingleRecordCursor()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN 'Hello!'" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN 'Hello!'" ) );
 
         Record record = await( cursor.singleAsync() );
 
@@ -595,7 +595,7 @@ class AsyncTransactionIT
     void shouldPropagateFailureFromFirstRecordInSingleAsync()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND [0] AS x RETURN 10 / x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND [0] AS x RETURN 10 / x" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
@@ -605,7 +605,7 @@ class AsyncTransactionIT
     void shouldNotPropagateFailureFromSecondRecordInSingleAsync()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 10 / x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 10 / x" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
@@ -630,7 +630,7 @@ class AsyncTransactionIT
         tx.runAsync( "CREATE (:MyLabel)" );
         assertNull( await( tx.commitAsync() ) );
 
-        StatementResultCursor cursor = await( session.runAsync( "MATCH (n:MyLabel) RETURN count(n)" ) );
+        ResultCursor cursor = await( session.runAsync( "MATCH (n:MyLabel) RETURN count(n)" ) );
         assertEquals( 1, await( cursor.singleAsync() ).get( 0 ).asInt() );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
@@ -644,7 +644,7 @@ class AsyncTransactionIT
         tx.runAsync( "CREATE (:MyLabel)" );
         assertNull( await( tx.rollbackAsync() ) );
 
-        StatementResultCursor cursor = await( session.runAsync( "MATCH (n:MyLabel) RETURN count(n)" ) );
+        ResultCursor cursor = await( session.runAsync( "MATCH (n:MyLabel) RETURN count(n)" ) );
         assertEquals( 0, await( cursor.singleAsync() ).get( 0 ).asInt() );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.runAsync( "CREATE (:MyOtherLabel)" ) ) );
@@ -772,7 +772,7 @@ class AsyncTransactionIT
     void shouldFailToCommitWhenRunFailureIsConsumed()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
         ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e1.code(), containsString( "SyntaxError" ) );
@@ -785,7 +785,7 @@ class AsyncTransactionIT
     void shouldFailToCommitWhenPullAllFailureIsConsumed()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync(
+        ResultCursor cursor = await( tx.runAsync(
                 "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" ) );
 
         ClientException e1 = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
@@ -799,7 +799,7 @@ class AsyncTransactionIT
     void shouldRollbackWhenRunFailureIsConsumed()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
@@ -810,7 +810,7 @@ class AsyncTransactionIT
     void shouldRollbackWhenPullAllFailureIsConsumed()
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 5 / x" ) );
+        ResultCursor cursor = await( tx.runAsync( "UNWIND [1, 0] AS x RETURN 5 / x" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
@@ -822,7 +822,7 @@ class AsyncTransactionIT
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
 
-        StatementResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
+        ResultCursor cursor = await( tx.runAsync( "RETURN Wrong" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( cursor.consumeAsync() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
@@ -831,14 +831,14 @@ class AsyncTransactionIT
 
     private int countNodes( Object id )
     {
-        StatementResultCursor cursor = await( session.runAsync( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) ) );
+        ResultCursor cursor = await( session.runAsync( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) ) );
         return await( cursor.singleAsync() ).get( 0 ).asInt();
     }
 
     private void testForEach( String query, int expectedSeenRecords )
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query ) );
+        ResultCursor cursor = await( tx.runAsync( query ) );
 
         AtomicInteger recordsSeen = new AtomicInteger();
         CompletionStage<ResultSummary> forEachDone = cursor.forEachAsync( record -> recordsSeen.incrementAndGet() );
@@ -853,7 +853,7 @@ class AsyncTransactionIT
     private <T> void testList( String query, List<T> expectedList )
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query ) );
+        ResultCursor cursor = await( tx.runAsync( query ) );
         List<Record> records = await( cursor.listAsync() );
         List<Object> actualList = new ArrayList<>();
         for ( Record record : records )
@@ -866,7 +866,7 @@ class AsyncTransactionIT
     private void testConsume( String query )
     {
         AsyncTransaction tx = await( session.beginTransactionAsync() );
-        StatementResultCursor cursor = await( tx.runAsync( query ) );
+        ResultCursor cursor = await( tx.runAsync( query ) );
         ResultSummary summary = await( cursor.consumeAsync() );
 
         assertNotNull( summary );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxNestedQueriesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxNestedQueriesIT.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import org.neo4j.driver.exceptions.TransactionNestingException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -53,7 +53,7 @@ class RxNestedQueriesIT
                 session -> Flux.from( session.run( "UNWIND range(1, $size) AS x RETURN x", Collections.singletonMap( "size", size ) ).records() )
                         .limitRate( 20 ).flatMap( record -> {
                             int x = record.get( "x" ).asInt();
-                            RxStatementResult innerResult = session.run( "CREATE (n:Node {id: $x}) RETURN n.id", Collections.singletonMap( "x", x ) );
+                            RxResult innerResult = session.run( "CREATE (n:Node {id: $x}) RETURN n.id", Collections.singletonMap( "x", x ) );
                             return innerResult.records();
                         } ).map( r -> r.get( 0 ).asInt() ),
                 RxSession::close );
@@ -131,11 +131,11 @@ class RxNestedQueriesIT
         Flux<Integer> nodeIds = Flux.usingWhen(
                 session.beginTransaction(),
                 tx -> {
-                    RxStatementResult result = tx.run( "UNWIND range(1, $size) AS x RETURN x",
+                    RxResult result = tx.run( "UNWIND range(1, $size) AS x RETURN x",
                             Collections.singletonMap( "size", size ) );
                     return Flux.from( result.records() ).limitRate( 20 ).flatMap( record -> {
                         int x = record.get( "x" ).asInt();
-                        RxStatementResult innerResult = tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
+                        RxResult innerResult = tx.run( "CREATE (n:Node {id: $x}) RETURN n.id",
                                 Collections.singletonMap( "x", x ) );
                         return innerResult.records();
                     } ).map( record -> record.get( 0 ).asInt() );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
@@ -32,7 +32,7 @@ import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 
@@ -228,7 +228,7 @@ class RxResultIT
 
         StepVerifier.create( summaryMono )
                 .assertNext( summary -> {
-                    assertThat( summary.statement().text(), equalTo( "INVALID" ) );
+                    assertThat( summary.query().text(), equalTo( "INVALID" ) );
                     assertNotNull( summary.server().address() );
                     assertNotNull( summary.server().version() );
                 } ).verifyComplete();
@@ -281,7 +281,7 @@ class RxResultIT
                 .assertNext( summary -> {
                     // Then
                     assertThat( summary, notNullValue() );
-                    assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );
+                    assertThat( summary.queryType(), equalTo( QueryType.READ_ONLY ) );
                 } ).expectComplete().verify();
     }
 
@@ -354,7 +354,7 @@ class RxResultIT
                 Flux.from( session.beginTransaction() ).single()
                         .flatMap( tx -> Flux.from( tx.rollback() ).singleOrEmpty().thenReturn( tx ) )
                         .flatMapMany( tx -> tx.run( "UNWIND [1,2] AS a RETURN a" ).records() ) )
-                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more statements" ) ) )
+                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more queries" ) ) )
                 .verify();
     }
 
@@ -370,7 +370,7 @@ class RxResultIT
                 Flux.from( session.beginTransaction() ).single()
                         .flatMap( tx -> Flux.from( tx.rollback() ).singleOrEmpty().thenReturn( tx ) )
                         .flatMapMany( tx -> tx.run( "UNWIND [1,2] AS a RETURN a" ).keys() ) )
-                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more statements" ) ) )
+                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more queries" ) ) )
                 .verify();
     }
 
@@ -386,7 +386,7 @@ class RxResultIT
                 Flux.from( session.beginTransaction() ).single()
                         .flatMap( tx -> Flux.from( tx.rollback() ).singleOrEmpty().thenReturn( tx ) )
                         .flatMapMany( tx -> tx.run( "UNWIND [1,2] AS a RETURN a" ).consume() ) )
-                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more statements" ) ) )
+                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more queries" ) ) )
                 .verify();
     }
 
@@ -402,7 +402,7 @@ class RxResultIT
                 Flux.from( session.beginTransaction() ).single()
                         .flatMap( tx -> Flux.from( tx.rollback() ).singleOrEmpty().thenReturn( tx ) )
                         .flatMapMany( tx -> tx.run( "UNWIND [1,2] AS a RETURN a" ).consume() ) )
-                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more statements" ) ) )
+                .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "Cannot run more queries" ) ) )
                 .verify();
     }
 
@@ -454,9 +454,9 @@ class RxResultIT
     private void verifyCanAccessSummary( RxResult res )
     {
         StepVerifier.create( res.consume() ).assertNext( summary -> {
-            assertThat( summary.statement().text(), equalTo( "UNWIND [1,2,3,4] AS a RETURN a" ) );
+            assertThat( summary.query().text(), equalTo( "UNWIND [1,2,3,4] AS a RETURN a" ) );
             assertThat( summary.counters().nodesCreated(), equalTo( 0 ) );
-            assertThat( summary.statementType(), equalTo( StatementType.READ_ONLY ) );
+            assertThat( summary.queryType(), equalTo( QueryType.READ_ONLY ) );
         } ).verifyComplete();
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
@@ -30,7 +30,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.StatementType;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -52,7 +52,7 @@ import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
 
 @EnabledOnNeo4jWith( BOLT_V4 )
 @ParallelizableIT
-class RxStatementResultIT
+class RxResultIT
 {
     @RegisterExtension
     static final DatabaseExtension neo4j = new DatabaseExtension();
@@ -61,7 +61,7 @@ class RxStatementResultIT
     void shouldAllowIteratingOverResultStream()
     {
         // When
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         // Then I should be able to iterate over the result
         verifyCanAccessFullRecords( res );
@@ -73,7 +73,7 @@ class RxStatementResultIT
         // When
         int size = 100000;
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult res = session.run( "UNWIND range(1, $size) AS x RETURN x", parameters( "size", size ) );
+        RxResult res = session.run( "UNWIND range(1, $size) AS x RETURN x", parameters( "size", size ) );
 
         // Then I should be able to iterate over the result
         StepVerifier.FirstStep<Integer> step = StepVerifier.create( Flux.from( res.records() ).limitRate( 100 ).map( r -> r.get( "x" ).asInt() ) );
@@ -89,7 +89,7 @@ class RxStatementResultIT
     void shouldReturnKeysRecordsAndSummaryInOrder()
     {
         // When
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         // Then I should be able to iterate over the result
         verifyCanAccessKeys( res );
@@ -101,7 +101,7 @@ class RxStatementResultIT
     void shouldSecondVisitOfRecordReceiveEmptyRecordStream() throws Throwable
     {
         // When
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         // Then I should be able to iterate over the result
         verifyCanAccessFullRecords( res );
@@ -113,7 +113,7 @@ class RxStatementResultIT
     void shouldReturnKeysSummaryAndDiscardRecords()
     {
         // When
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         verifyCanAccessKeys( res );
         verifyCanAccessSummary( res );
@@ -124,7 +124,7 @@ class RxStatementResultIT
     void shouldAllowOnlySummary()
     {
         // When
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         verifyCanAccessSummary( res );
     }
@@ -133,7 +133,7 @@ class RxStatementResultIT
     void shouldAllowAccessKeysAndSummaryAfterRecord() throws Throwable
     {
         // Given
-        RxStatementResult res = sessionRunUnwind();
+        RxResult res = sessionRunUnwind();
 
         // Then I should be able to iterate over the result
         verifyCanAccessFullRecords( res );
@@ -152,7 +152,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult rs =
+        RxResult rs =
                 session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
@@ -167,7 +167,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult rs =
+        RxResult rs =
                 session.run( "CREATE (n:Person {name:$name}) RETURN n", parameters( "name", "Tom Hanks" ) );
 
         // When
@@ -182,7 +182,7 @@ class RxStatementResultIT
     {
         // When
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult res = session.run( "CREATE (n:TestNode {name:'test'}) RETURN n" );
+        RxResult res = session.run( "CREATE (n:TestNode {name:'test'}) RETURN n" );
 
         // Then
         StepVerifier.create( res.keys() ).expectNext( singletonList( "n" ) ).expectComplete().verify();
@@ -199,7 +199,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
+        RxResult rs = session.run( "CREATE (n:Person {name:$name})", parameters( "name", "Tom Hanks" ) );
 
         // Then
         StepVerifier.create( rs.keys() ).expectNext( emptyList() ).expectComplete().verify();
@@ -211,7 +211,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "INVALID" );
+        RxResult result = session.run( "INVALID" );
 
         // When
         Flux<List<String>> keys = Flux.from( result.keys() );
@@ -240,7 +240,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "INVALID" );
+        RxResult result = session.run( "INVALID" );
 
         // When
         Flux<List<String>> keys = Flux.from( result.keys() );
@@ -266,7 +266,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run("UNWIND [1,2] AS a RETURN a");
+        RxResult result = session.run("UNWIND [1,2] AS a RETURN a");
 
         // When
         StepVerifier.create( Flux.from( result.records() )
@@ -290,7 +290,7 @@ class RxStatementResultIT
     {
         RxSession session = neo4j.driver().rxSession();
 
-        RxStatementResult result = session.run( "CYPHER runtime=interpreted UNWIND range(5, 0, -1) AS x RETURN x / x" );
+        RxResult result = session.run( "CYPHER runtime=interpreted UNWIND range(5, 0, -1) AS x RETURN x / x" );
         StepVerifier.create( Flux.from( result.records() ).map( record -> record.get( 0 ).asInt() ) )
                 .expectNext( 1 )
                 .expectNext( 1 )
@@ -308,7 +308,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create( Flux.from( session.close() ).thenMany( result.records() ) ).expectErrorSatisfies( error -> {
@@ -321,7 +321,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create( Flux.from( session.close() ).thenMany( result.keys() ) ).expectErrorSatisfies( error -> {
@@ -334,7 +334,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create( Flux.from( session.close() ).thenMany( result.consume() ) ).expectErrorSatisfies( error -> {
@@ -347,7 +347,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create(
@@ -363,7 +363,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create(
@@ -379,7 +379,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create(
@@ -395,7 +395,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
+        RxResult result = session.run( "UNWIND [1,2] AS a RETURN a" );
 
         // When
         StepVerifier.create(
@@ -411,7 +411,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "Invalid" );
+        RxResult result = session.run( "Invalid" );
 
         // When
         StepVerifier.create( Flux.from( result.consume() ) )
@@ -428,7 +428,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "Invalid" );
+        RxResult result = session.run( "Invalid" );
 
         // When
         StepVerifier.create( Flux.from( result.keys() ) ).expectNext( EMPTY_LIST ).verifyComplete();
@@ -440,7 +440,7 @@ class RxStatementResultIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult result = session.run( "Invalid" );
+        RxResult result = session.run( "Invalid" );
 
         // When
         StepVerifier.create( Flux.from( result.records() ) )
@@ -451,7 +451,7 @@ class RxStatementResultIT
         verifyRecordsAlreadyDiscarded( result );
     }
 
-    private void verifyCanAccessSummary( RxStatementResult res )
+    private void verifyCanAccessSummary( RxResult res )
     {
         StepVerifier.create( res.consume() ).assertNext( summary -> {
             assertThat( summary.statement().text(), equalTo( "UNWIND [1,2,3,4] AS a RETURN a" ) );
@@ -460,25 +460,25 @@ class RxStatementResultIT
         } ).verifyComplete();
     }
 
-    private void verifyRecordsAlreadyDiscarded( RxStatementResult res )
+    private void verifyRecordsAlreadyDiscarded( RxResult res )
     {
         StepVerifier.create( Flux.from( res.records() ) )
                 .expectErrorSatisfies( error -> assertThat( error.getMessage(), containsString( "has already been consumed" ) ) )
                 .verify();
     }
 
-    private void verifyCanAccessFullRecords( RxStatementResult res )
+    private void verifyCanAccessFullRecords( RxResult res )
     {
         StepVerifier.create( Flux.from( res.records() ).map( r -> r.get( "a" ).asInt() ) ).expectNext( 1 ).expectNext( 2 ).expectNext( 3 ).expectNext(
                 4 ).expectComplete().verify();
     }
 
-    private void verifyCanAccessKeys( RxStatementResult res )
+    private void verifyCanAccessKeys( RxResult res )
     {
         StepVerifier.create( res.keys() ).expectNext( singletonList( "a" ) ).verifyComplete();
     }
 
-    private RxStatementResult sessionRunUnwind()
+    private RxResult sessionRunUnwind()
     {
         RxSession session = neo4j.driver().rxSession();
         return session.run( "UNWIND [1,2,3,4] AS a RETURN a" );

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxSessionIT.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.DatabaseException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -39,7 +39,7 @@ import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.reactive.RxTransactionWork;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -65,7 +65,7 @@ class RxSessionIT
     {
         // When
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        RxResult res = session.run( "UNWIND [1,2,3,4] AS a RETURN a" );
 
         // Then I should be able to iterate over the result
         StepVerifier.create( Flux.from( res.records() ).map( r -> r.get( "a" ).asInt() ) )
@@ -82,12 +82,12 @@ class RxSessionIT
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
-        RxStatementResult res1 = session.run( "INVALID" );
+        RxResult res1 = session.run( "INVALID" );
 
         StepVerifier.create( res1.records() ).expectError( ClientException.class ).verify();
 
         // When
-        RxStatementResult res2 = session.run( "RETURN 1" );
+        RxResult res2 = session.run( "RETURN 1" );
 
         // Then
         StepVerifier.create( res2.records() ).assertNext( record -> {
@@ -196,7 +196,7 @@ class RxSessionIT
     {
         try ( Session session = neo4j.driver().session() )
         {
-            StatementResult result = session.run( "MATCH (n:" + label + ") RETURN count(n)" );
+            Result result = session.run( "MATCH (n:" + label + ") RETURN count(n)" );
             return result.single().get( 0 ).asLong();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
@@ -45,7 +45,7 @@ import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.StatementType;
@@ -147,13 +147,13 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
         await( cursor1.records() );
 
-        RxStatementResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
+        RxResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
         await( cursor2.records() );
 
-        RxStatementResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
         await( cursor3.records() );
 
         assertCanCommitOrRollback( commit, tx );
@@ -167,9 +167,9 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
-        RxStatementResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
-        RxStatementResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
+        RxResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
 
         await( Flux.from( cursor1.records() ).concatWith( cursor2.records() ).concatWith( cursor3.records() ) );
         assertCanCommitOrRollback( commit, tx );
@@ -183,8 +183,8 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult cursor1 = tx.run( "CREATE (n:Person {name: 'Alice'}) RETURN n.name" );
-        RxStatementResult cursor2 = tx.run( "CREATE (n:Person {name: 'Bob'}) RETURN n.name" );
+        RxResult cursor1 = tx.run( "CREATE (n:Person {name: 'Alice'}) RETURN n.name" );
+        RxResult cursor2 = tx.run( "CREATE (n:Person {name: 'Bob'}) RETURN n.name" );
 
         // The execution order is the same as the record publishing order.
         List<Record> records = await( Flux.from( cursor2.records() ).concatWith( cursor1.records() ) );
@@ -200,7 +200,7 @@ class RxTransactionIT
     void shouldDiscardOnCommitOrRollback( boolean commit )
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult cursor = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
+        RxResult cursor = tx.run( "UNWIND [1,2,3,4] AS a RETURN a" );
 
         // We only perform run without any pull
         await( Flux.from( cursor.keys() ) );
@@ -220,9 +220,9 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
-        RxStatementResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
-        RxStatementResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor1 = tx.run( "CREATE (n:Node {id: 1})" );
+        RxResult cursor2 = tx.run( "CREATE (n:Node {id: 2})" );
+        RxResult cursor3 = tx.run( "CREATE (n:Node {id: 1})" );
 
         await( Flux.from( cursor1.keys() ).concatWith( cursor2.keys() ).concatWith( cursor3.keys() ) );
         assertCanCommitOrRollback( commit, tx );
@@ -275,7 +275,7 @@ class RxTransactionIT
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
         assertFailToRunWrongStatement( tx );
 
-        RxStatementResult result = tx.run( "CREATE ()" );
+        RxResult result = tx.run( "CREATE ()" );
         Exception e = assertThrows( Exception.class, () -> await( result.records() ) );
         assertThat( e.getMessage(), startsWith( "Cannot run more statements in this transaction" ) );
 
@@ -361,7 +361,7 @@ class RxTransactionIT
     void shouldExposeStatementKeysForColumnsWithAliases()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "RETURN 1 AS one, 2 AS two, 3 AS three, 4 AS five" );
+        RxResult result = tx.run( "RETURN 1 AS one, 2 AS two, 3 AS three, 4 AS five" );
 
         List<String> keys = await( Mono.from( result.keys() ) );
         assertEquals( Arrays.asList( "one", "two", "three", "five" ), keys );
@@ -373,7 +373,7 @@ class RxTransactionIT
     void shouldExposeStatementKeysForColumnsWithoutAliases()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "RETURN 1, 2, 3, 5" );
+        RxResult result = tx.run( "RETURN 1, 2, 3, 5" );
 
         List<String> keys = await( Mono.from( result.keys() ) );
         assertEquals( Arrays.asList( "1", "2", "3", "5" ), keys );
@@ -388,7 +388,7 @@ class RxTransactionIT
         String query = "CREATE (p1:Person {name: $name1})-[:KNOWS]->(p2:Person {name: $name2}) RETURN p1, p2";
         Value params = parameters( "name1", "Bob", "name2", "John" );
 
-        RxStatementResult result = tx.run( query, params );
+        RxResult result = tx.run( query, params );
         await( result.records() ); // we run and stream
 
         ResultSummary summary = await( Mono.from( result.consume() ) );
@@ -416,7 +416,7 @@ class RxTransactionIT
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
         String query = "EXPLAIN MATCH (n) RETURN n";
 
-        RxStatementResult result = tx.run( query );
+        RxResult result = tx.run( query );
         await( result.records() ); // we run and stream
 
         ResultSummary summary = await( Mono.from( result.consume() ) );
@@ -448,7 +448,7 @@ class RxTransactionIT
 
         Value params = parameters( "name", "Bob" );
 
-        RxStatementResult result = tx.run( query, params );
+        RxResult result = tx.run( query, params );
         await( result.records() ); // we run and stream
 
         ResultSummary summary = await( Mono.from( result.consume() ) );
@@ -476,7 +476,7 @@ class RxTransactionIT
     void shouldCancelRecordStream()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "UNWIND ['a', 'b', 'c'] AS x RETURN x" );
+        RxResult result = tx.run( "UNWIND ['a', 'b', 'c'] AS x RETURN x" );
 
         Flux<String> abc = Flux.from( result.records() ).limitRate( 1 ).take( 1 ).map( record -> record.get( 0 ).asString() );
         StepVerifier.create( abc ).expectNext( "a" ).verifyComplete();
@@ -525,7 +525,7 @@ class RxTransactionIT
     void shouldConvertToTransformedListWithEmptyCursor()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "CREATE ()" );
+        RxResult result = tx.run( "CREATE ()" );
         List<Map<String,Object>> maps = await( Flux.from( result.records() ).map( record -> record.get( 0 ).asMap() )  );
         assertEquals( 0, maps.size() );
         assertCanRollback( tx );
@@ -535,7 +535,7 @@ class RxTransactionIT
     void shouldConvertToTransformedListWithNonEmptyCursor()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "UNWIND ['a', 'b', 'c'] AS x RETURN x" );
+        RxResult result = tx.run( "UNWIND ['a', 'b', 'c'] AS x RETURN x" );
         List<String> strings = await( Flux.from( result.records() ).map( record -> record.get( 0 ).asString() + "!" )  );
 
         assertEquals( Arrays.asList( "a!", "b!", "c!" ), strings );
@@ -560,7 +560,7 @@ class RxTransactionIT
     void shouldFailToCommitWhenServerIsRestarted()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "RETURN 1" );
+        RxResult result = tx.run( "RETURN 1" );
 
         assertThrows( ServiceUnavailableException.class, () -> {
             await( Flux.from( result.records() ).doOnSubscribe( subscription -> {
@@ -576,7 +576,7 @@ class RxTransactionIT
     void shouldFailSingleWithEmptyCursor()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "MATCH (n:NoSuchLabel) RETURN n" );
+        RxResult result = tx.run( "MATCH (n:NoSuchLabel) RETURN n" );
 
         NoSuchElementException e = assertThrows( NoSuchElementException.class, () -> await( Flux.from( result.records() ).single() ) );
         assertThat( e.getMessage(), containsString( "Source was empty" ) );
@@ -587,7 +587,7 @@ class RxTransactionIT
     void shouldFailSingleWithMultiRecordCursor()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "UNWIND ['a', 'b'] AS x RETURN x" );
+        RxResult result = tx.run( "UNWIND ['a', 'b'] AS x RETURN x" );
 
         IndexOutOfBoundsException e = assertThrows( IndexOutOfBoundsException.class, () -> await( Flux.from( result.records() ).single() ) );
         assertThat( e.getMessage(), startsWith( "Source emitted more than one item" ) );
@@ -598,7 +598,7 @@ class RxTransactionIT
     void shouldReturnSingleWithSingleRecordCursor()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "RETURN 'Hello!'" );
+        RxResult result = tx.run( "RETURN 'Hello!'" );
 
         Record record = await( Flux.from( result.records() ).single() );
         assertEquals( "Hello!", record.get( 0 ).asString() );
@@ -609,7 +609,7 @@ class RxTransactionIT
     void shouldPropagateFailureFromFirstRecordInSingleAsync()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "UNWIND [0] AS x RETURN 10 / x" );
+        RxResult result = tx.run( "UNWIND [0] AS x RETURN 10 / x" );
 
         ClientException e = assertThrows( ClientException.class, () -> await( Flux.from( result.records() ).single() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
@@ -620,7 +620,7 @@ class RxTransactionIT
     void shouldPropagateFailureFromSecondRecordInSingleAsync()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "UNWIND [1, 0] AS x RETURN 10 / x" );
+        RxResult result = tx.run( "UNWIND [1, 0] AS x RETURN 10 / x" );
 
         ClientException e = assertThrows( ClientException.class, () -> await( Flux.from( result.records() ).single() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
@@ -644,7 +644,7 @@ class RxTransactionIT
     void shouldFailToRunQueryAfterCommit( boolean commit )
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "CREATE (:MyLabel)" );
+        RxResult result = tx.run( "CREATE (:MyLabel)" );
         await( result.records() );
 
         assertCanCommitOrRollback( commit, tx );
@@ -696,10 +696,10 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult result1 = tx.run( "CREATE (:TestNode)" );
-        RxStatementResult result2 = tx.run( "CREATE (:TestNode)" );
-        RxStatementResult result3 = tx.run( "RETURN 10 / 0" );
-        RxStatementResult result4 = tx.run( "CREATE (:TestNode)" );
+        RxResult result1 = tx.run( "CREATE (:TestNode)" );
+        RxResult result2 = tx.run( "CREATE (:TestNode)" );
+        RxResult result3 = tx.run( "RETURN 10 / 0" );
+        RxResult result4 = tx.run( "CREATE (:TestNode)" );
 
         Flux<Record> records =
                 Flux.from( result1.records() ).concatWith( result2.records() ).concatWith( result3.records() ).concatWith( result4.records() );
@@ -713,10 +713,10 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult result1 = tx.run( "RETURN 1" );
-        RxStatementResult result2 = tx.run( "RETURN 2" );
-        RxStatementResult result3 = tx.run( "RETURN 3" );
-        RxStatementResult result4 = tx.run( "RETURN 4" );
+        RxResult result1 = tx.run( "RETURN 1" );
+        RxResult result2 = tx.run( "RETURN 2" );
+        RxResult result3 = tx.run( "RETURN 3" );
+        RxResult result4 = tx.run( "RETURN 4" );
 
         Flux<Record> records =
                 Flux.from( result4.records() ).concatWith( result3.records() ).concatWith( result2.records() ).concatWith( result1.records() );
@@ -744,7 +744,7 @@ class RxTransactionIT
     void shouldPropagateRunFailureOnRecord()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "RETURN 42 / 0" );
+        RxResult result = tx.run( "RETURN 42 / 0" );
         await( result.keys() ); // always returns keys
 
         ClientException e = assertThrows( ClientException.class, () -> await( result.records() ) );
@@ -756,7 +756,7 @@ class RxTransactionIT
     void shouldFailToCommitWhenPullAllFailureIsConsumed()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" );
+        RxResult result = tx.run( "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" );
 
         ClientException e1 = assertThrows( ClientException.class, () -> await( result.records() ) );
         assertThat( e1.code(), containsString( "TypeError" ) );
@@ -769,7 +769,7 @@ class RxTransactionIT
     void shouldBeAbleToRollbackWhenPullAllFailureIsConsumed()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
-        RxStatementResult result = tx.run( "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" );
+        RxResult result = tx.run( "FOREACH (value IN [1,2, 'aaa'] | CREATE (:Person {name: 10 / value}))" );
 
         ClientException e1 = assertThrows( ClientException.class, () -> await( result.records() ) );
         assertThat( e1.code(), containsString( "TypeError" ) );
@@ -782,7 +782,7 @@ class RxTransactionIT
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
 
-        RxStatementResult result = tx.run( "RETURN Wrong" );
+        RxResult result = tx.run( "RETURN Wrong" );
         ClientException e = assertThrows( ClientException.class, () -> await( result.records() ) );
         assertThat( e.code(), containsString( "SyntaxError" ) );
 
@@ -792,14 +792,14 @@ class RxTransactionIT
 
     private int countNodes( Object id )
     {
-        RxStatementResult result = session.run( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) );
+        RxResult result = session.run( "MATCH (n:Node {id: $id}) RETURN count(n)", parameters( "id", id ) );
         return await( Flux.from( result.records() ).single().map( record -> record.get( 0 ).asInt() ) );
     }
 
     private void testForEach( String query, int expectedSeenRecords )
     {
         Flux<ResultSummary> summary = Flux.usingWhen( session.beginTransaction(), tx -> {
-            RxStatementResult result = tx.run( query );
+            RxResult result = tx.run( query );
             AtomicInteger recordsSeen = new AtomicInteger();
             return Flux.from( result.records() )
                     .doOnNext( record -> recordsSeen.incrementAndGet() )
@@ -886,7 +886,7 @@ class RxTransactionIT
 
     private static void assertCanRunCreate( RxTransaction tx )
     {
-        RxStatementResult result = tx.run( "CREATE (n:Node {id: 4242}) RETURN n" );
+        RxResult result = tx.run( "CREATE (n:Node {id: 4242}) RETURN n" );
 
         Record record = await( Flux.from(result.records()).single() );
 
@@ -897,14 +897,14 @@ class RxTransactionIT
 
     private static void assertFailToRunWrongStatement( RxTransaction tx )
     {
-        RxStatementResult result = tx.run( "RETURN" );
+        RxResult result = tx.run( "RETURN" );
         Exception e = assertThrows( Exception.class, () -> await( result.records() ) );
         assertThat( e, is( syntaxError( "Unexpected end of input" ) ) );
     }
 
     private void assertCanRunReturnOne( RxTransaction tx )
     {
-        RxStatementResult result = tx.run( "RETURN 42" );
+        RxResult result = tx.run( "RETURN 42" );
         List<Record> records = await( result.records() );
         assertThat( records.size(), equalTo( 1 ) );
         Record record = records.get( 0 );

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -156,7 +156,7 @@ class DirectDriverBoltKitTest
     }
 
     @Test
-    void shouldSendReadAccessModeInStatementMetadata() throws Exception
+    void shouldSendReadAccessModeInQueryMetadata() throws Exception
     {
         StubServer server = StubServer.start( "hello_run_exit_read.script", 9001 );
 
@@ -174,7 +174,7 @@ class DirectDriverBoltKitTest
     }
 
     @Test
-    void shouldNotSendWriteAccessModeInStatementMetadata() throws Exception
+    void shouldNotSendWriteAccessModeInQueryMetadata() throws Exception
     {
         StubServer server = StubServer.start( "hello_run_exit.script", 9001 );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
@@ -356,12 +356,12 @@ class InternalResultTest
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
         runHandler.onSuccess( singletonMap( "fields", value( Arrays.asList( "k1", "k2" ) ) ) );
 
-        Statement statement = new Statement( "<unknown>" );
+        Query query = new Query( "<unknown>" );
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
         PullAllResponseHandler pullAllHandler =
-                new LegacyPullAllResponseHandler( statement, runHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ) );
+                new LegacyPullAllResponseHandler(query, runHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ) );
 
         for ( int i = 1; i <= numberOfRecords; i++ )
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
@@ -82,7 +82,7 @@ class InternalTransactionTest
                 tx -> tx.run( "RETURN $x", singletonMap( "x", 1 ) ),
                 tx -> tx.run( "RETURN $x",
                         new InternalRecord( singletonList( "x" ), new Value[]{new IntegerValue( 1 )} ) ),
-                tx -> tx.run( new Statement( "RETURN $x", parameters( "x", 1 ) ) )
+                tx -> tx.run( new Query( "RETURN $x", parameters( "x", 1 ) ) )
         );
     }
 
@@ -95,7 +95,7 @@ class InternalTransactionTest
         Result result = runReturnOne.apply( tx );
         ResultSummary summary = result.consume();
 
-        verifyRunAndPull( connection, summary.statement().text() );
+        verifyRunAndPull( connection, summary.query().text() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.async.ConnectionContext;
@@ -74,7 +74,7 @@ class InternalTransactionTest
         tx = session.beginTransaction();
     }
 
-    private static Stream<Function<Transaction,StatementResult>> allSessionRunMethods()
+    private static Stream<Function<Transaction, Result>> allSessionRunMethods()
     {
         return Stream.of(
                 tx -> tx.run( "RETURN 1" ),
@@ -88,11 +88,11 @@ class InternalTransactionTest
 
     @ParameterizedTest
     @MethodSource( "allSessionRunMethods" )
-    void shouldFlushOnRun( Function<Transaction,StatementResult> runReturnOne ) throws Throwable
+    void shouldFlushOnRun( Function<Transaction, Result> runReturnOne ) throws Throwable
     {
         setupSuccessfulRunAndPull( connection );
 
-        StatementResult result = runReturnOne.apply( tx );
+        Result result = runReturnOne.apply( tx );
         ResultSummary summary = result.consume();
 
         verifyRunAndPull( connection, summary.statement().text() );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
@@ -41,7 +41,7 @@ import org.neo4j.driver.internal.summary.InternalResultSummary;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.summary.InternalSummaryCounters;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -68,7 +68,7 @@ import static org.neo4j.driver.util.TestUtil.await;
 class AsyncResultCursorImplTest
 {
     @Test
-    void shouldReturnStatementKeys()
+    void shouldReturnQueryKeys()
     {
         RunResponseHandler runHandler = newRunResponseHandler();
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
@@ -86,8 +86,8 @@ class AsyncResultCursorImplTest
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
-        ResultSummary summary = new InternalResultSummary( new Statement( "RETURN 42" ),
-                new InternalServerInfo( BoltServerAddress.LOCAL_DEFAULT, anyServerVersion() ), DEFAULT_DATABASE_INFO, StatementType.SCHEMA_WRITE,
+        ResultSummary summary = new InternalResultSummary( new Query( "RETURN 42" ),
+                new InternalServerInfo( BoltServerAddress.LOCAL_DEFAULT, anyServerVersion() ), DEFAULT_DATABASE_INFO, QueryType.SCHEMA_WRITE,
                 new InternalSummaryCounters( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 ),
                 null, null, emptyList(), 42, 42 );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
@@ -33,7 +33,7 @@ import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.InternalRecord;
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursorImpl;
+import org.neo4j.driver.internal.cursor.AsyncResultCursorImpl;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.messaging.v1.BoltProtocolV1;
@@ -65,7 +65,7 @@ import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.util.TestUtil.anyServerVersion;
 import static org.neo4j.driver.util.TestUtil.await;
 
-class AsyncStatementResultCursorImplTest
+class AsyncResultCursorImplTest
 {
     @Test
     void shouldReturnStatementKeys()
@@ -76,7 +76,7 @@ class AsyncStatementResultCursorImplTest
         List<String> keys = asList( "key1", "key2", "key3" );
         runHandler.onSuccess( singletonMap( "fields", value( keys ) ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( runHandler, pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( runHandler, pullAllHandler );
 
         assertEquals( keys, cursor.keys() );
     }
@@ -92,7 +92,7 @@ class AsyncStatementResultCursorImplTest
                 null, null, emptyList(), 42, 42 );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( summary, await( cursor.consumeAsync() ) );
     }
@@ -105,7 +105,7 @@ class AsyncStatementResultCursorImplTest
         Record record = new InternalRecord( asList( "key1", "key2" ), values( 1, 2 ) );
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( record, await( cursor.nextAsync() ) );
     }
@@ -116,7 +116,7 @@ class AsyncStatementResultCursorImplTest
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertNull( await( cursor.nextAsync() ) );
     }
@@ -129,7 +129,7 @@ class AsyncStatementResultCursorImplTest
         Record record = new InternalRecord( asList( "key1", "key2", "key3" ), values( 3, 2, 1 ) );
         when( pullAllHandler.peekAsync() ).thenReturn( completedFuture( record ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( record, await( cursor.peekAsync() ) );
     }
@@ -140,7 +140,7 @@ class AsyncStatementResultCursorImplTest
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.peekAsync() ).thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertNull( await( cursor.peekAsync() ) );
     }
@@ -154,7 +154,7 @@ class AsyncStatementResultCursorImplTest
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record ) )
                 .thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( record, await( cursor.singleAsync() ) );
     }
@@ -165,7 +165,7 @@ class AsyncStatementResultCursorImplTest
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.nextAsync() ).thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), containsString( "result is empty" ) );
@@ -181,7 +181,7 @@ class AsyncStatementResultCursorImplTest
         when( pullAllHandler.nextAsync() ).thenReturn( completedFuture( record1 ) )
                 .thenReturn( completedFuture( record2 ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         NoSuchRecordException e = assertThrows( NoSuchRecordException.class, () -> await( cursor.singleAsync() ) );
         assertThat( e.getMessage(), containsString( "Ensure your query returns only one record" ) );
@@ -202,7 +202,7 @@ class AsyncStatementResultCursorImplTest
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         List<Record> records = new CopyOnWriteArrayList<>();
         CompletionStage<ResultSummary> summaryStage = cursor.forEachAsync( records::add );
@@ -223,7 +223,7 @@ class AsyncStatementResultCursorImplTest
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         List<Record> records = new CopyOnWriteArrayList<>();
         CompletionStage<ResultSummary> summaryStage = cursor.forEachAsync( records::add );
@@ -241,7 +241,7 @@ class AsyncStatementResultCursorImplTest
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         List<Record> records = new CopyOnWriteArrayList<>();
         CompletionStage<ResultSummary> summaryStage = cursor.forEachAsync( records::add );
@@ -262,7 +262,7 @@ class AsyncStatementResultCursorImplTest
                 .thenReturn( completedFuture( record2 ) ).thenReturn( completedFuture( record3 ) )
                 .thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         AtomicInteger recordsProcessed = new AtomicInteger();
         RuntimeException error = new RuntimeException( "Hello" );
@@ -294,7 +294,7 @@ class AsyncStatementResultCursorImplTest
         ServiceUnavailableException error = new ServiceUnavailableException( "Hi" );
         when( pullAllHandler.pullAllFailureAsync() ).thenReturn( completedFuture( error ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( error, await( cursor.pullAllFailureAsync() ) );
     }
@@ -305,7 +305,7 @@ class AsyncStatementResultCursorImplTest
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
         when( pullAllHandler.pullAllFailureAsync() ).thenReturn( completedWithNull() );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertNull( await( cursor.pullAllFailureAsync() ) );
     }
@@ -321,7 +321,7 @@ class AsyncStatementResultCursorImplTest
 
         when( pullAllHandler.listAsync( Function.identity() ) ).thenReturn( completedFuture( records ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( records, await( cursor.listAsync() ) );
         verify( pullAllHandler ).listAsync( Function.identity() );
@@ -336,7 +336,7 @@ class AsyncStatementResultCursorImplTest
         List<String> values = asList( "a", "b", "c", "d", "e" );
         when( pullAllHandler.listAsync( mapFunction ) ).thenReturn( completedFuture( values ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( values, await( cursor.listAsync( mapFunction ) ) );
         verify( pullAllHandler ).listAsync( mapFunction );
@@ -349,7 +349,7 @@ class AsyncStatementResultCursorImplTest
         RuntimeException error = new RuntimeException( "Hi" );
         when( pullAllHandler.listAsync( Function.identity() ) ).thenReturn( failedFuture( error ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.listAsync() ) );
         assertEquals( error, e );
@@ -364,7 +364,7 @@ class AsyncStatementResultCursorImplTest
         RuntimeException error = new RuntimeException( "Hi" );
         when( pullAllHandler.listAsync( mapFunction ) ).thenReturn( failedFuture( error ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.listAsync( mapFunction ) ) );
         assertEquals( error, e );
@@ -379,7 +379,7 @@ class AsyncStatementResultCursorImplTest
         ResultSummary summary = mock( ResultSummary.class );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         assertEquals( summary, await( cursor.consumeAsync() ) );
     }
@@ -391,20 +391,20 @@ class AsyncStatementResultCursorImplTest
         RuntimeException error = new RuntimeException( "Hi" );
         when( pullAllHandler.consumeAsync() ).thenReturn( failedFuture( error ) );
 
-        AsyncStatementResultCursorImpl cursor = newCursor( pullAllHandler );
+        AsyncResultCursorImpl cursor = newCursor( pullAllHandler );
 
         RuntimeException e = assertThrows( RuntimeException.class, () -> await( cursor.consumeAsync() ) );
         assertEquals( error, e );
     }
 
-    private static AsyncStatementResultCursorImpl newCursor( PullAllResponseHandler pullAllHandler )
+    private static AsyncResultCursorImpl newCursor(PullAllResponseHandler pullAllHandler )
     {
-        return new AsyncStatementResultCursorImpl( newRunResponseHandler(), pullAllHandler );
+        return new AsyncResultCursorImpl( newRunResponseHandler(), pullAllHandler );
     }
 
-    private static AsyncStatementResultCursorImpl newCursor( RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
+    private static AsyncResultCursorImpl newCursor(RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
     {
-        return new AsyncStatementResultCursorImpl( runHandler, pullAllHandler );
+        return new AsyncResultCursorImpl( runHandler, pullAllHandler );
     }
 
     private static RunResponseHandler newRunResponseHandler()

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.AsyncTransactionWork;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -97,7 +97,7 @@ class InternalAsyncSessionTest
         asyncSession = new InternalAsyncSession( session );
     }
 
-    private static Stream<Function<AsyncSession,CompletionStage<StatementResultCursor>>> allSessionRunMethods()
+    private static Stream<Function<AsyncSession,CompletionStage<ResultCursor>>> allSessionRunMethods()
     {
         return Stream.of(
                 session -> session.runAsync( "RETURN 1" ),
@@ -132,11 +132,11 @@ class InternalAsyncSessionTest
 
     @ParameterizedTest
     @MethodSource( "allSessionRunMethods" )
-    void shouldFlushOnRun( Function<AsyncSession,CompletionStage<StatementResultCursor>> runReturnOne ) throws Throwable
+    void shouldFlushOnRun( Function<AsyncSession,CompletionStage<ResultCursor>> runReturnOne ) throws Throwable
     {
         setupSuccessfulRunAndPull( connection );
 
-        StatementResultCursor cursor = await( runReturnOne.apply( asyncSession ) );
+        ResultCursor cursor = await( runReturnOne.apply( asyncSession ) );
 
         verifyRunAndPull( connection, await( cursor.consumeAsync() ).statement().text() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncSession;
@@ -105,8 +105,8 @@ class InternalAsyncSessionTest
                 session -> session.runAsync( "RETURN $x", singletonMap( "x", 1 ) ),
                 session -> session.runAsync( "RETURN $x",
                         new InternalRecord( singletonList( "x" ), new Value[]{new IntegerValue( 1 )} ) ),
-                session -> session.runAsync( new Statement( "RETURN $x", parameters( "x", 1 ) ) ),
-                session -> session.runAsync( new Statement( "RETURN $x", parameters( "x", 1 ) ), empty() ),
+                session -> session.runAsync( new Query( "RETURN $x", parameters( "x", 1 ) ) ),
+                session -> session.runAsync( new Query( "RETURN $x", parameters( "x", 1 ) ), empty() ),
                 session -> session.runAsync( "RETURN $x", singletonMap( "x", 1 ), empty() ),
                 session -> session.runAsync( "RETURN 1", empty() )
         );
@@ -138,7 +138,7 @@ class InternalAsyncSessionTest
 
         ResultCursor cursor = await( runReturnOne.apply( asyncSession ) );
 
-        verifyRunAndPull( connection, await( cursor.consumeAsync() ).statement().text() );
+        verifyRunAndPull( connection, await( cursor.consumeAsync() ).query().text() );
     }
 
     @ParameterizedTest

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.ResultCursor;
@@ -85,7 +85,7 @@ class InternalAsyncTransactionTest
                 tx -> tx.runAsync( "RETURN $x", singletonMap( "x", 1 ) ),
                 tx -> tx.runAsync( "RETURN $x",
                         new InternalRecord( singletonList( "x" ), new Value[]{new IntegerValue( 1 )} ) ),
-                tx -> tx.runAsync( new Statement( "RETURN $x", parameters( "x", 1 ) ) )
+                tx -> tx.runAsync( new Query( "RETURN $x", parameters( "x", 1 ) ) )
         );
     }
 
@@ -98,7 +98,7 @@ class InternalAsyncTransactionTest
         ResultCursor result = await( runReturnOne.apply( tx ) );
         ResultSummary summary = await( result.consumeAsync() );
 
-        verifyRunAndPull( connection, summary.statement().text() );
+        verifyRunAndPull( connection, summary.query().text() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
@@ -77,7 +77,7 @@ class InternalAsyncTransactionTest
         tx = (InternalAsyncTransaction) await( session.beginTransactionAsync() );
     }
 
-    private static Stream<Function<AsyncTransaction,CompletionStage<StatementResultCursor>>> allSessionRunMethods()
+    private static Stream<Function<AsyncTransaction,CompletionStage<ResultCursor>>> allSessionRunMethods()
     {
         return Stream.of(
                 tx -> tx.runAsync( "RETURN 1" ),
@@ -91,11 +91,11 @@ class InternalAsyncTransactionTest
 
     @ParameterizedTest
     @MethodSource( "allSessionRunMethods" )
-    void shouldFlushOnRun( Function<AsyncTransaction,CompletionStage<StatementResultCursor>> runReturnOne ) throws Throwable
+    void shouldFlushOnRun( Function<AsyncTransaction,CompletionStage<ResultCursor>> runReturnOne ) throws Throwable
     {
         setupSuccessfulRunAndPull( connection );
 
-        StatementResultCursor result = await( runReturnOne.apply( tx ) );
+        ResultCursor result = await( runReturnOne.apply( tx ) );
         ResultSummary summary = await( result.consumeAsync() );
 
         verifyRunAndPull( connection, summary.statement().text() );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -26,7 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
@@ -93,7 +93,7 @@ class NetworkSessionTest
     void shouldFlushOnRunAsync( boolean waitForResponse )
     {
         setupSuccessfulRunAndPull( connection );
-        await( session.runAsync( new Statement( "RETURN 1" ), TransactionConfig.empty(), waitForResponse ) );
+        await( session.runAsync( new Query( "RETURN 1" ), TransactionConfig.empty(), waitForResponse ) );
 
         verifyRunAndPull( connection, "RETURN 1" );
     }
@@ -102,7 +102,7 @@ class NetworkSessionTest
     void shouldFlushOnRunRx()
     {
         setupSuccessfulRunRx( connection );
-        await( session.runRx( new Statement( "RETURN 1" ), TransactionConfig.empty() ) );
+        await( session.runRx( new Query( "RETURN 1" ), TransactionConfig.empty() ) );
 
         verifyRunRx( connection, "RETURN 1" );
     }
@@ -254,7 +254,7 @@ class NetworkSessionTest
         setupSuccessfulRunAndPull( connection, query );
 
         UnmanagedTransaction tx = beginTransaction( session );
-        await( tx.runAsync( new Statement( query ), false ) );
+        await( tx.runAsync( new Query( query ), false ) );
 
         verify( connectionProvider ).acquireConnection( any( ConnectionContext.class ) );
         verifyRunAndPull( connection, query );
@@ -453,9 +453,9 @@ class NetworkSessionTest
         verify( connection ).reset();
     }
 
-    private static ResultCursor run(NetworkSession session, String statement )
+    private static ResultCursor run(NetworkSession session, String query )
     {
-        return await( session.runAsync( new Statement( statement ), TransactionConfig.empty(), false ) );
+        return await( session.runAsync( new Query( query ), TransactionConfig.empty(), false ) );
     }
 
     private static UnmanagedTransaction beginTransaction(NetworkSession session )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/ResultCursorsHolderTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeoutException;
 
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursorImpl;
+import org.neo4j.driver.internal.cursor.AsyncResultCursorImpl;
 import org.neo4j.driver.internal.util.Futures;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -136,19 +136,19 @@ class ResultCursorsHolderTest
         assertEquals( error1, await( failureFuture ) );
     }
 
-    private static CompletionStage<AsyncStatementResultCursorImpl> cursorWithoutError()
+    private static CompletionStage<AsyncResultCursorImpl> cursorWithoutError()
     {
         return cursorWithError( null );
     }
 
-    private static CompletionStage<AsyncStatementResultCursorImpl> cursorWithError( Throwable error )
+    private static CompletionStage<AsyncResultCursorImpl> cursorWithError(Throwable error )
     {
         return cursorWithFailureFuture( completedFuture( error ) );
     }
 
-    private static CompletionStage<AsyncStatementResultCursorImpl> cursorWithFailureFuture( CompletableFuture<Throwable> future )
+    private static CompletionStage<AsyncResultCursorImpl> cursorWithFailureFuture(CompletableFuture<Throwable> future )
     {
-        AsyncStatementResultCursorImpl cursor = mock( AsyncStatementResultCursorImpl.class );
+        AsyncResultCursorImpl cursor = mock( AsyncResultCursorImpl.class );
         when( cursor.discardAllFailureAsync() ).thenReturn( future );
         return completedFuture( cursor );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -26,7 +26,7 @@ import org.mockito.InOrder;
 import java.util.function.Consumer;
 
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.DefaultBookmarkHolder;
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil.UNLIMITED_FETCH_SIZE;
 import static org.neo4j.driver.util.TestUtil.await;
 import static org.neo4j.driver.util.TestUtil.connectionMock;
-import static org.neo4j.driver.util.TestUtil.runMessageWithStatementMatcher;
+import static org.neo4j.driver.util.TestUtil.runMessageWithQueryMatcher;
 import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunAndPull;
 import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunRx;
 import static org.neo4j.driver.util.TestUtil.verifyRunAndPull;
@@ -70,7 +70,7 @@ class UnmanagedTransactionTest
         setupSuccessfulRunAndPull( connection );
 
         // When
-        await( tx.runAsync( new Statement( "RETURN 1" ), waitForResponse ) );
+        await( tx.runAsync( new Query( "RETURN 1" ), waitForResponse ) );
 
         // Then
         verifyRunAndPull( connection, "RETURN 1" );
@@ -85,7 +85,7 @@ class UnmanagedTransactionTest
         setupSuccessfulRunRx( connection );
 
         // When
-        await( tx.runRx( new Statement( "RETURN 1" ) ) );
+        await( tx.runRx( new Query( "RETURN 1" ) ) );
 
         // Then
         verifyRunRx( connection, "RETURN 1" );
@@ -247,7 +247,7 @@ class UnmanagedTransactionTest
             ResponseHandler beginHandler = invocation.getArgument( 3 );
             beginBehaviour.accept( beginHandler );
             return null;
-        } ).when( connection ).writeAndFlush( argThat( runMessageWithStatementMatcher( "BEGIN" ) ), any(), any(), any() );
+        } ).when( connection ).writeAndFlush( argThat( runMessageWithQueryMatcher( "BEGIN" ) ), any(), any(), any() );
 
         return connection;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -58,7 +58,7 @@ import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunRx;
 import static org.neo4j.driver.util.TestUtil.verifyRunAndPull;
 import static org.neo4j.driver.util.TestUtil.verifyRunRx;
 
-class ExplicitTransactionTest
+class UnmanagedTransactionTest
 {
     @ParameterizedTest
     @ValueSource( strings = {"true", "false"} )
@@ -66,7 +66,7 @@ class ExplicitTransactionTest
     {
         // Given
         Connection connection = connectionMock( BoltProtocolV4.INSTANCE );
-        ExplicitTransaction tx = beginTx( connection );
+        UnmanagedTransaction tx = beginTx( connection );
         setupSuccessfulRunAndPull( connection );
 
         // When
@@ -81,7 +81,7 @@ class ExplicitTransactionTest
     {
         // Given
         Connection connection = connectionMock( BoltProtocolV4.INSTANCE );
-        ExplicitTransaction tx = beginTx( connection );
+        UnmanagedTransaction tx = beginTx( connection );
         setupSuccessfulRunRx( connection );
 
         // When
@@ -96,7 +96,7 @@ class ExplicitTransactionTest
     {
         // Given
         Connection connection = connectionMock();
-        ExplicitTransaction tx = beginTx( connection );
+        UnmanagedTransaction tx = beginTx( connection );
 
         // When
         await( tx.closeAsync() );
@@ -134,7 +134,7 @@ class ExplicitTransactionTest
     @Test
     void shouldBeOpenAfterConstruction()
     {
-        ExplicitTransaction tx = beginTx( connectionMock() );
+        UnmanagedTransaction tx = beginTx( connectionMock() );
 
         assertTrue( tx.isOpen() );
     }
@@ -142,7 +142,7 @@ class ExplicitTransactionTest
     @Test
     void shouldBeClosedWhenMarkedAsTerminated()
     {
-        ExplicitTransaction tx = beginTx( connectionMock() );
+        UnmanagedTransaction tx = beginTx( connectionMock() );
 
         tx.markTerminated();
 
@@ -152,7 +152,7 @@ class ExplicitTransactionTest
     @Test
     void shouldBeClosedWhenMarkedTerminatedAndClosed()
     {
-        ExplicitTransaction tx = beginTx( connectionMock() );
+        UnmanagedTransaction tx = beginTx( connectionMock() );
 
         tx.markTerminated();
         await( tx.closeAsync() );
@@ -165,7 +165,7 @@ class ExplicitTransactionTest
     {
         RuntimeException error = new RuntimeException( "Wrong bookmark!" );
         Connection connection = connectionWithBegin( handler -> handler.onFailure( error ) );
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
         Bookmark bookmark = InternalBookmark.parse( "SomeBookmark" );
         TransactionConfig txConfig = TransactionConfig.empty();
@@ -180,7 +180,7 @@ class ExplicitTransactionTest
     void shouldNotReleaseConnectionWhenBeginSucceeds()
     {
         Connection connection = connectionWithBegin( handler -> handler.onSuccess( emptyMap() ) );
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
         Bookmark bookmark = InternalBookmark.parse( "SomeBookmark" );
         TransactionConfig txConfig = TransactionConfig.empty();
@@ -194,7 +194,7 @@ class ExplicitTransactionTest
     void shouldReleaseConnectionWhenTerminatedAndCommitted()
     {
         Connection connection = connectionMock();
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
         tx.markTerminated();
 
@@ -208,7 +208,7 @@ class ExplicitTransactionTest
     void shouldReleaseConnectionWhenTerminatedAndRolledBack()
     {
         Connection connection = connectionMock();
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
         tx.markTerminated();
         await( tx.rollbackAsync() );
@@ -220,21 +220,21 @@ class ExplicitTransactionTest
     void shouldReleaseConnectionWhenClose() throws Throwable
     {
         Connection connection = connectionMock();
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
         await( tx.closeAsync() );
 
         verify( connection ).release();
     }
 
-    private static ExplicitTransaction beginTx( Connection connection )
+    private static UnmanagedTransaction beginTx(Connection connection )
     {
         return beginTx( connection, InternalBookmark.empty() );
     }
 
-    private static ExplicitTransaction beginTx( Connection connection, Bookmark initialBookmark )
+    private static UnmanagedTransaction beginTx(Connection connection, Bookmark initialBookmark )
     {
-        ExplicitTransaction tx = new ExplicitTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
+        UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
         return await( tx.beginAsync( initialBookmark, TransactionConfig.empty() ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.ReadOnlyBookmarkHolder;
@@ -69,8 +69,8 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         assertThat( runner.connection.databaseName(), equalTo( systemDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.READ ) );
 
-        Statement statement = generateMultiDatabaseRoutingStatement( EMPTY_MAP, db );
-        assertThat( runner.procedure, equalTo( statement ) );
+        Query query = generateMultiDatabaseRoutingQuery( EMPTY_MAP, db );
+        assertThat( runner.procedure, equalTo(query) );
     }
 
     @ParameterizedTest
@@ -90,9 +90,9 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         assertThat( runner.connection.databaseName(), equalTo( systemDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.READ ) );
 
-        Statement statement = generateMultiDatabaseRoutingStatement( context.asMap(), db );
-        assertThat( response.procedure(), equalTo( statement ) );
-        assertThat( runner.procedure, equalTo( statement ) );
+        Query query = generateMultiDatabaseRoutingQuery( context.asMap(), db );
+        assertThat( response.procedure(), equalTo(query) );
+        assertThat( runner.procedure, equalTo(query) );
     }
 
     @Override
@@ -107,17 +107,17 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         return new TestRoutingProcedureRunner( context, runProcedureResult );
     }
 
-    private static Statement generateMultiDatabaseRoutingStatement( Map context, String db )
+    private static Query generateMultiDatabaseRoutingQuery(Map context, String db )
     {
         Value parameters = parameters( ROUTING_CONTEXT, context, DATABASE_NAME, db );
-        return new Statement( MULTI_DB_GET_ROUTING_TABLE, parameters );
+        return new Query( MULTI_DB_GET_ROUTING_TABLE, parameters );
     }
 
     private static class TestRoutingProcedureRunner extends MultiDatabasesRoutingProcedureRunner
     {
         final CompletionStage<List<Record>> runProcedureResult;
         private Connection connection;
-        private Statement procedure;
+        private Query procedure;
         private BookmarkHolder bookmarkHolder;
 
         TestRoutingProcedureRunner( RoutingContext context )
@@ -132,7 +132,7 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         }
 
         @Override
-        CompletionStage<List<Record>> runProcedure( Connection connection, Statement procedure, BookmarkHolder bookmarkHolder )
+        CompletionStage<List<Record>> runProcedure(Connection connection, Query procedure, BookmarkHolder bookmarkHolder )
         {
             this.connection = connection;
             this.procedure = procedure;

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
@@ -293,12 +293,12 @@ class RoutingProcedureClusterCompositionProviderTest
 
     private static RoutingProcedureResponse newRoutingResponse( Record... records )
     {
-        return new RoutingProcedureResponse( new Statement( "procedure" ), asList( records ) );
+        return new RoutingProcedureResponse( new Query( "procedure" ), asList( records ) );
     }
 
     private static RoutingProcedureResponse newRoutingResponse( Throwable error )
     {
-        return new RoutingProcedureResponse( new Statement( "procedure" ), error );
+        return new RoutingProcedureResponse( new Query( "procedure" ), error );
     }
     
     private static RoutingProcedureClusterCompositionProvider newClusterCompositionProvider( RoutingProcedureRunner runner, Connection connection )

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureResponseTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 
 import static java.util.Arrays.asList;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RoutingProcedureResponseTest
 {
-    private static final Statement PROCEDURE = new Statement( "procedure" );
+    private static final Query PROCEDURE = new Query( "procedure" );
 
     private static final Record RECORD_1 = new InternalRecord( asList( "a", "b" ),
             new Value[]{new StringValue( "a" ), new StringValue( "b" )} );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -29,8 +29,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
 import org.neo4j.driver.internal.BookmarkHolder;
@@ -69,8 +69,8 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         assertThat( runner.connection.databaseName(), equalTo( defaultDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.WRITE ) );
 
-        Statement statement = generateRoutingStatement( EMPTY_MAP );
-        assertThat( runner.procedure, equalTo( statement ) );
+        Query query = generateRoutingQuery( EMPTY_MAP );
+        assertThat( runner.procedure, equalTo(query) );
     }
 
     @Test
@@ -89,9 +89,9 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         assertThat( runner.connection.databaseName(), equalTo( defaultDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.WRITE ) );
 
-        Statement statement = generateRoutingStatement( context.asMap() );
-        assertThat( response.procedure(), equalTo( statement ) );
-        assertThat( runner.procedure, equalTo( statement ) );
+        Query query = generateRoutingQuery( context.asMap() );
+        assertThat( response.procedure(), equalTo(query) );
+        assertThat( runner.procedure, equalTo(query) );
     }
 
     @ParameterizedTest
@@ -117,17 +117,17 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         return Stream.of( SYSTEM_DATABASE_NAME, "This is a string", "null" );
     }
 
-    private static Statement generateRoutingStatement( Map context )
+    private static Query generateRoutingQuery(Map context )
     {
         Value parameters = parameters( ROUTING_CONTEXT, context );
-        return new Statement( GET_ROUTING_TABLE, parameters );
+        return new Query( GET_ROUTING_TABLE, parameters );
     }
 
     private static class TestRoutingProcedureRunner extends RoutingProcedureRunner
     {
         final CompletionStage<List<Record>> runProcedureResult;
         private Connection connection;
-        private Statement procedure;
+        private Query procedure;
         private BookmarkHolder bookmarkHolder;
 
         TestRoutingProcedureRunner( RoutingContext context )
@@ -142,7 +142,7 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         }
 
         @Override
-        CompletionStage<List<Record>> runProcedure( Connection connection, Statement procedure, BookmarkHolder bookmarkHolder )
+        CompletionStage<List<Record>> runProcedure(Connection connection, Query procedure, BookmarkHolder bookmarkHolder )
         {
             this.connection = connection;
             this.procedure = procedure;

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/AsyncResultCursorOnlyFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/AsyncResultCursorOnlyFactoryTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.internal.util.Futures.getNow;
 
-class AsyncStatementResultCursorOnlyFactoryTest
+class AsyncResultCursorOnlyFactoryTest
 {
     private static Stream<Boolean> waitForRun()
     {
@@ -61,10 +61,10 @@ class AsyncStatementResultCursorOnlyFactoryTest
     {
         // Given
         Connection connection = mock( Connection.class );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
 
@@ -78,10 +78,10 @@ class AsyncStatementResultCursorOnlyFactoryTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         verifyRunCompleted( connection, cursorFuture );
@@ -92,10 +92,10 @@ class AsyncStatementResultCursorOnlyFactoryTest
     {
         // Given
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         CompletionException actual = assertThrows( CompletionException.class, () -> getNow( cursorFuture ) );
@@ -108,10 +108,10 @@ class AsyncStatementResultCursorOnlyFactoryTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, failedFuture( error ), false );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, failedFuture( error ), false );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         verifyRunCompleted( connection, cursorFuture );
@@ -130,7 +130,7 @@ class AsyncStatementResultCursorOnlyFactoryTest
 
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
-        StatementResultCursorFactory cursorFactory = new AsyncStatementResultCursorOnlyFactory( connection, runMessage, runHandler, pullAllHandler, waitForRun );
+        ResultCursorFactory cursorFactory = new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullAllHandler, waitForRun );
 
         // When
         cursorFactory.asyncResult();
@@ -145,15 +145,15 @@ class AsyncStatementResultCursorOnlyFactoryTest
     void shouldErrorForRxResult( boolean waitForRun ) throws Throwable
     {
         // Given
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( completedWithNull(), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( completedWithNull(), waitForRun );
 
         // When & Then
-        CompletionStage<RxStatementResultCursor> rxCursorFuture = cursorFactory.rxResult();
+        CompletionStage<RxResultCursor> rxCursorFuture = cursorFactory.rxResult();
         CompletionException error = assertThrows( CompletionException.class, () -> getNow( rxCursorFuture ) );
         assertThat( error.getCause().getMessage(), containsString( "Driver is connected to the database that does not support driver reactive API" ) );
     }
 
-    private AsyncStatementResultCursorOnlyFactory newResultCursorFactory( Connection connection, CompletableFuture<Throwable> runFuture, boolean waitForRun )
+    private AsyncResultCursorOnlyFactory newResultCursorFactory(Connection connection, CompletableFuture<Throwable> runFuture, boolean waitForRun )
     {
         Message runMessage = mock( Message.class );
 
@@ -162,18 +162,18 @@ class AsyncStatementResultCursorOnlyFactoryTest
 
         AutoPullResponseHandler pullHandler = mock( AutoPullResponseHandler.class );
 
-        return new AsyncStatementResultCursorOnlyFactory( connection, runMessage, runHandler, pullHandler, waitForRun );
+        return new AsyncResultCursorOnlyFactory( connection, runMessage, runHandler, pullHandler, waitForRun );
     }
 
-    private AsyncStatementResultCursorOnlyFactory newResultCursorFactory( CompletableFuture<Throwable> runFuture, boolean waitForRun )
+    private AsyncResultCursorOnlyFactory newResultCursorFactory(CompletableFuture<Throwable> runFuture, boolean waitForRun )
     {
         Connection connection = mock( Connection.class );
         return newResultCursorFactory( connection, runFuture, waitForRun );
     }
 
-    private void verifyRunCompleted( Connection connection, CompletionStage<AsyncStatementResultCursor> cursorFuture )
+    private void verifyRunCompleted( Connection connection, CompletionStage<AsyncResultCursor> cursorFuture )
     {
         verify( connection ).write( any( Message.class ), any( RunResponseHandler.class ) );
-        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursor.class ) );
+        assertThat( getNow( cursorFuture ), instanceOf( AsyncResultCursor.class ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursorTest.java
@@ -29,13 +29,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.util.TestUtil.await;
 
-class DisposableAsyncStatementResultCursorTest
+class DisposableAsyncResultCursorTest
 {
     @Test
     void summaryShouldDisposeCursor() throws Throwable
     {
         // Given
-        DisposableAsyncStatementResultCursor cursor = newCursor();
+        DisposableAsyncResultCursor cursor = newCursor();
 
         // When
         await( cursor.consumeAsync() );
@@ -48,7 +48,7 @@ class DisposableAsyncStatementResultCursorTest
     void consumeShouldDisposeCursor() throws Throwable
     {
         // Given
-        DisposableAsyncStatementResultCursor cursor = newCursor();
+        DisposableAsyncResultCursor cursor = newCursor();
 
         // When
         await( cursor.discardAllFailureAsync() );
@@ -61,7 +61,7 @@ class DisposableAsyncStatementResultCursorTest
     void shouldNotDisposeCursor() throws Throwable
     {
         // Given
-        DisposableAsyncStatementResultCursor cursor = newCursor();
+        DisposableAsyncResultCursor cursor = newCursor();
 
         // When
         cursor.keys();
@@ -77,9 +77,9 @@ class DisposableAsyncStatementResultCursorTest
         assertFalse( cursor.isDisposed() );
     }
 
-    private static DisposableAsyncStatementResultCursor newCursor()
+    private static DisposableAsyncResultCursor newCursor()
     {
-        AsyncStatementResultCursor delegate = mock( AsyncStatementResultCursor.class );
+        AsyncResultCursor delegate = mock( AsyncResultCursor.class );
         when( delegate.consumeAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.discardAllFailureAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.peekAsync() ).thenReturn( Futures.completedWithNull() );
@@ -89,6 +89,6 @@ class DisposableAsyncStatementResultCursorTest
         when( delegate.listAsync() ).thenReturn( Futures.completedWithNull() );
         when( delegate.listAsync( any() ) ).thenReturn( Futures.completedWithNull() );
         when( delegate.pullAllFailureAsync() ).thenReturn( Futures.completedWithNull() );
-        return new DisposableAsyncStatementResultCursor( delegate );
+        return new DisposableAsyncResultCursor( delegate );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/ResultCursorFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/ResultCursorFactoryImplTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 import static org.neo4j.driver.internal.util.Futures.getNow;
 
-class StatementResultCursorFactoryImplTest
+class ResultCursorFactoryImplTest
 {
     private static Stream<Boolean> waitForRun()
     {
@@ -61,10 +61,10 @@ class StatementResultCursorFactoryImplTest
     {
         // Given
         Connection connection = mock( Connection.class );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         verifyRunCompleted( connection, cursorFuture );
@@ -77,10 +77,10 @@ class StatementResultCursorFactoryImplTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         verifyRunCompleted( connection, cursorFuture );
@@ -91,10 +91,10 @@ class StatementResultCursorFactoryImplTest
     {
         // Given
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         CompletionException actual = assertThrows( CompletionException.class, () -> getNow( cursorFuture ) );
@@ -107,10 +107,10 @@ class StatementResultCursorFactoryImplTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, failedFuture( error ), false );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, failedFuture( error ), false );
 
         // When
-        CompletionStage<AsyncStatementResultCursor> cursorFuture = cursorFactory.asyncResult();
+        CompletionStage<AsyncResultCursor> cursorFuture = cursorFactory.asyncResult();
 
         // Then
         verifyRunCompleted( connection, cursorFuture );
@@ -130,7 +130,7 @@ class StatementResultCursorFactoryImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
-        StatementResultCursorFactory cursorFactory = new StatementResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRun );
+        ResultCursorFactory cursorFactory = new ResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRun );
 
         // When
         cursorFactory.asyncResult();
@@ -147,10 +147,10 @@ class StatementResultCursorFactoryImplTest
     {
         // Given
         Connection connection = mock( Connection.class );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedWithNull(), waitForRun );
 
         // When
-        CompletionStage<RxStatementResultCursor> cursorFuture = cursorFactory.rxResult();
+        CompletionStage<RxResultCursor> cursorFuture = cursorFactory.rxResult();
 
         // Then
         verifyRxRunCompleted( connection, cursorFuture );
@@ -163,10 +163,10 @@ class StatementResultCursorFactoryImplTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), waitForRun );
 
         // When
-        CompletionStage<RxStatementResultCursor> cursorFuture = cursorFactory.rxResult();
+        CompletionStage<RxResultCursor> cursorFuture = cursorFactory.rxResult();
 
         // Then
         verifyRxRunCompleted( connection, cursorFuture );
@@ -177,10 +177,10 @@ class StatementResultCursorFactoryImplTest
     {
         // Given
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( failedFuture( error ), true );
 
         // When & Then
-        CompletionStage<RxStatementResultCursor> rxCursorFuture = cursorFactory.rxResult();
+        CompletionStage<RxResultCursor> rxCursorFuture = cursorFactory.rxResult();
         CompletionException actual = assertThrows( CompletionException.class, () -> getNow( rxCursorFuture ) );
         assertThat( actual.getCause(), equalTo( error ) );
     }
@@ -191,16 +191,16 @@ class StatementResultCursorFactoryImplTest
         // Given
         Connection connection = mock( Connection.class );
         Throwable error = new RuntimeException( "Hi there" );
-        StatementResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), false );
+        ResultCursorFactory cursorFactory = newResultCursorFactory( connection, completedFuture( error ), false );
 
         // When
-        CompletionStage<RxStatementResultCursor> cursorFuture = cursorFactory.rxResult();
+        CompletionStage<RxResultCursor> cursorFuture = cursorFactory.rxResult();
 
         // Then
         verifyRxRunCompleted( connection, cursorFuture );
     }
 
-    private StatementResultCursorFactoryImpl newResultCursorFactory( Connection connection, CompletableFuture<Throwable> runFuture, boolean waitForRun )
+    private ResultCursorFactoryImpl newResultCursorFactory(Connection connection, CompletableFuture<Throwable> runFuture, boolean waitForRun )
     {
         Message runMessage = mock( Message.class );
 
@@ -210,24 +210,24 @@ class StatementResultCursorFactoryImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
-        return new StatementResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRun );
+        return new ResultCursorFactoryImpl( connection, runMessage, runHandler, pullHandler, pullAllHandler, waitForRun );
     }
 
-    private StatementResultCursorFactoryImpl newResultCursorFactory( CompletableFuture<Throwable> runFuture, boolean waitForRun )
+    private ResultCursorFactoryImpl newResultCursorFactory(CompletableFuture<Throwable> runFuture, boolean waitForRun )
     {
         Connection connection = mock( Connection.class );
         return newResultCursorFactory( connection, runFuture, waitForRun );
     }
 
-    private void verifyRunCompleted( Connection connection, CompletionStage<AsyncStatementResultCursor> cursorFuture )
+    private void verifyRunCompleted( Connection connection, CompletionStage<AsyncResultCursor> cursorFuture )
     {
         verify( connection ).write( any( Message.class ), any( RunResponseHandler.class ) );
-        assertThat( getNow( cursorFuture ), instanceOf( AsyncStatementResultCursor.class ) );
+        assertThat( getNow( cursorFuture ), instanceOf( AsyncResultCursor.class ) );
     }
 
-    private void verifyRxRunCompleted( Connection connection, CompletionStage<RxStatementResultCursor> cursorFuture )
+    private void verifyRxRunCompleted( Connection connection, CompletionStage<RxResultCursor> cursorFuture )
     {
         verify( connection ).writeAndFlush( any( Message.class ), any( RunResponseHandler.class ) );
-        assertThat( getNow( cursorFuture ), instanceOf( RxStatementResultCursorImpl.class ) );
+        assertThat( getNow( cursorFuture ), instanceOf( RxResultCursorImpl.class ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
@@ -80,7 +80,7 @@ class RxResultCursorImplTest
     }
 
     @Test
-    void shouldReturnStatementKeys() throws Throwable
+    void shouldReturnQueryKeys() throws Throwable
     {
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
@@ -98,7 +98,7 @@ class RxResultCursorImplTest
     }
 
     @Test
-    void shouldSupportReturnStatementKeysMultipleTimes() throws Throwable
+    void shouldSupportReturnQueryKeysMultipleTimes() throws Throwable
     {
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
@@ -43,11 +43,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.driver.Values.value;
-import static org.neo4j.driver.internal.cursor.RxStatementResultCursorImpl.DISCARD_RECORD_CONSUMER;
+import static org.neo4j.driver.internal.cursor.RxResultCursorImpl.DISCARD_RECORD_CONSUMER;
 import static org.neo4j.driver.internal.messaging.v3.BoltProtocolV3.METADATA_EXTRACTOR;
 import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
-class RxStatementResultCursorImplTest
+class RxResultCursorImplTest
 {
     @Test
     void shouldWaitForRunToFinishBeforeCreatingRxResultCurosr() throws Throwable
@@ -58,7 +58,7 @@ class RxStatementResultCursorImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
 
         // When
-        IllegalStateException error = assertThrows( IllegalStateException.class, () -> new RxStatementResultCursorImpl( runHandler, pullHandler ) );
+        IllegalStateException error = assertThrows( IllegalStateException.class, () -> new RxResultCursorImpl( runHandler, pullHandler ) );
         // Then
         assertThat( error.getMessage(), containsString( "Should wait for response of RUN" ) );
     }
@@ -72,7 +72,7 @@ class RxStatementResultCursorImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
 
         // When
-        new RxStatementResultCursorImpl( error, runHandler, pullHandler );
+        new RxResultCursorImpl( error, runHandler, pullHandler );
 
         // Then
         verify( pullHandler ).installSummaryConsumer( any( BiConsumer.class ) );
@@ -90,7 +90,7 @@ class RxStatementResultCursorImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
 
         // When
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
         List<String> actual = cursor.keys();
 
         // Then
@@ -108,7 +108,7 @@ class RxStatementResultCursorImplTest
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
 
         // When
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // Then
         List<String> actual = cursor.keys();
@@ -128,7 +128,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.request( 100 );
@@ -143,7 +143,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.cancel();
@@ -162,7 +162,7 @@ class RxStatementResultCursorImplTest
         // When
         RunResponseHandler runHandler = newRunResponseHandler( error );
         PullResponseHandler pullHandler = new ListBasedPullHandler();
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( error, runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( error, runHandler, pullHandler );
         cursor.installRecordConsumer( recordConsumer );
 
         // Then
@@ -176,7 +176,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = new ListBasedPullHandler();
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.installRecordConsumer( DISCARD_RECORD_CONSUMER );
@@ -193,7 +193,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = new ListBasedPullHandler();
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.summaryAsync();
@@ -208,7 +208,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = new ListBasedPullHandler();
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.summaryAsync();
@@ -224,7 +224,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.installRecordConsumer( DISCARD_RECORD_CONSUMER ); // any consumer
@@ -240,7 +240,7 @@ class RxStatementResultCursorImplTest
         // Given
         RunResponseHandler runHandler = newRunResponseHandler();
         PullResponseHandler pullHandler = mock( PullResponseHandler.class );
-        RxStatementResultCursor cursor = new RxStatementResultCursorImpl( runHandler, pullHandler );
+        RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // When
         cursor.summaryAsync();

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/LegacyPullAllResponseHandlerTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.summary.ResultSummary;
 
@@ -234,11 +234,11 @@ class LegacyPullAllResponseHandlerTest extends PullAllResponseHandlerTestBase<Le
         assertNotNull( summaryFuture.get() );
     }
 
-    protected LegacyPullAllResponseHandler newHandler( Statement statement, List<String> statementKeys,
-            Connection connection )
+    protected LegacyPullAllResponseHandler newHandler(Query query, List<String> queryKeys,
+                                                      Connection connection )
     {
         RunResponseHandler runResponseHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
-        runResponseHandler.onSuccess( singletonMap( "fields", value( statementKeys ) ) );
-        return new LegacyPullAllResponseHandler( statement, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ) );
+        runResponseHandler.onSuccess( singletonMap( "fields", value( queryKeys ) ) );
+        return new LegacyPullAllResponseHandler(query, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/RunResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/RunResponseHandlerTest.java
@@ -83,7 +83,7 @@ class RunResponseHandlerTest
 
         handler.onFailure( new RuntimeException() );
 
-        assertEquals( emptyList(), handler.statementKeys() );
+        assertEquals( emptyList(), handler.queryKeys() );
     }
 
     @Test
@@ -104,7 +104,7 @@ class RunResponseHandlerTest
         List<String> keys = asList( "key1", "key2", "key3" );
         handler.onSuccess( singletonMap( "fields", value( keys ) ) );
 
-        assertEquals( keys, handler.statementKeys() );
+        assertEquals( keys, handler.queryKeys() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListenerTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -83,7 +83,7 @@ class SessionPullResponseCompletionListenerTest
     {
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
         BasicPullResponseHandler handler =
-                new BasicPullResponseHandler( new Statement( "RETURN 1" ), runHandler, connection, METADATA_EXTRACTOR, listener );
+                new BasicPullResponseHandler( new Query( "RETURN 1" ), runHandler, connection, METADATA_EXTRACTOR, listener );
         handler.installRecordConsumer( ( record, throwable ) -> {} );
         handler.installSummaryConsumer( ( resultSummary, throwable ) -> {} );
         return handler;

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.pulln.BasicPullResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler;
 import org.neo4j.driver.internal.spi.Connection;
@@ -63,7 +63,7 @@ class TransactionPullResponseCompletionListenerTest
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         TransactionPullResponseCompletionListener listener = new TransactionPullResponseCompletionListener( tx );
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
         PullResponseHandler handler = new BasicPullResponseHandler( new Statement( "RETURN 1" ), runHandler,

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
@@ -66,7 +66,7 @@ class TransactionPullResponseCompletionListenerTest
         UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         TransactionPullResponseCompletionListener listener = new TransactionPullResponseCompletionListener( tx );
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
-        PullResponseHandler handler = new BasicPullResponseHandler( new Statement( "RETURN 1" ), runHandler,
+        PullResponseHandler handler = new BasicPullResponseHandler( new Query( "RETURN 1" ), runHandler,
                 connection, METADATA_EXTRACTOR, listener );
         handler.installRecordConsumer( ( record, throwable ) -> {} );
         handler.installSummaryConsumer( ( resultSummary, throwable ) -> {} );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandlerTest.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal.handlers.pulln;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandlerTestBase;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -36,12 +36,12 @@ import static org.neo4j.driver.internal.messaging.v1.BoltProtocolV1.METADATA_EXT
 class AutoPullResponseHandlerTest extends PullAllResponseHandlerTestBase<AutoPullResponseHandler>
 {
     @Override
-    protected AutoPullResponseHandler newHandler( Statement statement, List<String> statementKeys, Connection connection )
+    protected AutoPullResponseHandler newHandler(Query query, List<String> queryKeys, Connection connection )
     {
         RunResponseHandler runResponseHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
-        runResponseHandler.onSuccess( singletonMap( "fields", value( statementKeys ) ) );
+        runResponseHandler.onSuccess( singletonMap( "fields", value(queryKeys) ) );
         AutoPullResponseHandler handler =
-                new AutoPullResponseHandler( statement, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ),
+                new AutoPullResponseHandler(query, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ),
                         DEFAULT_FETCH_SIZE );
         handler.prePopulateRecords();
         return handler;

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/SessionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/SessionPullResponseCompletionListenerTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.function.BiConsumer;
 
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.SessionPullResponseCompletionListener;
@@ -96,7 +96,7 @@ class SessionPullResponseCompletionListenerTest extends BasicPullResponseHandler
         RunResponseHandler runHandler = mock( RunResponseHandler.class );
         SessionPullResponseCompletionListener listener = new SessionPullResponseCompletionListener( conn, bookmarkHolder );
         BasicPullResponseHandler handler =
-                new BasicPullResponseHandler( mock( Statement.class ), runHandler, conn, BoltProtocolV4.METADATA_EXTRACTOR, listener );
+                new BasicPullResponseHandler( mock( Query.class ), runHandler, conn, BoltProtocolV4.METADATA_EXTRACTOR, listener );
 
         handler.installRecordConsumer( recordConsumer );
         handler.installSummaryConsumer( summaryConsumer );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
@@ -23,7 +23,7 @@ import java.util.function.BiConsumer;
 
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.TransactionPullResponseCompletionListener;
 import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
@@ -66,7 +66,7 @@ public class TransactionPullResponseCompletionListenerTest extends BasicPullResp
         Connection conn = mockConnection();
         BiConsumer<Record,Throwable> recordConsumer = mock( BiConsumer.class );
         BiConsumer<ResultSummary,Throwable> summaryConsumer = mock( BiConsumer.class );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         BasicPullResponseHandler handler = newTxResponseHandler( conn, recordConsumer, summaryConsumer, tx, status );
 
         // When
@@ -84,12 +84,12 @@ public class TransactionPullResponseCompletionListenerTest extends BasicPullResp
     protected BasicPullResponseHandler newResponseHandlerWithStatus( Connection conn, BiConsumer<Record,Throwable> recordConsumer,
             BiConsumer<ResultSummary,Throwable> summaryConsumer, PullResponseHandler.Status status )
     {
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         return newTxResponseHandler( conn, recordConsumer, summaryConsumer, tx, status );
     }
 
-    private static BasicPullResponseHandler newTxResponseHandler( Connection conn, BiConsumer<Record,Throwable> recordConsumer,
-            BiConsumer<ResultSummary,Throwable> summaryConsumer, ExplicitTransaction tx, PullResponseHandler.Status status )
+    private static BasicPullResponseHandler newTxResponseHandler(Connection conn, BiConsumer<Record,Throwable> recordConsumer,
+                                                                 BiConsumer<ResultSummary,Throwable> summaryConsumer, UnmanagedTransaction tx, PullResponseHandler.Status status )
     {
         RunResponseHandler runHandler = mock( RunResponseHandler.class );
         TransactionPullResponseCompletionListener listener = new TransactionPullResponseCompletionListener( tx );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
@@ -21,8 +21,8 @@ package org.neo4j.driver.internal.handlers.pulln;
 import java.util.Collections;
 import java.util.function.BiConsumer;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.TransactionPullResponseCompletionListener;
@@ -94,7 +94,7 @@ public class TransactionPullResponseCompletionListenerTest extends BasicPullResp
         RunResponseHandler runHandler = mock( RunResponseHandler.class );
         TransactionPullResponseCompletionListener listener = new TransactionPullResponseCompletionListener( tx );
         BasicPullResponseHandler handler =
-                new BasicPullResponseHandler( mock( Statement.class ), runHandler, conn, BoltProtocolV4.METADATA_EXTRACTOR, listener );
+                new BasicPullResponseHandler( mock( Query.class ), runHandler, conn, BoltProtocolV4.METADATA_EXTRACTOR, listener );
 
         handler.installRecordConsumer( recordConsumer );
         handler.installSummaryConsumer( summaryConsumer );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/DiscardMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/DiscardMessageEncoderTest.java
@@ -68,7 +68,7 @@ class DiscardMessageEncoderTest
     }
 
     @Test
-    void shouldAvoidStatementId() throws Throwable
+    void shouldAvoidQueryId() throws Throwable
     {
         encoder.encode( new DiscardMessage( 100, -1 ), packer );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/PullMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/PullMessageEncoderTest.java
@@ -67,7 +67,7 @@ class PullMessageEncoderTest
     }
 
     @Test
-    void shouldAvoidStatementId() throws Exception
+    void shouldAvoidQueryId() throws Exception
     {
         encoder.encode( new PullMessage( 100, -1 ), packer );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.ValuePacker;
@@ -65,8 +65,8 @@ class RunWithMetadataMessageEncoderTest
 
         Duration txTimeout = Duration.ofMillis( 42 );
 
-        Statement statement = new Statement( "RETURN $answer", value( params ) );
-        encoder.encode( autoCommitTxRunMessage( statement, txTimeout, txMetadata, defaultDatabase(), mode, bookmark ), packer );
+        Query query = new Query( "RETURN $answer", value( params ) );
+        encoder.encode( autoCommitTxRunMessage(query, txTimeout, txMetadata, defaultDatabase(), mode, bookmark ), packer );
 
         InOrder order = inOrder( packer );
         order.verify( packer ).packStructHeader( 3, RunWithMetadataMessage.SIGNATURE );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -86,9 +86,9 @@ import static org.neo4j.driver.util.TestUtil.connectionMock;
 
 public class BoltProtocolV1Test
 {
-    private static final String QUERY = "RETURN $x";
+    private static final String QUERY_TEXT = "RETURN $x";
     private static final Map<String,Value> PARAMS = singletonMap( "x", value( 42 ) );
-    private static final Query QUERY = new Query( QUERY, value( PARAMS ) );
+    private static final Query QUERY = new Query( QUERY_TEXT, value( PARAMS ) );
 
     private final BoltProtocol protocol = createProtocol();
     private final EmbeddedChannel channel = new EmbeddedChannel();
@@ -370,7 +370,7 @@ public class BoltProtocolV1Test
         ArgumentCaptor<ResponseHandler> runHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
         ArgumentCaptor<ResponseHandler> pullAllHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
 
-        verify( connection ).write( eq( new RunMessage( QUERY, PARAMS ) ), runHandlerCaptor.capture() );
+        verify( connection ).write( eq( new RunMessage( QUERY_TEXT, PARAMS ) ), runHandlerCaptor.capture() );
         verify( connection ).writeAndFlush( eq( PullAllMessage.PULL_ALL ), pullAllHandlerCaptor.capture() );
 
         assertThat( runHandlerCaptor.getValue(), instanceOf( RunResponseHandler.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Logging;
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
@@ -88,7 +88,7 @@ public class BoltProtocolV1Test
 {
     private static final String QUERY = "RETURN $x";
     private static final Map<String,Value> PARAMS = singletonMap( "x", value( 42 ) );
-    private static final Statement STATEMENT = new Statement( QUERY, value( PARAMS ) );
+    private static final Query QUERY = new Query( QUERY, value( PARAMS ) );
 
     private final BoltProtocol protocol = createProtocol();
     private final EmbeddedChannel channel = new EmbeddedChannel();
@@ -273,7 +273,7 @@ public class BoltProtocolV1Test
                 .build();
 
         ClientException e = assertThrows( ClientException.class,
-                () -> protocol.runInAutoCommitTransaction( connectionMock( protocol ), new Statement( "RETURN 1" ), BookmarkHolder.NO_OP, config, true,
+                () -> protocol.runInAutoCommitTransaction( connectionMock( protocol ), new Query( "RETURN 1" ), BookmarkHolder.NO_OP, config, true,
                         UNLIMITED_FETCH_SIZE ) );
         assertThat( e.getMessage(), startsWith( "Driver is connected to the database that does not support transaction configuration" ) );
     }
@@ -292,7 +292,7 @@ public class BoltProtocolV1Test
     {
         ClientException e = assertThrows( ClientException.class,
                 () -> protocol.runInAutoCommitTransaction( connectionMock( "foo", protocol ),
-                        new Statement( "RETURN 1" ), BookmarkHolder.NO_OP, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE ) );
+                        new Query( "RETURN 1" ), BookmarkHolder.NO_OP, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE ) );
         assertThat( e.getMessage(), startsWith( "Database name parameter for selecting database is not supported" ) );
     }
 
@@ -315,13 +315,13 @@ public class BoltProtocolV1Test
         if ( autoCommitTx )
         {
             cursorStage = protocol
-                    .runInAutoCommitTransaction( connection, STATEMENT, BookmarkHolder.NO_OP, TransactionConfig.empty(), false, UNLIMITED_FETCH_SIZE )
+                    .runInAutoCommitTransaction( connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         else
         {
             cursorStage = protocol
-                    .runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
+                    .runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
@@ -339,12 +339,12 @@ public class BoltProtocolV1Test
         CompletionStage<AsyncResultCursor> cursorStage;
         if ( session )
         {
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, BookmarkHolder.NO_OP, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInAutoCommitTransaction( connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -321,7 +321,7 @@ public class BoltProtocolV1Test
         else
         {
             cursorStage = protocol
-                    .runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
+                    .runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
@@ -344,7 +344,7 @@ public class BoltProtocolV1Test
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -39,10 +39,10 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursor;
+import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
@@ -311,7 +311,7 @@ public class BoltProtocolV1Test
         Connection connection = mock( Connection.class );
         when( connection.databaseName() ).thenReturn( defaultDatabase() );
 
-        CompletionStage<AsyncStatementResultCursor> cursorStage;
+        CompletionStage<AsyncResultCursor> cursorStage;
         if ( autoCommitTx )
         {
             cursorStage = protocol
@@ -321,10 +321,10 @@ public class BoltProtocolV1Test
         else
         {
             cursorStage = protocol
-                    .runInExplicitTransaction( connection, STATEMENT, mock( ExplicitTransaction.class ), false, UNLIMITED_FETCH_SIZE )
+                    .runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture = cursorStage.toCompletableFuture();
+        CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
 
         assertTrue( cursorFuture.isDone() );
         assertNotNull( cursorFuture.get() );
@@ -336,7 +336,7 @@ public class BoltProtocolV1Test
         Connection connection = mock( Connection.class );
         when( connection.databaseName() ).thenReturn( defaultDatabase() );
 
-        CompletionStage<AsyncStatementResultCursor> cursorStage;
+        CompletionStage<AsyncResultCursor> cursorStage;
         if ( session )
         {
             cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, BookmarkHolder.NO_OP, TransactionConfig.empty(), true, UNLIMITED_FETCH_SIZE )
@@ -344,10 +344,10 @@ public class BoltProtocolV1Test
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( ExplicitTransaction.class ), true, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture = cursorStage.toCompletableFuture();
+        CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
 
         assertFalse( cursorFuture.isDone() );
         ResponseHandler runResponseHandler = verifyRunInvoked( connection );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -305,23 +305,23 @@ public class BoltProtocolV3Test
 
     @ParameterizedTest
     @EnumSource( AccessMode.class )
-    void shouldRunInExplicitTransactionWithoutWaitingForRunResponse( AccessMode mode ) throws Exception
+    void shouldRunInUnmanagedTransactionWithoutWaitingForRunResponse(AccessMode mode ) throws Exception
     {
         testRunWithoutWaitingForRunResponse( false, TransactionConfig.empty(), mode );
     }
 
     @ParameterizedTest
     @EnumSource( AccessMode.class )
-    void shouldRunInExplicitTransactionAndWaitForSuccessRunResponse( AccessMode mode ) throws Exception
+    void shouldRunInUnmanagedTransactionAndWaitForSuccessRunResponse(AccessMode mode ) throws Exception
     {
-        testRunInExplicitTransactionAndWaitForRunResponse( true, mode );
+        testRunInUnmanagedTransactionAndWaitForRunResponse( true, mode );
     }
 
     @ParameterizedTest
     @EnumSource( AccessMode.class )
-    void shouldRunInExplicitTransactionAndWaitForFailureRunResponse( AccessMode mode ) throws Exception
+    void shouldRunInUnmanagedTransactionAndWaitForFailureRunResponse(AccessMode mode ) throws Exception
     {
-        testRunInExplicitTransactionAndWaitForRunResponse( false, mode );
+        testRunInUnmanagedTransactionAndWaitForRunResponse( false, mode );
     }
 
     @Test
@@ -354,7 +354,7 @@ public class BoltProtocolV3Test
         assertThat( e.getMessage(), startsWith( "Database name parameter for selecting database is not supported" ) );
     }
 
-    protected void testRunInExplicitTransactionAndWaitForRunResponse( boolean success, AccessMode mode ) throws Exception
+    protected void testRunInUnmanagedTransactionAndWaitForRunResponse(boolean success, AccessMode mode ) throws Exception
     {
         // Given
         Connection connection = connectionMock( mode, protocol );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -360,7 +360,7 @@ public class BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
 
         CompletableFuture<AsyncResultCursor> cursorFuture =
-                protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE ).asyncResult().toCompletableFuture();
+                protocol.runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE ).asyncResult().toCompletableFuture();
 
         ResponseHandler runResponseHandler = verifyRunInvoked( connection, false, InternalBookmark.empty(), TransactionConfig.empty(), mode ).runHandler;
         assertFalse( cursorFuture.isDone() );
@@ -393,7 +393,7 @@ public class BoltProtocolV3Test
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE ).asyncResult();
+            cursorStage = protocol.runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE ).asyncResult();
         }
         CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
 
@@ -471,7 +471,7 @@ public class BoltProtocolV3Test
         }
         else
         {
-            expectedMessage = RunWithMetadataMessage.explicitTxRunMessage(QUERY);
+            expectedMessage = RunWithMetadataMessage.unmanagedTxRunMessage(QUERY);
         }
 
         verify( connection ).write( eq( expectedMessage ), runHandlerCaptor.capture() );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -42,10 +42,10 @@ import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DefaultBookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
-import org.neo4j.driver.internal.cursor.AsyncStatementResultCursor;
+import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
@@ -359,8 +359,8 @@ public class BoltProtocolV3Test
         // Given
         Connection connection = connectionMock( mode, protocol );
 
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture =
-                protocol.runInExplicitTransaction( connection, STATEMENT, mock( ExplicitTransaction.class ), true, UNLIMITED_FETCH_SIZE ).asyncResult().toCompletableFuture();
+        CompletableFuture<AsyncResultCursor> cursorFuture =
+                protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE ).asyncResult().toCompletableFuture();
 
         ResponseHandler runResponseHandler = verifyRunInvoked( connection, false, InternalBookmark.empty(), TransactionConfig.empty(), mode ).runHandler;
         assertFalse( cursorFuture.isDone() );
@@ -385,7 +385,7 @@ public class BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
         Bookmark initialBookmark = InternalBookmark.parse( "neo4j:bookmark:v1:tx987" );
 
-        CompletionStage<AsyncStatementResultCursor> cursorStage;
+        CompletionStage<AsyncResultCursor> cursorStage;
         if ( autoCommitTx )
         {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( initialBookmark );
@@ -393,9 +393,9 @@ public class BoltProtocolV3Test
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( ExplicitTransaction.class ), false, UNLIMITED_FETCH_SIZE ).asyncResult();
+            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE ).asyncResult();
         }
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture = cursorStage.toCompletableFuture();
+        CompletableFuture<AsyncResultCursor> cursorFuture = cursorStage.toCompletableFuture();
 
         assertTrue( cursorFuture.isDone() );
         assertNotNull( cursorFuture.get() );
@@ -415,7 +415,7 @@ public class BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( bookmark );
 
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture =
+        CompletableFuture<AsyncResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();
@@ -437,7 +437,7 @@ public class BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( bookmark );
 
-        CompletableFuture<AsyncStatementResultCursor> cursorFuture =
+        CompletableFuture<AsyncResultCursor> cursorFuture =
                 protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -93,9 +93,9 @@ import static org.neo4j.driver.util.TestUtil.connectionMock;
 
 public class BoltProtocolV3Test
 {
-    protected static final String QUERY = "RETURN $x";
+    protected static final String QUERY_TEXT = "RETURN $x";
     protected static final Map<String,Value> PARAMS = singletonMap( "x", value( 42 ) );
-    protected static final Query QUERY = new Query( QUERY, value( PARAMS ) );
+    protected static final Query QUERY = new Query( QUERY_TEXT, value( PARAMS ) );
 
     protected final BoltProtocol protocol = createProtocol();
     private final EmbeddedChannel channel = new EmbeddedChannel();

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal.messaging.v3;
 import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -70,21 +70,21 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
                 new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, defaultDatabase() ),
                 COMMIT,
                 ROLLBACK,
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
+                autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), WRITE,
+                autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                explicitTxRunMessage( new Statement( "RETURN 1" ) ),
+                explicitTxRunMessage( new Query( "RETURN 1" ) ),
                 PULL_ALL,
                 DISCARD_ALL,
                 RESET,
 
                 // Bolt V3 messages with struct values
-                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
+                autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
                         defaultDatabase(), READ, InternalBookmark.empty() ),
-                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
+                autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
                         defaultDatabase(), WRITE, InternalBookmark.empty() ),
-                explicitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
+                explicitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -49,7 +49,7 @@ import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_AL
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
 import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.autoCommitTxRunMessage;
-import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.explicitTxRunMessage;
+import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.unmanagedTxRunMessage;
 
 class MessageWriterV3Test extends AbstractMessageWriterTestBase
 {
@@ -74,7 +74,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
                 autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                explicitTxRunMessage( new Query( "RETURN 1" ) ),
+                unmanagedTxRunMessage( new Query( "RETURN 1" ) ),
                 PULL_ALL,
                 DISCARD_ALL,
                 RESET,
@@ -84,7 +84,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
                         defaultDatabase(), READ, InternalBookmark.empty() ),
                 autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
                         defaultDatabase(), WRITE, InternalBookmark.empty() ),
-                explicitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
+                unmanagedTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -132,7 +132,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
 
         CompletableFuture<AsyncResultCursor> cursorFuture =
-                protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
+                protocol.runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();
 
@@ -170,7 +170,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInUnmanagedTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
 
@@ -211,7 +211,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
 
     private ResponseHandler verifyTxRunInvoked( Connection connection )
     {
-        return verifyRunInvoked( connection, RunWithMetadataMessage.explicitTxRunMessage(QUERY) );
+        return verifyRunInvoked( connection, RunWithMetadataMessage.unmanagedTxRunMessage(QUERY) );
     }
 
     private ResponseHandler verifySessionRunInvoked( Connection connection, Bookmark bookmark, TransactionConfig config, AccessMode mode, DatabaseName databaseName )

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -85,7 +85,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( bookmark );
 
         CompletableFuture<AsyncResultCursor> cursorFuture =
-                protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
+                protocol.runInAutoCommitTransaction( connection, QUERY, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();
 
@@ -109,7 +109,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( bookmark );
 
         CompletableFuture<AsyncResultCursor> cursorFuture =
-                protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
+                protocol.runInAutoCommitTransaction( connection, QUERY, bookmarkHolder, config, true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();
 
@@ -132,7 +132,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         Connection connection = connectionMock( mode, protocol );
 
         CompletableFuture<AsyncResultCursor> cursorFuture =
-                protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
+                protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), true, UNLIMITED_FETCH_SIZE )
                         .asyncResult()
                         .toCompletableFuture();
 
@@ -165,12 +165,12 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         if ( autoCommitTx )
         {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder( initialBookmark );
-            cursorStage = protocol.runInAutoCommitTransaction( connection, STATEMENT, bookmarkHolder, config, false, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInAutoCommitTransaction( connection, QUERY, bookmarkHolder, config, false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
         else
         {
-            cursorStage = protocol.runInExplicitTransaction( connection, STATEMENT, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
+            cursorStage = protocol.runInExplicitTransaction( connection, QUERY, mock( UnmanagedTransaction.class ), false, UNLIMITED_FETCH_SIZE )
                     .asyncResult();
         }
 
@@ -197,7 +197,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
         if ( autoCommitTx )
         {
             ResultCursorFactory factory =
-                    protocol.runInAutoCommitTransaction( connection, STATEMENT, BookmarkHolder.NO_OP, TransactionConfig.empty(), false, UNLIMITED_FETCH_SIZE );
+                    protocol.runInAutoCommitTransaction( connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), false, UNLIMITED_FETCH_SIZE );
             await( factory.asyncResult() );
             verifySessionRunInvoked( connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database( "foo" ) );
         }
@@ -211,12 +211,12 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
 
     private ResponseHandler verifyTxRunInvoked( Connection connection )
     {
-        return verifyRunInvoked( connection, RunWithMetadataMessage.explicitTxRunMessage( STATEMENT ) );
+        return verifyRunInvoked( connection, RunWithMetadataMessage.explicitTxRunMessage(QUERY) );
     }
 
     private ResponseHandler verifySessionRunInvoked( Connection connection, Bookmark bookmark, TransactionConfig config, AccessMode mode, DatabaseName databaseName )
     {
-        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage( STATEMENT, config, databaseName, mode, bookmark );
+        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark );
         return verifyRunInvoked( connection, runMessage );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -126,7 +126,7 @@ class BoltProtocolV4Test extends BoltProtocolV3Test
     }
 
     @Override
-    protected void testRunInExplicitTransactionAndWaitForRunResponse( boolean success, AccessMode mode ) throws Exception
+    protected void testRunInUnmanagedTransactionAndWaitForRunResponse(boolean success, AccessMode mode ) throws Exception
     {
         // Given
         Connection connection = connectionMock( mode, protocol );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -52,7 +52,7 @@ import static org.neo4j.driver.internal.messaging.request.PullAllMessage.PULL_AL
 import static org.neo4j.driver.internal.messaging.request.ResetMessage.RESET;
 import static org.neo4j.driver.internal.messaging.request.RollbackMessage.ROLLBACK;
 import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.autoCommitTxRunMessage;
-import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.explicitTxRunMessage;
+import static org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage.unmanagedTxRunMessage;
 
 class MessageWriterV4Test extends AbstractMessageWriterTestBase
 {
@@ -84,14 +84,14 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
                 autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), database( "foo" ), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                explicitTxRunMessage( new Query( "RETURN 1" ) ),
+                unmanagedTxRunMessage( new Query( "RETURN 1" ) ),
 
                 // Bolt V3 messages with struct values
                 autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
                         defaultDatabase(), READ, InternalBookmark.empty() ),
                 autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(), database( "foo" ),
                         WRITE, InternalBookmark.empty() ),
-                explicitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
+                unmanagedTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.internal.messaging.v4;
 import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.Statement;
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -80,18 +80,18 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase
                 ROLLBACK,
 
                 RESET,
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
+                autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), defaultDatabase(), READ,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                autoCommitTxRunMessage( new Statement( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), database( "foo" ), WRITE,
+                autoCommitTxRunMessage( new Query( "RETURN 1" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), database( "foo" ), WRITE,
                         InternalBookmark.parse( "neo4j:bookmark:v1:tx1" ) ),
-                explicitTxRunMessage( new Statement( "RETURN 1" ) ),
+                explicitTxRunMessage( new Query( "RETURN 1" ) ),
 
                 // Bolt V3 messages with struct values
-                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
+                autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(),
                         defaultDatabase(), READ, InternalBookmark.empty() ),
-                autoCommitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(), database( "foo" ),
+                autoCommitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", value( ZonedDateTime.now() ) ) ), ofSeconds( 1 ), emptyMap(), database( "foo" ),
                         WRITE, InternalBookmark.empty() ),
-                explicitTxRunMessage( new Statement( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
+                explicitTxRunMessage( new Query( "RETURN $x", singletonMap( "x", point( 42, 1, 2, 3 ) )  ) )
         );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.reactive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -34,7 +35,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalRecord;
@@ -75,8 +75,8 @@ class InternalRxSessionTest
                 rxSession -> rxSession.run( "RETURN $x", singletonMap( "x", 1 ) ),
                 rxSession -> rxSession.run( "RETURN $x",
                         new InternalRecord( singletonList( "x" ), new Value[]{new IntegerValue( 1 )} ) ),
-                rxSession -> rxSession.run( new Statement( "RETURN $x", parameters( "x", 1 ) ) ),
-                rxSession -> rxSession.run( new Statement( "RETURN $x", parameters( "x", 1 ) ), empty() ),
+                rxSession -> rxSession.run( new Query( "RETURN $x", parameters( "x", 1 ) ) ),
+                rxSession -> rxSession.run( new Query( "RETURN $x", parameters( "x", 1 ) ), empty() ),
                 rxSession -> rxSession.run( "RETURN $x", singletonMap( "x", 1 ), empty() ),
                 rxSession -> rxSession.run( "RETURN 1", empty() )
         );
@@ -109,7 +109,7 @@ class InternalRxSessionTest
         RxResultCursor cursor = mock( RxResultCursorImpl.class );
 
         // Run succeeded with a cursor
-        when( session.runRx( any( Statement.class ), any( TransactionConfig.class ) ) ).thenReturn( completedFuture( cursor ) );
+        when( session.runRx( any( Query.class ), any( TransactionConfig.class ) ) ).thenReturn( completedFuture( cursor ) );
         InternalRxSession rxSession = new InternalRxSession( session );
 
         // When
@@ -118,7 +118,7 @@ class InternalRxSessionTest
         CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify( session ).runRx( any( Statement.class ), any( TransactionConfig.class ) );
+        verify( session ).runRx( any( Query.class ), any( TransactionConfig.class ) );
         assertThat( Futures.getNow( cursorFuture ), equalTo( cursor ) );
     }
 
@@ -131,7 +131,7 @@ class InternalRxSessionTest
         NetworkSession session = mock( NetworkSession.class );
 
         // Run failed with error
-        when( session.runRx( any( Statement.class ), any( TransactionConfig.class ) ) ).thenReturn( Futures.failedFuture( error ) );
+        when( session.runRx( any( Query.class ), any( TransactionConfig.class ) ) ).thenReturn( Futures.failedFuture( error ) );
         when( session.releaseConnectionAsync() ).thenReturn( Futures.completedWithNull() );
 
         InternalRxSession rxSession = new InternalRxSession( session );
@@ -142,7 +142,7 @@ class InternalRxSessionTest
         CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify( session ).runRx( any( Statement.class ), any( TransactionConfig.class ) );
+        verify( session ).runRx( any( Query.class ), any( TransactionConfig.class ) );
         RuntimeException t = assertThrows( CompletionException.class, () -> Futures.getNow( cursorFuture ) );
         assertThat( t.getCause(), equalTo( error ) );
         verify( session ).releaseConnectionAsync();

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
@@ -38,14 +38,14 @@ import org.neo4j.driver.Statement;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalRecord;
-import org.neo4j.driver.internal.async.ExplicitTransaction;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.NetworkSession;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursor;
-import org.neo4j.driver.internal.cursor.RxStatementResultCursorImpl;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
+import org.neo4j.driver.internal.cursor.RxResultCursorImpl;
 import org.neo4j.driver.internal.util.FixedRetryLogic;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.value.IntegerValue;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
 
@@ -67,7 +67,7 @@ import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 class InternalRxSessionTest
 {
-    private static Stream<Function<RxSession,RxStatementResult>> allSessionRunMethods()
+    private static Stream<Function<RxSession, RxResult>> allSessionRunMethods()
     {
         return Stream.of(
                 rxSession -> rxSession.run( "RETURN 1" ),
@@ -102,20 +102,20 @@ class InternalRxSessionTest
 
     @ParameterizedTest
     @MethodSource( "allSessionRunMethods" )
-    void shouldDelegateRun( Function<RxSession,RxStatementResult> runReturnOne ) throws Throwable
+    void shouldDelegateRun( Function<RxSession, RxResult> runReturnOne ) throws Throwable
     {
         // Given
         NetworkSession session = mock( NetworkSession.class );
-        RxStatementResultCursor cursor = mock( RxStatementResultCursorImpl.class );
+        RxResultCursor cursor = mock( RxResultCursorImpl.class );
 
         // Run succeeded with a cursor
         when( session.runRx( any( Statement.class ), any( TransactionConfig.class ) ) ).thenReturn( completedFuture( cursor ) );
         InternalRxSession rxSession = new InternalRxSession( session );
 
         // When
-        RxStatementResult result = runReturnOne.apply( rxSession );
+        RxResult result = runReturnOne.apply( rxSession );
         // Execute the run
-        CompletionStage<RxStatementResultCursor> cursorFuture = ((InternalRxStatementResult) result).cursorFutureSupplier().get();
+        CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
         verify( session ).runRx( any( Statement.class ), any( TransactionConfig.class ) );
@@ -124,7 +124,7 @@ class InternalRxSessionTest
 
     @ParameterizedTest
     @MethodSource( "allSessionRunMethods" )
-    void shouldReleaseConnectionIfFailedToRun( Function<RxSession,RxStatementResult> runReturnOne ) throws Throwable
+    void shouldReleaseConnectionIfFailedToRun( Function<RxSession, RxResult> runReturnOne ) throws Throwable
     {
         // Given
         Throwable error = new RuntimeException( "Hi there" );
@@ -137,9 +137,9 @@ class InternalRxSessionTest
         InternalRxSession rxSession = new InternalRxSession( session );
 
         // When
-        RxStatementResult result = runReturnOne.apply( rxSession );
+        RxResult result = runReturnOne.apply( rxSession );
         // Execute the run
-        CompletionStage<RxStatementResultCursor> cursorFuture = ((InternalRxStatementResult) result).cursorFutureSupplier().get();
+        CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
         verify( session ).runRx( any( Statement.class ), any( TransactionConfig.class ) );
@@ -154,7 +154,7 @@ class InternalRxSessionTest
     {
         // Given
         NetworkSession session = mock( NetworkSession.class );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
 
         when( session.beginTransactionAsync( any( TransactionConfig.class ) ) ).thenReturn( completedFuture( tx ) );
         InternalRxSession rxSession = new InternalRxSession( session );
@@ -198,7 +198,7 @@ class InternalRxSessionTest
     {
         // Given
         NetworkSession session = mock( NetworkSession.class );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         when( tx.commitAsync() ).thenReturn( completedWithNull() );
         when( tx.rollbackAsync() ).thenReturn( completedWithNull() );
 
@@ -221,7 +221,7 @@ class InternalRxSessionTest
         // Given
         int retryCount = 2;
         NetworkSession session = mock( NetworkSession.class );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         when( tx.commitAsync() ).thenReturn( completedWithNull() );
         when( tx.rollbackAsync() ).thenReturn( completedWithNull() );
 
@@ -248,7 +248,7 @@ class InternalRxSessionTest
         // Given
         int retryCount = 2;
         NetworkSession session = mock( NetworkSession.class );
-        ExplicitTransaction tx = mock( ExplicitTransaction.class );
+        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         when( tx.commitAsync() ).thenReturn( completedWithNull() );
         when( tx.rollbackAsync() ).thenReturn( completedWithNull() );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.reactive;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
 
@@ -29,7 +30,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
@@ -88,7 +88,7 @@ class InternalRxTransactionTest
                 rxSession -> rxSession.run( "RETURN $x", singletonMap( "x", 1 ) ),
                 rxSession -> rxSession.run( "RETURN $x",
                         new InternalRecord( singletonList( "x" ), new Value[]{new IntegerValue( 1 )} ) ),
-                rxSession -> rxSession.run( new Statement( "RETURN $x", parameters( "x", 1 ) ) )
+                rxSession -> rxSession.run( new Query( "RETURN $x", parameters( "x", 1 ) ) )
         );
     }
 
@@ -101,7 +101,7 @@ class InternalRxTransactionTest
         RxResultCursor cursor = mock( RxResultCursorImpl.class );
 
         // Run succeeded with a cursor
-        when( tx.runRx( any( Statement.class ) ) ).thenReturn( completedFuture( cursor ) );
+        when( tx.runRx( any( Query.class ) ) ).thenReturn( completedFuture( cursor ) );
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
 
         // When
@@ -110,7 +110,7 @@ class InternalRxTransactionTest
         CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify( tx ).runRx( any( Statement.class ) );
+        verify( tx ).runRx( any( Query.class ) );
         assertThat( Futures.getNow( cursorFuture ), equalTo( cursor ) );
     }
 
@@ -123,7 +123,7 @@ class InternalRxTransactionTest
         UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
 
         // Run failed with error
-        when( tx.runRx( any( Statement.class ) ) ).thenReturn( Futures.failedFuture( error ) );
+        when( tx.runRx( any( Query.class ) ) ).thenReturn( Futures.failedFuture( error ) );
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
 
         // When
@@ -132,7 +132,7 @@ class InternalRxTransactionTest
         CompletionStage<RxResultCursor> cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify( tx ).runRx( any( Statement.class ) );
+        verify( tx ).runRx( any( Query.class ) );
         RuntimeException t = assertThrows( CompletionException.class, () -> Futures.getNow( cursorFuture ) );
         assertThat( t.getCause(), equalTo( error ) );
         verify( tx ).markTerminated();

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/util/ListBasedPullHandler.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/util/ListBasedPullHandler.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.reactive.util;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.BasicPullResponseHandler;
@@ -28,7 +29,6 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.MetadataExtractor;
 import org.neo4j.driver.internal.value.BooleanValue;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.summary.ResultSummary;
 
@@ -63,16 +63,16 @@ public class ListBasedPullHandler extends BasicPullResponseHandler
 
     private ListBasedPullHandler( List<Record> list, Throwable error )
     {
-        super( mock( Statement.class ), mock( RunResponseHandler.class ), mock( Connection.class ), mock( MetadataExtractor.class ), mock(
+        super( mock( Query.class ), mock( RunResponseHandler.class ), mock( Connection.class ), mock( MetadataExtractor.class ), mock(
                 PullResponseCompletionListener.class ) );
         this.list = list;
         this.error = error;
-        when( super.metadataExtractor.extractSummary( any( Statement.class ), any( Connection.class ), anyLong(), any( Map.class ) ) ).thenReturn(
+        when( super.metadataExtractor.extractSummary( any( Query.class ), any( Connection.class ), anyLong(), any( Map.class ) ) ).thenReturn(
                 mock( ResultSummary.class ) );
         if ( list.size() > 1 )
         {
             Record record = list.get( 0 );
-            when( super.runResponseHandler.statementKeys() ).thenReturn( record.keys() );
+            when( super.runResponseHandler.queryKeys() ).thenReturn( record.keys() );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -58,11 +58,11 @@ import org.neo4j.driver.Logging;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.InternalDriver;
 import org.neo4j.driver.internal.logging.DevNullLogger;
@@ -529,7 +529,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
         {
             int nodesProcessed = session.readTransaction( tx ->
             {
-                StatementResult result = tx.run( "MATCH (n:Node) RETURN n" );
+                Result result = tx.run( "MATCH (n:Node) RETURN n" );
 
                 int nodesSeen = 0;
                 while ( result.hasNext() )
@@ -702,7 +702,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
     {
         Statement statement = createNodeInTxStatement( nodeIndex );
         return tx.runAsync( statement )
-                .thenCompose( StatementResultCursor::consumeAsync )
+                .thenCompose( ResultCursor::consumeAsync )
                 .thenApply( ignore -> (Void) null )
                 .toCompletableFuture();
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncFailingQuery.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.internal.util.Futures;
 
 import static org.hamcrest.Matchers.is;
@@ -44,7 +44,7 @@ public class AsyncFailingQuery<C extends AbstractContext> extends AbstractAsyncQ
         AsyncSession session = newSession( AccessMode.READ, context );
 
         return session.runAsync( "UNWIND [10, 5, 0] AS x RETURN 10 / x" )
-                .thenCompose( StatementResultCursor::listAsync )
+                .thenCompose( ResultCursor::listAsync )
                 .handle( ( records, error ) ->
                 {
                     session.closeAsync();

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncFailingQueryInTx.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.internal.util.Futures;
 
 import static org.hamcrest.Matchers.is;
@@ -46,7 +46,7 @@ public class AsyncFailingQueryInTx<C extends AbstractContext> extends AbstractAs
 
         return session.beginTransactionAsync()
                 .thenCompose( tx -> tx.runAsync( "UNWIND [10, 5, 0] AS x RETURN 10 / x" )
-                        .thenCompose( StatementResultCursor::listAsync )
+                        .thenCompose( ResultCursor::listAsync )
                         .handle( ( records, error ) ->
                         {
                             assertNull( records );

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQuery.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
 
@@ -58,7 +58,7 @@ public class AsyncReadQuery<C extends AbstractContext> extends AbstractAsyncQuer
         return queryFinished.thenApply( summary -> null );
     }
 
-    private CompletionStage<ResultSummary> processAndGetSummary( Record record, StatementResultCursor cursor )
+    private CompletionStage<ResultSummary> processAndGetSummary( Record record, ResultCursor cursor )
     {
         if ( record != null )
         {

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncReadQueryInTx.java
@@ -25,7 +25,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
 
@@ -54,7 +54,7 @@ public class AsyncReadQueryInTx<C extends AbstractContext> extends AbstractAsync
         return txCommitted;
     }
 
-    private CompletionStage<ResultSummary> processRecordAndGetSummary( Record record, StatementResultCursor cursor )
+    private CompletionStage<ResultSummary> processRecordAndGetSummary( Record record, ResultCursor cursor )
     {
         if ( record != null )
         {

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.internal.util.Futures;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +44,7 @@ public class AsyncWriteQuery<C extends AbstractContext> extends AbstractAsyncQue
         AsyncSession session = newSession( AccessMode.WRITE, context );
 
         return session.runAsync( "CREATE ()" )
-                .thenCompose( StatementResultCursor::consumeAsync )
+                .thenCompose( ResultCursor::consumeAsync )
                 .handle( ( summary, error ) ->
                 {
                     session.closeAsync();

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWrongQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWrongQuery.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.util.Futures;
@@ -47,7 +47,7 @@ public class AsyncWrongQuery<C extends AbstractContext> extends AbstractAsyncQue
         AsyncSession session = newSession( AccessMode.READ, context );
 
         return session.runAsync( "RETURN Wrong" )
-                .thenCompose( StatementResultCursor::nextAsync )
+                .thenCompose( ResultCursor::nextAsync )
                 .handle( ( record, error ) ->
                 {
                     session.closeAsync();

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWrongQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWrongQueryInTx.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.util.Futures;
@@ -49,7 +49,7 @@ public class AsyncWrongQueryInTx<C extends AbstractContext> extends AbstractAsyn
 
         return session.beginTransactionAsync()
                 .thenCompose( tx -> tx.runAsync( "RETURN Wrong" )
-                        .thenCompose( StatementResultCursor::nextAsync )
+                        .thenCompose( ResultCursor::nextAsync )
                         .handle( ( record, error ) ->
                         {
                             assertNull( record );

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQuery.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.stress;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -40,7 +40,7 @@ public class BlockingFailingQuery<C extends AbstractContext> extends AbstractBlo
     {
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
-            StatementResult result = session.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
+            Result result = session.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
             Exception e = assertThrows( Exception.class, result::consume );
             assertThat( e, is( arithmeticError() ) );
         }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryInTx.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.stress;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 
 import static org.hamcrest.Matchers.is;
@@ -43,7 +43,7 @@ public class BlockingFailingQueryInTx<C extends AbstractContext> extends Abstrac
         {
             try ( Transaction tx = beginTransaction( session, context ) )
             {
-                StatementResult result = tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
+                Result result = tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" );
 
                 Exception e = assertThrows( Exception.class, result::consume );
                 assertThat( e, is( arithmeticError() ) );

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQuery.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.types.Node;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,7 +42,7 @@ public class BlockingReadQuery<C extends AbstractContext> extends AbstractBlocki
     {
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
-            StatementResult result = session.run( "MATCH (n) RETURN n LIMIT 1" );
+            Result result = session.run( "MATCH (n) RETURN n LIMIT 1" );
             List<Record> records = result.list();
             if ( !records.isEmpty() )
             {

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryInTx.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.types.Node;
 
@@ -44,7 +44,7 @@ public class BlockingReadQueryInTx<C extends AbstractContext> extends AbstractBl
         try ( Session session = newSession( AccessMode.READ, context );
               Transaction tx = beginTransaction( session, context ) )
         {
-            StatementResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
+            Result result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
             List<Record> records = result.list();
             if ( !records.isEmpty() )
             {

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.stress;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,7 +38,7 @@ public class BlockingWriteQuery<C extends AbstractContext> extends AbstractBlock
     @Override
     public void execute( C context )
     {
-        StatementResult result = null;
+        Result result = null;
         Throwable queryError = null;
 
         try ( Session session = newSession( AccessMode.WRITE, context ) )

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryInTx.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.stress;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +39,7 @@ public class BlockingWriteQueryInTx<C extends AbstractContext> extends AbstractB
     @Override
     public void execute( C context )
     {
-        StatementResult result = null;
+        Result result = null;
         Throwable txError = null;
 
         try ( Session session = newSession( AccessMode.WRITE, context ) )

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSession.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSession.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.ClientException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,12 +40,12 @@ public class BlockingWriteQueryUsingReadSession<C extends AbstractContext> exten
     @Override
     public void execute( C context )
     {
-        AtomicReference<StatementResult> resultRef = new AtomicReference<>();
+        AtomicReference<Result> resultRef = new AtomicReference<>();
         assertThrows( ClientException.class, () ->
         {
             try ( Session session = newSession( AccessMode.READ, context ) )
             {
-                StatementResult result = session.run( "CREATE ()" );
+                Result result = session.run( "CREATE ()" );
                 resultRef.set( result );
             }
         } );

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQueryUsingReadSessionInTx.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
 
@@ -41,13 +41,13 @@ public class BlockingWriteQueryUsingReadSessionInTx<C extends AbstractContext> e
     @Override
     public void execute( C context )
     {
-        AtomicReference<StatementResult> resultRef = new AtomicReference<>();
+        AtomicReference<Result> resultRef = new AtomicReference<>();
         assertThrows( ClientException.class, () ->
         {
             try ( Session session = newSession( AccessMode.READ, context );
                   Transaction tx = beginTransaction( session, context ) )
             {
-                StatementResult result = tx.run( "CREATE ()" );
+                Result result = tx.run( "CREATE ()" );
                 resultRef.set( result );
                 tx.commit();
             }

--- a/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringIT.java
@@ -49,7 +49,7 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
-import org.neo4j.driver.StatementRunner;
+import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.async.AsyncSession;
@@ -577,7 +577,7 @@ public class CausalClusteringIT implements NestedQueries
 
             ServiceUnavailableException error = new ServiceUnavailableException( "Connection broke!" );
             driverFactory.setNextRunFailure( error );
-            assertUnableToRunMoreStatementsInTx( tx2, error );
+            assertUnableToRunMoreQueriesInTx( tx2, error );
 
             tx2.close();
             tx1.commit();
@@ -706,7 +706,7 @@ public class CausalClusteringIT implements NestedQueries
         }
     }
 
-    private static void assertUnableToRunMoreStatementsInTx( Transaction tx, ServiceUnavailableException cause )
+    private static void assertUnableToRunMoreQueriesInTx(Transaction tx, ServiceUnavailableException cause )
     {
         SessionExpiredException e = assertThrows( SessionExpiredException.class, () -> tx.run( "CREATE (n:Node3 {name: 'Node3'})" ).consume() );
         assertEquals( cause, e.getCause() );
@@ -1006,14 +1006,14 @@ public class CausalClusteringIT implements NestedQueries
         }
     }
 
-    private static Result runCreateNode(StatementRunner statementRunner, String label, String property, String value )
+    private static Result runCreateNode(QueryRunner queryRunner, String label, String property, String value )
     {
-        return statementRunner.run( "CREATE (n:" + label + ") SET n." + property + " = $value", parameters( "value", value ) );
+        return queryRunner.run( "CREATE (n:" + label + ") SET n." + property + " = $value", parameters( "value", value ) );
     }
 
-    private static int runCountNodes( StatementRunner statementRunner, String label, String property, String value )
+    private static int runCountNodes(QueryRunner queryRunner, String label, String property, String value )
     {
-        Result result = statementRunner.run( "MATCH (n:" + label + " {" + property + ": $value}) RETURN count(n)", parameters( "value", value ) );
+        Result result = queryRunner.run( "MATCH (n:" + label + " {" + property + ": $value}) RETURN count(n)", parameters( "value", value ) );
         return result.single().get( 0 ).asInt();
     }
 

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQuery.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
@@ -56,7 +56,7 @@ public class RxReadQuery<C extends AbstractContext> extends AbstractRxQuery<C>
 
     private Publisher<ResultSummary> processAndGetSummary( RxSession session )
     {
-        RxStatementResult result = session.run( "MATCH (n) RETURN n LIMIT 1" );
+        RxResult result = session.run( "MATCH (n) RETURN n LIMIT 1" );
         Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
         Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
         return records.then( summaryMono );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryInTx.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
@@ -59,7 +59,7 @@ public class RxReadQueryInTx<C extends AbstractContext> extends AbstractRxQuery<
 
     private Publisher<ResultSummary> processAndGetSummary( RxTransaction tx )
     {
-        RxStatementResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
+        RxResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
         Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
         Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
         return records.then( summaryMono );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxReadQueryWithRetries.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
@@ -57,7 +57,7 @@ public class RxReadQueryWithRetries<C extends AbstractContext> extends AbstractR
     private Publisher<ResultSummary> processAndGetSummary( RxSession session )
     {
         return session.readTransaction( tx -> {
-            RxStatementResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
+            RxResult result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
             Mono<Node> records = Flux.from( result.records() ).singleOrEmpty().map( record -> record.get( 0 ).asNode() );
             Mono<ResultSummary> summaryMono = Mono.from( result.consume() ).single();
             return records.then( summaryMono );

--- a/driver/src/test/java/org/neo4j/driver/stress/SessionPoolingStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/SessionPoolingStressIT.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 
@@ -158,7 +158,7 @@ class SessionPoolingStressIT
         {
             try ( Session session = driver.session() )
             {
-                StatementResult run = session.run( query );
+                Result run = session.run( query );
                 Thread.sleep( random.nextInt( 100 ) );
                 run.consume();
                 Thread.sleep( random.nextInt( 100 ) );

--- a/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.TransactionWork;
@@ -120,49 +120,49 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     }
 
     @Override
-    public StatementResult run( String statementText, Map<String,Object> statementParameters )
+    public Result run(String statementText, Map<String,Object> statementParameters )
     {
         return realSession.run( statementText, statementParameters );
     }
 
     @Override
-    public StatementResult run( String statementText, Value parameters )
+    public Result run(String statementText, Value parameters )
     {
         return realSession.run( statementText, parameters );
     }
 
     @Override
-    public StatementResult run( String statementText, Record parameters )
+    public Result run(String statementText, Record parameters )
     {
         return realSession.run( statementText, parameters );
     }
 
     @Override
-    public StatementResult run( String statementTemplate )
+    public Result run(String statementTemplate )
     {
         return realSession.run( statementTemplate );
     }
 
     @Override
-    public StatementResult run( Statement statement )
+    public Result run(Statement statement )
     {
         return realSession.run( statement.text(), statement.parameters() );
     }
 
     @Override
-    public StatementResult run( String statement, TransactionConfig config )
+    public Result run(String statement, TransactionConfig config )
     {
         return realSession.run( statement, config );
     }
 
     @Override
-    public StatementResult run( String statement, Map<String,Object> parameters, TransactionConfig config )
+    public Result run(String statement, Map<String,Object> parameters, TransactionConfig config )
     {
         return realSession.run( statement, parameters, config );
     }
 
     @Override
-    public StatementResult run( Statement statement, TransactionConfig config )
+    public Result run(Statement statement, TransactionConfig config )
     {
         return realSession.run( statement, config );
     }

--- a/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/SessionExtension.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Map;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
@@ -120,50 +120,50 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     }
 
     @Override
-    public Result run(String statementText, Map<String,Object> statementParameters )
+    public Result run(String query, Map<String,Object> parameters)
     {
-        return realSession.run( statementText, statementParameters );
+        return realSession.run(query, parameters);
     }
 
     @Override
-    public Result run(String statementText, Value parameters )
+    public Result run(String query, Value parameters )
     {
-        return realSession.run( statementText, parameters );
+        return realSession.run(query, parameters );
     }
 
     @Override
-    public Result run(String statementText, Record parameters )
+    public Result run(String query, Record parameters )
     {
-        return realSession.run( statementText, parameters );
+        return realSession.run(query, parameters );
     }
 
     @Override
-    public Result run(String statementTemplate )
+    public Result run(String query)
     {
-        return realSession.run( statementTemplate );
+        return realSession.run(query);
     }
 
     @Override
-    public Result run(Statement statement )
+    public Result run(Query query)
     {
-        return realSession.run( statement.text(), statement.parameters() );
+        return realSession.run( query.text(), query.parameters() );
     }
 
     @Override
-    public Result run(String statement, TransactionConfig config )
+    public Result run(String query, TransactionConfig config )
     {
-        return realSession.run( statement, config );
+        return realSession.run(query, config );
     }
 
     @Override
-    public Result run(String statement, Map<String,Object> parameters, TransactionConfig config )
+    public Result run(String query, Map<String,Object> parameters, TransactionConfig config )
     {
-        return realSession.run( statement, parameters, config );
+        return realSession.run(query, parameters, config );
     }
 
     @Override
-    public Result run(Statement statement, TransactionConfig config )
+    public Result run(Query query, TransactionConfig config )
     {
-        return realSession.run( statement, config );
+        return realSession.run(query, config );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -280,12 +280,12 @@ public final class TestUtil
 
     public static void verifyRunRx( Connection connection, String query )
     {
-        verify( connection ).writeAndFlush( argThat( runWithMetaMessageWithStatementMatcher( query ) ), any() );
+        verify( connection ).writeAndFlush( argThat( runWithMetaMessageWithQueryMatcher( query ) ), any() );
     }
 
     public static void verifyRunAndPull( Connection connection, String query )
     {
-        verify( connection ).write( argThat( runWithMetaMessageWithStatementMatcher( query ) ), any() );
+        verify( connection ).write( argThat( runWithMetaMessageWithQueryMatcher( query ) ), any() );
         verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
     }
 
@@ -445,7 +445,7 @@ public final class TestUtil
             ResponseHandler runHandler = invocation.getArgument( 1 );
             runHandler.onSuccess( emptyMap() );
             return null;
-        } ).when( connection ).write( argThat( runWithMetaMessageWithStatementMatcher( query ) ), any() );
+        } ).when( connection ).write( argThat( runWithMetaMessageWithQueryMatcher( query ) ), any() );
 
         doAnswer( invocation ->
         {
@@ -588,14 +588,14 @@ public final class TestUtil
         return sb.toString();
     }
 
-    public static ArgumentMatcher<Message> runMessageWithStatementMatcher( String statement )
+    public static ArgumentMatcher<Message> runMessageWithQueryMatcher(String query )
     {
-        return message -> message instanceof RunMessage && Objects.equals( statement, ((RunMessage) message).statement() );
+        return message -> message instanceof RunMessage && Objects.equals( query, ((RunMessage) message).query() );
     }
 
-    public static ArgumentMatcher<Message> runWithMetaMessageWithStatementMatcher( String statement )
+    public static ArgumentMatcher<Message> runWithMetaMessageWithQueryMatcher(String query )
     {
-        return message -> message instanceof RunWithMetadataMessage && Objects.equals( statement, ((RunWithMetadataMessage) message).statement() );
+        return message -> message instanceof RunWithMetadataMessage && Objects.equals( query, ((RunWithMetadataMessage) message).query() );
     }
 
     /**
@@ -606,14 +606,14 @@ public final class TestUtil
         return ServerVersion.v4_0_0;
     }
 
-    private static void setupSuccessfulPullAll( Connection connection, String statement )
+    private static void setupSuccessfulPullAll( Connection connection, String query )
     {
         doAnswer( invocation ->
         {
             ResponseHandler handler = invocation.getArgument( 3 );
             handler.onSuccess( emptyMap() );
             return null;
-        } ).when( connection ).writeAndFlush( argThat( runMessageWithStatementMatcher( statement ) ), any(), any(), any() );
+        } ).when( connection ).writeAndFlush( argThat( runMessageWithQueryMatcher( query ) ), any(), any(), any() );
     }
 
     private static void setupSuccessResponse( Connection connection, Class<? extends Message> messageType )

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -48,7 +48,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DefaultBookmarkHolder;
@@ -640,7 +640,7 @@ public final class TestUtil
     {
         return session.writeTransaction( tx ->
         {
-            StatementResult result = tx.run( "MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)" );
+            Result result = tx.run( "MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)" );
             return result.single().get( 0 ).asInt();
         } );
     }

--- a/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMemberRoleDiscoveryFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMemberRoleDiscoveryFactory.java
@@ -28,7 +28,7 @@ import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.util.ServerVersion;
@@ -76,7 +76,7 @@ public class ClusterMemberRoleDiscoveryFactory
         {
             try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ) )
             {
-                StatementResult result = session.run( "CALL dbms.cluster.overview()" );
+                Result result = session.run( "CALL dbms.cluster.overview()" );
                 Map<BoltServerAddress,ClusterMemberRole> overview = new HashMap<>();
                 for ( Record record : result.list() )
                 {
@@ -110,7 +110,7 @@ public class ClusterMemberRoleDiscoveryFactory
         {
             try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ) )
             {
-                StatementResult result = session.run( "CALL dbms.cluster.overview()" );
+                Result result = session.run( "CALL dbms.cluster.overview()" );
                 Map<BoltServerAddress,ClusterMemberRole> overview = new HashMap<>();
                 for ( Record record : result.list() )
                 {

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncExplicitTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncExplicitTransactionExample.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
-import org.neo4j.driver.async.StatementResultCursor;
+import org.neo4j.driver.async.ResultCursor;
 
 public class AsyncExplicitTransactionExample extends BaseApplication
 {
@@ -44,7 +44,7 @@ public class AsyncExplicitTransactionExample extends BaseApplication
 
         Function<AsyncTransaction,CompletionStage<Void>> printSingleTitle = tx ->
                 tx.runAsync( query, parameters )
-                        .thenCompose( StatementResultCursor::singleAsync )
+                        .thenCompose( ResultCursor::singleAsync )
                         .thenApply( record -> record.get( 0 ).asString() )
                         .thenApply( title ->
                         {

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncUnmanagedTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncUnmanagedTransactionExample.java
@@ -27,16 +27,16 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.ResultCursor;
 
-public class AsyncExplicitTransactionExample extends BaseApplication
+public class AsyncUnmanagedTransactionExample extends BaseApplication
 {
-    public AsyncExplicitTransactionExample( String uri, String user, String password )
+    public AsyncUnmanagedTransactionExample(String uri, String user, String password )
     {
         super( uri, user, password );
     }
 
     public CompletionStage<Void> printSingleProduct()
     {
-        // tag::async-explicit-transaction[]
+        // tag::async-unmanaged-transaction[]
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String,Object> parameters = Collections.singletonMap( "id", 0 );
 
@@ -69,6 +69,6 @@ public class AsyncExplicitTransactionExample extends BaseApplication
                     return null;
                 } )
                 .thenCompose( ignore -> session.closeAsync() );
-        // end::async-explicit-transaction[]
+        // end::async-unmanaged-transaction[]
     }
 }

--- a/examples/src/main/java/org/neo4j/docs/driver/BasicAuthExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/BasicAuthExample.java
@@ -23,7 +23,7 @@ package org.neo4j.docs.driver;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 // end::basic-auth-import[]
 
 public class BasicAuthExample implements AutoCloseable
@@ -45,7 +45,7 @@ public class BasicAuthExample implements AutoCloseable
 
     public boolean canConnect()
     {
-        StatementResult result = driver.session().run( "RETURN 1" );
+        Result result = driver.session().run( "RETURN 1" );
         return result.single().get( 0 ).asInt() == 1;
     }
 }

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionPoolExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigConnectionPoolExample.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 
 public class ConfigConnectionPoolExample  implements AutoCloseable
 {
@@ -51,7 +51,7 @@ public class ConfigConnectionPoolExample  implements AutoCloseable
 
     public boolean canConnect()
     {
-        StatementResult result = driver.session().run( "RETURN 1" );
+        Result result = driver.session().run( "RETURN 1" );
         return result.single().get( 0 ).asInt() == 1;
     }
 }

--- a/examples/src/main/java/org/neo4j/docs/driver/ConfigCustomResolverExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ConfigCustomResolverExample.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.net.ServerAddress;
 
 import static org.neo4j.driver.Values.parameters;
@@ -81,7 +81,7 @@ public class ConfigCustomResolverExample implements AutoCloseable
 
     public boolean canConnect()
     {
-        StatementResult result = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ).run( "RETURN 1" );
+        Result result = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ).run( "RETURN 1" );
         return result.single().get( 0 ).asInt() == 1;
     }
 }

--- a/examples/src/main/java/org/neo4j/docs/driver/CypherErrorExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/CypherErrorExample.java
@@ -21,7 +21,7 @@ package org.neo4j.docs.driver;
 // tag::cypher-error-import[]
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.exceptions.ClientException;
@@ -56,7 +56,7 @@ public class CypherErrorExample extends BaseApplication
     {
         try
         {
-            StatementResult result = tx.run( "SELECT * FROM Employees WHERE name = $name", parameters( "name", name ) );
+            Result result = tx.run( "SELECT * FROM Employees WHERE name = $name", parameters( "name", name ) );
             return result.single().get( "employee_number" ).asInt();
         }
         catch ( ClientException ex )

--- a/examples/src/main/java/org/neo4j/docs/driver/HelloWorldExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/HelloWorldExample.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 
@@ -56,7 +56,7 @@ public class HelloWorldExample implements AutoCloseable
                 @Override
                 public String execute( Transaction tx )
                 {
-                    StatementResult result = tx.run( "CREATE (a:Greeting) " +
+                    Result result = tx.run( "CREATE (a:Greeting) " +
                                                      "SET a.message = $message " +
                                                      "RETURN a.message + ', from node ' + id(a)",
                             parameters( "message", message ) );

--- a/examples/src/main/java/org/neo4j/docs/driver/PassBookmarkExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/PassBookmarkExample.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Bookmark;
 
@@ -43,20 +43,20 @@ public class PassBookmarkExample extends BaseApplication
 
     // tag::pass-bookmarks[]
     // Create a company node
-    private StatementResult addCompany( final Transaction tx, final String name )
+    private Result addCompany(final Transaction tx, final String name )
     {
         return tx.run( "CREATE (:Company {name: $name})", parameters( "name", name ) );
     }
 
     // Create a person node
-    private StatementResult addPerson( final Transaction tx, final String name )
+    private Result addPerson(final Transaction tx, final String name )
     {
         return tx.run( "CREATE (:Person {name: $name})", parameters( "name", name ) );
     }
 
     // Create an employment relationship to a pre-existing company node.
     // This relies on the person first having been created.
-    private StatementResult employ( final Transaction tx, final String person, final String company )
+    private Result employ(final Transaction tx, final String person, final String company )
     {
         return tx.run( "MATCH (person:Person {name: $person_name}) " +
                         "MATCH (company:Company {name: $company_name}) " +
@@ -65,7 +65,7 @@ public class PassBookmarkExample extends BaseApplication
     }
 
     // Create a friendship between two people.
-    private StatementResult makeFriends( final Transaction tx, final String person1, final String person2 )
+    private Result makeFriends(final Transaction tx, final String person1, final String person2 )
     {
         return tx.run( "MATCH (a:Person {name: $person_1}) " +
                         "MATCH (b:Person {name: $person_2}) " +
@@ -74,9 +74,9 @@ public class PassBookmarkExample extends BaseApplication
     }
 
     // Match and display all friendships.
-    private StatementResult printFriends( final Transaction tx )
+    private Result printFriends(final Transaction tx )
     {
-        StatementResult result = tx.run( "MATCH (a)-[:KNOWS]->(b) RETURN a.name, b.name" );
+        Result result = tx.run( "MATCH (a)-[:KNOWS]->(b) RETURN a.name, b.name" );
         while ( result.hasNext() )
         {
             Record record = result.next();

--- a/examples/src/main/java/org/neo4j/docs/driver/ReadWriteTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ReadWriteTransactionExample.java
@@ -21,7 +21,7 @@ package org.neo4j.docs.driver;
 // tag::read-write-transaction-import[]
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 
@@ -67,7 +67,7 @@ public class ReadWriteTransactionExample extends BaseApplication
 
     private static long matchPersonNode( Transaction tx, String name )
     {
-        StatementResult result = tx.run( "MATCH (a:Person {name: $name}) RETURN id(a)", parameters( "name", name ) );
+        Result result = tx.run( "MATCH (a:Person {name: $name}) RETURN id(a)", parameters( "name", name ) );
         return result.single().get( 0 ).asLong();
     }
     // end::read-write-transaction[]

--- a/examples/src/main/java/org/neo4j/docs/driver/ResultConsumeExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/ResultConsumeExample.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.driver.Session;
-import org.neo4j.driver.StatementResult;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 // end::result-consume-import[]
@@ -55,7 +55,7 @@ public class ResultConsumeExample extends BaseApplication
     private static List<String> matchPersonNodes( Transaction tx )
     {
         List<String> names = new ArrayList<>();
-        StatementResult result = tx.run( "MATCH (a:Person) RETURN a.name ORDER BY a.name" );
+        Result result = tx.run( "MATCH (a:Person) RETURN a.name ORDER BY a.name" );
         while ( result.hasNext() )
         {
             names.add( result.next().get( 0 ).asString() );

--- a/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 import java.util.Collections;
 import java.util.Map;
 
-import org.neo4j.driver.reactive.RxStatementResult;
+import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.summary.ResultSummary;
 
@@ -44,7 +44,7 @@ public class RxTransactionFunctionExample extends BaseApplication
 
         return Flux.usingWhen( Mono.fromSupplier( driver::rxSession ),
                 session -> session.readTransaction( tx -> {
-                    RxStatementResult result = tx.run( query, parameters );
+                    RxResult result = tx.run( query, parameters );
                     return Flux.from( result.records() )
                             .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).then( Mono.from( result.consume() ) );
                 }
@@ -60,7 +60,7 @@ public class RxTransactionFunctionExample extends BaseApplication
 
         RxSession session = driver.rxSession();
         return Flowable.fromPublisher( session.readTransaction( tx -> {
-                    RxStatementResult result = tx.run( query, parameters );
+                    RxResult result = tx.run( query, parameters );
                     return Flowable.fromPublisher( result.records() )
                             .doOnNext( record -> System.out.println( record.get( 0 ).asString() ) ).ignoreElements().andThen( result.consume() );
                 } ) ).onErrorResumeNext( error -> {

--- a/examples/src/main/java/org/neo4j/docs/driver/RxUnmanagedTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxUnmanagedTransactionExample.java
@@ -27,16 +27,16 @@ import java.util.Map;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
 
-public class RxExplicitTransactionExample extends BaseApplication
+public class RxUnmanagedTransactionExample extends BaseApplication
 {
-    public RxExplicitTransactionExample( String uri, String user, String password )
+    public RxUnmanagedTransactionExample(String uri, String user, String password )
     {
         super( uri, user, password );
     }
 
     public Flux<String> readSingleProductReactor()
     {
-        // tag::reactor-explicit-transaction[]
+        // tag::reactor-unmanaged-transaction[]
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String,Object> parameters = Collections.singletonMap( "id", 0 );
 
@@ -44,12 +44,12 @@ public class RxExplicitTransactionExample extends BaseApplication
         return Flux.usingWhen( session.beginTransaction(),
                 tx -> Flux.from( tx.run( query, parameters ).records() ).map( record -> record.get( 0 ).asString() ),
                 RxTransaction::commit, ( tx, error ) -> tx.rollback(), null );
-        // end::reactor-explicit-transaction[]
+        // end::reactor-unmanaged-transaction[]
     }
 
     public Flowable<String> readSingleProductRxJava()
     {
-        // tag::RxJava-explicit-transaction[]
+        // tag::RxJava-unmanaged-transaction[]
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String,Object> parameters = Collections.singletonMap( "id", 0 );
 
@@ -63,6 +63,6 @@ public class RxExplicitTransactionExample extends BaseApplication
                                     // We rollback and rethrow the error. For a real application, you may want to handle the error directly here
                                     return Flowable.<String>fromPublisher( tx.rollback() ).concatWith( Flowable.error( error ) );
                                 } ) );
-        // end::RxJava-explicit-transaction[]
+        // end::RxJava-unmanaged-transaction[]
     }
 }

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -423,7 +423,7 @@ class ExamplesIT
     @Test
     void testAsyncExplicitTransactionExample() throws Exception
     {
-        try ( AsyncExplicitTransactionExample example = new AsyncExplicitTransactionExample( uri, USER, PASSWORD ) )
+        try ( AsyncUnmanagedTransactionExample example = new AsyncUnmanagedTransactionExample( uri, USER, PASSWORD ) )
         {
             // create a 'Product' node
             try ( Session session = neo4j.driver().session() )
@@ -510,7 +510,7 @@ class ExamplesIT
     @EnabledOnNeo4jWith( BOLT_V4 )
     void testRxExplicitTransactionExample() throws Exception
     {
-        try ( RxExplicitTransactionExample example = new RxExplicitTransactionExample( uri, USER, PASSWORD ) )
+        try ( RxUnmanagedTransactionExample example = new RxUnmanagedTransactionExample( uri, USER, PASSWORD ) )
         {
             // create a 'Product' node
             try ( Session session = neo4j.driver().session() )

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.Session;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.StatementType;
+import org.neo4j.driver.summary.QueryType;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.StdIOCapture;
@@ -69,34 +69,34 @@ class ExamplesIT
 
     private String uri;
 
-    private int readInt( final String statement, final Value parameters )
+    private int readInt( final String query, final Value parameters )
     {
         try ( Session session = neo4j.driver().session() )
         {
-            return session.readTransaction( tx -> tx.run( statement, parameters ).single().get( 0 ).asInt() );
+            return session.readTransaction( tx -> tx.run( query, parameters ).single().get( 0 ).asInt() );
         }
     }
 
-    private int readInt( final String statement )
+    private int readInt( final String query )
     {
-        return readInt( statement, parameters() );
+        return readInt( query, parameters() );
     }
 
-    private void write( final String statement, final Value parameters )
+    private void write( final String query, final Value parameters )
     {
         try ( Session session = neo4j.driver().session() )
         {
             session.writeTransaction( tx ->
             {
-                tx.run( statement, parameters );
+                tx.run( query, parameters );
                 return null;
             } );
         }
     }
 
-    private void write( String statement )
+    private void write( String query )
     {
-        write( statement, parameters() );
+        write( query, parameters() );
     }
 
     private int personCount( String name )
@@ -384,7 +384,7 @@ class ExamplesIT
             try ( AutoCloseable ignore = stdIOCapture.capture() )
             {
                 ResultSummary summary = await( example.printAllProducts() );
-                assertEquals( StatementType.READ_ONLY, summary.statementType() );
+                assertEquals( QueryType.READ_ONLY, summary.queryType() );
             }
 
             Set<String> capturedOutput = new HashSet<>( stdIOCapture.stdout() );
@@ -551,7 +551,7 @@ class ExamplesIT
                 final List<ResultSummary> summaryList = await( example.printAllProductsReactor() );
                 assertThat( summaryList.size(), equalTo( 1 ) );
                 ResultSummary summary = summaryList.get( 0 );
-                assertEquals( StatementType.READ_ONLY, summary.statementType() );
+                assertEquals( QueryType.READ_ONLY, summary.queryType() );
             }
 
             Set<String> capturedOutput = new HashSet<>( stdIOCapture.stdout() );
@@ -581,7 +581,7 @@ class ExamplesIT
                 final List<ResultSummary> summaryList = await( example.printAllProductsRxJava() );
                 assertThat( summaryList.size(), equalTo( 1 ) );
                 ResultSummary summary = summaryList.get( 0 );
-                assertEquals( StatementType.READ_ONLY, summary.statementType() );
+                assertEquals( QueryType.READ_ONLY, summary.queryType() );
             }
 
             Set<String> capturedOutput = new HashSet<>( stdIOCapture.stdout() );

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -421,7 +421,7 @@ class ExamplesIT
     }
 
     @Test
-    void testAsyncExplicitTransactionExample() throws Exception
+    void testAsyncUnmanagedTransactionExample() throws Exception
     {
         try ( AsyncUnmanagedTransactionExample example = new AsyncUnmanagedTransactionExample( uri, USER, PASSWORD ) )
         {
@@ -508,7 +508,7 @@ class ExamplesIT
 
     @Test
     @EnabledOnNeo4jWith( BOLT_V4 )
-    void testRxExplicitTransactionExample() throws Exception
+    void testRxUnmanagedTransactionExample() throws Exception
     {
         try ( RxUnmanagedTransactionExample example = new RxUnmanagedTransactionExample( uri, USER, PASSWORD ) )
         {


### PR DESCRIPTION
This PR adds a handful of naming changes, largely around synchronising naming and the associated mental model throughout the product suite.

1. `StatementResult` has been renamed to `Result` along with all derivations and associated text.
2. `Statement` has been renamed to `Query` along with all derivations and associated text.
3. `ExplicitTransaction` has been renamed to `UnmanagedTransaction` along with all derivations and associated text.
4. Transaction functions and auto-commit transactions have been described as "managed" in several places, as a contrast to "unmanaged" in the context of (3).