### PR TITLE
Don’t swallow the cause of a TX termination.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
@@ -50,11 +50,6 @@ public class InternalAsyncTransaction extends AsyncAbstractQueryRunner implement
         return tx.runAsync(query, true );
     }
 
-    public void markTerminated()
-    {
-        tx.markTerminated();
-    }
-
     public boolean isOpen()
     {
         return tx.isOpen();

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -138,7 +138,7 @@ public class NetworkSession
                 {
                     if ( tx != null )
                     {
-                        tx.markTerminated();
+                        tx.markTerminated( null );
                     }
                 } )
                 .thenCompose( ignore -> connectionStage )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
@@ -45,6 +45,6 @@ public class TransactionPullResponseCompletionListener implements PullResponseCo
         // always mark transaction as terminated because every error is "acknowledged" with a RESET message
         // so database forgets about the transaction after the first error
         // such transaction should not attempt to commit and can be considered as rolled back
-        tx.markTerminated();
+        tx.markTerminated( error );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -56,7 +56,7 @@ public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTr
                     // The logic here shall be the same as `TransactionPullResponseHandler#afterFailure` as that is where cursor handling failure
                     // This is optional as tx still holds a reference to all cursor futures and they will be clean up properly in commit
                     Throwable error = Futures.completionExceptionCause( completionError );
-                    tx.markTerminated();
+                    tx.markTerminated( error );
                     cursorFuture.completeExceptionally( error );
                 }
             } );

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -620,7 +620,8 @@ class RoutingDriverBoltKitTest
     }
 
     // This does not exactly reproduce the async and blocking versions above, as we don't have any means of ignoring
-    // the flux of the RETURN 1 query (not pulling the result) like we do in above, so
+    // the flux of the RETURN 1 query (not pulling the result) like we do in above, so this is "just" a test for
+    // a leader going away during the execution of a flux.
     @Test
     void shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunctionRX() throws IOException, InterruptedException
     {

--- a/driver/src/test/java/org/neo4j/driver/integration/UnmanagedTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/UnmanagedTransactionIT.java
@@ -128,7 +128,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
         assertThat( e.getMessage(), startsWith( "Transaction can't be committed" ) );
@@ -162,7 +162,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         assertNull( await( tx.rollbackAsync() ) );
         assertFalse( tx.isOpen() );
@@ -173,7 +173,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
         txRun( tx, "CREATE (:MyLabel)" );
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         ClientException e = assertThrows( ClientException.class, () -> txRun( tx, "CREATE (:MyOtherLabel)" ) );
         assertThat( e.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
@@ -183,7 +183,7 @@ class UnmanagedTransactionIT
     void shouldBePossibleToRunMoreTransactionsAfterOneIsTerminated()
     {
         UnmanagedTransaction tx1 = beginTransaction();
-        tx1.markTerminated();
+        tx1.markTerminated( null );
 
         // commit should fail, make session forget about this transaction and release the connection to the pool
         ClientException e = assertThrows( ClientException.class, () -> await( tx1.commitAsync() ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -144,7 +144,7 @@ class UnmanagedTransactionTest
     {
         UnmanagedTransaction tx = beginTx( connectionMock() );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         assertTrue( tx.isOpen() );
     }
@@ -154,7 +154,7 @@ class UnmanagedTransactionTest
     {
         UnmanagedTransaction tx = beginTx( connectionMock() );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
         await( tx.closeAsync() );
 
         assertFalse( tx.isOpen() );
@@ -196,7 +196,7 @@ class UnmanagedTransactionTest
         Connection connection = connectionMock();
         UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
-        tx.markTerminated();
+        tx.markTerminated(  null  );
 
         assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
 
@@ -210,7 +210,7 @@ class UnmanagedTransactionTest
         Connection connection = connectionMock();
         UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
         await( tx.rollbackAsync() );
 
         verify( connection ).release();

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
@@ -73,6 +73,6 @@ class TransactionPullResponseCompletionListenerTest
 
         handler.onFailure( error );
 
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
@@ -73,7 +73,7 @@ public class TransactionPullResponseCompletionListenerTest extends BasicPullResp
 
         // Then
         assertThat( handler.state(), equalTo( BasicPullResponseHandler.State.FAILURE_STATE ) );
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
         verify( recordConsumer ).accept( null, error );
         verify( summaryConsumer ).accept( any( ResultSummary.class ), eq( error ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -135,6 +135,6 @@ class InternalRxTransactionTest
         verify( tx ).runRx( any( Query.class ) );
         RuntimeException t = assertThrows( CompletionException.class, () -> Futures.getNow( cursorFuture ) );
         assertThat( t.getCause(), equalTo( error ) );
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
     }
 }

--- a/driver/src/test/resources/acquire_endpoints_twice_v4.script
+++ b/driver/src/test/resources/acquire_endpoints_twice_v4.script
@@ -1,0 +1,16 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": { "address": "127.0.0.1:9001"}, "database": "mydatabase"} {"mode": "r", "db": "system"}
+   PULL {"n": -1}
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": { "address": "127.0.0.1:9001"}, "database": "mydatabase"} {"mode": "r", "db": "system"}
+   PULL {"n": -1}
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+   <EXIT>

--- a/driver/src/test/resources/not_able_to_write_server_tx_func_retries.script
+++ b/driver/src/test/resources/not_able_to_write_server_tx_func_retries.script
@@ -1,0 +1,25 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO BEGIN
+!: AUTO HELLO
+!: AUTO GOODBYE
+!: AUTO ROLLBACK
+
+C: RUN "RETURN 1" {} {}
+   PULL {"n": 1000}
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+   IGNORED
+C: RUN "RETURN 1" {} {}
+   PULL {"n": 1000}
+S: SUCCESS {"fields": ["1"]}
+   RECORD [1]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {} {}
+   PULL {"n": 1000}
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS {"bookmark": "NewBookmark"}
+   <EXIT>

--- a/driver/src/test/resources/not_able_to_write_server_tx_func_retries_rx.script
+++ b/driver/src/test/resources/not_able_to_write_server_tx_func_retries_rx.script
@@ -1,0 +1,25 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO BEGIN
+!: AUTO HELLO
+!: AUTO GOODBYE
+!: AUTO ROLLBACK
+
+C: RUN "RETURN 1" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": 100}
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+C: RUN "RETURN 1" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": 100}
+S: RECORD [1]
+   SUCCESS {"has_more": false}
+C: RUN "MATCH (n) RETURN n.name" {} {}
+S: SUCCESS {"fields": ["n.name"]}
+C: PULL {"n": 100}
+S: RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {"has_more": false}
+C: COMMIT
+S: SUCCESS {"bookmark": "NewBookmark"}
+   <EXIT>


### PR DESCRIPTION
There are a couple of scenarions in which a transaction gets terminated. The cause will be propagated by the pull handler and the transaction will be marked accordingly. There might be a chance that a degration from a leader to a follower on the server side happens in between to calls to a run method on that transaction: The transaction is still open, but cannot run queries any longer. Outside a transactional function this leads correctly to a ClientException. Inside a transactional function, this must not happen.

The retry logic must be able to find the cause of the termination and if there’s any, it should judge on the cause if it retries or not.

This PR changes the following:

- Add a StateHolder to the UnmangedTransaction
- The holder is necessary to keep the single field volatie
- The holder holds the state and a possible cause of termination
- The holder is able to determine whether a session is still open or not.
- It removes markTerminated from InternalAsyncTransaction as it was used only for tests.