### PR TITLE
Use Protocol Version instead of server_agent for Bolt V4 connections

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -81,7 +81,7 @@ public class BoltProtocolV3 implements BoltProtocol
         Channel channel = channelInitializedPromise.channel();
 
         HelloMessage message = new HelloMessage( userAgent, authToken );
-        HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise );
+        HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise, version() );
 
         messageDispatcher( channel ).enqueue( handler );
         channel.writeAndFlush( message, channel.voidPromise() );

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ServerVersion.java
@@ -24,6 +24,9 @@ import java.util.regex.Pattern;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
+import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
+import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 
 import static java.lang.Integer.compare;
 
@@ -173,5 +176,20 @@ public class ServerVersion
             return NEO4J_IN_DEV_VERSION_STRING;
         }
         return String.format( "%s/%s.%s.%s", product, major, minor, patch );
+    }
+
+    public static ServerVersion fromBoltProtocolVersion( BoltProtocolVersion protocolVersion )
+    {
+
+        if ( BoltProtocolV4.VERSION.equals( protocolVersion ) )
+        {
+            return ServerVersion.v4_0_0;
+        }
+        else if ( BoltProtocolV41.VERSION.equals( protocolVersion ) )
+        {
+            return ServerVersion.v4_1_0;
+        }
+
+        return ServerVersion.vInDev;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ServerVersionTest.java
@@ -20,6 +20,11 @@ package org.neo4j.driver.internal.util;
 
 import org.junit.jupiter.api.Test;
 
+import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
+import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
+import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
+
+import static java.lang.Integer.MAX_VALUE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,5 +64,13 @@ class ServerVersionTest
         ServerVersion version2 = ServerVersion.version( "OtherNeo4j/1.2.4" );
 
         assertThrows( IllegalArgumentException.class, () -> version1.greaterThanOrEqual( version2 ) );
+    }
+
+    @Test
+    void shouldReturnCorrectServerVersionFromBoltProtocolVersion()
+    {
+        assertEquals( ServerVersion.v4_0_0, ServerVersion.fromBoltProtocolVersion( BoltProtocolV4.VERSION ) );
+        assertEquals( ServerVersion.v4_1_0, ServerVersion.fromBoltProtocolVersion( BoltProtocolV41.VERSION ) );
+        assertEquals( ServerVersion.vInDev, ServerVersion.fromBoltProtocolVersion( new BoltProtocolVersion( MAX_VALUE, MAX_VALUE ) ) );
     }
 }


### PR DESCRIPTION
Since Server v4.0 the server agent received in response to the Hello message is unreliable. Instead, since the server and Bolt protocol versions are aligned, we use the protocol version instead for all connections to Server 4.0 and higher (#708)

Note: A future refactoring is required when support for 3.5 is dropped. The name serverVersion filed of the netty channel no longer reflects its true purpose since it essentially becomes protocolVersion. We keep the current naming for now since the split in meaning between 3.5 and 4.X+

(Adapted from #708)