### PR TITLE
Refactored BasicPullResponseHandler to use an explicit state machine

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandler.java
@@ -40,18 +40,7 @@ import static org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil.UNLIMITED_F
 import static org.neo4j.driver.internal.messaging.request.DiscardMessage.newDiscardAllMessage;
 
 /**
- * In this class we have a hidden state machine.
- * Here is how it looks like:
- * |                    | DONE | FAILED | STREAMING                      | READY              | CANCELED       |
- * |--------------------|------|--------|--------------------------------|--------------------|----------------|
- * | request            | X    | X      | toRequest++ ->STREAMING        | PULL ->STREAMING   | X              |
- * | cancel             | X    | X      | ->CANCELED                     | DISCARD ->CANCELED | ->CANCELED     |
- * | onSuccess has_more | X    | X      | ->READY request if toRequest>0 | X                  | ->READY cancel |
- * | onSuccess          | X    | X      | summary ->DONE                 | X                  | summary ->DONE |
- * | onRecord           | X    | X      | yield record ->STREAMING       | X                  | ->CANCELED     |
- * | onFailure          | X    | X      | ->FAILED                       | X                  | ->FAILED       |
- *
- * Currently the error state (marked with X on the table above) might not be enforced.
+ * Provides basic handling of pull responses from sever. The state is managed by {@link State}.
  */
 public class BasicPullResponseHandler implements PullResponseHandler
 {
@@ -61,92 +50,104 @@ public class BasicPullResponseHandler implements PullResponseHandler
     protected final Connection connection;
     private final PullResponseCompletionListener completionListener;
 
-    private Status status = Status.READY;
+    private State state;
     private long toRequest;
     private BiConsumer<Record,Throwable> recordConsumer = null;
-    private BiConsumer<ResultSummary, Throwable> summaryConsumer = null;
+    private BiConsumer<ResultSummary,Throwable> summaryConsumer = null;
 
-    public BasicPullResponseHandler(Query query, RunResponseHandler runResponseHandler, Connection connection, MetadataExtractor metadataExtractor,
-                                    PullResponseCompletionListener completionListener )
+    public BasicPullResponseHandler( Query query, RunResponseHandler runResponseHandler,
+                                     Connection connection, MetadataExtractor metadataExtractor,
+                                     PullResponseCompletionListener completionListener )
     {
-        this.query = requireNonNull(query);
+        this.query = requireNonNull( query );
         this.runResponseHandler = requireNonNull( runResponseHandler );
         this.metadataExtractor = requireNonNull( metadataExtractor );
         this.connection = requireNonNull( connection );
         this.completionListener = requireNonNull( completionListener );
+
+        this.state = State.READY_STATE;
     }
 
     @Override
     public synchronized void onSuccess( Map<String,Value> metadata )
     {
         assertRecordAndSummaryConsumerInstalled();
-        if ( metadata.getOrDefault( "has_more", BooleanValue.FALSE ).asBoolean() )
-        {
-            handleSuccessWithHasMore();
-        }
-        else
-        {
-            handleSuccessWithSummary( metadata );
-        }
+        state.onSuccess( this, metadata );
     }
 
     @Override
     public synchronized void onFailure( Throwable error )
     {
         assertRecordAndSummaryConsumerInstalled();
-        status = Status.FAILED;
-        completionListener.afterFailure( error );
-
-        complete( extractResultSummary( emptyMap() ), error );
+        state.onFailure( this, error );
     }
 
     @Override
     public synchronized void onRecord( Value[] fields )
     {
         assertRecordAndSummaryConsumerInstalled();
-        if ( isStreaming() )
-        {
-            Record record = new InternalRecord( runResponseHandler.queryKeys(), fields );
-            recordConsumer.accept( record, null );
-        }
+        state.onRecord( this, fields );
     }
 
     @Override
     public synchronized void request( long size )
     {
         assertRecordAndSummaryConsumerInstalled();
-        if ( isStreamingPaused() )
-        {
-            status = Status.STREAMING;
-            connection.writeAndFlush( new PullMessage( size, runResponseHandler.queryId() ), this );
-        }
-        else if ( isStreaming() )
-        {
-            addToRequest( size );
-        }
+        state.request( this, size );
     }
 
     @Override
     public synchronized void cancel()
     {
         assertRecordAndSummaryConsumerInstalled();
-        if ( isStreamingPaused() )
+        state.cancel( this );
+    }
+
+    protected void completeWithFailure( Throwable error )
+    {
+        completionListener.afterFailure( error );
+        complete( extractResultSummary( emptyMap() ), error );
+    }
+
+    protected void completeWithSuccess( Map<String,Value> metadata )
+    {
+        completionListener.afterSuccess( metadata );
+        ResultSummary summary = extractResultSummary( metadata );
+
+        complete( summary, null );
+    }
+
+    protected void successHasMore()
+    {
+        if ( toRequest > 0 || toRequest == UNLIMITED_FETCH_SIZE )
         {
-            status = Status.CANCELED;
-            // Reactive API does not provide a way to discard N. Only discard all.
-            connection.writeAndFlush( newDiscardAllMessage( runResponseHandler.queryId() ), this );
+            request( toRequest );
+            toRequest = 0;
         }
-        else if ( isStreaming() )
-        {
-            status = Status.CANCELED;
-        }
-        // no need to change status if it is already done
+        // summary consumer use (null, null) to identify done handling of success with has_more
+        summaryConsumer.accept( null, null );
+    }
+
+    protected void handleRecord( Value[] fields )
+    {
+        Record record = new InternalRecord( runResponseHandler.queryKeys(), fields );
+        recordConsumer.accept( record, null );
+    }
+
+    protected void writePull( long n )
+    {
+        connection.writeAndFlush( new PullMessage( n, runResponseHandler.queryId() ), this );
+    }
+
+    protected void discardAll()
+    {
+        connection.writeAndFlush( newDiscardAllMessage( runResponseHandler.queryId() ), this );
     }
 
     @Override
     public synchronized void installSummaryConsumer( BiConsumer<ResultSummary,Throwable> summaryConsumer )
     {
-        if( this.summaryConsumer != null )
+        if ( this.summaryConsumer != null )
         {
             throw new IllegalStateException( "Summary consumer already installed." );
         }
@@ -156,61 +157,22 @@ public class BasicPullResponseHandler implements PullResponseHandler
     @Override
     public synchronized void installRecordConsumer( BiConsumer<Record,Throwable> recordConsumer )
     {
-        if( this.recordConsumer != null )
+        if ( this.recordConsumer != null )
         {
             throw new IllegalStateException( "Record consumer already installed." );
         }
         this.recordConsumer = recordConsumer;
     }
 
-    private boolean isStreaming()
-    {
-        return status == Status.STREAMING;
-    }
-
-    private boolean isStreamingPaused()
-    {
-        return status == Status.READY;
-    }
-
     protected boolean isDone()
     {
-        return status == Status.SUCCEEDED || status == Status.FAILED;
-    }
-
-    private void handleSuccessWithSummary( Map<String,Value> metadata )
-    {
-        status = Status.SUCCEEDED;
-        completionListener.afterSuccess( metadata );
-        ResultSummary summary = extractResultSummary( metadata );
-
-        complete( summary, null );
-    }
-
-    private void handleSuccessWithHasMore()
-    {
-        if ( this.status == Status.CANCELED )
-        {
-            this.status = Status.READY; // cancel request accepted.
-            cancel();
-        }
-        else if ( this.status == Status.STREAMING )
-        {
-            this.status = Status.READY;
-            if ( toRequest > 0 || toRequest == UNLIMITED_FETCH_SIZE )
-            {
-                request( toRequest );
-                toRequest = 0;
-            }
-            // summary consumer use (null, null) to identify done handling of success with has_more
-            summaryConsumer.accept( null, null );
-        }
+        return state.equals( State.SUCCEEDED_STATE ) || state.equals( State.FAILURE_STATE );
     }
 
     private ResultSummary extractResultSummary( Map<String,Value> metadata )
     {
         long resultAvailableAfter = runResponseHandler.resultAvailableAfter();
-        return metadataExtractor.extractSummary(query, connection, resultAvailableAfter, metadata );
+        return metadataExtractor.extractSummary( query, connection, resultAvailableAfter, metadata );
     }
 
     private void addToRequest( long toAdd )
@@ -239,15 +201,15 @@ public class BasicPullResponseHandler implements PullResponseHandler
 
     private void assertRecordAndSummaryConsumerInstalled()
     {
-        if( isDone() )
+        if ( isDone() )
         {
             // no need to check if we've finished.
             return;
         }
-        if( recordConsumer == null || summaryConsumer == null )
+        if ( recordConsumer == null || summaryConsumer == null )
         {
-            throw new IllegalStateException( format("Access record stream without record consumer and/or summary consumer. " +
-                    "Record consumer=%s, Summary consumer=%s", recordConsumer, summaryConsumer) );
+            throw new IllegalStateException( format( "Access record stream without record consumer and/or summary consumer. " +
+                                                     "Record consumer=%s, Summary consumer=%s", recordConsumer, summaryConsumer ) );
         }
     }
 
@@ -267,13 +229,217 @@ public class BasicPullResponseHandler implements PullResponseHandler
         this.summaryConsumer = null;
     }
 
-    protected Status status()
+    protected State state()
     {
-        return this.status;
+        return state;
     }
 
-    protected void status( Status status )
+    protected void state( State state )
     {
-        this.status = status;
+        this.state = state;
+    }
+
+    enum State
+    {
+        READY_STATE
+                {
+                    @Override
+                    void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                        context.completeWithSuccess( metadata );
+                    }
+
+                    @Override
+                    void onFailure( BasicPullResponseHandler context, Throwable error )
+                    {
+                        context.state( FAILURE_STATE );
+                        context.completeWithFailure( error );
+                    }
+
+                    @Override
+                    void onRecord( BasicPullResponseHandler context, Value[] fields )
+                    {
+                        context.state( READY_STATE );
+                    }
+
+                    @Override
+                    void request( BasicPullResponseHandler context, long n )
+                    {
+                        context.state( STREAMING_STATE );
+                        context.writePull( n );
+                    }
+
+                    @Override
+                    void cancel( BasicPullResponseHandler context )
+                    {
+                        context.state( CANCELLED_STATE );
+                        context.discardAll();
+                    }
+                },
+        STREAMING_STATE
+                {
+                    @Override
+                    void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata )
+                    {
+                        if ( metadata.getOrDefault( "has_more", BooleanValue.FALSE ).asBoolean() )
+                        {
+                            context.state( READY_STATE );
+                            context.successHasMore();
+                        }
+                        else
+                        {
+                            context.state( SUCCEEDED_STATE );
+                            context.completeWithSuccess( metadata );
+                        }
+                    }
+
+                    @Override
+                    void onFailure( BasicPullResponseHandler context, Throwable error )
+                    {
+                        context.state( FAILURE_STATE );
+                        context.completeWithFailure( error );
+                    }
+
+                    @Override
+                    void onRecord( BasicPullResponseHandler context, Value[] fields )
+                    {
+                        context.state( STREAMING_STATE );
+                        context.handleRecord( fields );
+                    }
+
+                    @Override
+                    void request( BasicPullResponseHandler context, long n )
+                    {
+                        context.state( STREAMING_STATE );
+                        context.addToRequest( n );
+                    }
+
+                    @Override
+                    void cancel( BasicPullResponseHandler context )
+                    {
+                        context.state( CANCELLED_STATE );
+                    }
+                },
+        CANCELLED_STATE
+                {
+                    @Override
+                    void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata )
+                    {
+                        if ( metadata.getOrDefault( "has_more", BooleanValue.FALSE ).asBoolean() )
+                        {
+                            context.state( CANCELLED_STATE );
+                            context.discardAll();
+                        }
+                        else
+                        {
+                            context.state( SUCCEEDED_STATE );
+                            context.completeWithSuccess( metadata );
+                        }
+                    }
+
+                    @Override
+                    void onFailure( BasicPullResponseHandler context, Throwable error )
+                    {
+                        context.state( FAILURE_STATE );
+                        context.completeWithFailure( error );
+                    }
+
+                    @Override
+                    void onRecord( BasicPullResponseHandler context, Value[] fields )
+                    {
+                        context.state( CANCELLED_STATE );
+                    }
+
+                    @Override
+                    void request( BasicPullResponseHandler context, long n )
+                    {
+                        context.state( CANCELLED_STATE );
+                    }
+
+                    @Override
+                    void cancel( BasicPullResponseHandler context )
+                    {
+                        context.state( CANCELLED_STATE );
+                    }
+                },
+        SUCCEEDED_STATE
+                {
+                    @Override
+                    void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                        context.completeWithSuccess( metadata );
+                    }
+
+                    @Override
+                    void onFailure( BasicPullResponseHandler context, Throwable error )
+                    {
+                        context.state( FAILURE_STATE );
+                        context.completeWithFailure( error );
+                    }
+
+                    @Override
+                    void onRecord( BasicPullResponseHandler context, Value[] fields )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                    }
+
+                    @Override
+                    void request( BasicPullResponseHandler context, long n )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                    }
+
+                    @Override
+                    void cancel( BasicPullResponseHandler context )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                    }
+                },
+        FAILURE_STATE
+                {
+                    @Override
+                    void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata )
+                    {
+                        context.state( SUCCEEDED_STATE );
+                        context.completeWithSuccess( metadata );
+                    }
+
+                    @Override
+                    void onFailure( BasicPullResponseHandler context, Throwable error )
+                    {
+                        context.state( FAILURE_STATE );
+                        context.completeWithFailure( error );
+                    }
+
+                    @Override
+                    void onRecord( BasicPullResponseHandler context, Value[] fields )
+                    {
+                        context.state( FAILURE_STATE );
+                    }
+
+                    @Override
+                    void request( BasicPullResponseHandler context, long n )
+                    {
+                        context.state( FAILURE_STATE );
+                    }
+
+                    @Override
+                    void cancel( BasicPullResponseHandler context )
+                    {
+                        context.state( FAILURE_STATE );
+                    }
+                };
+
+        abstract void onSuccess( BasicPullResponseHandler context, Map<String,Value> metadata );
+
+        abstract void onFailure( BasicPullResponseHandler context, Throwable error );
+
+        abstract void onRecord( BasicPullResponseHandler context, Value[] fields );
+
+        abstract void request( BasicPullResponseHandler context, long n );
+
+        abstract void cancel( BasicPullResponseHandler context );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/PullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/PullResponseHandler.java
@@ -44,12 +44,4 @@ public interface PullResponseHandler extends ResponseHandler, Subscription
      */
     void installSummaryConsumer( BiConsumer<ResultSummary,Throwable> summaryConsumer );
 
