### PR TITLE
Fix the error where the cluster memeber cannot be started in tests.

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CausalClusteringIT.java
@@ -386,7 +386,7 @@ public class CausalClusteringIT implements NestedQueries
             Set<ClusterMember> cores = cluster.cores();
             for ( ClusterMember follower : cluster.followers() )
             {
-                cluster.kill( follower );
+                cluster.stop( follower );
             }
             awaitLeaderToStepDown( cores );
 
@@ -428,7 +428,7 @@ public class CausalClusteringIT implements NestedQueries
             Set<ClusterMember> cores = cluster.cores();
             for ( ClusterMember follower : cluster.followers() )
             {
-                cluster.kill( follower );
+                cluster.stop( follower );
             }
             awaitLeaderToStepDown( cores );
 

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/CredentialsIT.java
@@ -26,6 +26,8 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import org.neo4j.driver.internal.security.InternalAuthToken;
+import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
+import org.neo4j.driver.internal.util.Neo4jFeature;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Config;
@@ -58,6 +60,8 @@ class CredentialsIT
     static final DatabaseExtension neo4j = new DatabaseExtension();
 
     @Test
+    @DisabledOnNeo4jWith( Neo4jFeature.BOLT_V4 )
+    // This feature is removed in 4.0
     void shouldBePossibleToChangePassword() throws Exception
     {
         String newPassword = "secret";

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/Cluster.java
@@ -273,11 +273,7 @@ public class Cluster implements AutoCloseable
             try
             {
                 final Map<BoltServerAddress,ClusterMemberRole> clusterOverview = discovery.findClusterOverview( driver );
-                // we will wait until the leader is online
-                if ( clusterOverview.containsValue( ClusterMemberRole.LEADER ) )
-                {
-                    actualOnlineAddresses = clusterOverview.keySet();
-                }
+                actualOnlineAddresses = clusterOverview.keySet();
             }
             catch ( Throwable t )
             {


### PR DESCRIPTION
The cluster memeber shutdown requires proper stop call rather than kill to ensure the databases are closed properly in 4.0.
Also the status check shall not assume a LEADER is always presented in the cluster.