### PR TITLE
Add support for the version 4.0 of BoltProtocol and remove 4.2

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
@@ -24,7 +24,6 @@ import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
 import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
 import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
-import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 
 import static io.netty.buffer.Unpooled.copyInt;
@@ -43,8 +42,8 @@ public final class BoltProtocolUtil
     private static final ByteBuf HANDSHAKE_BUF = unreleasableBuffer( copyInt(
             BOLT_MAGIC_PREAMBLE,
             BoltProtocolV43.VERSION.toInt(),
-            BoltProtocolV42.VERSION.toInt(),
             BoltProtocolV41.VERSION.toInt(),
+            BoltProtocolV4.VERSION.toInt(),
             BoltProtocolV3.VERSION.toInt() ) ).asReadOnly();
 
     private static final String HANDSHAKE_STRING = createHandshakeString();

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
+import org.neo4j.driver.internal.messaging.v4.BoltProtocolV4;
 import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
@@ -43,15 +44,15 @@ class BoltProtocolUtilTest
     {
         assertByteBufContains(
                 handshakeBuf(),
-                BOLT_MAGIC_PREAMBLE, BoltProtocolV43.VERSION.toInt(), BoltProtocolV42.VERSION.toInt(),
-                BoltProtocolV41.VERSION.toInt(), BoltProtocolV3.VERSION.toInt()
+                BOLT_MAGIC_PREAMBLE, BoltProtocolV43.VERSION.toInt(), BoltProtocolV41.VERSION.toInt(),
+                BoltProtocolV4.VERSION.toInt(), BoltProtocolV3.VERSION.toInt()
         );
     }
 
     @Test
     void shouldReturnHandshakeString()
     {
-        assertEquals( "[0x6060b017, 772, 516, 260, 3]", handshakeString() );
+        assertEquals( "[0x6060b017, 772, 260, 4, 3]", handshakeString() );
     }
 
     @Test


### PR DESCRIPTION
The version 4.2 doesn't bring anything new feature for the protocol and it's compatible with 4.1 and 4.0.

Remove 4.2 in favor of 4.0 will enable the driver support multi-databases in 4.0 Neo4j Servers again.