### PR TITLE
OCSP Stapling Checks

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -30,7 +30,6 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
-import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.SecuritySettings;
 import org.neo4j.driver.internal.async.pool.PoolSettings;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
@@ -802,6 +801,7 @@ public class Config
         private final Strategy strategy;
         private final File certFile;
         private boolean hostnameVerificationEnabled = true;
+        private boolean ocspRevocationCheckEnabled = false;
 
         private TrustStrategy( Strategy strategy )
         {
@@ -863,6 +863,38 @@ public class Config
         public TrustStrategy withoutHostnameVerification()
         {
             hostnameVerificationEnabled = false;
+            return this;
+        }
+
+        /**
+         * Check if certificate revocation checking has been enabled for this trust strategy.
+         * @return {@code true} if certificate revocation checking  has been enabled via {@link #withCertificateRevocationCheck()} , {@code false} otherwise.
+         */
+        public boolean isCertificateRevocationCheckEnabled()
+        {
+            return ocspRevocationCheckEnabled;
+        }
+
+        /**
+         * Enables checking of certificate revocation status via OCSP response(s) stapled to the returned certificate.
+         * Note: This requires enabling OCSP stapling on the server.
+         *
+         * @return the current test strategy.
+         */
+        public TrustStrategy withCertificateRevocationCheck()
+        {
+            ocspRevocationCheckEnabled = true;
+            return this;
+        }
+
+        /**
+         * Disables checking of certificate revocation status via OCSP response(s) stapled to the returned certificate.
+         *
+         * @return the current test strategy.
+         */
+        public TrustStrategy withoutCertificateRevocationCheck()
+        {
+            ocspRevocationCheckEnabled = false;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
+import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.SecuritySettings;
 import org.neo4j.driver.internal.async.pool.PoolSettings;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
@@ -801,7 +802,7 @@ public class Config
         private final Strategy strategy;
         private final File certFile;
         private boolean hostnameVerificationEnabled = true;
-        private boolean ocspRevocationCheckEnabled = false;
+        private RevocationStrategy revocationStrategy = RevocationStrategy.NO_CHECKS;
 
         private TrustStrategy( Strategy strategy )
         {
@@ -867,38 +868,6 @@ public class Config
         }
 
         /**
-         * Check if certificate revocation checking has been enabled for this trust strategy.
-         * @return {@code true} if certificate revocation checking  has been enabled via {@link #withCertificateRevocationCheck()} , {@code false} otherwise.
-         */
-        public boolean isCertificateRevocationCheckEnabled()
-        {
-            return ocspRevocationCheckEnabled;
-        }
-
-        /**
-         * Enables checking of certificate revocation status via OCSP response(s) stapled to the returned certificate.
-         * Note: This requires enabling OCSP stapling on the server.
-         *
-         * @return the current test strategy.
-         */
-        public TrustStrategy withCertificateRevocationCheck()
-        {
-            ocspRevocationCheckEnabled = true;
-            return this;
-        }
-
-        /**
-         * Disables checking of certificate revocation status via OCSP response(s) stapled to the returned certificate.
-         *
-         * @return the current test strategy.
-         */
-        public TrustStrategy withoutCertificateRevocationCheck()
-        {
-            ocspRevocationCheckEnabled = false;
-            return this;
-        }
-
-        /**
          * Only encrypted connections to Neo4j instances with certificates signed by a trusted certificate will be accepted.
          * The file specified should contain one or more trusted X.509 certificates.
          * <p>
@@ -932,6 +901,54 @@ public class Config
         public static TrustStrategy trustAllCertificates()
         {
             return new TrustStrategy( Strategy.TRUST_ALL_CERTIFICATES );
+        }
+
+        /**
+         * The revocation strategy used for verifying certificates.
+         * @return this {@link TrustStrategy}'s revocation strategy
+         */
+        public RevocationStrategy revocationStrategy()
+        {
+            return revocationStrategy;
+        }
+
+        /**
+         * Configures the {@link TrustStrategy} to not carry out OCSP revocation checks on certificates. This is the
+         * option that is configured by default.
+         * @return the current trust strategy
+         */
+        public TrustStrategy withoutCertificateRevocationChecks()
+        {
+            this.revocationStrategy = RevocationStrategy.NO_CHECKS;
+            return this;
+        }
+
+        /**
+         * Configures the {@link TrustStrategy} to carry out OCSP revocation checks when the revocation status is
+         * stapled to the certificate. If no stapled response is found, then certificate verification continues
+         * (and does not fail verification). This setting also requires the server to be configured to enable
+         * OCSP stapling.
+         * @return the current trust strategy
+         */
+        public TrustStrategy withVerifyIfPresentRevocationChecks()
+        {
+            this.revocationStrategy = RevocationStrategy.VERIFY_IF_PRESENT;
+            return this;
+        }
+
+        /**
+         * Configures the {@link TrustStrategy} to carry out strict OCSP revocation checks for revocation status that
+         * are stapled to the certificate. If no stapled response is found, then the driver will fail certificate verification
+         * and not connect to the server. This setting also requires the server to be configured to enable OCSP stapling.
+         *
+         * Note: enabling this setting will prevent the driver connecting to the server when the server is unable to reach
+         * the certificate's configured OCSP responder URL.
+         * @return the current trust strategy
+         */
+        public TrustStrategy withStrictRevocationChecks()
+        {
+            this.revocationStrategy = RevocationStrategy.STRICT;
+            return this;
         }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/RevocationStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RevocationStrategy.java
@@ -21,8 +21,11 @@ package org.neo4j.driver.internal;
 
 public enum RevocationStrategy
 {
+    /** Don't do any OCSP revocation checks, regardless whether there are stapled revocation statuses or not. */
     NO_CHECKS,
+    /** Verify OCSP revocation checks when the revocation status is stapled to the certificate, continue if not. */
     VERIFY_IF_PRESENT,
+    /** Require stapled revocation status and verify OCSP revocation checks, fail if no revocation status is stapled to the certificate. */
     STRICT;
 
     public static boolean requiresRevocationChecking( RevocationStrategy revocationStrategy )

--- a/driver/src/main/java/org/neo4j/driver/internal/RevocationStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/RevocationStrategy.java
@@ -16,22 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.security;
 
-import javax.net.ssl.SSLContext;
+package org.neo4j.driver.internal;
 
-import org.neo4j.driver.internal.RevocationStrategy;
-
-/**
- * A SecurityPlan consists of encryption and trust details.
- */
-public interface SecurityPlan
+public enum RevocationStrategy
 {
-    boolean requiresEncryption();
+    NO_CHECKS,
+    VERIFY_IF_PRESENT,
+    STRICT;
 
-    SSLContext sslContext();
-
-    boolean requiresHostnameVerification();
-
-    RevocationStrategy revocationStrategy();
+    public static boolean requiresRevocationChecking( RevocationStrategy revocationStrategy )
+    {
+        return revocationStrategy.equals( STRICT ) || revocationStrategy.equals( VERIFY_IF_PRESENT );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
@@ -92,11 +92,11 @@ public class SecuritySettings
     {
         if ( isHighTrustScheme(scheme) )
         {
-            return SecurityPlanImpl.forSystemCASignedCertificates( true );
+            return SecurityPlanImpl.forSystemCASignedCertificates( true, false );
         }
         else
         {
-            return SecurityPlanImpl.forAllCertificates( false );
+            return SecurityPlanImpl.forAllCertificates( false, false );
         }
     }
 
@@ -110,14 +110,15 @@ public class SecuritySettings
         if ( encrypted )
         {
             boolean hostnameVerificationEnabled = trustStrategy.isHostnameVerificationEnabled();
+            boolean revocationCheckingEnabled = trustStrategy.isCertificateRevocationCheckEnabled();
             switch ( trustStrategy.strategy() )
             {
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled );
+                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled, revocationCheckingEnabled );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlanImpl.forSystemCASignedCertificates( hostnameVerificationEnabled );
+                return SecurityPlanImpl.forSystemCASignedCertificates( hostnameVerificationEnabled, revocationCheckingEnabled );
             case TRUST_ALL_CERTIFICATES:
-                return SecurityPlanImpl.forAllCertificates( hostnameVerificationEnabled );
+                return SecurityPlanImpl.forAllCertificates( hostnameVerificationEnabled, revocationCheckingEnabled );
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + trustStrategy.strategy().name() );

--- a/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
@@ -92,11 +92,11 @@ public class SecuritySettings
     {
         if ( isHighTrustScheme(scheme) )
         {
-            return SecurityPlanImpl.forSystemCASignedCertificates( true, false );
+            return SecurityPlanImpl.forSystemCASignedCertificates( true, RevocationStrategy.NO_CHECKS );
         }
         else
         {
-            return SecurityPlanImpl.forAllCertificates( false, false );
+            return SecurityPlanImpl.forAllCertificates( false, RevocationStrategy.NO_CHECKS );
         }
     }
 
@@ -110,15 +110,15 @@ public class SecuritySettings
         if ( encrypted )
         {
             boolean hostnameVerificationEnabled = trustStrategy.isHostnameVerificationEnabled();
-            boolean revocationCheckingEnabled = trustStrategy.isCertificateRevocationCheckEnabled();
+            RevocationStrategy revocationStrategy = trustStrategy.revocationStrategy();
             switch ( trustStrategy.strategy() )
             {
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled, revocationCheckingEnabled );
+                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled, revocationStrategy );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlanImpl.forSystemCASignedCertificates( hostnameVerificationEnabled, revocationCheckingEnabled );
+                return SecurityPlanImpl.forSystemCASignedCertificates( hostnameVerificationEnabled, revocationStrategy );
             case TRUST_ALL_CERTIFICATES:
-                return SecurityPlanImpl.forAllCertificates( hostnameVerificationEnabled, revocationCheckingEnabled );
+                return SecurityPlanImpl.forAllCertificates( hostnameVerificationEnabled, revocationStrategy );
             default:
                 throw new ClientException(
                         "Unknown TLS authentication strategy: " + trustStrategy.strategy().name() );

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -30,4 +30,6 @@ public interface SecurityPlan
     SSLContext sslContext();
 
     boolean requiresHostnameVerification();
+
+    boolean requiresRevocationChecking();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
@@ -63,7 +63,7 @@ public class SecurityPlanImpl implements SecurityPlan
         return new SecurityPlanImpl( true, sslContext, requiresHostnameVerification, requiresRevocationChecking );
     }
 
-    public static SSLContext configureSSLContext( File customCertFile, boolean requiresRevocationChecking )
+    private static SSLContext configureSSLContext( File customCertFile, boolean requiresRevocationChecking )
             throws GeneralSecurityException, IOException
     {
         KeyStore trustedKeyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
@@ -85,18 +85,16 @@ public class SecurityPlanImpl implements SecurityPlan
         // sets checking of stapled ocsp response
         pkixBuilderParameters.setRevocationEnabled( requiresRevocationChecking );
 
-        // enables status_request exentension in client hello
+        // enables status_request extension in client hello
         if ( requiresRevocationChecking )
         {
             System.setProperty( "jdk.tls.client.enableStatusRequestExtension", "true" );
         }
 
-        // Create TrustManager from TrustedKeyStore
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
-        trustManagerFactory.init( new CertPathTrustManagerParameters( pkixBuilderParameters ) );
-
         SSLContext sslContext = SSLContext.getInstance( "TLS" );
 
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
+        trustManagerFactory.init( new CertPathTrustManagerParameters( pkixBuilderParameters ) );
         sslContext.init( new KeyManager[0], trustManagerFactory.getTrustManagers(), null );
 
         return sslContext;

--- a/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
@@ -30,6 +30,7 @@ import java.security.KeyStoreException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Base64;
 
 /**
@@ -136,6 +137,14 @@ public class CertificateTool
                     throw new IOException( "Failed to load certificate from `" + certFile.getAbsolutePath() + "`: " + certCount + " : " + e.getMessage(), e );
                 }
             }
+        }
+    }
+
+    public static void loadX509Cert( X509Certificate[] certificates, KeyStore keyStore ) throws GeneralSecurityException, IOException
+    {
+        for ( int i = 0; i < certificates.length; i++ )
+        {
+            loadX509Cert( certificates[i], "neo4j.javadriver.trustedcert." + i, keyStore );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/CertificateTool.java
@@ -36,7 +36,7 @@ import java.util.Base64;
 /**
  * A tool used to save, load certs, etc.
  */
-public class CertificateTool
+public final class CertificateTool
 {
     private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
     private static final String END_CERT = "-----END CERTIFICATE-----";
@@ -169,6 +169,10 @@ public class CertificateTool
     {
         String cert64CharPerLine = cert.replaceAll( "(.{64})", "$1\n" );
         return BEGIN_CERT + "\n" + cert64CharPerLine + "\n"+ END_CERT + "\n";
+    }
+
+    private CertificateTool()
+    {
     }
 }
 

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -265,6 +265,19 @@ class ConfigTest
     }
 
     @Test
+    void shouldEnableAndDisableCertificateRevocationChecksOnTestStrategy()
+    {
+        Config.TrustStrategy trustStrategy = Config.TrustStrategy.trustSystemCertificates();
+        assertFalse( trustStrategy.isCertificateRevocationCheckEnabled() );
+
+        assertSame( trustStrategy, trustStrategy.withoutCertificateRevocationCheck() );
+        assertFalse( trustStrategy.isCertificateRevocationCheckEnabled() );
+
+        assertSame( trustStrategy, trustStrategy.withCertificateRevocationCheck() );
+        assertTrue( trustStrategy.isCertificateRevocationCheckEnabled() );
+    }
+
+    @Test
     void shouldAllowToConfigureResolver()
     {
         ServerAddressResolver resolver = mock( ServerAddressResolver.class );

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -35,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.driver.internal.RevocationStrategy.STRICT;
+import static org.neo4j.driver.internal.RevocationStrategy.NO_CHECKS;
+import static org.neo4j.driver.internal.RevocationStrategy.VERIFY_IF_PRESENT;
 import static org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil.DEFAULT_FETCH_SIZE;
 
 class ConfigTest
@@ -268,13 +271,16 @@ class ConfigTest
     void shouldEnableAndDisableCertificateRevocationChecksOnTestStrategy()
     {
         Config.TrustStrategy trustStrategy = Config.TrustStrategy.trustSystemCertificates();
-        assertFalse( trustStrategy.isCertificateRevocationCheckEnabled() );
+        assertEquals( NO_CHECKS, trustStrategy.revocationStrategy() );
 
-        assertSame( trustStrategy, trustStrategy.withoutCertificateRevocationCheck() );
-        assertFalse( trustStrategy.isCertificateRevocationCheckEnabled() );
+        assertSame( trustStrategy, trustStrategy.withoutCertificateRevocationChecks() );
+        assertEquals( NO_CHECKS, trustStrategy.revocationStrategy() );
 
-        assertSame( trustStrategy, trustStrategy.withCertificateRevocationCheck() );
-        assertTrue( trustStrategy.isCertificateRevocationCheckEnabled() );
+        assertSame( trustStrategy, trustStrategy.withStrictRevocationChecks() );
+        assertEquals( STRICT, trustStrategy.revocationStrategy() );
+
+        assertSame( trustStrategy, trustStrategy.withVerifyIfPresentRevocationChecks() );
+        assertEquals( VERIFY_IF_PRESENT, trustStrategy.revocationStrategy() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -237,6 +237,6 @@ class ChannelConnectorImplIT
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException
     {
-        return SecurityPlanImpl.forAllCertificates( false );
+        return SecurityPlanImpl.forAllCertificates( false, false );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -42,6 +42,7 @@ import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
@@ -237,6 +238,6 @@ class ChannelConnectorImplIT
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException
     {
-        return SecurityPlanImpl.forAllCertificates( false, false );
+        return SecurityPlanImpl.forAllCertificates( false, RevocationStrategy.NO_CHECKS );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
@@ -23,13 +23,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
-import javax.net.ssl.SSLContext;
 
 import org.neo4j.driver.Config;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.security.SecurityPlan;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,11 +73,9 @@ class SecuritySettingsTest
 
         SecurityPlan securityPlan = securitySettings.createSecurityPlan( scheme );
 
-        SSLContext defaultContext = SSLContext.getDefault();
-
         assertTrue( securityPlan.requiresEncryption() );
         assertTrue( securityPlan.requiresHostnameVerification() );
-        assertEquals( defaultContext, securityPlan.sslContext() );
+        assertFalse( securityPlan.requiresRevocationChecking() );
     }
 
     @ParameterizedTest
@@ -140,7 +136,7 @@ class SecuritySettingsTest
         assertTrue( ex.getMessage().contains( String.format( "Scheme %s is not configurable with manual encryption and trust settings", scheme ) ));
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @MethodSource( "unencryptedSchemes" )
     void testNoEncryption( String scheme )
     {
@@ -151,7 +147,7 @@ class SecuritySettingsTest
         assertFalse( securityPlan.requiresEncryption() );
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @MethodSource( "unencryptedSchemes" )
     void testConfiguredEncryption( String scheme )
     {
@@ -163,7 +159,7 @@ class SecuritySettingsTest
         assertTrue( securityPlan.requiresEncryption() );
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @MethodSource( "unencryptedSchemes" )
     void testConfiguredAllCertificates( String scheme)
     {
@@ -177,7 +173,7 @@ class SecuritySettingsTest
         assertTrue( securityPlan.requiresEncryption() );
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @MethodSource( "unencryptedSchemes" )
     void testConfigureRevocationChecking( String scheme )
     {
@@ -191,7 +187,7 @@ class SecuritySettingsTest
         assertTrue( securityPlan.requiresRevocationChecking() );
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest
     @MethodSource( "unencryptedSchemes" )
     void testRevocationCheckingDisabledByDefault( String scheme )
     {

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
@@ -143,7 +143,7 @@ class NettyChannelInitializerTest
 
     private void testHostnameVerificationSetting( boolean enabled, String expectedValue ) throws Exception
     {
-        NettyChannelInitializer initializer = newInitializer( SecurityPlanImpl.forAllCertificates( enabled ) );
+        NettyChannelInitializer initializer = newInitializer( SecurityPlanImpl.forAllCertificates( enabled, false ) );
 
         initializer.initChannel( channel );
 
@@ -172,6 +172,6 @@ class NettyChannelInitializerTest
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException
     {
-        return SecurityPlanImpl.forAllCertificates( false );
+        return SecurityPlanImpl.forAllCertificates( false, false );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
@@ -143,7 +144,7 @@ class NettyChannelInitializerTest
 
     private void testHostnameVerificationSetting( boolean enabled, String expectedValue ) throws Exception
     {
-        NettyChannelInitializer initializer = newInitializer( SecurityPlanImpl.forAllCertificates( enabled, false ) );
+        NettyChannelInitializer initializer = newInitializer( SecurityPlanImpl.forAllCertificates( enabled, RevocationStrategy.NO_CHECKS ) );
 
         initializer.initChannel( channel );
 
@@ -172,6 +173,6 @@ class NettyChannelInitializerTest
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException
     {
-        return SecurityPlanImpl.forAllCertificates( false, false );
+        return SecurityPlanImpl.forAllCertificates( false, RevocationStrategy.NO_CHECKS );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/CertificateUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/CertificateUtil.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.util;
 
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
@@ -93,6 +94,7 @@ public class CertificateUtil
         // Subject alternative name (part of SNI extension, used for hostname verification)
         GeneralNames subjectAlternativeName = new GeneralNames( new GeneralName( GeneralName.dNSName, DEFAULT_HOST_NAME ) );
         certBuilder.addExtension( Extension.subjectAlternativeName, false, subjectAlternativeName );
+        certBuilder.addExtension( Extension.basicConstraints, false, new BasicConstraints( true ) );
 
         // Get the certificate back
         ContentSigner signer = new JcaContentSignerBuilder( "SHA512WithRSAEncryption" ).build( issuerKeys.getPrivate() );

--- a/examples/src/main/java/org/neo4j/docs/driver/HelloWorldExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/HelloWorldExample.java
@@ -23,8 +23,8 @@ package org.neo4j.docs.driver;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
 


### PR DESCRIPTION
 Adds the ability for TrustStategy to configure whether or not certificate revocation checking is to be carried out. By default revocation checking is disabled.
    
If enabled with the corresponding server configuration, the driver will check the validity of stapled OCSP (Online Certificate Status Protocol) response(s). These responses are returned during the TLS handshake by the server and if not present, the driver will fail to accept the certificate.
    
See: https://tools.ietf.org/html/rfc6961
