### PR TITLE
Fix clirr-maven-plugin to compare api changes with 4.0.0 (#725)

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -1,3 +1,3 @@
 <differences>
-<!--2.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 2.0.0-->
+<!--4.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 4.0.0-->
 </differences>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -87,8 +87,8 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>
-          <comparisonVersion>2.0.0</comparisonVersion>
-          <excludes>org/neo4j/driver/**/internal/**</excludes>
+          <comparisonVersion>4.0.0</comparisonVersion>
+          <excludes>org/neo4j/driver/internal/**</excludes>
           <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fix clirr-maven-plugin to compare api changes with 4.0.0

Co-authored-by: Michael Simons <michael.simons@neo4j.com>