### PR TITLE
Allow simple/async sessions to request data as needed

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -35,6 +37,7 @@ import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.value.BooleanValue;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.QueryType;
 
@@ -679,7 +682,6 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
 
         assertEquals( expectedRecords, list );
     }
-
     protected T newHandler()
     {
         return newHandler( new Query( "RETURN 1" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandlerTest.java
@@ -18,32 +18,178 @@
  */
 package org.neo4j.driver.internal.handlers.pulln;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.Query;
+import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandlerTestBase;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
+import org.neo4j.driver.internal.messaging.request.PullMessage;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.internal.value.BooleanValue;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.Values.values;
 import static org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil.DEFAULT_FETCH_SIZE;
 import static org.neo4j.driver.internal.messaging.v1.BoltProtocolV1.METADATA_EXTRACTOR;
 
 class AutoPullResponseHandlerTest extends PullAllResponseHandlerTestBase<AutoPullResponseHandler>
 {
     @Override
-    protected AutoPullResponseHandler newHandler(Query query, List<String> queryKeys, Connection connection )
+    protected AutoPullResponseHandler newHandler( Query query, List<String> queryKeys, Connection connection )
     {
         RunResponseHandler runResponseHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
-        runResponseHandler.onSuccess( singletonMap( "fields", value(queryKeys) ) );
+        runResponseHandler.onSuccess( singletonMap( "fields", value( queryKeys ) ) );
         AutoPullResponseHandler handler =
-                new AutoPullResponseHandler(query, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ),
-                        DEFAULT_FETCH_SIZE );
+                new AutoPullResponseHandler( query, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ),
+                                             DEFAULT_FETCH_SIZE );
         handler.prePopulateRecords();
         return handler;
+    }
+
+    protected AutoPullResponseHandler newHandler( Query query, Connection connection, long fetchSize )
+    {
+        RunResponseHandler runResponseHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
+        runResponseHandler.onSuccess( emptyMap() );
+        AutoPullResponseHandler handler =
+                new AutoPullResponseHandler( query, runResponseHandler, connection, METADATA_EXTRACTOR, mock( PullResponseCompletionListener.class ),
+                                             fetchSize );
+        handler.prePopulateRecords();
+        return handler;
+    }
+
+    @Test
+    void shouldKeepRequestingWhenBetweenRange()
+    {
+        Connection connection = connectionMock();
+        InOrder inOrder = Mockito.inOrder( connection );
+
+        //highwatermark=2, lowwatermark=1
+        AutoPullResponseHandler handler = newHandler( new Query( "RETURN 1" ), connection, 4 );
+
+        Map<String,Value> metaData = new HashMap<>( 1 );
+        metaData.put( "has_more", BooleanValue.TRUE );
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
+
+        handler.onRecord( values( 1 ) );
+        handler.onRecord( values( 2 ) );
+        handler.onSuccess( metaData ); //2 in the record queue
+
+        //should send another pulln request since maxValue not met
+        inOrder.verify( connection ).writeAndFlush( any(), any() );
+    }
+
+    @Test
+    void shouldStopRequestingWhenOverMaxWatermark()
+    {
+        Connection connection = connectionMock();
+        InOrder inOrder = Mockito.inOrder( connection );
+
+        //highWatermark=2, lowWatermark=1
+        AutoPullResponseHandler handler = newHandler( new Query( "RETURN 1" ), connection, 4 );
+
+        Map<String,Value> metaData = new HashMap<>( 1 );
+        metaData.put( "has_more", BooleanValue.TRUE );
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
+
+        handler.onRecord( values( 1 ) );
+        handler.onRecord( values( 2 ) );
+        handler.onRecord( values( 3 ) );
+        handler.onSuccess( metaData );
+
+        //only initial writeAndFlush()
+        verify( connection, times( 1 ) ).writeAndFlush( any( PullMessage.class ), any() );
+    }
+
+    @Test
+    void shouldRestartRequestingWhenMinimumWatermarkMet()
+    {
+        Connection connection = connectionMock();
+        InOrder inOrder = Mockito.inOrder( connection );
+
+        //highwatermark=4, lowwatermark=2
+        AutoPullResponseHandler handler = newHandler( new Query( "RETURN 1" ), connection, 7 );
+
+        Map<String,Value> metaData = new HashMap<>( 1 );
+        metaData.put( "has_more", BooleanValue.TRUE );
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
+
+        handler.onRecord( values( 1 ) );
+        handler.onRecord( values( 2 ) );
+        handler.onRecord( values( 3 ) );
+        handler.onRecord( values( 4 ) );
+        handler.onRecord( values( 5 ) );
+        handler.onSuccess( metaData );
+
+        verify( connection, times( 1 ) ).writeAndFlush( any( PullMessage.class ), any() );
+
+        handler.nextAsync();
+        handler.nextAsync();
+        handler.nextAsync();
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
+    }
+
+    @Test
+    void shouldKeepRequestingMoreRecordsWhenPullAll()
+    {
+        Connection connection = connectionMock();
+        AutoPullResponseHandler handler = newHandler( new Query( "RETURN 1" ), connection, -1 );
+
+        Map<String,Value> metaData = new HashMap<>( 1 );
+        metaData.put( "has_more", BooleanValue.TRUE );
+
+        handler.onRecord( values( 1 ) );
+        handler.onSuccess( metaData );
+
+        handler.onRecord( values( 2 ) );
+        handler.onSuccess( metaData );
+
+        handler.onRecord( values( 3 ) );
+        handler.onSuccess( emptyMap() );
+
+        verify( connection, times( 3 ) ).writeAndFlush( any( PullMessage.class ), any() );
+    }
+
+    @Test
+    void shouldFunctionWhenHighAndLowWatermarksAreEqual()
+    {
+        Connection connection = connectionMock();
+        InOrder inOrder = Mockito.inOrder( connection );
+
+        //highwatermark=0, lowwatermark=0
+        AutoPullResponseHandler handler = newHandler( new Query( "RETURN 1" ), connection, 1 );
+
+        Map<String,Value> metaData = new HashMap<>( 1 );
+        metaData.put( "has_more", BooleanValue.TRUE );
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
+
+        handler.onRecord( values( 1 ) );
+        handler.onSuccess( metaData );
+
+        inOrder.verify( connection, never() ).writeAndFlush( any(), any() );
+
+        handler.nextAsync();
+
+        inOrder.verify( connection ).writeAndFlush( any( PullMessage.class ), any() );
     }
 }

--- a/driver/src/test/resources/streaming_records_v4_buffering.script
+++ b/driver/src/test/resources/streaming_records_v4_buffering.script
@@ -1,0 +1,19 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+
+C: RUN "MATCH (n) RETURN n.name" {} {}
+   PULL { "n": 2 }
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Bob"]
+   RECORD ["Alice"]
+   SUCCESS {"has_more": true}
+C: PULL { "n": 2 }
+S: RECORD ["Tina"]
+   RECORD ["Frank"]
+   SUCCESS {"has_more": true}
+C: PULL { "n": 2 }
+S: RECORD ["Daisy"]
+   RECORD ["Clive"]
+   SUCCESS {}

--- a/driver/src/test/resources/streaming_records_v4_list_async.script
+++ b/driver/src/test/resources/streaming_records_v4_list_async.script
@@ -1,0 +1,23 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+
+C: RUN "MATCH (n) RETURN n.name" {} {}
+   PULL { "n": 10 }
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["A"]
+   RECORD ["B"]
+   RECORD ["C"]
+   RECORD ["D"]
+   RECORD ["E"]
+   RECORD ["F"]
+   RECORD ["G"]
+   RECORD ["H"]
+   RECORD ["I"]
+   RECORD ["J"]
+   SUCCESS {"has_more": true}
+C: PULL { "n": -1 }
+S: RECORD ["K"]
+   RECORD ["L"]
+   SUCCESS {}


### PR DESCRIPTION
Optimizing record buffer for `AutoPullResponseHandler`. Simple and Async sessions will now buffer records in a similar way to the reactive sessions by only requesting more records when the Query's consumer is close to catching up. This prevents excessive records being buffered by the driver/client.

The driver will request additional records when the current buffer contains less than 30% of the fetchSize (`LOW_RECORD_WATERMARK`). When the driver has buffered more than 70% of the fetchSize (`HIGH_RECORD_WATERMARK`), the driver will stop requesting more records until it drops below the `LOW_RECORD_WATERMARK`. A `fetchSize` of zero effectively disables this buffering.