### PR TITLE
Improved error messages on driver.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/exceptions/DiscoveryException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/DiscoveryException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.exceptions;
+
+/**
+ * An error has happened while getting routing table with a remote server.
+ * While this error is not fatal and we might be able to recover if we continue trying on another server.
+ * If we fail to get a valid routing table from all routing servers known to this driver,
+ * then we will end up with a fatal error {@link ServiceUnavailableException}.
+ *
+ * If you see this error in your logs, it is safe to ignore if your cluster is temporarily changing structure during that time.
+ */
+public class DiscoveryException extends Neo4jException
+{
+    public DiscoveryException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -50,8 +50,8 @@ public final class ErrorUtil
     public static ServiceUnavailableException newConnectionTerminatedError()
     {
         return new ServiceUnavailableException( "Connection to the database terminated. " +
-                                                "This can happen due to network instabilities, " +
-                                                "or due to restarts of the database" );
+                "Please ensure that your database is listening on the correct host and port and that you have compatible encryption settings both on Neo4j server and driver. " +
+                "Note that the default encryption setting has changed in Neo4j 4.0." );
     }
 
     public static ResultConsumedException newResultConsumedError()

--- a/driver/src/test/java/org/neo4j/driver/integration/EncryptionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/EncryptionIT.java
@@ -25,8 +25,8 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.Neo4jSettings;
@@ -35,7 +35,6 @@ import org.neo4j.driver.util.ParallelizableIT;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Config.TrustStrategy.trustAllCertificates;
@@ -107,10 +106,9 @@ class EncryptionIT
         neo4j.restartDb( Neo4jSettings.TEST_SETTINGS.updateWith( Neo4jSettings.BOLT_TLS_LEVEL, tlsLevel.toString() ) );
         Config config = newConfig( driverEncrypted );
 
-        RuntimeException e = assertThrows( RuntimeException.class,
+        ServiceUnavailableException e = assertThrows( ServiceUnavailableException.class,
                 () -> GraphDatabase.driver( neo4j.uri(), neo4j.authToken(), config ).verifyConnectivity() );
 
-        assertThat( e, instanceOf( ServiceUnavailableException.class ) );
         assertThat( e.getMessage(), startsWith( "Connection to the database terminated" ) );
     }
 


### PR DESCRIPTION
When rediscovery failed, we will suppress all discovery errors together on a service unavailable error.
Also improved error message when failed to connect to server due to incompatible encryption configurations.