### PR TITLE
Differentiate between transactions with open resources and committable transactions

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
@@ -65,7 +65,7 @@ public class InternalTransaction extends AbstractQueryRunner implements Transact
     @Override
     public boolean isOpen()
     {
-        return tx.isOpen();
+        return tx.isActive();
     }
 
     private void terminateConnectionOnThreadInterrupt( String reason )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -92,7 +92,7 @@ public class UnmanagedTransaction
 
     public CompletionStage<Void> closeAsync()
     {
-        if ( isOpen() )
+        if ( isOpen() || state.equals( State.TERMINATED ))
         {
             return rollbackAsync();
         }
@@ -158,7 +158,13 @@ public class UnmanagedTransaction
 
     public boolean isOpen()
     {
-        return state != State.COMMITTED && state != State.ROLLED_BACK;
+        // TERMINATED is still considered open w.r.t to resources available
+        return state == State.ACTIVE || state == State.TERMINATED;
+    }
+
+    public boolean isActive()
+    {
+        return state == State.ACTIVE;
     }
 
     public void markTerminated()

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.async.ConnectionContext;
 import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
 import org.neo4j.driver.internal.spi.Connection;
@@ -146,6 +147,16 @@ class InternalTransactionTest
         assertThrows( Exception.class, () -> tx.commit() );
 
         verify( connection ).release();
+        assertFalse( tx.isOpen() );
+    }
+
+    @Test
+    void shouldNotCommitOnTerminatedTransaction() throws Throwable
+    {
+
+        setupFailingRun( connection, new SessionExpiredException( "" ) );
+        tx.run("RETURN 1");
+
         assertFalse( tx.isOpen() );
     }
 

--- a/driver/src/test/resources/not_a_leader_v4.script
+++ b/driver/src/test/resources/not_a_leader_v4.script
@@ -1,0 +1,14 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+!: AUTO BEGIN
+
+C: RUN "CREATE ()" {} {}
+C: PULL { "n": 1000 }
+S: SUCCESS {}
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "No write operations are allowed directly on this database. Writes must pass through the leader. The role of this server is: FOLLOWER"}
+C: RESET
+S: SUCCESS {}
+C: RESET
+S: SUCCESS {}


### PR DESCRIPTION
Differentiate between a transaction which is open with respect to the resources it has and open in the sense it is in a committable state