### PR TITLE
Stop database properly in tests

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/SessionAsyncIT.java
@@ -192,7 +192,7 @@ class SessionAsyncIT
 
                 if ( i == 0 )
                 {
-                    neo4j.killDb();
+                    neo4j.stopDb();
                 }
 
                 List<Record> records = await( cursor.listAsync() );
@@ -583,7 +583,7 @@ class SessionAsyncIT
     @Test
     void shouldRunAfterRunFailureToAcquireConnection()
     {
-        neo4j.killDb();
+        neo4j.stopDb();
 
         assertThrows( ServiceUnavailableException.class, () ->
         {
@@ -633,7 +633,7 @@ class SessionAsyncIT
     @Test
     void shouldBeginTxAfterRunFailureToAcquireConnection()
     {
-        neo4j.killDb();
+        neo4j.stopDb();
 
         assertThrows( ServiceUnavailableException.class, () ->
         {

--- a/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/integration/TransactionAsyncIT.java
@@ -575,7 +575,7 @@ class TransactionAsyncIT
 
         await( tx.runAsync( "CREATE ()" ) );
 
-        neo4j.killDb();
+        neo4j.stopDb();
 
         assertThrows( ServiceUnavailableException.class, () -> await( tx.commitAsync() ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/AbstractStressTestBase.java
@@ -99,14 +99,12 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
         System.setProperty( DRIVER_METRICS_ENABLED_KEY, "true" );
         logging = new LoggerNameTrackingLogging();
 
-        Config config = Config.builder()
-                .withoutEncryption()
+        Config.ConfigBuilder builder = Config.builder()
                 .withLogging( logging )
                 .withMaxConnectionPoolSize( 100 )
-                .withConnectionAcquisitionTimeout( 1, MINUTES )
-                .build();
+                .withConnectionAcquisitionTimeout( 1, MINUTES );
 
-        driver = (InternalDriver) GraphDatabase.driver( databaseUri(), authToken(), config );
+        driver = (InternalDriver) GraphDatabase.driver( databaseUri(), authToken(), config( builder ) );
         System.setProperty( DRIVER_METRICS_ENABLED_KEY, "false" );
 
         ThreadFactory threadFactory = new DaemonThreadFactory( getClass().getSimpleName() + "-worker-" );
@@ -185,6 +183,8 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
     abstract URI databaseUri();
 
     abstract AuthToken authToken();
+
+    abstract Config config( Config.ConfigBuilder builder );
 
     abstract C createContext();
 

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/CausalClusteringStressIT.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.summary.ResultSummary;
@@ -64,6 +65,12 @@ class CausalClusteringStressIT extends AbstractStressTestBase<CausalClusteringSt
     AuthToken authToken()
     {
         return clusterRule.getAuthToken();
+    }
+
+    @Override
+    Config config( Config.ConfigBuilder builder )
+    {
+        return clusterRule.getDriverConfig( builder );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/stress/SingleInstanceStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/stress/SingleInstanceStressIT.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.DatabaseExtension;
 import org.neo4j.driver.v1.util.ParallelizableIT;
@@ -50,6 +51,12 @@ class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStress
     AuthToken authToken()
     {
         return neo4j.authToken();
+    }
+
+    @Override
+    Config config( Config.ConfigBuilder builder )
+    {
+        return builder.build();
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/v1/util/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/DatabaseExtension.java
@@ -163,11 +163,6 @@ public class DatabaseExtension implements BeforeEachCallback
         runner.stopNeo4j();
     }
 
-    public void killDb()
-    {
-        runner.killNeo4j();
-    }
-
     public ServerVersion version()
     {
         return ServerVersion.version( driver() );

--- a/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/v1/util/cc/LocalOrRemoteClusterExtension.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import org.neo4j.driver.internal.util.DriverFactoryWithOneEventLoopThread;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.util.TestUtil;
 
@@ -60,6 +61,20 @@ public class LocalOrRemoteClusterExtension implements BeforeAllCallback, AfterEa
             return AuthTokens.basic( "neo4j", neo4jUserPasswordFromSystemProperty() );
         }
         return localClusterExtension.getDefaultAuthToken();
+    }
+
+    public Config getDriverConfig( Config.ConfigBuilder builder )
+    {
+        if ( remoteClusterExists() )
+        {
+            builder.withEncryption();
+        }
+        else
+        {
+            builder.withoutEncryption();
+        }
+
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
Removed force kill as it may cause some state error in system db in 4.0.
Based on #691