### PR TITLE
Fix clirr-maven-plugin to compare api changes with 4.0.0

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -1,3 +1,3 @@
 <differences>
-<!--2.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 2.0.0-->
+<!--4.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 4.0.0-->
 </differences>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -87,7 +87,7 @@
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>
           <comparisonVersion>4.0.0</comparisonVersion>
-          <excludes>org/neo4j/driver/**/internal/**</excludes>
+          <excludes>org/neo4j/driver/internal/**</excludes>
           <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
         </configuration>
       </plugin>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -86,7 +86,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>
-          <comparisonVersion>2.0.0</comparisonVersion>
+          <comparisonVersion>4.0.0</comparisonVersion>
           <excludes>org/neo4j/driver/**/internal/**</excludes>
           <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
         </configuration>


### PR DESCRIPTION
Fixes the broken clirr check and sets the correct comparison version to `4.0.0`