### PR TITLE
Do not expect package com.oracle.svm at OSGi runtime

### DIFF
--- a/driver/osgi.bnd
+++ b/driver/osgi.bnd
@@ -1,11 +1,11 @@
 package-version=${version;===;${Bundle-Version}}
 
 Export-Package: \
- !*.internal.*, \
  *;version="${package-version}"
 
 Import-Package: \
  !io.netty.*, \
+ !com.oracle.svm.*, \
  javax.security.cert, \
  *
 


### PR DESCRIPTION
In the current build process, some SVM substitutions got integrated to generate a native-image of the library. From an OSGi perspective, the integration of Oracles, respectively, Graal's substrate dependency causes an unintentional statement in the manifest.mf of the build result expecting a package called com.oracle.svm.

This pull request adjusts the osgi.bnd file to avoid the com.oracle.svm package from being required when the bundle gets executed in an OSGi runtime.