### PR TITLE
Fix JavaDoc on JDK 11. (#702)

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -120,7 +120,17 @@
           <sourceFileIncludes>
             <sourceFileInclude>org/neo4j/driver/**/*.java</sourceFileInclude>
           </sourceFileIncludes>
-	  <excludePackageNames>org.neo4j.driver.internal</excludePackageNames>
+          <excludePackageNames>org.neo4j.driver.internal</excludePackageNames>
+          <bottom>
+            <![CDATA[
+                    <script>
+                    if (typeof useModuleDirectories !== 'undefined') {
+                      useModuleDirectories = false;
+                    }
+                    </script>
+                ]]>
+          </bottom>
+          <additionalJOption>--allow-script-in-comments</additionalJOption>
         </configuration>
       </plugin>
       <plugin>

--- a/driver/src/main/javadoc/overview.html
+++ b/driver/src/main/javadoc/overview.html
@@ -32,7 +32,7 @@ public class SmallExample
             // and makes handling errors much easier.
             // Use `session.writeTransaction` for writes and `session.readTransaction` for reading data.
             // These methods are also able to handle connection problems and transient errors using an automatic retry mechanism.
-            session.writeTransaction(tx -> tx.run("MERGE (a:Person {name: $x})", parameters("x", name)));
+            session.writeTransaction(tx -&gt; tx.run("MERGE (a:Person {name: $x})", parameters("x", name)));
         }
     }
 
@@ -40,7 +40,7 @@ public class SmallExample
     {
         try (Session session = driver.session())
         {
-            // A Managed Transaction transactions are a quick and easy way to wrap a Cypher Query.
+            // A Managed transaction is a quick and easy way to wrap a Cypher Query.
             // The `session.run` method will run the specified Query.
             // This simpler method does not use any automatic retry mechanism.
             Result result = session.run(


### PR DESCRIPTION
- JDK 11 JavaDoc is less lenient with HTML tags inside a <code>-block, so this needed a fix.
- We don’t use java-modules, so all modules are undefined. Therefor the search is broken.

There are 2 solutions to the later:
1. Disabling modules in java-doc with `--no-module-directories`, but that also applies to references to JDK classes, which would than be broken.

2. (The one applied here): Check if `useModuleDirectories` is set to something different than literal `undefined`: If so, leave it and let JavaDocs JavaScript magic handle things, otherwise set it to false, causing JavaDocs JavaScript todo nothing. For reference: https://stackoverflow.com/a/57284322/1547989