### PR TITLE
DNS change fix

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.net.ServerAddress;
@@ -62,7 +61,16 @@ public class BoltServerAddress implements ServerAddress
         this( host, null, port );
     }
 
-    private BoltServerAddress( String host, InetAddress resolved, int port )
+    /**
+     * Create a new instance with the provided {@link InetAddress}.
+     * <p>
+     * This is not meant to be used externally to this class and is open for testing purposes only.
+     *
+     * @param host     the host name
+     * @param resolved the resolved {@link InetAddress}
+     * @param port     the port number
+     */
+    public BoltServerAddress( String host, InetAddress resolved, int port )
     {
         this.host = requireNonNull( host, "host" );
         this.resolved = resolved;
@@ -89,13 +97,14 @@ public class BoltServerAddress implements ServerAddress
             return false;
         }
         BoltServerAddress that = (BoltServerAddress) o;
-        return port == that.port && host.equals( that.host );
+        return port == that.port && host.equals( that.host ) &&
+               ((resolved == null && that.resolved == null) || (resolved != null && resolved.equals( that.resolved )));
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( host, port );
+        return Objects.hash( host, port, resolved );
     }
 
     @Override
@@ -152,6 +161,11 @@ public class BoltServerAddress implements ServerAddress
     public int port()
     {
         return port;
+    }
+
+    public boolean isResolved()
+    {
+        return resolved != null;
     }
 
     private static String hostFrom( URI uri )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -26,6 +27,7 @@ import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.ProtocolException;
+import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.value.ValueException;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.spi.Connection;
@@ -114,6 +116,10 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
             throw new ProtocolException( format(
                     PROTOCOL_ERROR_MESSAGE + "unparsable record received.",
                     invokedProcedureString( response ) ), e );
+        }
+        catch ( UnknownHostException e )
+        {
+            throw new ServiceUnavailableException( "Failed to resolve server addresses", e );
         }
 
         // the cluster result is not a legal reply

--- a/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/RoutingDriverBoltKitIT.java
@@ -20,7 +20,6 @@ package org.neo4j.driver.integration;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -276,7 +275,7 @@ class RoutingDriverBoltKitIT
                 tx.commit();
             }
         } );
-        assertEquals( "Server at 127.0.0.1:9005 is no longer available", e.getMessage() );
+        assertEquals( "Server at 127.0.0.1(127.0.0.1):9005 is no longer available", e.getMessage() );
         assertThat( server.exitStatus(), equalTo( 0 ) );
         assertThat( readServer.exitStatus(), equalTo( 0 ) );
     }
@@ -480,7 +479,7 @@ class RoutingDriverBoltKitIT
         catch ( SessionExpiredException e )
         {
             failed = true;
-            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1:9007 no longer accepts writes" ) );
+            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1(127.0.0.1):9007 no longer accepts writes" ) );
         }
         assertTrue( failed );
 
@@ -507,7 +506,7 @@ class RoutingDriverBoltKitIT
         catch ( SessionExpiredException e )
         {
             failed = true;
-            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1:9007 no longer accepts writes" ) );
+            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1(127.0.0.1):9007 no longer accepts writes" ) );
         }
         assertTrue( failed );
 
@@ -534,7 +533,7 @@ class RoutingDriverBoltKitIT
         catch ( SessionExpiredException e )
         {
             failed = true;
-            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1:9007 no longer accepts writes" ) );
+            assertThat( e.getMessage(), equalTo( "Server at 127.0.0.1(127.0.0.1):9007 no longer accepts writes" ) );
         }
         assertTrue( failed );
 
@@ -827,7 +826,7 @@ class RoutingDriverBoltKitIT
             assertEquals( 0, writer.exitStatus() );
         }
         verify( logger, times( 3 ) ).warn( startsWith( "Transaction failed and will be retried in" ), any( SessionExpiredException.class ) );
-        verify( logger ).warn( startsWith( "Failed to obtain a connection towards address 127.0.0.1:9004" ), any( SessionExpiredException.class ) );
+        verify( logger ).warn( startsWith( "Failed to obtain a connection towards address 127.0.0.1(127.0.0.1):9004" ), any( SessionExpiredException.class ) );
     }
 
     @Test
@@ -861,7 +860,7 @@ class RoutingDriverBoltKitIT
         }
         verify( logger, times( 1 ) ).warn( startsWith( "Transaction failed and will be retried in" ), any( TransientException.class ) );
         verify( logger, times( 2 ) ).warn( startsWith( "Transaction failed and will be retried in" ), any( SessionExpiredException.class ) );
