### PR TITLE
Correct behaviour for +s and +ssc. +s enable hostname verification

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
@@ -92,11 +92,11 @@ public class SecuritySettings
     {
         if ( isHighTrustScheme(scheme) )
         {
-            return SecurityPlanImpl.forSystemCASignedCertificates( trustStrategy.isHostnameVerificationEnabled() );
+            return SecurityPlanImpl.forSystemCASignedCertificates( true );
         }
         else
         {
-            return SecurityPlanImpl.forAllCertificates( trustStrategy.isHostnameVerificationEnabled() );
+            return SecurityPlanImpl.forAllCertificates( false );
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
@@ -75,7 +75,20 @@ class SecuritySettingsTest
         SSLContext defaultContext = SSLContext.getDefault();
 
         assertTrue( securityPlan.requiresEncryption() );
+        assertTrue( securityPlan.requiresHostnameVerification() );
         assertEquals( defaultContext, securityPlan.sslContext() );
+    }
+
+    @ParameterizedTest
+    @MethodSource( "selfSignedSchemes" )
+    void testSelfSignedCertConfigDisablesHostnameVerification( String scheme ) throws Exception
+    {
+        SecuritySettings securitySettings = new SecuritySettings.SecuritySettingsBuilder().build();
+
+        SecurityPlan securityPlan = securitySettings.createSecurityPlan( scheme );
+
+        assertTrue( securityPlan.requiresEncryption() );
+        assertFalse( securityPlan.requiresHostnameVerification() );
     }
 
     @ParameterizedTest
@@ -156,7 +169,7 @@ class SecuritySettingsTest
     }
 
     @Test
-    void testConfiguredAllCertificates() throws NoSuchAlgorithmException
+    void testConfiguredAllCertificates()
     {
         SecuritySettings securitySettings = new SecuritySettings.SecuritySettingsBuilder()
                 .withEncryption()


### PR DESCRIPTION
Corrects the behaviour for `+s` and `+ssc` schemes by:
- enabling hostname verification for `+s` scheme
- disabling hostname verification for `+ssc` scheme