### PR TITLE
Ensure error is propagated from rx queries correctly.

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -30,7 +30,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -99,7 +98,6 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
 
     private static final int BIG_DATA_TEST_NODE_COUNT = Integer.getInteger( "bigDataTestNodeCount", 30_000 );
     private static final int BIG_DATA_TEST_BATCH_SIZE = Integer.getInteger( "bigDataTestBatchSize", 10_000 );
-    private static final Duration DEFAULT_BLOCKING_TIME_OUT = Duration.ofMinutes( 10 );
 
     private LoggerNameTrackingLogging logging;
     private ExecutorService executor;
@@ -638,7 +636,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
 
         Flux.concat( Flux.range( 0, batchCount ).map( batchIndex ->
             session.writeTransaction( tx -> createNodesInTxRx( tx, batchIndex, batchSize ) )
-        ) ).blockLast( DEFAULT_BLOCKING_TIME_OUT ); // throw any error if happened
+        ) ).blockLast(); // throw any error if happened
 
         long end = System.nanoTime();
         System.out.println( "Node creation with reactive API took: " + NANOSECONDS.toMillis( end - start ) + "ms" );
@@ -673,7 +671,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
             verifyNodeProperties( node );
         } ).then() );
 
-        Flux.from( readQuery ).blockLast( DEFAULT_BLOCKING_TIME_OUT );
+        Flux.from( readQuery ).blockLast();
 
         assertEquals( expectedNodeCount, nodesSeen.get() );
 

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQuery.java
@@ -55,6 +55,7 @@ public class AsyncWriteQuery<C extends AbstractContext> extends AbstractAsyncQue
                     }
                     else
                     {
+                        context.setBookmark( session.lastBookmark() );
                         assertEquals( 1, summary.counters().nodesCreated() );
                         context.nodeCreated();
                     }

