### PR TITLE
Fix flaky CausalClusteringStressIT (#800)

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractContext.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractContext.java
@@ -65,10 +65,7 @@ public abstract class AbstractContext
     public final void readCompleted( ResultSummary summary )
     {
         readNodesCount.incrementAndGet();
-        processSummary( summary );
     }
-
-    public abstract void processSummary( ResultSummary summary );
 
     public long getReadNodesCount()
     {

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -225,8 +225,6 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
 
     abstract boolean handleWriteFailure( Throwable error, C context );
 
-    abstract void assertExpectedReadQueryDistribution( C context );
-
     abstract <A extends C> void printStats( A context );
 
     private List<Future<?>> launchBlockingWorkerThreads( C context )
@@ -437,7 +435,6 @@ abstract class AbstractStressTestBase<C extends AbstractContext>
         assertNoFileDescriptorLeak( resourcesInfo.openFileDescriptorCount );
         assertNoLoggersLeak( resourcesInfo.acquiredLoggerNames );
         assertExpectedNumberOfNodesCreated( context.getCreatedNodesCount() );
-        assertExpectedReadQueryDistribution( context );
     }
 
     private void assertNoFileDescriptorLeak( long previousOpenFileDescriptors )

--- a/driver/src/test/java/org/neo4j/driver/stress/SingleInstanceStressIT.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/SingleInstanceStressIT.java
@@ -23,17 +23,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Config;
-import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
-
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ParallelizableIT
 class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStressIT.Context>
@@ -62,7 +56,7 @@ class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStress
     @Override
     Context createContext()
     {
-        return new Context( neo4j.address().toString() );
+        return new Context();
     }
 
     @Override
@@ -79,12 +73,6 @@ class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStress
     }
 
     @Override
-    void assertExpectedReadQueryDistribution( Context context )
-    {
-        assertThat( context.getReadQueryCount(), greaterThan( 0L ) );
-    }
-
-    @Override
     <A extends Context> void printStats( A context )
     {
         System.out.println( "Nodes read: " + context.getReadNodesCount() );
@@ -95,31 +83,6 @@ class SingleInstanceStressIT extends AbstractStressTestBase<SingleInstanceStress
 
     static class Context extends AbstractContext
     {
-        final String expectedAddress;
-        final AtomicLong readQueries = new AtomicLong();
-
-        Context( String expectedAddress )
-        {
-            this.expectedAddress = expectedAddress;
-        }
-
-        @Override
-        public void processSummary( ResultSummary summary )
-        {
-            if ( summary == null )
-            {
-                return;
-            }
-
-            String address = summary.server().address();
-            assertEquals( expectedAddress, address );
-            readQueries.incrementAndGet();
-        }
-
-        long getReadQueryCount()
-        {
-            return readQueries.get();
-        }
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/util/TemporalUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TemporalUtil.java
@@ -60,8 +60,9 @@ public final class TemporalUtil
             "Africa/Casablanca",
             "tzid",
             "Asia/Qostanay",
-            "America/Santiago" // Can cause flakyness on windows, see https://stackoverflow.com/questions/37533796/java-calendar-returns-wrong-hour-in-ms-windows-for-america-santiago-zone.
-            );
+            "America/Santiago",// Can cause flakyness on windows, see https://stackoverflow.com/questions/37533796/java-calendar-returns-wrong-hour-in-ms-windows-for-america-santiago-zone.
+            "Pacific/Easter"
+    );
 
     private TemporalUtil()
     {


### PR DESCRIPTION
Fix flaky CausalClusteringStressIT by removing read distribution checks from stress tests

cherry-picked from #800 