### PR TITLE
Exclude reactor.core.* from imported packages in OSGI environments.

### DIFF
--- a/driver/osgi.bnd
+++ b/driver/osgi.bnd
@@ -5,6 +5,7 @@ Export-Package: \
 
 Import-Package: \
  !io.netty.*, \
+ !reactor.core.*, \
  !com.oracle.svm.*, \
  javax.security.cert, \
  *


### PR DESCRIPTION
This closes #750 and should be a no-brainer. I would cherry-pick into 4.0 as well.