### PR TITLE
Fix native compilation with Netty 4.1.50 on GraalVM.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/svm/NettySubstitutions.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/svm/NettySubstitutions.java
@@ -22,6 +22,7 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.jdk.JDK11OrLater;
+import com.oracle.svm.core.jdk.JDK8OrEarlier;
 
 import java.security.PrivateKey;
 import java.security.Provider;
@@ -113,20 +114,58 @@ final class Target_io_netty_handler_ssl_SslHandler$SslEngineType {
 @TargetClass(className = "io.netty.handler.ssl.JdkAlpnApplicationProtocolNegotiator$AlpnWrapper", onlyWith = JDK11OrLater.class)
 final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_AlpnWrapper {
     @Substitute
-    @SuppressWarnings( "deprecation" )
-    public SSLEngine wrapSslEngine( SSLEngine engine, ByteBufAllocator alloc,
+    public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
             JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
-        return (SSLEngine) (Object) new Target_io_netty_handler_ssl_Java9SslEngine(
-                engine, applicationNegotiator, isServer);
+        return (SSLEngine) (Object) new Target_io_netty_handler_ssl_JdkAlpnSslEngine(engine, applicationNegotiator, isServer);
     }
 
 }
 
-@TargetClass(className = "io.netty.handler.ssl.Java9SslEngine", onlyWith = JDK11OrLater.class)
-final class Target_io_netty_handler_ssl_Java9SslEngine {
+@TargetClass(className = "io.netty.handler.ssl.JdkAlpnApplicationProtocolNegotiator$AlpnWrapper", onlyWith = JDK8OrEarlier.class)
+final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_AlpnWrapperJava8 {
+    @Substitute
+    public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
+            JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
+        if (Target_io_netty_handler_ssl_JettyAlpnSslEngine.isAvailable()) {
+            return isServer
+                   ? (SSLEngine) (Object) Target_io_netty_handler_ssl_JettyAlpnSslEngine.newServerEngine(engine,
+                    applicationNegotiator)
+                   : (SSLEngine) (Object) Target_io_netty_handler_ssl_JettyAlpnSslEngine.newClientEngine(engine,
+                           applicationNegotiator);
+        }
+        throw new RuntimeException("Unable to wrap SSLEngine of type " + engine.getClass().getName());
+    }
+
+}
+
+@TargetClass(className = "io.netty.handler.ssl.JettyAlpnSslEngine", onlyWith = JDK8OrEarlier.class)
+final class Target_io_netty_handler_ssl_JettyAlpnSslEngine {
+    @Substitute
+    static boolean isAvailable() {
+        return false;
+    }
+
+    @Substitute
+    @SuppressWarnings( "deprecation" )
+    static Target_io_netty_handler_ssl_JettyAlpnSslEngine newClientEngine(SSLEngine engine,
+            JdkApplicationProtocolNegotiator applicationNegotiator) {
+        return null;
+    }
+
+    @Substitute
+    @SuppressWarnings( "deprecation" )
+    static Target_io_netty_handler_ssl_JettyAlpnSslEngine newServerEngine(SSLEngine engine,
+            JdkApplicationProtocolNegotiator applicationNegotiator) {
+        return null;
+    }
+}
+
+@TargetClass(className = "io.netty.handler.ssl.JdkAlpnSslEngine", onlyWith = JDK11OrLater.class)
+final class Target_io_netty_handler_ssl_JdkAlpnSslEngine {
+
     @Alias
     @SuppressWarnings( "deprecation" )
-    Target_io_netty_handler_ssl_Java9SslEngine(final SSLEngine engine,
+    Target_io_netty_handler_ssl_JdkAlpnSslEngine(final SSLEngine engine,
             final JdkApplicationProtocolNegotiator applicationNegotiator, final boolean isServer) {
 
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/svm/NettySubstitutions.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/svm/NettySubstitutions.java
@@ -27,8 +27,6 @@ import com.oracle.svm.core.jdk.JDK8OrEarlier;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
-import java.util.Queue;
-import java.util.concurrent.LinkedBlockingDeque;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -337,15 +335,5 @@ final class Target_io_netty_bootstrap_AbstractBootstrap {
     }
 }
 
-@TargetClass(className = "io.netty.channel.nio.NioEventLoop")
-final class Target_io_netty_channel_nio_NioEventLoop {
-
-    @Substitute
-    private static Queue<Runnable> newTaskQueue0(int maxPendingTasks) {
-        return new LinkedBlockingDeque<>();
-    }
-}
-
 class NettySubstitutions {
-
 }

--- a/driver/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-java-driver/reflection-config.json
+++ b/driver/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-java-driver/reflection-config.json
@@ -18,5 +18,41 @@
     {
       "name" : "org.neo4j.driver.internal.shaded.io.netty.util.ReferenceCountUtil",
       "allDeclaredMethods" : true
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {"name": "producerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {"name": "producerLimit", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {"name": "consumerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields": [
+        {"name": "producerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields": [
+        {"name": "producerLimit", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields": [
+        {"name": "consumerIndex", "allowUnsafeAccess": true}
+      ]
     }
 ]


### PR DESCRIPTION
@gsmet ping us in https://github.com/quarkusio/quarkus/pull/10200 that the 4.1 driver fails to work with Quarkus in native mode. After investigation it is apparent that the failure is due to an upgrade to [Netty 4.1.50](https://github.com/neo4j/neo4j-java-driver/commit/6fa15e99f81597403fa9ac1b8c483fe9b8a50ef6).

To fix this, several things are needed:

* Remove substitutions for `io.netty.handler.ssl.Java9SslEngine`

`io.netty.handler.ssl.Java9SslEngine` has been removed in Netty 4.1.50, Graal cannot substitute a class not on the classpath. 

* Remove task queue substitution and allow JCTools Mpsc queue to work.

This removes the substitution for the task queue in the `io.netty.channel.nio.NioEventLoop` class. Thus, the JCTools Mpsc queues will be used instead.

The Mpsc queues need a bit of reflection to work in native mode, but this is very isolated. Also, Netty upgraded to JCTools 3.0.0 in 4.1.46 and the Mpsc queues now are triggered during class initialition already, even with the substitution.
So we should live with the bits of reflection in native mode and remove the somewhat brittle substitution along the way.

This should be cherry picked into 4.0 as well. 

I'll raise at least an issue for discussion with Netty regarding the reflection config for JCTools. cc @normanmaurer