### PR TITLE
4.1 add routing context to hello message

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -93,17 +93,18 @@ public class DriverFactory
         RetryLogic retryLogic = createRetryLogic( retrySettings, eventExecutorGroup, config.logging() );
 
         MetricsProvider metricsProvider = createDriverMetrics( config, createClock() );
-        ConnectionPool connectionPool = createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
+        ConnectionPool connectionPool = createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config,
+                                                              ownsEventLoopGroup, newRoutingSettings.routingContext() );
 
         return createDriver( uri, securityPlan, address, connectionPool, eventExecutorGroup, newRoutingSettings, retryLogic, metricsProvider, config );
     }
 
     protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup, RoutingContext routingContext )
     {
         Clock clock = createClock();
         ConnectionSettings settings = new ConnectionSettings( authToken, config.connectionTimeoutMillis() );
-        ChannelConnector connector = createConnector( settings, securityPlan, config, clock );
+        ChannelConnector connector = createConnector( settings, securityPlan, config, clock, routingContext );
         PoolSettings poolSettings = new PoolSettings( config.maxConnectionPoolSize(),
                 config.connectionAcquisitionTimeoutMillis(), config.maxConnectionLifetimeMillis(),
                 config.idleTimeBeforeConnectionTest()
@@ -124,9 +125,9 @@ public class DriverFactory
     }
 
     protected ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan,
-            Config config, Clock clock )
+            Config config, Clock clock, RoutingContext routingContext )
     {
-        return new ChannelConnectorImpl( settings, securityPlan, config.logging(), clock );
+        return new ChannelConnectorImpl( settings, securityPlan, config.logging(), clock, routingContext );
     }
 
     private InternalDriver createDriver( URI uri, SecurityPlan securityPlan, BoltServerAddress address, ConnectionPool connectionPool,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
@@ -45,7 +45,7 @@ import static java.util.Objects.requireNonNull;
 public class ChannelConnectorImpl implements ChannelConnector
 {
     private final String userAgent;
-    private final Map<String,Value> authToken;
+    private final AuthToken authToken;
     private final RoutingContext routingContext;
     private final SecurityPlan securityPlan;
     private final ChannelPipelineBuilder pipelineBuilder;
@@ -63,7 +63,7 @@ public class ChannelConnectorImpl implements ChannelConnector
             ChannelPipelineBuilder pipelineBuilder, Logging logging, Clock clock, RoutingContext routingContext )
     {
         this.userAgent = connectionSettings.userAgent();
-        this.authToken = tokenAsMap( connectionSettings.authToken() );
+        this.authToken = requireValidAuthToken( connectionSettings.authToken() );
         this.routingContext = routingContext;
         this.connectTimeoutMillis = connectionSettings.connectTimeoutMillis();
         this.securityPlan = requireNonNull( securityPlan );
@@ -119,11 +119,11 @@ public class ChannelConnectorImpl implements ChannelConnector
         handshakeCompleted.addListener( new HandshakeCompletedListener( userAgent, authToken, routingContext, connectionInitialized ) );
     }
 
-    private static Map<String,Value> tokenAsMap( AuthToken token )
+    private static AuthToken requireValidAuthToken( AuthToken token )
     {
         if ( token instanceof InternalAuthToken )
         {
-            return ((InternalAuthToken) token).toMap();
+            return token;
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 
 import java.util.Map;
 
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.Value;
 
@@ -33,13 +34,15 @@ public class HandshakeCompletedListener implements ChannelFutureListener
 {
     private final String userAgent;
     private final Map<String,Value> authToken;
+    private final RoutingContext routingContext;
     private final ChannelPromise connectionInitializedPromise;
 
     public HandshakeCompletedListener( String userAgent, Map<String,Value> authToken,
-            ChannelPromise connectionInitializedPromise )
+                                       RoutingContext routingContext, ChannelPromise connectionInitializedPromise )
     {
         this.userAgent = requireNonNull( userAgent );
         this.authToken = requireNonNull( authToken );
+        this.routingContext = routingContext;
         this.connectionInitializedPromise = requireNonNull( connectionInitializedPromise );
     }
 
@@ -49,7 +52,7 @@ public class HandshakeCompletedListener implements ChannelFutureListener
         if ( future.isSuccess() )
         {
             BoltProtocol protocol = BoltProtocol.forChannel( future.channel() );
-            protocol.initializeChannel( userAgent, authToken, connectionInitializedPromise );
+            protocol.initializeChannel( userAgent, authToken, routingContext, connectionInitializedPromise );
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 
 import java.util.Map;
 
+import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.Value;
@@ -33,11 +34,11 @@ import static java.util.Objects.requireNonNull;
 public class HandshakeCompletedListener implements ChannelFutureListener
 {
     private final String userAgent;
-    private final Map<String,Value> authToken;
+    private final AuthToken authToken;
     private final RoutingContext routingContext;
     private final ChannelPromise connectionInitializedPromise;
 
-    public HandshakeCompletedListener( String userAgent, Map<String,Value> authToken,
+    public HandshakeCompletedListener( String userAgent, AuthToken authToken,
                                        RoutingContext routingContext, ChannelPromise connectionInitializedPromise )
     {
         this.userAgent = requireNonNull( userAgent );

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
@@ -54,7 +54,7 @@ public class MultiDatabasesRoutingProcedureRunner extends RoutingProcedureRunner
     Query procedureQuery(ServerVersion serverVersion, DatabaseName databaseName )
     {
         HashMap<String,Value> map = new HashMap<>();
-        map.put( ROUTING_CONTEXT, value( context.asMap() ) );
+        map.put( ROUTING_CONTEXT, value( context.toMap() ) );
         map.put( DATABASE_NAME, value( (Object) databaseName.databaseName().orElse( null ) ) );
         return new Query( MULTI_DB_GET_ROUTING_TABLE, value( map ) );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.Scheme;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -43,13 +44,13 @@ public class RoutingContext
 
     public RoutingContext( URI uri )
     {
-        this.isServerRoutingEnabled = uri.getScheme().startsWith( "neo4j" );
+        this.isServerRoutingEnabled = Scheme.isRoutingScheme( uri.getScheme() );
         this.context = unmodifiableMap( parseParameters( uri ) );
     }
 
     public boolean isDefined()
     {
-        return context.size() > 1;
+        return !context.isEmpty();
     }
 
     public Map<String,String> asMap()

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -33,14 +33,17 @@ public class RoutingContext
     private static final String ROUTING_ADDRESS_KEY = "address";
 
     private final Map<String,String> context;
+    private final boolean isServerRoutingEnabled;
 
     private RoutingContext()
     {
+        this.isServerRoutingEnabled = true;
         this.context = emptyMap();
     }
 
     public RoutingContext( URI uri )
     {
+        this.isServerRoutingEnabled = uri.getScheme().startsWith( "neo4j" );
         this.context = unmodifiableMap( parseParameters( uri ) );
     }
 
@@ -54,10 +57,15 @@ public class RoutingContext
         return context;
     }
 
+    public boolean isServerRoutingEnabled()
+    {
+        return isServerRoutingEnabled;
+    }
+
     @Override
     public String toString()
     {
-        return "RoutingContext" + context;
+        return "RoutingContext" + context + " isServerRoutingEnabled=" + isServerRoutingEnabled;
     }
 
     private static Map<String,String> parseParameters( URI uri )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -53,7 +53,7 @@ public class RoutingContext
         return !context.isEmpty();
     }
 
-    public Map<String,String> asMap()
+    public Map<String,String> toMap()
     {
         return context;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -50,7 +50,7 @@ public class RoutingContext
 
     public boolean isDefined()
     {
-        return !context.isEmpty();
+        return context.size() > 1;
     }
 
     public Map<String,String> toMap()

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -76,7 +76,7 @@ public class RoutingProcedureRunner
                     "Refreshing routing table for multi-databases is not supported in server version lower than 4.0. " +
                             "Current server version: %s. Database name: '%s'", serverVersion, databaseName.description() ) );
         }
-        return new Query( GET_ROUTING_TABLE, parameters( ROUTING_CONTEXT, context.asMap() ) );
+        return new Query( GET_ROUTING_TABLE, parameters( ROUTING_CONTEXT, context.toMap() ) );
     }
 
     BookmarkHolder bookmarkHolder( Bookmark ignored )

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.messaging.v1.BoltProtocolV1;
 import org.neo4j.driver.internal.messaging.v2.BoltProtocolV2;
@@ -58,9 +59,10 @@ public interface BoltProtocol
      *
      * @param userAgent the user agent string.
      * @param authToken the authentication token.
+     * @param routingContext the configured routing context
      * @param channelInitializedPromise the promise to be notified when initialization is completed.
      */
-    void initializeChannel( String userAgent, Map<String,Value> authToken, ChannelPromise channelInitializedPromise );
+    void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise );
 
     /**
      * Prepare to close channel before it is closed.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
@@ -62,7 +63,7 @@ public interface BoltProtocol
      * @param routingContext the configured routing context
      * @param channelInitializedPromise the promise to be notified when initialization is completed.
      */
-    void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise );
+    void initializeChannel( String userAgent, AuthToken authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise );
 
     /**
      * Prepare to close channel before it is closed.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
@@ -32,10 +32,11 @@ public class HelloMessage extends MessageWithMetadata
     public final static byte SIGNATURE = 0x01;
 
     private static final String USER_AGENT_METADATA_KEY = "user_agent";
+    private static final String ROUTING_CONTEXT_METADATA_KEY = "routing";
 
-    public HelloMessage( String userAgent, Map<String,Value> authToken )
+    public HelloMessage( String userAgent, Map<String,Value> authToken, Map<String,String> routingContext )
     {
-        super( buildMetadata( userAgent, authToken ) );
+        super( buildMetadata( userAgent, authToken, routingContext ) );
     }
 
     @Override
@@ -73,10 +74,11 @@ public class HelloMessage extends MessageWithMetadata
         return "HELLO " + metadataCopy;
     }
 
-    private static Map<String,Value> buildMetadata( String userAgent, Map<String,Value> authToken )
+    private static Map<String,Value> buildMetadata( String userAgent, Map<String,Value> authToken, Map<String,String> routingContext )
     {
         Map<String,Value> result = new HashMap<>( authToken );
         result.put( USER_AGENT_METADATA_KEY, value( userAgent ) );
+        result.put( ROUTING_CONTEXT_METADATA_KEY, value( routingContext ) );
         return result;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
@@ -53,6 +54,7 @@ import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.request.InitMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.RunMessage;
+import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
@@ -85,12 +87,12 @@ public class BoltProtocolV1 implements BoltProtocol
     }
 
     @Override
-    public void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext,
+    public void initializeChannel( String userAgent, AuthToken authToken, RoutingContext routingContext,
                                    ChannelPromise channelInitializedPromise )
     {
         Channel channel = channelInitializedPromise.channel();
 
-        InitMessage message = new InitMessage( userAgent, authToken );
+        InitMessage message = new InitMessage( userAgent, ((InternalAuthToken) authToken).toMap() );
         InitResponseHandler handler = new InitResponseHandler( channelInitializedPromise );
 
         messageDispatcher( channel ).enqueue( handler );

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1.java
@@ -35,6 +35,7 @@ import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
@@ -84,7 +85,8 @@ public class BoltProtocolV1 implements BoltProtocol
     }
 
     @Override
-    public void initializeChannel( String userAgent, Map<String,Value> authToken, ChannelPromise channelInitializedPromise )
+    public void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext,
+                                   ChannelPromise channelInitializedPromise )
     {
         Channel channel = channelInitializedPromise.channel();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging.v3;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -33,6 +34,7 @@ import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
@@ -76,11 +78,20 @@ public class BoltProtocolV3 implements BoltProtocol
     }
 
     @Override
-    public void initializeChannel( String userAgent, Map<String,Value> authToken, ChannelPromise channelInitializedPromise )
+    public void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise )
     {
         Channel channel = channelInitializedPromise.channel();
+        HelloMessage message;
 
-        HelloMessage message = new HelloMessage( userAgent, authToken );
+        if ( routingContext.isServerRoutingEnabled() )
+        {
+            message = new HelloMessage( userAgent, authToken, routingContext.asMap() );
+        }
+        else
+        {
+            message = new HelloMessage( userAgent, authToken, null );
+        }
+
         HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise, version() );
 
         messageDispatcher( channel ).enqueue( handler );

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -21,18 +21,17 @@ package org.neo4j.driver.internal.messaging.v3;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursorOnlyFactory;
@@ -51,6 +50,7 @@ import org.neo4j.driver.internal.messaging.request.BeginMessage;
 import org.neo4j.driver.internal.messaging.request.GoodbyeMessage;
 import org.neo4j.driver.internal.messaging.request.HelloMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
+import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.MetadataExtractor;
@@ -78,18 +78,18 @@ public class BoltProtocolV3 implements BoltProtocol
     }
 
     @Override
-    public void initializeChannel( String userAgent, Map<String,Value> authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise )
+    public void initializeChannel( String userAgent, AuthToken authToken, RoutingContext routingContext, ChannelPromise channelInitializedPromise )
     {
         Channel channel = channelInitializedPromise.channel();
         HelloMessage message;
 
         if ( routingContext.isServerRoutingEnabled() )
         {
-            message = new HelloMessage( userAgent, authToken, routingContext.asMap() );
+            message = new HelloMessage( userAgent, ( ( InternalAuthToken ) authToken ).toMap(), routingContext.toMap() );
         }
         else
         {
-            message = new HelloMessage( userAgent, authToken, null );
+            message = new HelloMessage( userAgent, ( ( InternalAuthToken ) authToken ).toMap(), null );
         }
 
         HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise, version() );

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -46,6 +46,7 @@ import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
 import org.neo4j.driver.internal.async.inbound.ConnectTimeoutHandler;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.FakeClock;
@@ -231,7 +232,7 @@ class ChannelConnectorImplIT
             int connectTimeoutMillis )
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, connectTimeoutMillis );
-        return new ChannelConnectorImpl( settings, securityPlan, DEV_NULL_LOGGING, new FakeClock() );
+        return new ChannelConnectorImpl( settings, securityPlan, DEV_NULL_LOGGING, new FakeClock(), RoutingContext.EMPTY );
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -49,6 +49,7 @@ import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
 import org.neo4j.driver.internal.async.pool.PoolSettings;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.metrics.MetricsProvider;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -445,14 +446,15 @@ class ConnectionHandlingIT
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider ignored, Config config, boolean ownsEventLoopGroup )
+                                                       MetricsProvider ignored, Config config, boolean ownsEventLoopGroup,
+                                                       RoutingContext routingContext )
         {
             ConnectionSettings connectionSettings = new ConnectionSettings( authToken, 1000 );
             PoolSettings poolSettings = new PoolSettings( config.maxConnectionPoolSize(),
                     config.connectionAcquisitionTimeoutMillis(), config.maxConnectionLifetimeMillis(),
                     config.idleTimeBeforeConnectionTest() );
             Clock clock = createClock();
-            ChannelConnector connector = super.createConnector( connectionSettings, securityPlan, config, clock );
+            ChannelConnector connector = super.createConnector( connectionSettings, securityPlan, config, clock, routingContext );
             connectionPool = new MemorizingConnectionPool( connector, bootstrap, poolSettings, config.logging(), clock, ownsEventLoopGroup );
             return connectionPool;
         }

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -893,6 +893,46 @@ class RoutingDriverBoltKitTest
     }
 
     @Test
+    void shouldSendRoutingContextInHelloMessage() throws Exception
+    {
+        // stub server is both a router and reader
+        StubServer server = StubServer.start( "routing_context_in_hello_neo4j.script", 9001 );
+
+        URI uri = URI.create( "neo4j://127.0.0.1:9001/?policy=my_policy&region=china" );
+        try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG ); Session session = driver.session() )
+        {
+            List<Record> records = session.run( "MATCH (n) RETURN n.name AS name" ).list();
+            assertEquals( 2, records.size() );
+            assertEquals( "Alice", records.get( 0 ).get( "name" ).asString() );
+            assertEquals( "Bob", records.get( 1 ).get( "name" ).asString() );
+        }
+        finally
+        {
+            assertEquals( 0, server.exitStatus() );
+        }
+    }
+
+    @Test
+    void shouldSendEmptyRoutingContextInHelloMessage() throws Exception
+    {
+        // stub server is both a router and reader
+        StubServer server = StubServer.start( "empty_routing_context_in_hello_neo4j.script", 9001 );
+
+        URI uri = URI.create( "neo4j://127.0.0.1:9001/" );
+        try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG ); Session session = driver.session() )
+        {
+            List<Record> records = session.run( "MATCH (n) RETURN n.name AS name" ).list();
+            assertEquals( 2, records.size() );
+            assertEquals( "Alice", records.get( 0 ).get( "name" ).asString() );
+            assertEquals( "Bob", records.get( 1 ).get( "name" ).asString() );
+        }
+        finally
+        {
+            assertEquals( 0, server.exitStatus() );
+        }
+    }
+
+    @Test
     void shouldServeReadsButFailWritesWhenNoWritersAvailable() throws Exception
     {
         StubServer router1 = StubServer.start( "discover_no_writers_9010.script", 9010 );

--- a/driver/src/test/java/org/neo4j/driver/internal/CustomSecurityPlanTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/CustomSecurityPlanTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Config;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.metrics.MetricsProvider;
 import org.neo4j.driver.internal.retry.RetrySettings;
@@ -74,10 +75,11 @@ class CustomSecurityPlanTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+                                                       MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup,
+                                                       RoutingContext routingContext )
         {
             capturedSecurityPlans.add( securityPlan );
-            return super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
+            return super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup, routingContext );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DirectDriverBoltKitTest.java
@@ -126,6 +126,24 @@ class DirectDriverBoltKitTest
     }
 
     @Test
+    void shouldSendNullRoutingContextForBoltUri() throws Exception
+    {
+        StubServer server = StubServer.start( "hello_with_routing_context_bolt.script", 9001 );
+
+        try ( Driver driver = GraphDatabase.driver( "bolt://localhost:9001", INSECURE_CONFIG );
+              Session session = driver.session() )
+        {
+            List<String> names = session.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( 0 ).asString() );
+            assertEquals( asList( "Foo", "Bar" ), names );
+
+        }
+        finally
+        {
+            assertEquals( 0, server.exitStatus() );
+        }
+    }
+
+    @Test
     void shouldLogConnectionIdInDebugMode() throws Exception
     {
         StubServer server = StubServer.start( "hello_run_exit.script", 9001 );

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -36,6 +36,7 @@ import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.internal.async.LeakLoggingNetworkSession;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.cluster.loadbalancing.LoadBalancer;
 import org.neo4j.driver.internal.metrics.InternalMetricsProvider;
@@ -211,7 +212,8 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+                                                       MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup,
+                                                       RoutingContext routingContext )
         {
             return connectionPool;
         }
@@ -247,7 +249,7 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup, RoutingContext routingContext )
         {
             return connectionPoolMock();
         }
@@ -270,7 +272,7 @@ class DriverFactoryTest
 
         @Override
         protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+                MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup, RoutingContext routingContext )
         {
             return connectionPoolMock();
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -40,6 +42,7 @@ import org.neo4j.driver.internal.messaging.request.InitMessage;
 import org.neo4j.driver.internal.messaging.v1.BoltProtocolV1;
 import org.neo4j.driver.internal.messaging.v2.BoltProtocolV2;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
+import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,19 +88,19 @@ class HandshakeCompletedListenerTest
     @Test
     void shouldWriteInitializationMessageInBoltV1WhenHandshakeCompleted()
     {
-        testWritingOfInitializationMessage( BoltProtocolV1.VERSION, new InitMessage( USER_AGENT, authToken() ), InitResponseHandler.class );
+        testWritingOfInitializationMessage( BoltProtocolV1.VERSION, new InitMessage( USER_AGENT, authToken().toMap() ), InitResponseHandler.class );
     }
 
     @Test
     void shouldWriteInitializationMessageInBoltV2WhenHandshakeCompleted()
     {
-        testWritingOfInitializationMessage( BoltProtocolV2.VERSION, new InitMessage( USER_AGENT, authToken() ), InitResponseHandler.class );
+        testWritingOfInitializationMessage( BoltProtocolV2.VERSION, new InitMessage( USER_AGENT, authToken().toMap() ), InitResponseHandler.class );
     }
 
     @Test
     void shouldWriteInitializationMessageInBoltV3WhenHandshakeCompleted()
     {
-        testWritingOfInitializationMessage( BoltProtocolV3.VERSION, new HelloMessage( USER_AGENT, authToken(), Collections.emptyMap() ), HelloResponseHandler.class );
+        testWritingOfInitializationMessage( BoltProtocolV3.VERSION, new HelloMessage( USER_AGENT, authToken().toMap(), Collections.emptyMap() ), HelloResponseHandler.class );
     }
 
     private void testWritingOfInitializationMessage( BoltProtocolVersion protocolVersion, Message expectedMessage, Class<? extends ResponseHandler> handlerType )
@@ -121,11 +124,8 @@ class HandshakeCompletedListenerTest
         assertEquals( expectedMessage, outboundMessage );
     }
 
-    private static Map<String,Value> authToken()
+    private static InternalAuthToken authToken()
     {
-        Map<String,Value> authToken = new HashMap<>();
-        authToken.put( "username", value( "neo4j" ) );
-        authToken.put( "password", value( "secret" ) );
-        return authToken;
+        return (InternalAuthToken) AuthTokens.basic( "neo4j", "secret" );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
@@ -24,11 +24,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.handlers.HelloResponseHandler;
 import org.neo4j.driver.internal.handlers.InitResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
@@ -67,7 +69,7 @@ class HandshakeCompletedListenerTest
     void shouldFailConnectionInitializedPromiseWhenHandshakeFails()
     {
         ChannelPromise channelInitializedPromise = channel.newPromise();
-        HandshakeCompletedListener listener = new HandshakeCompletedListener( "user-agent", authToken(),
+        HandshakeCompletedListener listener = new HandshakeCompletedListener( "user-agent", authToken(), RoutingContext.EMPTY,
                 channelInitializedPromise );
 
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
@@ -95,7 +97,7 @@ class HandshakeCompletedListenerTest
     @Test
     void shouldWriteInitializationMessageInBoltV3WhenHandshakeCompleted()
     {
-        testWritingOfInitializationMessage( BoltProtocolV3.VERSION, new HelloMessage( USER_AGENT, authToken() ), HelloResponseHandler.class );
+        testWritingOfInitializationMessage( BoltProtocolV3.VERSION, new HelloMessage( USER_AGENT, authToken(), Collections.emptyMap() ), HelloResponseHandler.class );
     }
 
     private void testWritingOfInitializationMessage( BoltProtocolVersion protocolVersion, Message expectedMessage, Class<? extends ResponseHandler> handlerType )
@@ -105,8 +107,8 @@ class HandshakeCompletedListenerTest
         setMessageDispatcher( channel, messageDispatcher );
 
         ChannelPromise channelInitializedPromise = channel.newPromise();
-        HandshakeCompletedListener listener = new HandshakeCompletedListener( USER_AGENT, authToken(),
-                channelInitializedPromise );
+        HandshakeCompletedListener listener = new HandshakeCompletedListener( USER_AGENT, authToken(), RoutingContext.EMPTY,
+                                                                              channelInitializedPromise );
 
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
         handshakeCompletedPromise.setSuccess();

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.FakeClock;
@@ -146,7 +147,7 @@ class ConnectionPoolImplIT
         FakeClock clock = new FakeClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( neo4j.authToken(), 5000 );
         ChannelConnector connector = new ChannelConnectorImpl( connectionSettings, SecurityPlanImpl.insecure(),
-                DEV_NULL_LOGGING, clock );
+                                                               DEV_NULL_LOGGING, clock, RoutingContext.EMPTY );
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
         return new ConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_METRICS, DEV_NULL_LOGGING, clock, true );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
@@ -37,6 +37,7 @@ import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.util.FakeClock;
@@ -183,7 +184,7 @@ class NettyChannelPoolIT
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, 5_000 );
         ChannelConnectorImpl connector = new ChannelConnectorImpl( settings, SecurityPlanImpl.insecure(), DEV_NULL_LOGGING,
-                new FakeClock() );
+                                                                   new FakeClock(), RoutingContext.EMPTY );
         return new NettyChannelPool( neo4j.address(), connector, bootstrap, poolHandler, ChannelHealthChecker.ACTIVE,
                 1_000, maxConnections );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
@@ -90,7 +90,7 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         assertThat( runner.connection.databaseName(), equalTo( systemDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.READ ) );
 
-        Query query = generateMultiDatabaseRoutingQuery( context.asMap(), db );
+        Query query = generateMultiDatabaseRoutingQuery( context.toMap(), db );
         assertThat( response.procedure(), equalTo(query) );
         assertThat( runner.procedure, equalTo(query) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
@@ -73,6 +73,24 @@ class RoutingContextTest
     }
 
     @Test
+    void boltUriDisablesServerSideRouting()
+    {
+        URI uri = URI.create( "bolt://localhost:7687/?key1=value1&key2=value2&key3=value3" );
+        RoutingContext context = new RoutingContext( uri );
+
+        assertEquals( false, context.isServerRoutingEnabled() );
+    }
+
+    @Test
+    void neo4jUriEnablesServerSideRouting()
+    {
+        URI uri = URI.create( "neo4j://localhost:7687/?key1=value1&key2=value2&key3=value3" );
+        RoutingContext context = new RoutingContext( uri );
+
+        assertEquals( true, context.isServerRoutingEnabled() );
+    }
+
+    @Test
     void throwsForInvalidUriQuery()
     {
         testIllegalUri( URI.create( "neo4j://localhost:7687/?justKey" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingContextTest.java
@@ -41,7 +41,7 @@ class RoutingContextTest
     @Test
     void emptyContextInEmptyMap()
     {
-        assertTrue( RoutingContext.EMPTY.asMap().isEmpty() );
+        assertTrue( RoutingContext.EMPTY.toMap().isEmpty() );
     }
 
     @Test
@@ -69,7 +69,7 @@ class RoutingContextTest
         expectedMap.put( "key2", "value2" );
         expectedMap.put( "key3", "value3" );
         expectedMap.put( "address", "localhost:7687" );
-        assertEquals( expectedMap, context.asMap() );
+        assertEquals( expectedMap, context.toMap() );
     }
 
     @Test
@@ -124,10 +124,10 @@ class RoutingContextTest
         expectedMap.put( "key1", "value1" );
         expectedMap.put( "address", "localhost:7687" );
 
-        assertEquals( expectedMap, context.asMap() );
+        assertEquals( expectedMap, context.toMap() );
 
-        assertThrows( UnsupportedOperationException.class, () -> context.asMap().put( "key2", "value2" ) );
-        assertEquals( expectedMap, context.asMap() );
+        assertThrows( UnsupportedOperationException.class, () -> context.toMap().put( "key2", "value2" ) );
+        assertEquals( expectedMap, context.toMap() );
     }
 
     @Test
@@ -136,7 +136,7 @@ class RoutingContextTest
         URI uri = URI.create( "neo4j://localhost/" );
         RoutingContext context = new RoutingContext( uri );
 
-        assertEquals( singletonMap( "address", "localhost:7687" ), context.asMap() );
+        assertEquals( singletonMap( "address", "localhost:7687" ), context.toMap() );
     }
 
     @Test
@@ -161,6 +161,6 @@ class RoutingContextTest
         expectedMap.put( "address", "localhost:7687" );
 
         assertFalse( context.isDefined() );
-        assertEquals( singletonMap( "address", "localhost:7687" ), context.asMap() );
+        assertEquals( singletonMap( "address", "localhost:7687" ), context.toMap() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunnerTest.java
@@ -89,7 +89,7 @@ class RoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest
         assertThat( runner.connection.databaseName(), equalTo( defaultDatabase() ) );
         assertThat( runner.connection.mode(), equalTo( AccessMode.WRITE ) );
 
-        Query query = generateRoutingQuery( context.asMap() );
+        Query query = generateRoutingQuery( context.toMap() );
         assertThat( response.procedure(), equalTo(query) );
         assertThat( runner.procedure, equalTo(query) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.messaging.request;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.neo4j.driver.Values.NULL;
 import static org.neo4j.driver.internal.security.InternalAuthToken.CREDENTIALS_KEY;
 import static org.neo4j.driver.internal.security.InternalAuthToken.PRINCIPAL_KEY;
 import static org.neo4j.driver.Values.value;
@@ -42,12 +44,33 @@ class HelloMessageTest
         authToken.put( "user", value( "Alice" ) );
         authToken.put( "credentials", value( "SecretPassword" ) );
 
-        HelloMessage message = new HelloMessage( "MyDriver/1.0.2", authToken );
+        HelloMessage message = new HelloMessage( "MyDriver/1.0.2", authToken, Collections.emptyMap() );
 
         Map<String,Value> expectedMetadata = new HashMap<>( authToken );
         expectedMetadata.put( "user_agent", value( "MyDriver/1.0.2" ) );
+        expectedMetadata.put( "routing", value ( Collections.emptyMap() ) );
         assertEquals( expectedMetadata, message.metadata() );
     }
+
+    @Test
+    void shouldHaveCorrectRoutingContext()
+    {
+        Map<String,Value> authToken = new HashMap<>();
+        authToken.put( "user", value( "Alice" ) );
+        authToken.put( "credentials", value( "SecretPassword" ) );
+
+        Map<String,String> routingContext = new HashMap<>();
+        routingContext.put( "region", "China" );
+        routingContext.put( "speed", "Slow" );
+
+        HelloMessage message = new HelloMessage( "MyDriver/1.0.2", authToken, routingContext );
+
+        Map<String,Value> expectedMetadata = new HashMap<>( authToken );
+        expectedMetadata.put( "user_agent", value( "MyDriver/1.0.2" ) );
+        expectedMetadata.put( "routing", value( routingContext ) );
+        assertEquals( expectedMetadata, message.metadata() );
+    }
+
 
     @Test
     void shouldNotExposeCredentialsInToString()
@@ -56,7 +79,7 @@ class HelloMessageTest
         authToken.put( PRINCIPAL_KEY, value( "Alice" ) );
         authToken.put( CREDENTIALS_KEY, value( "SecretPassword" ) );
 
-        HelloMessage message = new HelloMessage( "MyDriver/1.0.2", authToken );
+        HelloMessage message = new HelloMessage( "MyDriver/1.0.2", authToken, Collections.emptyMap() );
 
         assertThat( message.toString(), not( containsString( "SecretPassword" ) ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
@@ -55,6 +56,7 @@ import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.request.InitMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.RunMessage;
+import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
@@ -380,11 +382,8 @@ public class BoltProtocolV1Test
         return runHandlerCaptor.getValue();
     }
 
-    private static Map<String,Value> dummyAuthToken()
+    private static InternalAuthToken dummyAuthToken()
     {
-        Map<String,Value> authToken = new HashMap<>();
-        authToken.put( "username", value( "hello" ) );
-        authToken.put( "password", value( "world" ) );
-        return authToken;
+        return (InternalAuthToken) AuthTokens.basic( "hello", "world" );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/BoltProtocolV1Test.java
@@ -42,6 +42,7 @@ import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
@@ -117,7 +118,7 @@ public class BoltProtocolV1Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/5.3", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/5.3", dummyAuthToken(), RoutingContext.EMPTY, promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
         assertThat( channel.outboundMessages().poll(), instanceOf( InitMessage.class ) );
@@ -135,7 +136,7 @@ public class BoltProtocolV1Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/3.1", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/3.1", dummyAuthToken(), RoutingContext.EMPTY, promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
         assertThat( channel.outboundMessages().poll(), instanceOf( InitMessage.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/MessageWriterV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/MessageWriterV1Test.java
@@ -70,7 +70,7 @@ class MessageWriterV1Test extends AbstractMessageWriterTestBase
                 new RunMessage( "RETURN $here", singletonMap( "now", point( 42, 1, 1 ) ) ),
 
                 // Bolt V3 messages
-                new HelloMessage( "Driver/2.3.4", emptyMap(), Collections.emptyMap() ),
+                new HelloMessage( "Driver/2.3.4", emptyMap(), emptyMap() ),
                 GOODBYE,
                 COMMIT,
                 ROLLBACK

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/MessageWriterV1Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v1/MessageWriterV1Test.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.messaging.v1;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.util.messaging.AbstractMessageWriterTestBase;
@@ -69,7 +70,7 @@ class MessageWriterV1Test extends AbstractMessageWriterTestBase
                 new RunMessage( "RETURN $here", singletonMap( "now", point( 42, 1, 1 ) ) ),
 
                 // Bolt V3 messages
-                new HelloMessage( "Driver/2.3.4", emptyMap() ),
+                new HelloMessage( "Driver/2.3.4", emptyMap(), Collections.emptyMap() ),
                 GOODBYE,
                 COMMIT,
                 ROLLBACK

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/MessageWriterV2Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/MessageWriterV2Test.java
@@ -67,7 +67,7 @@ class MessageWriterV2Test extends AbstractMessageWriterTestBase
     protected Stream<Message> unsupportedMessages()
     {
         return Stream.of(
-                new HelloMessage( "JavaDriver/1.1.0", emptyMap(), Collections.emptyMap() ),
+                new HelloMessage( "JavaDriver/1.1.0", emptyMap(), emptyMap() ),
                 GOODBYE,
                 COMMIT,
                 ROLLBACK

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/MessageWriterV2Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v2/MessageWriterV2Test.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.messaging.v2;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.internal.util.messaging.AbstractMessageWriterTestBase;
@@ -66,7 +67,7 @@ class MessageWriterV2Test extends AbstractMessageWriterTestBase
     protected Stream<Message> unsupportedMessages()
     {
         return Stream.of(
-                new HelloMessage( "JavaDriver/1.1.0", emptyMap() ),
+                new HelloMessage( "JavaDriver/1.1.0", emptyMap(), Collections.emptyMap() ),
                 GOODBYE,
                 COMMIT,
                 ROLLBACK

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -45,6 +45,7 @@ import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
@@ -139,7 +140,7 @@ public class BoltProtocolV3Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/0.0.1", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
         assertThat( channel.outboundMessages().poll(), instanceOf( HelloMessage.class ) );
@@ -171,7 +172,7 @@ public class BoltProtocolV3Test
     {
         ChannelPromise promise = channel.newPromise();
 
-        protocol.initializeChannel( "MyDriver/2.2.1", dummyAuthToken(), promise );
+        protocol.initializeChannel( "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise );
 
         assertThat( channel.outboundMessages(), hasSize( 1 ) );
         assertThat( channel.outboundMessages().poll(), instanceOf( HelloMessage.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
@@ -62,6 +64,7 @@ import org.neo4j.driver.internal.messaging.request.HelloMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.RollbackMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
+import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 
@@ -452,12 +455,9 @@ public class BoltProtocolV3Test
         assertNotNull( cursorFuture.get() );
     }
 
-    private static Map<String,Value> dummyAuthToken()
+    private static InternalAuthToken dummyAuthToken()
     {
-        Map<String,Value> authToken = new HashMap<>();
-        authToken.put( "username", value( "hello" ) );
-        authToken.put( "password", value( "world" ) );
-        return authToken;
+        return (InternalAuthToken) AuthTokens.basic( "hello", "world");
     }
 
     private static ResponseHandlers verifyRunInvoked( Connection connection, boolean session, Bookmark bookmark, TransactionConfig config, AccessMode mode )

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.messaging.v3;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.Query;
@@ -64,7 +65,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase
     {
         return Stream.of(
                 // Bolt V3 messages
-                new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap() ),
+                new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap(), Collections.emptyMap() ),
                 GOODBYE,
                 new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, defaultDatabase() ),
                 new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, defaultDatabase() ),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.messaging.v4;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.Query;
@@ -72,7 +73,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase
                 new DiscardMessage( 300, 400 ),
 
                 // Bolt V3 messages
-                new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap() ),
+                new HelloMessage( "MyDriver/1.2.3", ((InternalAuthToken) basic( "neo4j", "neo4j" )).toMap(), Collections.emptyMap() ),
                 GOODBYE,
                 new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), READ, defaultDatabase() ),
                 new BeginMessage( InternalBookmark.parse( "neo4j:bookmark:v1:tx123" ), ofSeconds( 5 ), singletonMap( "key", value( 42 ) ), WRITE, database( "foo" ) ),

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.metrics.MetricsProvider;
@@ -43,9 +44,11 @@ public class FailingConnectionDriverFactory extends DriverFactory
 
     @Override
     protected ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+                                                   MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup,
+                                                   RoutingContext routingContext )
     {
-        ConnectionPool pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
+        ConnectionPool pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config,
+                                                          ownsEventLoopGroup, routingContext );
         return new ConnectionPoolWithFailingConnections( pool, nextRunFailure );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
@@ -35,6 +35,7 @@ import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
 import org.neo4j.driver.internal.async.connection.ChannelPipelineBuilder;
 import org.neo4j.driver.internal.async.connection.ChannelPipelineBuilderImpl;
 import org.neo4j.driver.internal.async.outbound.OutboundMessageHandler;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.security.SecurityPlan;
@@ -51,10 +52,11 @@ public class MessageRecordingDriverFactory extends DriverFactory
     }
 
     @Override
-    protected ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan, Config config, Clock clock )
+    protected ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan, Config config, Clock clock,
+                                                RoutingContext routingContext )
     {
         ChannelPipelineBuilder pipelineBuilder = new MessageRecordingChannelPipelineBuilder();
-        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock );
+        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext );
     }
 
     private class MessageRecordingChannelPipelineBuilder extends ChannelPipelineBuilderImpl

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.metrics.MetricsProvider;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.ConnectionPool;
@@ -67,23 +68,23 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock
 
     @Override
     protected final ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan,
-            Config config, Clock clock )
+                                                      Config config, Clock clock, RoutingContext routingContext )
     {
-        return createChannelTrackingConnector( createRealConnector( settings, securityPlan, config, clock ) );
+        return createChannelTrackingConnector( createRealConnector( settings, securityPlan, config, clock, routingContext ) );
     }
 
     @Override
     protected final ConnectionPool createConnectionPool( AuthToken authToken, SecurityPlan securityPlan, Bootstrap bootstrap,
-            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup )
+            MetricsProvider metricsProvider, Config config, boolean ownsEventLoopGroup, RoutingContext routingContext )
     {
-        pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup );
+        pool = super.createConnectionPool( authToken, securityPlan, bootstrap, metricsProvider, config, ownsEventLoopGroup, routingContext );
         return pool;
     }
 
     protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan,
-            Config config, Clock clock )
+            Config config, Clock clock, RoutingContext routingContext )
     {
-        return super.createConnector( settings, securityPlan, config, clock );
+        return super.createConnector( settings, securityPlan, config, clock, routingContext );
     }
 
     private ChannelTrackingConnector createChannelTrackingConnector( ChannelConnector connector )

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.util.io;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
+import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.FailingMessageFormat;
@@ -36,9 +37,10 @@ public class ChannelTrackingDriverFactoryWithFailingMessageFormat extends Channe
     }
 
     @Override
-    protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan, Config config, Clock clock )
+    protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan,
+                                                    Config config, Clock clock, RoutingContext routingContext )
     {
-        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock );
+        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext );
     }
 
     public FailingMessageFormat getFailingMessageFormat()

--- a/driver/src/test/resources/empty_routing_context_in_hello_neo4j.script
+++ b/driver/src/test/resources/empty_routing_context_in_hello_neo4j.script
@@ -1,0 +1,17 @@
+!: BOLT 3
+!: AUTO RESET
+!: AUTO GOODBYE
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev", "routing": { "address": "127.0.0.1:9001"} }
+S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": { "address": "127.0.0.1:9001"} } {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Alice"]
+   RECORD ["Bob"]
+   SUCCESS {}

--- a/driver/src/test/resources/hello_with_routing_context_bolt.script
+++ b/driver/src/test/resources/hello_with_routing_context_bolt.script
@@ -10,4 +10,3 @@ S: SUCCESS {"fields": ["n.name"]}
    RECORD ["Foo"]
    RECORD ["Bar"]
    SUCCESS {}
-S: <EXIT>

--- a/driver/src/test/resources/routing_context_in_hello_neo4j.script
+++ b/driver/src/test/resources/routing_context_in_hello_neo4j.script
@@ -1,0 +1,17 @@
+!: BOLT 3
+!: AUTO RESET
+!: AUTO GOODBYE
+
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev", "routing": { "address": "127.0.0.1:9001", "region": "china", "policy": "my_policy"}}
+S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": { "address": "127.0.0.1:9001", "policy": "my_policy", "region": "china"}} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["name"]}
+   RECORD ["Alice"]
+   RECORD ["Bob"]
+   SUCCESS {}

--- a/driver/src/test/resources/untrusted_server.script
+++ b/driver/src/test/resources/untrusted_server.script
@@ -2,5 +2,5 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev"}
+C: HELLO {"scheme": "none", "user_agent": "neo4j-java/dev", "routing": null}
 S: SUCCESS {"server": "AgentSmith/0.0.1", "connection_id": "bolt-123456789"}


### PR DESCRIPTION
Include the routing context configured in the connection URI in the Hello message. This enables the server to make routing decisions with the same information provided to the driver.

For example with the URI `neo4j://localhost:7687?policy=fast&region=eu` the driver will send the map: `{'policy': 'fast', 'region': 'eu'}` in the Hello message's metadata with the key `routing`.

Since `bolt` is for direct connections the map is configured with `{'routing': null}`inform that the sever should not route queries.