--- a/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AsyncWriteQueryInTx.java
@@ -45,8 +45,10 @@ public class AsyncWriteQueryInTx<C extends AbstractContext> extends AbstractAsyn
 
         CompletionStage<ResultSummary> txCommitted = session.beginTransactionAsync().thenCompose( tx ->
                 tx.runAsync( "CREATE ()" ).thenCompose( cursor ->
-                        cursor.consumeAsync().thenCompose( summary ->
-                                tx.commitAsync().thenApply( ignore -> summary ) ) ) );
+                        cursor.consumeAsync().thenCompose( summary -> tx.commitAsync().thenApply( ignore -> {
+                            context.setBookmark( session.lastBookmark() );
+                            return summary;
+                        } ) ) ) );
 
         return txCommitted.handle( ( summary, error ) ->
         {

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingWriteQuery.java
@@ -21,7 +21,7 @@ package org.neo4j.driver.stress;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Result;
+import org.neo4j.driver.summary.ResultSummary;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,12 +38,13 @@ public class BlockingWriteQuery<C extends AbstractContext> extends AbstractBlock
     @Override
     public void execute( C context )
     {
-        Result result = null;
+        ResultSummary summary = null;
         Throwable queryError = null;
 
         try ( Session session = newSession( AccessMode.WRITE, context ) )
         {
-            result = session.run( "CREATE ()" );
+            summary = session.run( "CREATE ()" ).consume();
+            context.setBookmark( session.lastBookmark() );
         }
         catch ( Throwable error )
         {
@@ -54,9 +55,9 @@ public class BlockingWriteQuery<C extends AbstractContext> extends AbstractBlock
             }
         }
 
-        if ( queryError == null && result != null )
+        if ( queryError == null && summary != null )
         {
-            assertEquals( 1, result.consume().counters().nodesCreated() );
+            assertEquals( 1, summary.counters().nodesCreated() );
             context.nodeCreated();
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQuery.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
@@ -51,8 +52,7 @@ public class RxFailingQuery<C extends AbstractContext> extends AbstractRxQuery<C
                 RxSession::close )
                 .subscribe( record -> {
                     assertThat( record.get( 0 ).asInt(), either( equalTo( 1 ) ).or( equalTo( 2 ) ) );
-                    queryFinished.complete( null );
-                }, error -> {
+                    }, error -> {
                     Throwable cause = Futures.completionExceptionCause( error );
                     assertThat( cause, is( arithmeticError() ) );
                     queryFinished.complete( null );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryInTx.java
@@ -52,7 +52,6 @@ public class RxFailingQueryInTx<C extends AbstractContext> extends AbstractRxQue
                 RxTransaction::commit, ( tx, error ) -> tx.rollback(), null )
                 .subscribe( record -> {
                     assertThat( record.get( 0 ).asInt(), either( equalTo( 1 ) ).or( equalTo( 2 ) ) );
-                    queryFinished.complete( null );
                 }, error -> {
                     Throwable cause = Futures.completionExceptionCause( error );
                     assertThat( cause, is( arithmeticError() ) );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxFailingQueryWithRetries.java
@@ -51,7 +51,6 @@ public class RxFailingQueryWithRetries<C extends AbstractContext> extends Abstra
                 RxSession::close )
                 .subscribe( record -> {
                     assertThat( record.get( 0 ).asInt(), either( equalTo( 1 ) ).or( equalTo( 2 ) ) );
-                    queryFinished.complete( null );
                 }, error -> {
                     Throwable cause = Futures.completionExceptionCause( error );
                     assertThat( cause, is( arithmeticError() ) );

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQuery.java
@@ -49,22 +49,23 @@ public class RxWriteQuery<C extends AbstractContext> extends AbstractRxQuery<C>
         Flux.usingWhen( Mono.fromSupplier( () -> newSession( AccessMode.WRITE, context ) ),
                 session -> session.run( "CREATE ()" ).consume(), RxSession::close )
                 .subscribe( summary -> {
-                    queryFinished.complete( null );
                     assertEquals( 1, summary.counters().nodesCreated() );
                     context.nodeCreated();
-                }, error -> {
                     queryFinished.complete( null );
-                    handleError( Futures.completionExceptionCause( error ), context );
-                } );
+                }, error -> handleError( Futures.completionExceptionCause( error ), context, queryFinished ) );
 
         return queryFinished;
     }
 
-    private void handleError( Throwable error, C context )
+    private void handleError( Throwable error, C context, CompletableFuture<Void> queryFinished )
     {
         if ( !stressTest.handleWriteFailure( error, context ) )
         {
-            throw new RuntimeException( error );
+            queryFinished.completeExceptionally( error );
+        }
+        else
+        {
+            queryFinished.complete( null );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
@@ -53,18 +53,21 @@ public class RxWriteQueryInTx<C extends AbstractContext> extends AbstractRxQuery
                     context.nodeCreated();
                     queryFinished.complete( null );
                 }, error -> {
-                    handleError( Futures.completionExceptionCause( error ), context );
-                    queryFinished.complete( null );
+                    handleError( Futures.completionExceptionCause( error ), context, queryFinished );
                 } );
 
         return queryFinished;
     }
 
-    private void handleError( Throwable error, C context )
+    private void handleError( Throwable error, C context, CompletableFuture<Void> queryFinished )
     {
         if ( !stressTest.handleWriteFailure( error, context ) )
         {
-            throw new RuntimeException( error );
+            queryFinished.completeExceptionally( error );
+        }
+        else
+        {
+            queryFinished.complete( null );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryInTx.java
@@ -49,6 +49,7 @@ public class RxWriteQueryInTx<C extends AbstractContext> extends AbstractRxQuery
         Flux.usingWhen( session.beginTransaction(), tx -> tx.run( "CREATE ()" ).consume(),
                 RxTransaction::commit, ( tx, error ) -> tx.rollback(), null ).subscribe(
                 summary -> {
+                    context.setBookmark( session.lastBookmark() );
                     assertEquals( 1, summary.counters().nodesCreated() );
                     context.nodeCreated();
                     queryFinished.complete( null );


### PR DESCRIPTION
The rx queries should be semantically the same as the async queries.
Fixed a few wrong handling of finish future and error propergation used in rx queries.