-        verify( logger ).warn( startsWith( "Failed to obtain a connection towards address 127.0.0.1:9004" ), any( SessionExpiredException.class ) );
+        verify( logger ).warn( startsWith( "Failed to obtain a connection towards address 127.0.0.1(127.0.0.1):9004" ), any( SessionExpiredException.class ) );
     }
 
     @Test
@@ -1134,11 +1133,11 @@ class RoutingDriverBoltKitIT
 
             Result readResult1 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult1.list().size() );
-            assertEquals( "127.0.0.1:9003", readResult1.consume().server().address() );
+            assertEquals( "127.0.0.1(127.0.0.1):9003", readResult1.consume().server().address() );
 
             Result readResult2 = session.run( "MATCH (n) RETURN n.name" );
             assertEquals( 3, readResult2.list().size() );
-            assertEquals( "127.0.0.1:9004", readResult2.consume().server().address() );
+            assertEquals( "127.0.0.1(127.0.0.1):9004", readResult2.consume().server().address() );
         }
         finally
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.cluster;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -131,8 +132,8 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "READ", "one:1337", "two:1337" ),
-                serverInfo( "WRITE", "one:1337" ) ) )
+                serverInfo( "READ", "192.168.99.1:1337", "192.168.99.2:1337" ),
+                serverInfo( "WRITE", "192.168.99.1:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
@@ -156,8 +157,8 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "READ", "one:1337", "two:1337" ),
-                serverInfo( "WRITE", "one:1337" ) ) )
+                serverInfo( "READ", "192.168.99.1:1337", "192.168.99.2:1337" ),
+                serverInfo( "WRITE", "192.168.99.1:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
@@ -181,8 +182,8 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "WRITE", "one:1337" ),
-                serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
+                serverInfo( "WRITE", "192.168.99.1:1337" ),
+                serverInfo( "ROUTE", "192.168.99.1:1337", "192.168.99.2:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
@@ -206,8 +207,8 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "WRITE", "one:1337" ),
-                serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
+                serverInfo( "WRITE", "192.168.99.1:1337" ),
+                serverInfo( "ROUTE", "192.168.99.1:1337", "192.168.99.2:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) ).thenReturn( completedFuture( routingResponse ) );
@@ -238,7 +239,7 @@ class RoutingProcedureClusterCompositionProviderTest
     }
 
     @Test
-    void shouldReturnSuccessResultWhenNoError()
+    void shouldReturnSuccessResultWhenNoError() throws UnknownHostException
     {
         // Given
         Clock mockedClock = mock( Clock.class );
@@ -249,9 +250,9 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "READ", "one:1337", "two:1337" ),
-                serverInfo( "WRITE", "one:1337" ),
-                serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
+                serverInfo( "READ", "192.168.99.1:1337", "192.168.99.2:1337" ),
+                serverInfo( "WRITE", "192.168.99.1:1337" ),
+                serverInfo( "ROUTE", "192.168.99.1:1337", "192.168.99.2:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) )
@@ -263,13 +264,13 @@ class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertEquals( 12345 + 100_000, cluster.expirationTimestamp() );
-        assertEquals( serverSet( "one:1337", "two:1337" ), cluster.readers() );
-        assertEquals( serverSet( "one:1337" ), cluster.writers() );
-        assertEquals( serverSet( "one:1337", "two:1337" ), cluster.routers() );
+        assertEquals( serverSet( "192.168.99.1:1337", "192.168.99.2:1337" ), cluster.readers() );
+        assertEquals( serverSet( "192.168.99.1:1337" ), cluster.writers() );
+        assertEquals( serverSet( "192.168.99.1:1337", "192.168.99.2:1337" ), cluster.routers() );
     }
 
     @Test
-    void routeMessageRoutingProcedureShouldReturnSuccessResultWhenNoError()
+    void routeMessageRoutingProcedureShouldReturnSuccessResultWhenNoError() throws UnknownHostException
     {
         // Given
         Clock mockedClock = mock( Clock.class );
@@ -280,9 +281,9 @@ class RoutingProcedureClusterCompositionProviderTest
 
         Record record = new InternalRecord( asList( "ttl", "servers" ), new Value[]{
                 value( 100 ), value( asList(
-                serverInfo( "READ", "one:1337", "two:1337" ),
-                serverInfo( "WRITE", "one:1337" ),
-                serverInfo( "ROUTE", "one:1337", "two:1337" ) ) )
+                serverInfo( "READ", "192.168.99.1:1337", "192.168.99.2:1337" ),
+                serverInfo( "WRITE", "192.168.99.1:1337" ),
+                serverInfo( "ROUTE", "192.168.99.1:1337", "192.168.99.2:1337" ) ) )
         } );
         RoutingProcedureResponse routingResponse = newRoutingResponse( record );
         when( mockedRunner.run( eq( connection ), any( DatabaseName.class ), any( InternalBookmark.class ) ) )
