### PR TITLE
Nicer duration format

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
@@ -331,34 +331,42 @@ class TemporalTypesIT
     @Test
     void shouldFormatDurationToString()
     {
-        testDurationToString( 1, 0, "P0M0DT1S" );
-        testDurationToString( -1, 0, "P0M0DT-1S" );
+        testDurationToString( 1, 0, "PT1S" );
+        testDurationToString( -1, 0, "PT-1S" );
 
-        testDurationToString( 0, 5, "P0M0DT0.000000005S" );
-        testDurationToString( 0, -5, "P0M0DT-0.000000005S" );
-        testDurationToString( 0, 999_999_999, "P0M0DT0.999999999S" );
-        testDurationToString( 0, -999_999_999, "P0M0DT-0.999999999S" );
+        testDurationToString( 0, 5, "PT0.000000005S" );
+        testDurationToString( 0, -5, "PT-0.000000005S" );
+        testDurationToString( 0, 999_999_999, "PT0.999999999S" );
+        testDurationToString( 0, -999_999_999, "PT-0.999999999S" );
 
-        testDurationToString( 1, 5, "P0M0DT1.000000005S" );
-        testDurationToString( -1, -5, "P0M0DT-1.000000005S" );
-        testDurationToString( 1, -5, "P0M0DT0.999999995S" );
-        testDurationToString( -1, 5, "P0M0DT-0.999999995S" );
-        testDurationToString( 1, 999999999, "P0M0DT1.999999999S" );
-        testDurationToString( -1, -999999999, "P0M0DT-1.999999999S" );
-        testDurationToString( 1, -999999999, "P0M0DT0.000000001S" );
-        testDurationToString( -1, 999999999, "P0M0DT-0.000000001S" );
+        testDurationToString( 1, 5, "PT1.000000005S" );
+        testDurationToString( -1, -5, "PT-1.000000005S" );
+        testDurationToString( 1, -5, "PT0.999999995S" );
+        testDurationToString( -1, 5, "PT-0.999999995S" );
+        testDurationToString( 1, 999999999, "PT1.999999999S" );
+        testDurationToString( -1, -999999999, "PT-1.999999999S" );
+        testDurationToString( 1, -999999999, "PT0.000000001S" );
+        testDurationToString( -1, 999999999, "PT-0.000000001S" );
 
-        testDurationToString( -78036, -143000000, "P0M0DT-78036.143000000S" );
+        testDurationToString( -78036, -143000000, "PT-21H-40M-36.143S" );
 
-        testDurationToString( 0, 1_000_000_000, "P0M0DT1S" );
-        testDurationToString( 0, -1_000_000_000, "P0M0DT-1S" );
-        testDurationToString( 0, 1_000_000_007, "P0M0DT1.000000007S" );
-        testDurationToString( 0, -1_000_000_007, "P0M0DT-1.000000007S" );
+        testDurationToString( 0, 1_000_000_000, "PT1S" );
+        testDurationToString( 0, -1_000_000_000, "PT-1S" );
+        testDurationToString( 0, 1_000_000_007, "PT1.000000007S" );
+        testDurationToString( 0, -1_000_000_007, "PT-1.000000007S" );
 
-        testDurationToString( 40, 2_123_456_789, "P0M0DT42.123456789S" );
-        testDurationToString( -40, 2_123_456_789, "P0M0DT-37.876543211S" );
-        testDurationToString( 40, -2_123_456_789, "P0M0DT37.876543211S" );
-        testDurationToString( -40, -2_123_456_789, "P0M0DT-42.123456789S" );
+        testDurationToString( 40, 2_123_456_789, "PT42.123456789S" );
+        testDurationToString( -40, 2_123_456_789, "PT-37.876543211S" );
+        testDurationToString( 40, -2_123_456_789, "PT37.876543211S" );
+        testDurationToString( -40, -2_123_456_789, "PT-42.123456789S" );
+    }
+
+    @Test
+    void shouldFormatDurationSensibly()
+    {
+        Result result = session.run( "RETURN duration({months: 0.75})" );
+        IsoDuration duration = result.single().get( 0 ).asIsoDuration();
+        assertEquals( "P22DT19H51M49.5S", duration.toString() );
     }
 
     private static <T> void testSendAndReceiveRandomValues( Supplier<T> valueSupplier, Function<Value,T> converter )

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalIsoDurationTest.java
@@ -149,34 +149,34 @@ class InternalIsoDurationTest
     @Test
     void toStringShouldPrintInIsoStandardFormat()
     {
-        assertThat( newDuration( 0, 0, 0, 0 ).toString(), equalTo( "P0M0DT0S" ) );
+        assertThat( newDuration( 0, 0, 0, 0 ).toString(), equalTo( "PT0S" ) );
         assertThat( newDuration( 2, 45, 59, 11 ).toString(), equalTo( "P2M45DT59.000000011S" ) );
         assertThat( newDuration( 4, -101, 1, 999 ).toString(), equalTo( "P4M-101DT1.000000999S" ) );
         assertThat( newDuration( -1, 12, -19, 1 ).toString(), equalTo( "P-1M12DT-18.999999999S" ) );
-        assertThat( newDuration( 0, 0, -1, 1 ).toString(), equalTo( "P0M0DT-0.999999999S" ) );
+        assertThat( newDuration( 0, 0, -1, 1 ).toString(), equalTo( "PT-0.999999999S" ) );
 
-        assertThat( new InternalIsoDuration( Period.parse( "P356D" ) ).toString(), equalTo( "P0M356DT0S" ) );
-        assertThat( new InternalIsoDuration( Duration.parse( "PT45S" ) ).toString(), equalTo( "P0M0DT45S" ) );
+        assertThat( new InternalIsoDuration( Period.parse( "P356D" ) ).toString(), equalTo( "P356D" ) );
+        assertThat( new InternalIsoDuration( Duration.parse( "PT45S" ) ).toString(), equalTo( "PT45S" ) );
 
-        assertThat( new InternalIsoDuration( 0, 14, Duration.parse( "PT16H12M" ) ).toString(), equalTo( "P0M14DT58320S" ) );
-        assertThat( new InternalIsoDuration( 5, 1, Duration.parse( "PT12H" ) ).toString(), equalTo( "P5M1DT43200S" ) );
-        assertThat( new InternalIsoDuration( 0, 17, Duration.parse( "PT2H0.111222333S" ) ).toString(), equalTo( "P0M17DT7200.111222333S" ) );
+        assertThat( new InternalIsoDuration( 0, 14, Duration.parse( "PT16H12M" ) ).toString(), equalTo( "P14DT16H12M" ) );
+        assertThat( new InternalIsoDuration( 5, 1, Duration.parse( "PT12H" ) ).toString(), equalTo( "P5M1DT12H" ) );
+        assertThat( new InternalIsoDuration( 0, 17, Duration.parse( "PT2H0.111222333S" ) ).toString(), equalTo( "P17DT2H0.111222333S" ) );
 
-        assertThat( newDuration( 42, 42, 42, 0 ).toString(), equalTo( "P42M42DT42S" ) );
-        assertThat( newDuration( 42, 42, -42, 0 ).toString(), equalTo( "P42M42DT-42S" ) );
+        assertThat( newDuration( 42, 42, 42, 0 ).toString(), equalTo( "P3Y6M42DT42S" ) );
+        assertThat( newDuration( 42, 42, -42, 0 ).toString(), equalTo( "P3Y6M42DT-42S" ) );
 
-        assertThat( newDuration( 42, 42, 0, 5 ).toString(), equalTo( "P42M42DT0.000000005S" ) );
-        assertThat( newDuration( 42, 42, 0, -5 ).toString(), equalTo( "P42M42DT-0.000000005S" ) );
+        assertThat( newDuration( 42, 42, 0, 5 ).toString(), equalTo( "P3Y6M42DT0.000000005S" ) );
+        assertThat( newDuration( 42, 42, 0, -5 ).toString(), equalTo( "P3Y6M42DT-0.000000005S" ) );
 
-        assertThat( newDuration( 42, 42, 1, 5 ).toString(), equalTo( "P42M42DT1.000000005S" ) );
-        assertThat( newDuration( 42, 42, -1, 5 ).toString(), equalTo( "P42M42DT-0.999999995S" ) );
-        assertThat( newDuration( 42, 42, 1, -5 ).toString(), equalTo( "P42M42DT0.999999995S" ) );
-        assertThat( newDuration( 42, 42, -1, -5 ).toString(), equalTo( "P42M42DT-1.000000005S" ) );
+        assertThat( newDuration( 42, 42, 1, 5 ).toString(), equalTo( "P3Y6M42DT1.000000005S" ) );
+        assertThat( newDuration( 42, 42, -1, 5 ).toString(), equalTo( "P3Y6M42DT-0.999999995S" ) );
+        assertThat( newDuration( 42, 42, 1, -5 ).toString(), equalTo( "P3Y6M42DT0.999999995S" ) );
+        assertThat( newDuration( 42, 42, -1, -5 ).toString(), equalTo( "P3Y6M42DT-1.000000005S" ) );
 
-        assertThat( newDuration( 42, 42, 28, 9 ).toString(), equalTo( "P42M42DT28.000000009S" ) );
-        assertThat( newDuration( 42, 42, -28, 9 ).toString(), equalTo( "P42M42DT-27.999999991S" ) );
-        assertThat( newDuration( 42, 42, 28, -9 ).toString(), equalTo( "P42M42DT27.999999991S" ) );
-        assertThat( newDuration( 42, 42, -28, -9 ).toString(), equalTo( "P42M42DT-28.000000009S" ) );
+        assertThat( newDuration( 42, 42, 28, 9 ).toString(), equalTo( "P3Y6M42DT28.000000009S" ) );
+        assertThat( newDuration( 42, 42, -28, 9 ).toString(), equalTo( "P3Y6M42DT-27.999999991S" ) );
+        assertThat( newDuration( 42, 42, 28, -9 ).toString(), equalTo( "P3Y6M42DT27.999999991S" ) );
+        assertThat( newDuration( 42, 42, -28, -9 ).toString(), equalTo( "P3Y6M42DT-28.000000009S" ) );
     }
 
     private static IsoDuration newDuration( long months, long days, long seconds, int nanoseconds )


### PR DESCRIPTION
The current implementation of
`InternalIsoDuration::toString` will always write out months and days even though the value is 0,
so it will write `P0M0DT0S` instead of the shorter `PT0S`. It will also favour using seconds instead
of using minutes, hours, days when possible. For example

```
RETURN duration({months:0.75}
```

would be rendered as

```
P0M22DT71509.500000000S
```
(0 months, 22 days, 71509.500000000 seconds)

instead of

```
P22DT19H51M49.5S
```
(22 days, 19 hours, 51 minutes, 49.5 seconds)

This has been reported as bugs on cypher-shell and browser and we could of course address it there
but it would be nice if not all clients would have to patch.