### PR TITLE
Revert "Since Server v4.0 the server agent received in response to th…

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
@@ -37,13 +37,11 @@ public class HelloResponseHandler implements ResponseHandler
 
     private final ChannelPromise connectionInitializedPromise;
     private final Channel channel;
-    private final int protocolVersion;
 
-    public HelloResponseHandler( ChannelPromise connectionInitializedPromise, int protocolVersion )
+    public HelloResponseHandler( ChannelPromise connectionInitializedPromise )
     {
         this.connectionInitializedPromise = connectionInitializedPromise;
         this.channel = connectionInitializedPromise.channel();
-        this.protocolVersion = protocolVersion;
     }
 
     @Override
@@ -51,16 +49,8 @@ public class HelloResponseHandler implements ResponseHandler
     {
         try
         {
-            // From Server V4 extracting server from metadata in the success message is unreliable
-            // so we fix the Server version against the Bolt Protocol version for Server V4 and above.
-            if ( protocolVersion == 4 )
-            {
-                setServerVersion( channel, ServerVersion.v4_0_0 );
-            }
-            else
-            {
-                setServerVersion( channel, extractNeo4jServerVersion( metadata ) );
-            }
+            ServerVersion serverVersion = extractNeo4jServerVersion( metadata );
+            setServerVersion( channel, serverVersion );
 
             String connectionId = extractConnectionId( metadata );
             setConnectionId( channel, connectionId );

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -80,7 +80,7 @@ public class BoltProtocolV3 implements BoltProtocol
         Channel channel = channelInitializedPromise.channel();
 
         HelloMessage message = new HelloMessage( userAgent, authToken );
-        HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise, version() );
+        HelloResponseHandler handler = new HelloResponseHandler( channelInitializedPromise );
 
         messageDispatcher( channel ).enqueue( handler );
         channel.writeAndFlush( message, channel.voidPromise() );

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
@@ -37,7 +37,6 @@ import org.neo4j.driver.internal.async.inbound.ChannelErrorHandler;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.async.outbound.OutboundMessageHandler;
 import org.neo4j.driver.internal.messaging.v1.MessageFormatV1;
-import org.neo4j.driver.internal.util.ServerVersion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -74,7 +73,7 @@ class HelloResponseHandlerTest
     void shouldSetServerVersionOnChannel()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( anyServerVersion(), "bolt-1" );
         handler.onSuccess( metadata );
@@ -87,7 +86,7 @@ class HelloResponseHandlerTest
     void shouldThrowWhenServerVersionNotReturned()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( null, "bolt-1" );
         assertThrows( UntrustedServerException.class, () -> handler.onSuccess( metadata ) );
@@ -100,7 +99,7 @@ class HelloResponseHandlerTest
     void shouldThrowWhenServerVersionIsNull()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( Values.NULL, "bolt-x" );
         assertThrows( UntrustedServerException.class, () -> handler.onSuccess( metadata ) );
@@ -113,7 +112,7 @@ class HelloResponseHandlerTest
     void shouldThrowWhenServerVersionCantBeParsed()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( "WrongServerVersion", "bolt-x" );
         assertThrows( IllegalArgumentException.class, () -> handler.onSuccess( metadata ) );
@@ -123,24 +122,10 @@ class HelloResponseHandlerTest
     }
 
     @Test
-    void shouldUseProtocolVersionForServerVersionWhenConnectedWithBoltV4()
-    {
-        ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 4 );
-
-        // server used in metadata should be ignored
-        Map<String,Value> metadata = metadata( ServerVersion.vInDev, "bolt-1" );
-        handler.onSuccess( metadata );
-
-        assertTrue( channelPromise.isSuccess() );
-        assertEquals( ServerVersion.v4_0_0, serverVersion( channel ) );
-    }
-
-    @Test
     void shouldSetConnectionIdOnChannel()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( anyServerVersion(), "bolt-42" );
         handler.onSuccess( metadata );
@@ -153,7 +138,7 @@ class HelloResponseHandlerTest
     void shouldThrowWhenConnectionIdNotReturned()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( anyServerVersion(), null );
         assertThrows( IllegalStateException.class, () -> handler.onSuccess( metadata ) );
@@ -166,7 +151,7 @@ class HelloResponseHandlerTest
     void shouldThrowWhenConnectionIdIsNull()
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         Map<String,Value> metadata = metadata( anyServerVersion(), Values.NULL );
         assertThrows( IllegalStateException.class, () -> handler.onSuccess( metadata ) );
@@ -179,7 +164,7 @@ class HelloResponseHandlerTest
     void shouldCloseChannelOnFailure() throws Exception
     {
         ChannelPromise channelPromise = channel.newPromise();
-        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, 3 );
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise );
 
         RuntimeException error = new RuntimeException( "Hi!" );
         handler.onFailure( error );


### PR DESCRIPTION
Revert "Since Server v4.0 the server agent received in response to the Hello message is unreliable.

Since the bolt protocol version does not include a patch element we revert this change until a suitable alternative can be designed.

This reverts commit 31d3495a16aaf02a78d1ebfc70b0a73f0f554f46.