### PR TITLE
Don’t swallow the cause of a TX termination. (#731)

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
@@ -50,11 +50,6 @@ public class InternalAsyncTransaction extends AsyncAbstractQueryRunner implement
         return tx.runAsync(query, true );
     }
 
-    public void markTerminated()
-    {
-        tx.markTerminated();
-    }
-
     public boolean isOpen()
     {
         return tx.isOpen();

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -138,7 +138,7 @@ public class NetworkSession
                 {
                     if ( tx != null )
                     {
-                        tx.markTerminated();
+                        tx.markTerminated( null );
                     }
                 } )
                 .thenCompose( ignore -> connectionStage )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListener.java
@@ -45,6 +45,6 @@ public class TransactionPullResponseCompletionListener implements PullResponseCo
         // always mark transaction as terminated because every error is "acknowledged" with a RESET message
         // so database forgets about the transaction after the first error
         // such transaction should not attempt to commit and can be considered as rolled back
-        tx.markTerminated();
+        tx.markTerminated( error );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -56,7 +56,7 @@ public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTr
                     // The logic here shall be the same as `TransactionPullResponseHandler#afterFailure` as that is where cursor handling failure
                     // This is optional as tx still holds a reference to all cursor futures and they will be clean up properly in commit
                     Throwable error = Futures.completionExceptionCause( completionError );
-                    tx.markTerminated();
+                    tx.markTerminated( error );
                     cursorFuture.completeExceptionally( error );
                 }
             } );

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitTest.java
@@ -21,6 +21,9 @@ package org.neo4j.driver.integration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,8 +33,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.AuthToken;
@@ -41,10 +46,11 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
+import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
@@ -55,9 +61,12 @@ import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.util.DriverFactoryWithClock;
 import org.neo4j.driver.internal.util.DriverFactoryWithFixedRetryLogic;
+import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.SleeplessClock;
 import org.neo4j.driver.net.ServerAddress;
 import org.neo4j.driver.net.ServerAddressResolver;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.util.StubServer;
 import org.neo4j.driver.util.StubServerController;
 
@@ -109,7 +118,8 @@ class RoutingDriverBoltKitTest
         StubServer readServer = stubController.startStub( "read_server_v3_read.script", 9005 );
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
 
-        try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG ); Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ) )
+        try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
+                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ) )
         {
             List<String> result = session.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() );
 
@@ -133,8 +143,7 @@ class RoutingDriverBoltKitTest
                 Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ) )
 
         {
-            List<String> result = session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" )
-                    .list( record -> record.get( "n.name" ).asString() ) );
+            List<String> result = session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() ) );
 
             assertThat( result, equalTo( asList( "Bob", "Alice", "Tina" ) ) );
         }
@@ -153,8 +162,7 @@ class RoutingDriverBoltKitTest
         StubServer readServer = stubController.startStub( "read_server_v3_read_tx.script", 9005 );
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
         try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
-                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() );
-                Transaction tx = session.beginTransaction() )
+                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ); Transaction tx = session.beginTransaction() )
         {
             List<String> result = tx.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() );
 
