### PR TITLE
Fix native compilation with Netty 4.1.50 on GraalVM.

### DIFF
--- a/driver/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-java-driver/reflection-config.json
+++ b/driver/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-java-driver/reflection-config.json
@@ -18,5 +18,41 @@
     {
       "name" : "org.neo4j.driver.internal.shaded.io.netty.util.ReferenceCountUtil",
       "allDeclaredMethods" : true
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {"name": "producerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {"name": "producerLimit", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {"name": "consumerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields": [
+        {"name": "producerIndex", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields": [
+        {"name": "producerLimit", "allowUnsafeAccess": true}
+      ]
+    },
+    {
+      "name" : "org.neo4j.driver.internal.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields": [
+        {"name": "consumerIndex", "allowUnsafeAccess": true}
+      ]
     }
 ]


### PR DESCRIPTION
Netty 4.1.50 needs two fixes for in our setup for native compilation on GraalVM:

* Remove substitutions for io.netty.handler.ssl.Java9SslEngine. as `io.netty.handler.ssl.Java9SslEngine` has been removed in Netty 4.1.50, Graal cannot substitute a class not on the classpath.

* Remove the substitution for the task queue in the `io.netty.channel.nio.NioEventLoop` class. Thus, the JCTools Mpsc will be used instead.

The Mpsc queues need a bit of reflection to work in native mode, but this is very isolated. Also, Netty upgraded to JCTools 3.0.0 in 4.1.46 and the Mpsc queues now are triggered during class initialition already, even with the substitution.
So we should live with the bits of reflection in native mode and remove the somewhat brittle substitution along the way.

Also it seems that the system property `io.netty.noUnsafe` which we set in the `native-image.properties` is not taken into account at all.