@@ -294,9 +295,9 @@ class RoutingProcedureClusterCompositionProviderTest
 
         // Then
         assertEquals( 12345 + 100_000, cluster.expirationTimestamp() );
-        assertEquals( serverSet( "one:1337", "two:1337" ), cluster.readers() );
-        assertEquals( serverSet( "one:1337" ), cluster.writers() );
-        assertEquals( serverSet( "one:1337", "two:1337" ), cluster.routers() );
+        assertEquals( serverSet( "192.168.99.1:1337", "192.168.99.2:1337" ), cluster.readers() );
+        assertEquals( serverSet( "192.168.99.1:1337" ), cluster.writers() );
+        assertEquals( serverSet( "192.168.99.1:1337", "192.168.99.2:1337" ), cluster.routers() );
     }
 
     @Test
@@ -370,12 +371,12 @@ class RoutingProcedureClusterCompositionProviderTest
         return map;
     }
 
-    private static Set<BoltServerAddress> serverSet( String... addresses )
+    private static Set<BoltServerAddress> serverSet( String... addresses ) throws UnknownHostException
     {
         Set<BoltServerAddress> result = new HashSet<>();
         for ( String address : addresses )
         {
-            result.add( new BoltServerAddress( address ) );
+            result.add( new BoltServerAddress( address ).resolve() );
         }
         return result;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.util;
 
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -29,16 +30,42 @@ import org.neo4j.driver.internal.cluster.ClusterComposition;
 
 public final class ClusterCompositionUtil
 {
-    private ClusterCompositionUtil() {}
+    private ClusterCompositionUtil()
+    {
+    }
 
     public static final long NEVER_EXPIRE = System.currentTimeMillis() + TimeUnit.HOURS.toMillis( 1 );
 
-    public static final BoltServerAddress A = new BoltServerAddress( "1111:11" );
-    public static final BoltServerAddress B = new BoltServerAddress( "2222:22" );
-    public static final BoltServerAddress C = new BoltServerAddress( "3333:33" );
-    public static final BoltServerAddress D = new BoltServerAddress( "4444:44" );
-    public static final BoltServerAddress E = new BoltServerAddress( "5555:55" );
-    public static final BoltServerAddress F = new BoltServerAddress( "6666:66" );
+    public static final BoltServerAddress A = new BoltServerAddress( "192.168.99.1:11" );
+    public static final BoltServerAddress B = new BoltServerAddress( "192.168.99.2:22" );
+    public static final BoltServerAddress C = new BoltServerAddress( "192.168.99.3:33" );
+    public static final BoltServerAddress D = new BoltServerAddress( "192.168.99.4:44" );
+    public static final BoltServerAddress E = new BoltServerAddress( "192.168.99.5:55" );
+    public static final BoltServerAddress F = new BoltServerAddress( "192.168.99.6:66" );
+
+    public static BoltServerAddress A_RESOLVED;
+    public static BoltServerAddress B_RESOLVED;
+    public static BoltServerAddress C_RESOLVED;
+    public static BoltServerAddress D_RESOLVED;
+    public static BoltServerAddress E_RESOLVED;
+    public static BoltServerAddress F_RESOLVED;
+
+    static
+    {
+        try
+        {
+            A_RESOLVED = A.resolve();
+            B_RESOLVED = B.resolve();
+            C_RESOLVED = C.resolve();
+            D_RESOLVED = D.resolve();
+            E_RESOLVED = E.resolve();
+            F_RESOLVED = F.resolve();
+        }
+        catch ( UnknownHostException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
 
     public static final List<BoltServerAddress> EMPTY = new ArrayList<>();
 


### PR DESCRIPTION
This change fixes a problem when DNS name resolution changes to a different IP address and the driver fails to update its routing table. The existing connection pool implementation indexed connection pools by just hostnames and ports and ignored the resolved IP address, this update fixes it. We will also resolve the hostnames provided by the database immediately on cluster composition retrieval.