-    enum Status
-    {
-        SUCCEEDED,       // successfully completed
-        FAILED,     // failed
-        CANCELED,   // canceled
-        STREAMING,  // streaming records
-        READY       // steaming is paused. ready to accept request or cancel commands from user
-    }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -41,28 +41,28 @@ import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.Session;
-import org.neo4j.driver.Result;
 import org.neo4j.driver.QueryRunner;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.TransientException;
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
-import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
-import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxResult;
-import org.neo4j.driver.summary.ResultSummary;
+import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.summary.QueryType;
+import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.TestUtil;
@@ -942,6 +942,7 @@ class SessionIT
     }
 
     @Test
+    @DisabledOnNeo4jWith( BOLT_V4 )
     void shouldAllowToConsumeRecordsSlowlyAndCloseSession() throws InterruptedException
     {
         Session session = neo4j.driver().session();

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/SessionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/SessionPullResponseCompletionListenerTest.java
@@ -26,7 +26,6 @@ import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.handlers.SessionPullResponseCompletionListener;
-import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler.Status;
 import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.summary.ResultSummary;
@@ -37,19 +36,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.driver.internal.handlers.pulln.PullResponseHandler.Status.FAILED;
 
 class SessionPullResponseCompletionListenerTest extends BasicPullResponseHandlerTestBase
 {
-    @Override
-    protected void shouldHandleSuccessWithSummary( Status status )
+    protected void shouldHandleSuccessWithSummary( BasicPullResponseHandler.State state )
     {
         // Given
         Connection conn = mockConnection();
         BiConsumer<Record,Throwable> recordConsumer = mock( BiConsumer.class );
         BiConsumer<ResultSummary,Throwable> summaryConsumer = mock( BiConsumer.class );
         BookmarkHolder bookmarkHolder = mock( BookmarkHolder.class );
-        PullResponseHandler handler = newSessionResponseHandler( conn, recordConsumer, summaryConsumer, bookmarkHolder, status);
+        PullResponseHandler handler = newSessionResponseHandler( conn, recordConsumer, summaryConsumer, bookmarkHolder, state );
 
         // When
         handler.onSuccess( Collections.emptyMap() );
@@ -63,20 +60,20 @@ class SessionPullResponseCompletionListenerTest extends BasicPullResponseHandler
     }
 
     @Override
-    protected void shouldHandleFailure( Status status )
+    protected void shouldHandleFailure( BasicPullResponseHandler.State state )
     {
         // Given
         Connection conn = mockConnection();
         BiConsumer<Record,Throwable> recordConsumer = mock( BiConsumer.class );
         BiConsumer<ResultSummary,Throwable> summaryConsumer = mock( BiConsumer.class );
-        BasicPullResponseHandler handler = newResponseHandlerWithStatus( conn, recordConsumer, summaryConsumer, status );
+        BasicPullResponseHandler handler = newResponseHandlerWithStatus( conn, recordConsumer, summaryConsumer, state );
 
         // When
         RuntimeException error = new RuntimeException( "I am an error" );
         handler.onFailure( error );
 
         // Then
-        assertThat( handler.status(), equalTo( FAILED ) );
+        assertThat( handler.state(), equalTo( BasicPullResponseHandler.State.FAILURE_STATE ) );
         verify( conn ).release();
         verify( recordConsumer ).accept( null, error );
         verify( summaryConsumer ).accept( any( ResultSummary.class ), eq( error ) );
@@ -84,14 +81,15 @@ class SessionPullResponseCompletionListenerTest extends BasicPullResponseHandler
 
     @Override
     protected BasicPullResponseHandler newResponseHandlerWithStatus( Connection conn, BiConsumer<Record,Throwable> recordConsumer,
-            BiConsumer<ResultSummary,Throwable> summaryConsumer, Status status )
+                                                                     BiConsumer<ResultSummary,Throwable> summaryConsumer, BasicPullResponseHandler.State state )
     {
         BookmarkHolder bookmarkHolder = BookmarkHolder.NO_OP;
-        return newSessionResponseHandler( conn, recordConsumer, summaryConsumer, bookmarkHolder, status );
+        return newSessionResponseHandler( conn, recordConsumer, summaryConsumer, bookmarkHolder, state );
     }
 
     private static BasicPullResponseHandler newSessionResponseHandler( Connection conn, BiConsumer<Record,Throwable> recordConsumer,
-            BiConsumer<ResultSummary,Throwable> summaryConsumer, BookmarkHolder bookmarkHolder, Status status )
+                                                                       BiConsumer<ResultSummary,Throwable> summaryConsumer, BookmarkHolder bookmarkHolder,
+                                                                       BasicPullResponseHandler.State state )
     {
         RunResponseHandler runHandler = mock( RunResponseHandler.class );
         SessionPullResponseCompletionListener listener = new SessionPullResponseCompletionListener( conn, bookmarkHolder );
@@ -101,7 +99,7 @@ class SessionPullResponseCompletionListenerTest extends BasicPullResponseHandler
         handler.installRecordConsumer( recordConsumer );
         handler.installSummaryConsumer( summaryConsumer );
 
-        handler.status( status );
+        handler.state( state );
         return handler;
     }
 }


### PR DESCRIPTION
This PR refactors `BasicPullResponseHandler` to make its state machine explicit.