### PR TITLE
DNS change fix

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltServerAddress.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.net.ServerAddress;
@@ -152,6 +151,11 @@ public class BoltServerAddress implements ServerAddress
     public int port()
     {
         return port;
+    }
+
+    public boolean isResolved()
+    {
+        return resolved != null;
     }
 
     private static String hostFrom( URI uri )

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -268,9 +268,9 @@ public class RediscoveryImpl implements Rediscovery
     public List<BoltServerAddress> resolve()
     {
         return resolver.resolve( initialRouter )
-                .stream()
-                .flatMap( resolved -> resolveAll( BoltServerAddress.from( resolved ) ) )
-                .collect( toList() ); // collect to list to preserve the order
+                       .stream()
+                       .map( BoltServerAddress::from )
+                       .collect( toList() ); // collect to list to preserve the order
     }
 
     private Stream<BoltServerAddress> resolveAll( BoltServerAddress address )


### PR DESCRIPTION
This update fixes an issue when the driver fails to update the routing table if the router DNS entry returns a different IP address.

This PR cherry-picks the changes from: https://github.com/neo4j/neo4j-java-driver/pull/818