@@ -209,7 +217,8 @@ class RoutingDriverBoltKitTest
             // Run twice, one on each read server
             for ( int i = 0; i < 2; i++ )
             {
-                try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ); Transaction tx = session.beginTransaction() )
+                try ( Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() );
+                        Transaction tx = session.beginTransaction() )
                 {
                     assertThat( tx.run( "MATCH (n) RETURN n.name" ).list( record -> record.get( "n.name" ).asString() ),
                             equalTo( asList( "Bob", "Alice", "Tina" ) ) );
@@ -234,7 +243,8 @@ class RoutingDriverBoltKitTest
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
 
         //Expect
-        assertThrows( SessionExpiredException.class, () -> {
+        assertThrows( SessionExpiredException.class, () ->
+        {
             try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
                     Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() ) )
             {
@@ -256,7 +266,8 @@ class RoutingDriverBoltKitTest
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
 
         //Expect
-        SessionExpiredException e = assertThrows( SessionExpiredException.class, () -> {
+        SessionExpiredException e = assertThrows( SessionExpiredException.class, () ->
+        {
             try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
                     Session session = driver.session( builder().withDefaultAccessMode( AccessMode.READ ).build() );
                     Transaction tx = session.beginTransaction() )
@@ -305,8 +316,7 @@ class RoutingDriverBoltKitTest
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
         //Expect
         try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
-                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() );
-                Transaction tx = session.beginTransaction() )
+                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ); Transaction tx = session.beginTransaction() )
         {
             assertThrows( SessionExpiredException.class, () -> tx.run( "MATCH (n) RETURN n.name" ).consume() );
         }
@@ -364,8 +374,7 @@ class RoutingDriverBoltKitTest
         StubServer writeServer = stubController.startStub( "write_server_v3_write_tx.script", 9007 );
         URI uri = URI.create( "neo4j://127.0.0.1:9001" );
         try ( Driver driver = GraphDatabase.driver( uri, INSECURE_CONFIG );
-                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() );
-                Transaction tx = session.beginTransaction() )
+                Session session = driver.session( builder().withDefaultAccessMode( AccessMode.WRITE ).build() ); Transaction tx = session.beginTransaction() )
         {
             tx.run( "CREATE (n {name:'Bob'})" );
             tx.commit();
@@ -535,6 +544,113 @@ class RoutingDriverBoltKitTest
     }
 
     @Test
+    void shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunction() throws IOException, InterruptedException
+    {
+        // Given
+        StubServer server = stubController.startStub( "acquire_endpoints_twice_v4.script", 9001 );
+
+        // START a write server that fails on the first write attempt but then succeeds on the second
+        StubServer writeServer = stubController.startStub( "not_able_to_write_server_tx_func_retries.script", 9007 );
+        URI uri = URI.create( "neo4j://127.0.0.1:9001" );
+
+        Driver driver = GraphDatabase.driver( uri, Config.builder().withMaxTransactionRetryTime( 1, TimeUnit.MILLISECONDS ).build() );
+        List<String> names;
+
+        try ( Session session = driver.session( builder().withDatabase( "mydatabase" ).build() ) )
+        {
+            names = session.writeTransaction( tx ->
+            {
+                tx.run( "RETURN 1" );
+                try
+                {
+                    Thread.sleep( 100 );
+                }
+                catch ( InterruptedException ex )
+                {
+                }
+                return tx.run( "MATCH (n) RETURN n.name" ).list( RoutingDriverBoltKitTest::extractNameField );
+            } );
+        }
+
+        assertEquals( asList( "Foo", "Bar" ), names );
+
+        // Finally
+        driver.close();
+        assertThat( server.exitStatus(), equalTo( 0 ) );
+        assertThat( writeServer.exitStatus(), equalTo( 0 ) );
+    }
+
+    @Test
+    void shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunctionAsync() throws IOException, InterruptedException
+    {
+        // Given
+        StubServer server = stubController.startStub( "acquire_endpoints_twice_v4.script", 9001 );
+
+        // START a write server that fails on the first write attempt but then succeeds on the second
+        StubServer writeServer = stubController.startStub( "not_able_to_write_server_tx_func_retries.script", 9007 );
+        URI uri = URI.create( "neo4j://127.0.0.1:9001" );
+
+        Driver driver = GraphDatabase.driver( uri, Config.builder().withMaxTransactionRetryTime( 1, TimeUnit.MILLISECONDS ).build() );
+        AsyncSession session = driver.asyncSession( builder().withDatabase( "mydatabase" ).build() );
+        List<String> names = Futures.blockingGet( session.writeTransactionAsync(
+                tx -> tx.runAsync( "RETURN 1" )
+                        .thenComposeAsync( ignored -> {
+                            try
+                            {
+                                Thread.sleep( 100 );
+                            }
+                            catch ( InterruptedException ex )
+                            {
+                            }
+                            return tx.runAsync( "MATCH (n) RETURN n.name" );
+                        } )
+                        .thenComposeAsync( cursor -> cursor.listAsync( RoutingDriverBoltKitTest::extractNameField ) ) ) );
+
+        assertEquals( asList( "Foo", "Bar" ), names );
+
+        // Finally
+        driver.close();
+        assertThat( server.exitStatus(), equalTo( 0 ) );
+        assertThat( writeServer.exitStatus(), equalTo( 0 ) );
+    }
+
+    private static String extractNameField(Record record)
+    {
+        return record.get( 0 ).asString();
+    }
+
+    // This does not exactly reproduce the async and blocking versions above, as we don't have any means of ignoring
+    // the flux of the RETURN 1 query (not pulling the result) like we do in above, so this is "just" a test for
+    // a leader going away during the execution of a flux.
+    @Test
+    void shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunctionRX() throws IOException, InterruptedException
+    {
+        // Given
+        StubServer server = stubController.startStub( "acquire_endpoints_twice_v4.script", 9001 );
+
+        // START a write server that fails on the first write attempt but then succeeds on the second
+        StubServer writeServer = stubController.startStub( "not_able_to_write_server_tx_func_retries_rx.script", 9007 );
+        URI uri = URI.create( "neo4j://127.0.0.1:9001" );
+
+        Driver driver = GraphDatabase.driver( uri, Config.builder().withMaxTransactionRetryTime( 1, TimeUnit.MILLISECONDS ).build() );
+
+        Flux<String> fluxOfNames = Flux.usingWhen( Mono.fromSupplier( () -> driver.rxSession( builder().withDatabase( "mydatabase" ).build() ) ),
+                session -> session.writeTransaction( tx ->
+                {
+                    RxResult result = tx.run( "RETURN 1" );
+                    return Flux.from( result.records() ).limitRate( 100 ).thenMany( tx.run( "MATCH (n) RETURN n.name" ).records() ).limitRate( 100 ).map(
+                            RoutingDriverBoltKitTest::extractNameField );
+                } ), RxSession::close );
+
+        StepVerifier.create( fluxOfNames ).expectNext( "Foo", "Bar" ).verifyComplete();
+
+        // Finally
+        driver.close();
+        assertThat( server.exitStatus(), equalTo( 0 ) );
+        assertThat( writeServer.exitStatus(), equalTo( 0 ) );
+    }
+
+    @Test
     void shouldSendInitialBookmark() throws Exception
     {
         StubServer router = stubController.startStub( "acquire_endpoints_v3.script", 9001 );
@@ -696,8 +812,7 @@ class RoutingDriverBoltKitTest
 
         Logger logger = mock( Logger.class );
         Config config = insecureBuilder().withLogging( ignored -> logger ).build();
-        try ( Driver driver = newDriverWithSleeplessClock( "neo4j://127.0.0.1:9001", config );
-                Session session = driver.session() )
+        try ( Driver driver = newDriverWithSleeplessClock( "neo4j://127.0.0.1:9001", config ); Session session = driver.session() )
         {
             AtomicInteger invocations = new AtomicInteger();
             List<Record> records = session.writeTransaction( queryWork( "CREATE (n {name:'Bob'})", invocations ) );
@@ -730,8 +845,7 @@ class RoutingDriverBoltKitTest
 
         Logger logger = mock( Logger.class );
         Config config = insecureBuilder().withLogging( ignored -> logger ).build();
-        try ( Driver driver = newDriverWithSleeplessClock( "neo4j://127.0.0.1:9001", config );
-                Session session = driver.session() )
+        try ( Driver driver = newDriverWithSleeplessClock( "neo4j://127.0.0.1:9001", config ); Session session = driver.session() )
         {
             AtomicInteger invocations = new AtomicInteger();
             List<Record> records = session.writeTransaction( queryWork( "CREATE (n {name:'Bob'})", invocations ) );
@@ -757,8 +871,7 @@ class RoutingDriverBoltKitTest
         StubServer brokenReader1 = stubController.startStub( "dead_read_server_tx.script", 9005 );
         StubServer brokenReader2 = stubController.startStub( "dead_read_server_tx.script", 9006 );
 
-        try ( Driver driver = newDriverWithFixedRetries( "neo4j://127.0.0.1:9001", 1 );
-              Session session = driver.session() )
+        try ( Driver driver = newDriverWithFixedRetries( "neo4j://127.0.0.1:9001", 1 ); Session session = driver.session() )
         {
             AtomicInteger invocations = new AtomicInteger();
             assertThrows( SessionExpiredException.class, () -> session.readTransaction( queryWork( "MATCH (n) RETURN n.name", invocations ) ) );
@@ -958,8 +1071,7 @@ class RoutingDriverBoltKitTest
         StubServer router2 = stubController.startStub( "discover_no_writers_9010.script", 9004 );
         StubServer reader = stubController.startStub( "read_server_v3_read_tx.script", 9003 );
 
-        try ( Driver driver = GraphDatabase.driver( "neo4j://127.0.0.1:9010", INSECURE_CONFIG );
-                Session session = driver.session() )
+        try ( Driver driver = GraphDatabase.driver( "neo4j://127.0.0.1:9010", INSECURE_CONFIG ); Session session = driver.session() )
         {
             assertEquals( asList( "Bob", "Alice", "Tina" ), readStrings( "MATCH (n) RETURN n.name", session ) );
 
@@ -1042,10 +1154,9 @@ class RoutingDriverBoltKitTest
         StubServer router = stubController.startStub( "acquire_endpoints_v3.script", 9001 );
         StubServer writer = stubController.startStub( "multiple_bookmarks.script", 9007 );
 
-        try ( Driver driver = GraphDatabase.driver( "neo4j://127.0.0.1:9001", INSECURE_CONFIG );
-                Session session = driver.session( builder().withBookmarks( InternalBookmark.parse(
-                        asOrderedSet( "neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56",
-                                "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68" ) ) ).build() ) )
+        try ( Driver driver = GraphDatabase.driver( "neo4j://127.0.0.1:9001", INSECURE_CONFIG ); Session session = driver.session( builder().withBookmarks(
+                InternalBookmark.parse( asOrderedSet( "neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56",
+                        "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68" ) ) ).build() ) )
         {
             try ( Transaction tx = session.beginTransaction() )
             {
@@ -1117,7 +1228,8 @@ class RoutingDriverBoltKitTest
         StubServer reader = stubController.startStub( "read_server_v3_read_tx.script", 9005 );
 
         AtomicBoolean resolverInvoked = new AtomicBoolean();
-        ServerAddressResolver resolver = address -> {
+        ServerAddressResolver resolver = address ->
+        {
             if ( resolverInvoked.compareAndSet( false, true ) )
             {
                 // return the address first time
@@ -1139,13 +1251,11 @@ class RoutingDriverBoltKitTest
             try ( Session session = driver.session() )
             {
                 // run first query against 9001, which should return result and exit
-                List<String> names1 = session.run( "MATCH (n) RETURN n.name AS name" )
-                        .list( record -> record.get( "name" ).asString() );
+                List<String> names1 = session.run( "MATCH (n) RETURN n.name AS name" ).list( record -> record.get( "name" ).asString() );
                 assertEquals( asList( "Alice", "Bob", "Eve" ), names1 );
 
                 // run second query with retries, it should rediscover using 9042 returned by the resolver and read from 9005
-                List<String> names2 = session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" )
-                        .list( record -> record.get( 0 ).asString() ) );
+                List<String> names2 = session.readTransaction( tx -> tx.run( "MATCH (n) RETURN n.name" ).list( RoutingDriverBoltKitTest::extractNameField ) );
                 assertEquals( asList( "Bob", "Alice", "Tina" ), names2 );
             }
         }
@@ -1187,7 +1297,8 @@ class RoutingDriverBoltKitTest
     @Test
     void shouldRevertToInitialRouterIfKnownRouterThrowsProtocolErrors() throws Exception
     {
-        ServerAddressResolver resolver = a -> {
+        ServerAddressResolver resolver = a ->
+        {
             SortedSet<ServerAddress> addresses = new TreeSet<>( new PortBasedServerAddressComparator() );
             addresses.add( ServerAddress.of( "127.0.0.1", 9001 ) );
             addresses.add( ServerAddress.of( "127.0.0.1", 9003 ) );
@@ -1273,7 +1384,8 @@ class RoutingDriverBoltKitTest
 
     private static TransactionWork<List<Record>> queryWork( final String query, final AtomicInteger invocations )
     {
-        return tx -> {
+        return tx ->
+        {
             invocations.incrementAndGet();
             return tx.run( query ).list();
         };
@@ -1281,7 +1393,8 @@ class RoutingDriverBoltKitTest
 
     private static List<String> readStrings( final String query, Session session )
     {
-        return session.readTransaction( tx -> {
+        return session.readTransaction( tx ->
+        {
             List<Record> records = tx.run( query ).list();
             List<String> names = new ArrayList<>( records.size() );
             for ( Record record : records )

--- a/driver/src/test/java/org/neo4j/driver/integration/UnmanagedTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/UnmanagedTransactionIT.java
@@ -128,7 +128,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
         assertThat( e.getMessage(), startsWith( "Transaction can't be committed" ) );
@@ -162,7 +162,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         assertNull( await( tx.rollbackAsync() ) );
         assertFalse( tx.isOpen() );
@@ -173,7 +173,7 @@ class UnmanagedTransactionIT
     {
         UnmanagedTransaction tx = beginTransaction();
         txRun( tx, "CREATE (:MyLabel)" );
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         ClientException e = assertThrows( ClientException.class, () -> txRun( tx, "CREATE (:MyOtherLabel)" ) );
         assertThat( e.getMessage(), startsWith( "Cannot run more queries in this transaction" ) );
@@ -183,7 +183,7 @@ class UnmanagedTransactionIT
     void shouldBePossibleToRunMoreTransactionsAfterOneIsTerminated()
     {
         UnmanagedTransaction tx1 = beginTransaction();
-        tx1.markTerminated();
+        tx1.markTerminated( null );
 
         // commit should fail, make session forget about this transaction and release the connection to the pool
         ClientException e = assertThrows( ClientException.class, () -> await( tx1.commitAsync() ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -144,7 +144,7 @@ class UnmanagedTransactionTest
     {
         UnmanagedTransaction tx = beginTx( connectionMock() );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
 
         assertTrue( tx.isOpen() );
     }
@@ -154,7 +154,7 @@ class UnmanagedTransactionTest
     {
         UnmanagedTransaction tx = beginTx( connectionMock() );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
         await( tx.closeAsync() );
 
         assertFalse( tx.isOpen() );
@@ -196,7 +196,7 @@ class UnmanagedTransactionTest
         Connection connection = connectionMock();
         UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
-        tx.markTerminated();
+        tx.markTerminated(  null  );
 
         assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
 
@@ -210,7 +210,7 @@ class UnmanagedTransactionTest
         Connection connection = connectionMock();
         UnmanagedTransaction tx = new UnmanagedTransaction( connection, new DefaultBookmarkHolder(), UNLIMITED_FETCH_SIZE );
 
-        tx.markTerminated();
+        tx.markTerminated( null );
         await( tx.rollbackAsync() );
 
         verify( connection ).release();

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
@@ -73,6 +73,6 @@ class TransactionPullResponseCompletionListenerTest
 
         handler.onFailure( error );
 
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/TransactionPullResponseCompletionListenerTest.java
@@ -73,7 +73,7 @@ public class TransactionPullResponseCompletionListenerTest extends BasicPullResp
 
         // Then
         assertThat( handler.state(), equalTo( BasicPullResponseHandler.State.FAILURE_STATE ) );
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
         verify( recordConsumer ).accept( null, error );
         verify( summaryConsumer ).accept( any( ResultSummary.class ), eq( error ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -135,6 +135,6 @@ class InternalRxTransactionTest
         verify( tx ).runRx( any( Query.class ) );
         RuntimeException t = assertThrows( CompletionException.class, () -> Futures.getNow( cursorFuture ) );
         assertThat( t.getCause(), equalTo( error ) );
-        verify( tx ).markTerminated();
+        verify( tx ).markTerminated( error );
     }
 }

--- a/driver/src/test/resources/acquire_endpoints_twice_v4.script
+++ b/driver/src/test/resources/acquire_endpoints_twice_v4.script
@@ -1,0 +1,16 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO HELLO
+!: AUTO GOODBYE
+
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": { "address": "127.0.0.1:9001"}, "database": "mydatabase"} {"mode": "r", "db": "system"}
+   PULL {"n": -1}
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": { "address": "127.0.0.1:9001"}, "database": "mydatabase"} {"mode": "r", "db": "system"}
+   PULL {"n": -1}
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9007"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9005","127.0.0.1:9006"], "role": "READ"},{"addresses": ["127.0.0.1:9001","127.0.0.1:9002","127.0.0.1:9003"], "role": "ROUTE"}]]
+   SUCCESS {}
+   <EXIT>

--- a/driver/src/test/resources/not_able_to_write_server_tx_func_retries.script
+++ b/driver/src/test/resources/not_able_to_write_server_tx_func_retries.script
@@ -1,0 +1,25 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO BEGIN
+!: AUTO HELLO
+!: AUTO GOODBYE
+!: AUTO ROLLBACK
+
+C: RUN "RETURN 1" {} {}
+   PULL {"n": 1000}
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+   IGNORED
+C: RUN "RETURN 1" {} {}
+   PULL {"n": 1000}
+S: SUCCESS {"fields": ["1"]}
+   RECORD [1]
+   SUCCESS {}
+C: RUN "MATCH (n) RETURN n.name" {} {}
+   PULL {"n": 1000}
+S: SUCCESS {"fields": ["n.name"]}
+   RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {}
+C: COMMIT
+S: SUCCESS {"bookmark": "NewBookmark"}
+   <EXIT>

--- a/driver/src/test/resources/not_able_to_write_server_tx_func_retries_rx.script
+++ b/driver/src/test/resources/not_able_to_write_server_tx_func_retries_rx.script
@@ -1,0 +1,25 @@
+!: BOLT 4
+!: AUTO RESET
+!: AUTO BEGIN
+!: AUTO HELLO
+!: AUTO GOODBYE
+!: AUTO ROLLBACK
+
+C: RUN "RETURN 1" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": 100}
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+C: RUN "RETURN 1" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": 100}
+S: RECORD [1]
+   SUCCESS {"has_more": false}
+C: RUN "MATCH (n) RETURN n.name" {} {}
+S: SUCCESS {"fields": ["n.name"]}
+C: PULL {"n": 100}
+S: RECORD ["Foo"]
+   RECORD ["Bar"]
+   SUCCESS {"has_more": false}
+C: COMMIT
+S: SUCCESS {"bookmark": "NewBookmark"}
+   <EXIT>


### PR DESCRIPTION
* Don’t swallow the cause of a TX termination.

There are a couple of scenarions in which a transaction gets terminated. The cause will be propagated by the pull handler and the transaction will be marked accordingly. There might be a chance that a degration from a leader to a follower on the server side happens in between to calls to a run method on that transaction: The transaction is still open, but cannot run queries any longer. Outside a transactional function this leads correctly to a ClientException. Inside a transactional function, this must not happen.

The retry logic must be able to find the cause of the termination and if there’s any, it should judge on the cause if it retries or not.

This PR changes the following:

- Add a StateHolder to the UnmangedTransaction
- The holder is necessary to keep the single field volatie
- The holder holds the state and a possible cause of termination
- The holder is able to determine whether a session is still open or not.
- It removes markTerminated from InternalAsyncTransaction as it was used only for tests.