### PR TITLE
Add example for database selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To use the driver in a project, please use the released driver via Maven Central
 
 #### Running Tests and Creating a Package
 
-The driver unit tests relies on latest [`boltkit`](https://github.com/neo4j-contrib/boltkit) installed on your local machine. 
+The driver unit tests relies on latest [`boltkit`](https://github.com/neo4j-drivers/boltkit) installed on your local machine. 
 If `boltkit` is not installed, then all tests that requires `boltkit` will be ignored and will not be executed.
 
 The following Maven command shows how to run all tests and build the source code:

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jEdition.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jEdition.java
@@ -18,21 +18,28 @@
  */
 package org.neo4j.driver.internal.util;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Target( {ElementType.TYPE, ElementType.METHOD} )
-@Retention( RetentionPolicy.RUNTIME )
-@Documented
-@ExtendWith( Neo4jWithFeatureCondition.class )
-public @interface EnabledOnNeo4jWith
+public enum Neo4jEdition
 {
-    Neo4jFeature value();
+    UNDEFINED( "n/a" ),
+    COMMUNITY( "community" ),
+    ENTERPRISE( "enterprise" );
 
-    Neo4jEdition edition() default Neo4jEdition.UNDEFINED;
+    private final String value;
+
+    Neo4jEdition( String value )
+    {
+        this.value = value;
+    }
+
+    public boolean matches( String otherValue )
+    {
+        if ( this == UNDEFINED )
+        {
+            return true;
+        }
+        else
+        {
+            return this.value.equals( otherValue );
+        }
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
@@ -86,7 +86,7 @@ public class Neo4jWithFeatureCondition implements ExecutionCondition
         {
             try ( Session session = driver.session() )
             {
-                String value = session.run( "call dbms.components() yield edition" ).single().get( "edition" ).asString();
+                String value = session.run( "CALL dbms.components() YIELD edition" ).single().get( "edition" ).asString();
                 boolean editionMatches = edition.matches( value );
                 return editionMatches
                        ? enabled( previousResult.getReason().map( v -> v + " and enabled" ).orElse( "Enabled" ) + " on " + value + "-edition" )

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jWithFeatureCondition.java
@@ -26,6 +26,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
 
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.util.Neo4jRunner;
 import org.neo4j.driver.util.Neo4jSettings;
 
@@ -48,7 +49,11 @@ public class Neo4jWithFeatureCondition implements ExecutionCondition
             EnabledOnNeo4jWith enabledAnnotation = element.getAnnotation( EnabledOnNeo4jWith.class );
             if ( enabledAnnotation != null )
             {
-                return checkFeatureAvailability( enabledAnnotation.value(), false );
+                ConditionEvaluationResult result = checkFeatureAvailability( enabledAnnotation.value(), false );
+                if ( enabledAnnotation.edition() != Neo4jEdition.UNDEFINED )
+                {
+                    result = checkEditionAvailability( result, enabledAnnotation.edition() );
+                } return result;
             }
 
             DisabledOnNeo4jWith disabledAnnotation = element.getAnnotation( DisabledOnNeo4jWith.class );
@@ -67,6 +72,26 @@ public class Neo4jWithFeatureCondition implements ExecutionCondition
         {
             ServerVersion version = ServerVersion.version( driver );
             return createResult( version, feature, negated );
+        }
+        return ENABLED_UNKNOWN_DB_VERSION;
+    }
+
+    private static ConditionEvaluationResult checkEditionAvailability( ConditionEvaluationResult previousResult, Neo4jEdition edition )
+    {
+        if(previousResult.isDisabled()) {
+            return previousResult;
+        }
+        Driver driver = getSharedNeo4jDriver();
+        if ( driver != null )
+        {
+            try ( Session session = driver.session() )
+            {
+                String value = session.run( "call dbms.components() yield edition" ).single().get( "edition" ).asString();
+                boolean editionMatches = edition.matches( value );
+                return editionMatches
+                       ? enabled( previousResult.getReason().map( v -> v + " and enabled" ).orElse( "Enabled" ) + " on " + value + "-edition" )
+                       : disabled( previousResult.getReason().map( v -> v + " but disabled" ).orElse( "Disabled" ) + " on " + value + "-edition" );
+            }
         }
         return ENABLED_UNKNOWN_DB_VERSION;
     }

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -47,8 +47,9 @@ import java.util.function.BooleanSupplier;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DefaultBookmarkHolder;
@@ -249,14 +250,29 @@ public final class TestUtil
 
     public static void dropDatabase( Driver driver, String database )
     {
+        boolean databaseExists = databaseExists( driver, database );
+        if ( !databaseExists )
+        {
+            return;
+        }
+
         try ( Session session = driver.session( forDatabase( "system" ) ) )
         {
-            // No procedure equivalent and `call dbms.database.state("db")` also throws an exception when db doesn't exist
-            boolean databaseExists = databaseExists( driver, database );
-            if ( databaseExists )
-            {
-                session.run( "DROP DATABASE " + database ).consume();
-            }
+            session.run( "DROP DATABASE " + database ).consume();
+        }
+    }
+
+    public static void createDatabase( Driver driver, String database )
+    {
+        boolean databaseExists = databaseExists( driver, database );
+        if ( databaseExists )
+        {
+            return;
+        }
+
+        try ( Session session = driver.session( SessionConfig.forDatabase( "system" ) ) )
+        {
+            session.run( "CREATE DATABASE " + database ).consume();
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -92,6 +92,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.AccessMode.WRITE;
 import static org.neo4j.driver.SessionConfig.builder;
+import static org.neo4j.driver.SessionConfig.forDatabase;
 import static org.neo4j.driver.internal.DatabaseNameUtil.database;
 import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
 import static org.neo4j.driver.internal.InternalBookmark.empty;
@@ -243,6 +244,28 @@ public final class TestUtil
         {
             cleanDb( session );
             return session.lastBookmark();
+        }
+    }
+
+    public static void dropDatabase( Driver driver, String database )
+    {
+        try ( Session session = driver.session( forDatabase( "system" ) ) )
+        {
+            // No procedure equivalent and `call dbms.database.state("db")` also throws an exception when db doesn't exist
+            boolean databaseExists = databaseExists( driver, database );
+            if ( databaseExists )
+            {
+                session.run( "DROP DATABASE " + database ).consume();
+            }
+        }
+    }
+
+    public static boolean databaseExists( Driver driver, String database )
+    {
+        try ( Session session = driver.session( forDatabase( "system" ) ) )
+        {
+            // No procedure equivalent and `call dbms.database.state("db")` also throws an exception when db doesn't exist
+            return session.run( "SHOW DATABASES" ).stream().anyMatch( r -> r.get( "name" ).asString().equals( database ) );
         }
     }
 

--- a/examples/src/main/java/org/neo4j/docs/driver/DatabaseSelectionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/DatabaseSelectionExample.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.docs.driver;
+
+import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.summary.ResultSummary;
+
+public class DatabaseSelectionExample extends BaseApplication
+{
+    public DatabaseSelectionExample( String uri, String user, String password )
+    {
+        super( uri, user, password );
+    }
+
+    public void createExampleDatabase()
+    {
+        try ( Session session = driver.session( SessionConfig.forDatabase( "system" ) ) )
+        {
+            ResultSummary summary = session.run( "CREATE DATABASE examples" ).consume();
+            System.out.println( summary.counters().systemUpdates() + " updates in " + summary.database().name() );
+        }
+    }
+
+    public void useAnotherDatabaseExample()
+    {
+        createExampleDatabase();
+
+        try ( Session session = driver.session( SessionConfig.forDatabase( "examples" ) ) )
+        {
+            session.run( "CREATE (a:Greeting {message: 'Hello, Example-Database'}) RETURN a" ).consume();
+        }
+
+        try ( Session session = driver.session( SessionConfig.builder().withDatabase( "examples" ).withDefaultAccessMode( AccessMode.READ ).build() ) )
+        {
+            String msg = session.run( "MATCH (a:Greeting) RETURN a.message as msg" ).single().get( "msg" ).asString();
+            System.out.println(msg);
+        }
+    }
+}

--- a/examples/src/main/java/org/neo4j/docs/driver/DatabaseSelectionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/DatabaseSelectionExample.java
@@ -18,10 +18,11 @@
  */
 package org.neo4j.docs.driver;
 
+// tag::database-selection-import[]
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
-import org.neo4j.driver.summary.ResultSummary;
+// end::database-selection-import[]
 
 public class DatabaseSelectionExample extends BaseApplication
 {
@@ -30,28 +31,23 @@ public class DatabaseSelectionExample extends BaseApplication
         super( uri, user, password );
     }
 
-    public void createExampleDatabase()
-    {
-        try ( Session session = driver.session( SessionConfig.forDatabase( "system" ) ) )
-        {
-            ResultSummary summary = session.run( "CREATE DATABASE examples" ).consume();
-            System.out.println( summary.counters().systemUpdates() + " updates in " + summary.database().name() );
-        }
-    }
-
     public void useAnotherDatabaseExample()
     {
-        createExampleDatabase();
-
+        // tag::database-selection[]
         try ( Session session = driver.session( SessionConfig.forDatabase( "examples" ) ) )
         {
             session.run( "CREATE (a:Greeting {message: 'Hello, Example-Database'}) RETURN a" ).consume();
         }
 
-        try ( Session session = driver.session( SessionConfig.builder().withDatabase( "examples" ).withDefaultAccessMode( AccessMode.READ ).build() ) )
+        SessionConfig sessionConfig = SessionConfig.builder()
+                .withDatabase( "examples" )
+                .withDefaultAccessMode( AccessMode.READ )
+                .build();
+        try ( Session session = driver.session( sessionConfig ) )
         {
             String msg = session.run( "MATCH (a:Greeting) RETURN a.message as msg" ).single().get( "msg" ).asString();
             System.out.println(msg);
         }
+        // end::database-selection[]
     }
 }

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -63,6 +63,7 @@ import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
 import static org.neo4j.driver.util.Neo4jRunner.PASSWORD;
 import static org.neo4j.driver.util.Neo4jRunner.USER;
 import static org.neo4j.driver.util.TestUtil.await;
+import static org.neo4j.driver.util.TestUtil.createDatabase;
 import static org.neo4j.driver.util.TestUtil.databaseExists;
 import static org.neo4j.driver.util.TestUtil.dropDatabase;
 
@@ -661,36 +662,19 @@ class ExamplesIT
 
     @Test
     @EnabledOnNeo4jWith( value = BOLT_V4, edition = ENTERPRISE)
-    void testShouldTestThings() throws Exception
+    void testUseAnotherDatabaseExample() throws Exception
     {
         Driver driver = neo4j.driver();
         dropDatabase( driver, "examples" );
+        createDatabase( driver, "examples" );
 
-        // Given
-        try ( DatabaseSelectionExample example = new DatabaseSelectionExample( uri, USER, PASSWORD ) )
-        {
-            // When
-            example.createExampleDatabase();
-
-            // Then
-            assertTrue( databaseExists( driver, "examples" ) );
-        }
-    }
-
-    @Test
-    @EnabledOnNeo4jWith( value = BOLT_V4, edition = ENTERPRISE)
-    void morethingstotest() throws Exception
-    {
-        dropDatabase( neo4j.driver(), "examples" );
-
-        // Given
         try ( DatabaseSelectionExample example = new DatabaseSelectionExample( uri, USER, PASSWORD ) )
         {
             // When
             example.useAnotherDatabaseExample();
 
             // Then
-            int greetingCount = readInt( "examples",  "MATCH (a:Greeting) RETURN count(a)", Values.parameters() );
+            int greetingCount = readInt( "examples", "MATCH (a:Greeting) RETURN count(a)", Values.parameters() );
             assertThat( greetingCount, is( 1 ) );
         }
     }

--- a/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
+++ b/examples/src/test/java/org/neo4j/docs/driver/ExamplesIT.java
@@ -32,11 +32,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
-import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.QueryType;
+import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.StdIOCapture;
@@ -55,10 +58,13 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.util.Neo4jEdition.ENTERPRISE;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
 import static org.neo4j.driver.util.Neo4jRunner.PASSWORD;
 import static org.neo4j.driver.util.Neo4jRunner.USER;
 import static org.neo4j.driver.util.TestUtil.await;
+import static org.neo4j.driver.util.TestUtil.databaseExists;
+import static org.neo4j.driver.util.TestUtil.dropDatabase;
 
 @ParallelizableIT
 @Execution( ExecutionMode.CONCURRENT )
@@ -69,12 +75,26 @@ class ExamplesIT
 
     private String uri;
 
-    private int readInt( final String query, final Value parameters )
+    private int readInt( String database, final String query, final Value parameters )
     {
-        try ( Session session = neo4j.driver().session() )
+        SessionConfig sessionConfig;
+        if ( database == null )
+        {
+            sessionConfig = SessionConfig.defaultConfig();
+        }
+        else
+        {
+            sessionConfig = SessionConfig.forDatabase( database );
+        }
+        try ( Session session = neo4j.driver().session( sessionConfig ) )
         {
             return session.readTransaction( tx -> tx.run( query, parameters ).single().get( 0 ).asInt() );
         }
+    }
+
+    private int readInt( final String query, final Value parameters )
+    {
+        return readInt( null, query, parameters );
     }
 
     private int readInt( final String query )
@@ -636,6 +656,42 @@ class ExamplesIT
 
             // Then
             assertThat( names, equalTo( asList( "Alice", "Bob" ) ) );
+        }
+    }
+
+    @Test
+    @EnabledOnNeo4jWith( value = BOLT_V4, edition = ENTERPRISE)
+    void testShouldTestThings() throws Exception
+    {
+        Driver driver = neo4j.driver();
+        dropDatabase( driver, "examples" );
+
+        // Given
+        try ( DatabaseSelectionExample example = new DatabaseSelectionExample( uri, USER, PASSWORD ) )
+        {
+            // When
+            example.createExampleDatabase();
+
+            // Then
+            assertTrue( databaseExists( driver, "examples" ) );
+        }
+    }
+
+    @Test
+    @EnabledOnNeo4jWith( value = BOLT_V4, edition = ENTERPRISE)
+    void morethingstotest() throws Exception
+    {
+        dropDatabase( neo4j.driver(), "examples" );
+
+        // Given
+        try ( DatabaseSelectionExample example = new DatabaseSelectionExample( uri, USER, PASSWORD ) )
+        {
+            // When
+            example.useAnotherDatabaseExample();
+
+            // Then
+            int greetingCount = readInt( "examples",  "MATCH (a:Greeting) RETURN count(a)", Values.parameters() );
+            assertThat( greetingCount, is( 1 ) );
         }
     }
 }


### PR DESCRIPTION
This PR brings in an extension to the `Neo4jWithFeatureCondition` that allows to check wether a test is run on community or enterprise edition (i.e. `@EnabledOnNeo4jWith( value = BOLT_V4, edition = ENTERPRISE)`) and the required mechanism.

Then, it adds some utilities to `TestUtil` (checking for database existence and such).

Finally it adds `DatabaseSelectionExample` that shows the session API for database selection.

I have a docs branch ready describing the example: https://github.com/michael-simons/driver-documentation/commit/abd26fef870e4d91faa688aa32be0dc6d79fba9c

PR for the JavaScript driver follows.