### PR TITLE
adding the ability to dump logs of local standalone and cluster neo4j…

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.ConcurrentSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -88,6 +89,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.neo4j.driver.SessionConfig.builder;
 
+@ExtendWith( DumpLogsOnFailureWatcher.class )
 abstract class AbstractStressTestBase<C extends AbstractContext>
 {
     private static final int THREAD_COUNT = Integer.getInteger( "threadCount", 8 );
@@ -208,6 +210,8 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
 
         verifyResults( context, resourcesInfo );
     }
+
+    abstract void dumpLogs();
 
     abstract URI databaseUri();
 

--- a/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/CausalClusteringStressIT.java
@@ -128,6 +128,12 @@ class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringSt
         System.out.println( "Bookmark failures: " + context.getBookmarkFailures() );
     }
 
+    @Override
+    void dumpLogs()
+    {
+        clusterRule.dumpClusterLogs();
+    }
+
     private static ClusterAddresses fetchClusterAddresses( Driver driver )
     {
         Set<String> followers = new HashSet<>();

--- a/driver/src/test/java/org/neo4j/driver/stress/DumpLogsOnFailureWatcher.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/DumpLogsOnFailureWatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.stress;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.util.Optional;
+
+public class DumpLogsOnFailureWatcher implements TestWatcher
+{
+    @Override
+    public void testDisabled( ExtensionContext context, Optional<String> reason )
+    {
+        // do nothing
+    }
+
+    @Override
+    public void testSuccessful( ExtensionContext context )
+    {
+        // do nothing
+    }
+
+    @Override
+    public void testAborted( ExtensionContext context, Throwable cause )
+    {
+        // do nothing
+    }
+
+    @Override
+    public void testFailed( ExtensionContext context, Throwable cause )
+    {
+        if ( context.getTestInstance().isPresent() && context.getTestInstance().get() instanceof AbstractStressTestBase<?>)
+        {
+            AbstractStressTestBase<?> clusterTest = (AbstractStressTestBase<?>)  context.getTestInstance().get();
+            clusterTest.dumpLogs();
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.reactive.RxSession;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RxWriteQuery<C extends AbstractContext> extends AbstractRxQuery<C>
 {

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
@@ -30,6 +30,8 @@ import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.reactive.RxSession;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RxWriteQueryWithRetries<C extends AbstractContext> extends AbstractRxQuery<C>
 {
@@ -45,7 +47,7 @@ public class RxWriteQueryWithRetries<C extends AbstractContext> extends Abstract
     public CompletionStage<Void> execute( C context )
     {
         CompletableFuture<Void> queryFinished = new CompletableFuture<>();
-        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.READ, context ) ),
+        Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.WRITE, context ) ),
                 session -> session.writeTransaction( tx -> tx.run( "CREATE ()" ).consume() ), RxSession::close )
                 .subscribe( summary -> {
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/SingleInstanceStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/SingleInstanceStressIT.java
@@ -114,4 +114,10 @@ class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStress
             return readQueries.get();
         }
     }
+
+    @Override
+    void dumpLogs()
+    {
+        neo4j.dumpLogs();
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/DatabaseExtension.java
@@ -173,4 +173,9 @@ public class DatabaseExtension implements BeforeEachCallback
     {
         return ServerVersion.version( driver() );
     }
+
+    public void dumpLogs()
+    {
+        runner.dumpDebugLog();
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.util;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.StandardSocketOptions;
 import java.net.URI;
@@ -26,6 +27,7 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Config;
@@ -238,6 +240,29 @@ public class Neo4jRunner
         {
             forceToRestart();
         }
+    }
+
+    /**
+     * prints the debug log contents to stdOut
+     */
+    public void dumpDebugLog()
+    {
+        try
+        {
+            System.out.println( "Debug log for: " + HOME_DIR );
+            Scanner input = new Scanner( new File( HOME_DIR + "/logs/debug.log" ));
+
+            while (input.hasNextLine())
+            {
+                System.out.println(input.nextLine());
+            }
+        }
+        catch ( FileNotFoundException e )
+        {
+            System.out.println("Unable to find debug log file for: " + HOME_DIR);
+            e.printStackTrace();
+        }
+
     }
 
     private enum ServerStatus

--- a/driver/src/test/java/org/neo4j/driver/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/Cluster.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.util.cc;
 
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -173,6 +174,24 @@ public class Cluster implements AutoCloseable
     public Driver getDirectDriver( ClusterMember member )
     {
         return clusterDrivers.getDriver( member );
+    }
+
+    public void dumpClusterDebugLog()
+    {
+        for ( ClusterMember member : members )
+        {
+
+            System.out.println( "Debug log for: " + member.getPath().toString() );
+            try
+            {
+                member.dumpDebugLog();
+            }
+            catch ( FileNotFoundException e )
+            {
+                System.out.println("Unable to find debug log file for: " + member.getPath().toString());
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMember.java
@@ -18,10 +18,13 @@
  */
 package org.neo4j.driver.util.cc;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Scanner;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 
@@ -61,6 +64,16 @@ public class ClusterMember
     public Path getPath()
     {
         return path;
+    }
+
+    public void dumpDebugLog() throws FileNotFoundException
+    {
+        Scanner input = new Scanner( new File( path.toAbsolutePath().toString() + "/logs/debug.log" ));
+
+        while (input.hasNextLine())
+        {
+            System.out.println(input.nextLine());
+        }
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/util/cc/LocalOrRemoteClusterExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/LocalOrRemoteClusterExtension.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.io.FileNotFoundException;
 import java.net.URI;
 
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
@@ -96,6 +97,14 @@ public class LocalOrRemoteClusterExtension implements BeforeAllCallback, AfterEa
         if ( !remoteClusterExists() )
         {
             localClusterExtension.afterAll( context );
+        }
+    }
+
+    public void dumpClusterLogs()
+    {
+        if ( localClusterExtension != null )
+        {
+            localClusterExtension.getCluster().dumpClusterDebugLog();
         }
     }
 


### PR DESCRIPTION
To help with debugging flakey tests we dump the logs on failure of the Neo4j instance/cluster the failure occurred against.