### PR TITLE
Adapt JavaDoc of Value#asObject to be consistent with documentation.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/Value.java
@@ -174,17 +174,24 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue
      * for common types is as follows:
      *
      * <ul>
+     *     <li>{@link TypeSystem#NULL()} - {@code null}</li>
+     *     <li>{@link TypeSystem#LIST()} - {@link List}</li>
+     *     <li>{@link TypeSystem#MAP()} - {@link Map}</li>
+     *     <li>{@link TypeSystem#BOOLEAN()} - {@link Boolean}</li>
      *     <li>{@link TypeSystem#INTEGER()} - {@link Long}</li>
      *     <li>{@link TypeSystem#FLOAT()} - {@link Double}</li>
-     *     <li>{@link TypeSystem#NUMBER()} - {@link Number}</li>
      *     <li>{@link TypeSystem#STRING()} - {@link String}</li>
-     *     <li>{@link TypeSystem#BOOLEAN()} - {@link Boolean}</li>
-     *     <li>{@link TypeSystem#NULL()} - {@code null}</li>
+     *     <li>{@link TypeSystem#BYTES()} - {@literal byte[]}</li>
+     *     <li>{@link TypeSystem#DATE()} - {@link LocalDate}</li>
+     *     <li>{@link TypeSystem#TIME()} - {@link OffsetTime}</li>
+     *     <li>{@link TypeSystem#LOCAL_TIME()} - {@link LocalTime}</li>
+     *     <li>{@link TypeSystem#DATE_TIME()} - {@link ZonedDateTime}</li>
+     *     <li>{@link TypeSystem#LOCAL_DATE_TIME()} - {@link LocalDateTime}</li>
+     *     <li>{@link TypeSystem#DURATION()} - {@link IsoDuration}</li>
+     *     <li>{@link TypeSystem#POINT()} - {@link Point}</li>
      *     <li>{@link TypeSystem#NODE()} - {@link Node}</li>
      *     <li>{@link TypeSystem#RELATIONSHIP()} - {@link Relationship}</li>
      *     <li>{@link TypeSystem#PATH()} - {@link Path}</li>
-     *     <li>{@link TypeSystem#MAP()} - {@link Map}</li>
-     *     <li>{@link TypeSystem#LIST()} - {@link List}</li>
      * </ul>
      *
      * Note that the types in {@link TypeSystem} refers to the Neo4j type system


### PR DESCRIPTION
Regarding our efforts to be more developer focussed, I would appreciate the JavaDoc having the same information of type mappings as https://neo4j.com/docs/driver-manual/current/cypher-values/. I always have to go to that page to lookup stuff, so that would make life easier.