### PR TITLE
Updating stress tests exception and session handling

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingFailingQueryWithRetries.java
@@ -41,12 +41,7 @@ public class BlockingFailingQueryWithRetries<C extends AbstractContext> extends 
         {
             Exception e = assertThrows(
                     Exception.class,
-                    () -> session.readTransaction(
-                            tx ->
-                            {
-                                tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" ).consume();
-                                return 1;
-                            } ) );
+                    () -> session.readTransaction( tx -> tx.run( "UNWIND [10, 5, 0] AS x RETURN 10 / x" ).consume() ) );
             assertThat( e, is( arithmeticError() ) );
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/BlockingReadQueryWithRetries.java
@@ -25,6 +25,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,7 +43,7 @@ public class BlockingReadQueryWithRetries<C extends AbstractContext> extends Abs
     {
         try ( Session session = newSession( AccessMode.READ, context ) )
         {
-            session.readTransaction(
+            ResultSummary resultSummary = session.readTransaction(
                     tx ->
                     {
                         Result result = tx.run( "MATCH (n) RETURN n LIMIT 1" );
@@ -54,9 +55,9 @@ public class BlockingReadQueryWithRetries<C extends AbstractContext> extends Abs
                             assertNotNull( node );
                         }
 
-                        context.readCompleted( result.consume() );
-                        return 1;
+                        return result.consume();
                     } );
+            context.readCompleted( resultSummary );
         }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/RxWriteQueryWithRetries.java
@@ -69,13 +69,7 @@ public class RxWriteQueryWithRetries<C extends AbstractContext> extends Abstract
 
     private void handleError( Throwable error, C context, CompletableFuture<Void> queryFinished )
     {
-        if ( !stressTest.handleWriteFailure( error, context ) )
-        {
-            queryFinished.completeExceptionally( error );
-        }
-        else
-        {
-            queryFinished.complete( null );
-        }
+        stressTest.handleWriteFailure( error, context );
+        queryFinished.completeExceptionally( error );
     }
 }


### PR DESCRIPTION
Exception handling is updated to expose the leader switching exceptions for managed transactions.
Async session handling is updated to close session and report problems if they arise.