### PR TITLE
Fix for initial routers DNS resolution

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DefaultDomainNameResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DefaultDomainNameResolver.java
@@ -16,19 +16,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.cluster;
+package org.neo4j.driver.internal;
 
+import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.spi.ConnectionPool;
-
-public interface Rediscovery
+public class DefaultDomainNameResolver implements DomainNameResolver
 {
-    CompletionStage<ClusterCompositionLookupResult> lookupClusterComposition( RoutingTable routingTable, ConnectionPool connectionPool, Bookmark bookmark );
+    private static final DefaultDomainNameResolver INSTANCE = new DefaultDomainNameResolver();
 
-    List<BoltServerAddress> resolve() throws UnknownHostException;
+    public static DefaultDomainNameResolver getInstance()
+    {
+        return INSTANCE;
+    }
+
+    private DefaultDomainNameResolver()
+    {
+    }
+
+    @Override
+    public InetAddress[] resolve( String name ) throws UnknownHostException
+    {
+        return InetAddress.getAllByName( name );
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DomainNameResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DomainNameResolver.java
@@ -16,19 +16,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.cluster;
+package org.neo4j.driver.internal;
 
+import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.spi.ConnectionPool;
-
-public interface Rediscovery
+/**
+ * A resolver function used by the driver to resolve domain names.
+ */
+@FunctionalInterface
+public interface DomainNameResolver
 {
-    CompletionStage<ClusterCompositionLookupResult> lookupClusterComposition( RoutingTable routingTable, ConnectionPool connectionPool, Bookmark bookmark );
-
-    List<BoltServerAddress> resolve() throws UnknownHostException;
+    /**
+     * Resolve the given domain name to a set of addresses.
+     *
+     * @param name the name to resolve.
+     * @return the resolved addresses.
+     * @throws UnknownHostException must be thrown if the given name can not be resolved to at least one address.
+     */
+    InetAddress[] resolve( String name ) throws UnknownHostException;
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -127,7 +127,7 @@ public class DriverFactory
     protected ChannelConnector createConnector( ConnectionSettings settings, SecurityPlan securityPlan,
             Config config, Clock clock, RoutingContext routingContext )
     {
-        return new ChannelConnectorImpl( settings, securityPlan, config.logging(), clock, routingContext );
+        return new ChannelConnectorImpl( settings, securityPlan, config.logging(), clock, routingContext, getDomainNameResolver() );
     }
 
     private InternalDriver createDriver( URI uri, SecurityPlan securityPlan, BoltServerAddress address, ConnectionPool connectionPool,
@@ -210,7 +210,7 @@ public class DriverFactory
         LoadBalancingStrategy loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy( connectionPool, config.logging() );
         ServerAddressResolver resolver = createResolver( config );
         return new LoadBalancer( address, routingSettings, connectionPool, eventExecutorGroup, createClock(),
-                config.logging(), loadBalancingStrategy, resolver );
+                                 config.logging(), loadBalancingStrategy, resolver, getDomainNameResolver() );
     }
 
     private static ServerAddressResolver createResolver( Config config )
@@ -271,6 +271,17 @@ public class DriverFactory
         return BootstrapFactory.newBootstrap( eventLoopGroup );
     }
 
+    /**
+     * Provides an instance of {@link DomainNameResolver} that is used for domain name resolution.
+     * <p>
+     * <b>This method is protected only for testing</b>
+     *
+     * @return the instance of {@link DomainNameResolver}.
+     */
+    protected DomainNameResolver getDomainNameResolver()
+    {
+        return DefaultDomainNameResolver.getInstance();
+    }
 
     private static void assertNoRoutingContext( URI uri, RoutingSettings routingSettings )
     {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
@@ -24,21 +24,22 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.resolver.AddressResolverGroup;
 
-import java.util.Map;
+import java.net.InetSocketAddress;
 
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Logging;
+import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DomainNameResolver;
 import org.neo4j.driver.internal.async.inbound.ConnectTimeoutHandler;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
-import org.neo4j.driver.AuthToken;
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Logging;
-import org.neo4j.driver.Value;
-import org.neo4j.driver.exceptions.ClientException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,15 +53,17 @@ public class ChannelConnectorImpl implements ChannelConnector
     private final int connectTimeoutMillis;
     private final Logging logging;
     private final Clock clock;
+    private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
 
     public ChannelConnectorImpl( ConnectionSettings connectionSettings, SecurityPlan securityPlan, Logging logging,
-            Clock clock, RoutingContext routingContext )
+                                 Clock clock, RoutingContext routingContext, DomainNameResolver domainNameResolver )
     {
-        this( connectionSettings, securityPlan, new ChannelPipelineBuilderImpl(), logging, clock, routingContext );
+        this( connectionSettings, securityPlan, new ChannelPipelineBuilderImpl(), logging, clock, routingContext, domainNameResolver );
     }
 
     public ChannelConnectorImpl( ConnectionSettings connectionSettings, SecurityPlan securityPlan,
-            ChannelPipelineBuilder pipelineBuilder, Logging logging, Clock clock, RoutingContext routingContext )
+                                 ChannelPipelineBuilder pipelineBuilder, Logging logging, Clock clock, RoutingContext routingContext,
+                                 DomainNameResolver domainNameResolver )
     {
         this.userAgent = connectionSettings.userAgent();
         this.authToken = requireValidAuthToken( connectionSettings.authToken() );
@@ -70,6 +73,7 @@ public class ChannelConnectorImpl implements ChannelConnector
         this.pipelineBuilder = pipelineBuilder;
         this.logging = requireNonNull( logging );
         this.clock = requireNonNull( clock );
+        this.addressResolverGroup = new NettyDomainNameResolverGroup( requireNonNull( domainNameResolver ) );
     }
 
     @Override
@@ -77,6 +81,7 @@ public class ChannelConnectorImpl implements ChannelConnector
     {
         bootstrap.option( ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis );
         bootstrap.handler( new NettyChannelInitializer( address, securityPlan, connectTimeoutMillis, clock, logging ) );
+        bootstrap.resolver( addressResolverGroup );
 
         ChannelFuture channelConnected = bootstrap.connect( address.toSocketAddress() );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/NettyDomainNameResolver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/NettyDomainNameResolver.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.connection;
+
+import io.netty.resolver.InetNameResolver;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.driver.internal.DomainNameResolver;
+
+public class NettyDomainNameResolver extends InetNameResolver
+{
+    private final DomainNameResolver domainNameResolver;
+
+    public NettyDomainNameResolver( EventExecutor executor, DomainNameResolver domainNameResolver )
+    {
+        super( executor );
+        this.domainNameResolver = domainNameResolver;
+    }
+
+    @Override
+    protected void doResolve( String inetHost, Promise<InetAddress> promise )
+    {
+        try
+        {
+            promise.setSuccess( domainNameResolver.resolve( inetHost )[0] );
+        }
+        catch ( UnknownHostException e )
+        {
+            promise.setFailure( e );
+        }
+    }
+
+    @Override
+    protected void doResolveAll( String inetHost, Promise<List<InetAddress>> promise )
+    {
+        try
+        {
+            promise.setSuccess( Arrays.asList( domainNameResolver.resolve( inetHost ) ) );
+        }
+        catch ( UnknownHostException e )
+        {
+            promise.setFailure( e );
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/NettyDomainNameResolverGroup.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/NettyDomainNameResolverGroup.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.connection;
+
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.concurrent.EventExecutor;
+
+import java.net.InetSocketAddress;
+
+import org.neo4j.driver.internal.DomainNameResolver;
+
+public class NettyDomainNameResolverGroup extends AddressResolverGroup<InetSocketAddress>
+{
+    private final DomainNameResolver domainNameResolver;
+
+    public NettyDomainNameResolverGroup( DomainNameResolver domainNameResolver )
+    {
+        this.domainNameResolver = domainNameResolver;
+    }
+
+    @Override
+    protected AddressResolver<InetSocketAddress> newResolver( EventExecutor executor ) throws Exception
+    {
+        return new NettyDomainNameResolver( executor, domainNameResolver ).asAddressResolver();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterComposition.java
@@ -45,7 +45,9 @@ public final class ClusterComposition
         this.expirationTimestamp = expirationTimestamp;
     }
 
-    /** For testing */
+    /**
+     * For testing
+     */
     public ClusterComposition(
             long expirationTimestamp,
             Set<BoltServerAddress> readers,
@@ -83,7 +85,8 @@ public final class ClusterComposition
         return new LinkedHashSet<>( routers );
     }
 
-    public long expirationTimestamp() {
+    public long expirationTimestamp()
+    {
         return this.expirationTimestamp;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionLookupResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionLookupResult.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.cluster;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+
+public class ClusterCompositionLookupResult
+{
+    private final ClusterComposition composition;
+
+    private final Set<BoltServerAddress> resolvedInitialRouters;
+
+    public ClusterCompositionLookupResult( ClusterComposition composition )
+    {
+        this( composition, null );
+    }
+
+    public ClusterCompositionLookupResult( ClusterComposition composition, Set<BoltServerAddress> resolvedInitialRouters )
+    {
+        this.composition = composition;
+        this.resolvedInitialRouters = resolvedInitialRouters;
+    }
+
+    public ClusterComposition getClusterComposition()
+    {
+        return composition;
+    }
+
+    public Optional<Set<BoltServerAddress>> getResolvedInitialRouters()
+    {
+        return Optional.ofNullable( resolvedInitialRouters );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterRoutingTable.java
@@ -47,7 +47,7 @@ public class ClusterRoutingTable implements RoutingTable
     public ClusterRoutingTable( DatabaseName ofDatabase, Clock clock, BoltServerAddress... routingAddresses )
     {
         this( ofDatabase, clock );
-        routers.update( new LinkedHashSet<>( asList( routingAddresses ) ) );
+        routers.retainAllAndAdd( new LinkedHashSet<>( asList( routingAddresses ) ) );
     }
 
     private ClusterRoutingTable( DatabaseName ofDatabase, Clock clock )
@@ -86,9 +86,9 @@ public class ClusterRoutingTable implements RoutingTable
     public synchronized void update( ClusterComposition cluster )
     {
         expirationTimestamp = cluster.expirationTimestamp();
-        readers.update( cluster.readers() );
-        writers.update( cluster.writers() );
-        routers.update( cluster.routers() );
+        readers.retainAllAndAdd( cluster.readers() );
+        writers.retainAllAndAdd( cluster.writers() );
+        routers.retainAllAndAdd( cluster.routers() );
         preferInitialRouter = !cluster.hasWriters();
     }
 
@@ -138,6 +138,12 @@ public class ClusterRoutingTable implements RoutingTable
     public void forgetWriter( BoltServerAddress toRemove )
     {
         writers.remove( toRemove );
+    }
+
+    @Override
+    public void replaceRouterIfPresent( BoltServerAddress oldRouter, BoltServerAddress newRouter )
+    {
+        routers.replaceIfPresent( oldRouter, newRouter );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTable.java
@@ -20,8 +20,8 @@ package org.neo4j.driver.internal.cluster;
 
 import java.util.Set;
 
-import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 
 public interface RoutingTable
@@ -45,6 +45,8 @@ public interface RoutingTable
     DatabaseName database();
 
     void forgetWriter( BoltServerAddress toRemove );
+
+    void replaceRouterIfPresent( BoltServerAddress oldRouter, BoltServerAddress newRouter );
 
     boolean preferInitialRouter();
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -42,14 +42,15 @@ import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
 import org.neo4j.driver.internal.async.inbound.ConnectTimeoutHandler;
 import org.neo4j.driver.internal.cluster.RoutingContext;
-import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.security.SecurityPlan;
+import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
@@ -233,7 +234,8 @@ class ChannelConnectorImplIT
             int connectTimeoutMillis )
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, "test", connectTimeoutMillis );
-        return new ChannelConnectorImpl( settings, securityPlan, DEV_NULL_LOGGING, new FakeClock(), RoutingContext.EMPTY );
+        return new ChannelConnectorImpl( settings, securityPlan, DEV_NULL_LOGGING, new FakeClock(), RoutingContext.EMPTY,
+                                         DefaultDomainNameResolver.getInstance() );
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
@@ -147,7 +148,7 @@ class ConnectionPoolImplIT
         FakeClock clock = new FakeClock();
         ConnectionSettings connectionSettings = new ConnectionSettings( neo4j.authToken(), "test", 5000 );
         ChannelConnector connector = new ChannelConnectorImpl( connectionSettings, SecurityPlanImpl.insecure(),
-                                                               DEV_NULL_LOGGING, clock, RoutingContext.EMPTY );
+                                                               DEV_NULL_LOGGING, clock, RoutingContext.EMPTY, DefaultDomainNameResolver.getInstance() );
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
         return new ConnectionPoolImpl( connector, bootstrap, poolSettings, DEV_NULL_METRICS, DEV_NULL_LOGGING, clock, true );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
@@ -35,11 +35,12 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
 import org.neo4j.driver.internal.cluster.RoutingContext;
-import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.security.InternalAuthToken;
+import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.internal.util.ImmediateSchedulingEventExecutor;
 import org.neo4j.driver.util.DatabaseExtension;
@@ -184,7 +185,7 @@ class NettyChannelPoolIT
     {
         ConnectionSettings settings = new ConnectionSettings( authToken, "test", 5_000 );
         ChannelConnectorImpl connector = new ChannelConnectorImpl( settings, SecurityPlanImpl.insecure(), DEV_NULL_LOGGING,
-                                                                   new FakeClock(), RoutingContext.EMPTY );
+                                                                   new FakeClock(), RoutingContext.EMPTY, DefaultDomainNameResolver.getInstance() );
         return new NettyChannelPool( neo4j.address(), connector, bootstrap, poolHandler, ChannelHealthChecker.ACTIVE,
                 1_000, maxConnections );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/AddressSetTest.java
@@ -37,7 +37,7 @@ class AddressSetTest
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
 
         AddressSet set = new AddressSet();
-        set.update( servers );
+        set.retainAllAndAdd( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -46,7 +46,7 @@ class AddressSetTest
 
         // when
         servers.add( new BoltServerAddress( "fyr" ) );
-        set.update( servers );
+        set.retainAllAndAdd( servers );
 
         // then
         assertArrayEquals( new BoltServerAddress[]{
@@ -62,7 +62,7 @@ class AddressSetTest
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
         AddressSet set = new AddressSet();
-        set.update( servers );
+        set.retainAllAndAdd( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -84,7 +84,7 @@ class AddressSetTest
         // given
         Set<BoltServerAddress> servers = addresses( "one", "two", "tre" );
         AddressSet set = new AddressSet();
-        set.update( servers );
+        set.retainAllAndAdd( servers );
 
         assertArrayEquals( new BoltServerAddress[]{
                 new BoltServerAddress( "one" ),
@@ -93,7 +93,7 @@ class AddressSetTest
 
         // when
         servers.remove( new BoltServerAddress( "one" ) );
-        set.update( servers );
+        set.retainAllAndAdd( servers );
 
         // then
         assertArrayEquals( new BoltServerAddress[]{
@@ -115,7 +115,7 @@ class AddressSetTest
     void shouldExposeCorrectArray()
     {
         AddressSet addressSet = new AddressSet();
-        addressSet.update( addresses( "one", "two", "tre" ) );
+        addressSet.retainAllAndAdd( addresses( "one", "two", "tre" ) );
 
         BoltServerAddress[] addresses = addressSet.toArray();
 
@@ -137,7 +137,7 @@ class AddressSetTest
     void shouldHaveCorrectSize()
     {
         AddressSet addressSet = new AddressSet();
-        addressSet.update( addresses( "one", "two" ) );
+        addressSet.retainAllAndAdd( addresses( "one", "two" ) );
 
         assertEquals( 2, addressSet.size() );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -417,7 +417,7 @@ class RediscoveryTest
     }
 
     @Test
-    void shouldNotResolveToIPs() throws UnknownHostException
+    void shouldResolveToIP() throws UnknownHostException
     {
         ServerAddressResolver resolver = resolverMock( A, A );
         DomainNameResolver domainNameResolver = mock( DomainNameResolver.class );

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
@@ -111,7 +111,7 @@ class RoutingTableHandlerTest
         ClusterComposition clusterComposition = new ClusterComposition( 42, readers, writers, routers );
         Rediscovery rediscovery = mock( RediscoveryImpl.class );
         when( rediscovery.lookupClusterComposition( eq( routingTable ), eq( connectionPool ), any() ) )
-                .thenReturn( completedFuture( clusterComposition ) );
+                .thenReturn( completedFuture( new ClusterCompositionLookupResult( clusterComposition ) ) );
 
         RoutingTableHandler handler = newRoutingTableHandler( routingTable, rediscovery, connectionPool );
 
@@ -158,7 +158,7 @@ class RoutingTableHandlerTest
 
         Rediscovery rediscovery = newRediscoveryMock();
         when( rediscovery.lookupClusterComposition( any(), any(), any() ) ).thenReturn( completedFuture(
-                new ClusterComposition( 42, asOrderedSet( A, B ), asOrderedSet( B, C ), asOrderedSet( A, C ) ) ) );
+                new ClusterCompositionLookupResult( new ClusterComposition( 42, asOrderedSet( A, B ), asOrderedSet( B, C ), asOrderedSet( A, C ) ) ) ) );
 
         RoutingTableRegistry registry = new RoutingTableRegistry()
         {
@@ -253,7 +253,7 @@ class RoutingTableHandlerTest
         when( routingTable.isStaleFor( mode ) ).thenReturn( true );
 
         AddressSet addresses = new AddressSet();
-        addresses.update( new HashSet<>( singletonList( LOCAL_DEFAULT ) ) );
+        addresses.retainAllAndAdd( new HashSet<>( singletonList( LOCAL_DEFAULT ) ) );
         when( routingTable.readers() ).thenReturn( addresses );
         when( routingTable.writers() ).thenReturn( addresses );
         when( routingTable.database() ).thenReturn( defaultDatabase() );
@@ -272,7 +272,7 @@ class RoutingTableHandlerTest
         Set<BoltServerAddress> noServers = Collections.emptySet();
         ClusterComposition clusterComposition = new ClusterComposition( 1, noServers, noServers, noServers );
         when( rediscovery.lookupClusterComposition( any( RoutingTable.class ), any( ConnectionPool.class ), any( InternalBookmark.class ) ) )
-                .thenReturn( completedFuture( clusterComposition ) );
+                .thenReturn( completedFuture( new ClusterCompositionLookupResult( clusterComposition ) ) );
         return rediscovery;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -414,7 +414,7 @@ class LoadBalancerTest
         when( routingTables.ensureRoutingTable( any( ConnectionContext.class ) ) ).thenReturn( CompletableFuture.completedFuture( handler ) );
         Rediscovery rediscovery = mock( Rediscovery.class );
         return new LoadBalancer( connectionPool, routingTables, rediscovery, new LeastConnectedLoadBalancingStrategy( connectionPool, DEV_NULL_LOGGING ),
-                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGER );
+                                 GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGER );
     }
 
     private static LoadBalancer newLoadBalancer( ConnectionPool connectionPool, Rediscovery rediscovery )
@@ -428,6 +428,6 @@ class LoadBalancerTest
     {
         // Used only in testing
         return new LoadBalancer( connectionPool, routingTables, rediscovery, new LeastConnectedLoadBalancingStrategy( connectionPool, DEV_NULL_LOGGING ),
-                GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGER );
+                                 GlobalEventExecutor.INSTANCE, DEV_NULL_LOGGER );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -22,20 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 import java.net.URI;
-import java.util.List;
 
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.net.ServerAddress;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -147,57 +138,9 @@ class BoltServerAddressTest
     }
 
     @Test
-    void shouldResolveDNSToIPs() throws Exception
-    {
-        BoltServerAddress address = new BoltServerAddress( "google.com", 80 );
-        List<BoltServerAddress> resolved = address.resolveAll();
-        assertThat( resolved, hasSize( greaterThanOrEqualTo( 1 ) ) );
-        assertThat( resolved, everyItem( equalTo( address ) ) );
-    }
-
-    @Test
-    void shouldResolveLocalhostIPDNSToIPs() throws Exception
-    {
-        BoltServerAddress address = new BoltServerAddress( "127.0.0.1", 80 );
-        List<BoltServerAddress> resolved = address.resolveAll();
-        assertThat( resolved, hasSize( 1 ) );
-        assertThat( resolved, everyItem( equalTo( address ) ) );
-    }
-
-    @Test
-    void shouldResolveLocalhostDNSToIPs() throws Exception
-    {
-        BoltServerAddress address = new BoltServerAddress( "localhost", 80 );
-        List<BoltServerAddress> resolved = address.resolveAll();
-        assertThat( resolved, hasSize( greaterThanOrEqualTo( 1 ) ) );
-        assertThat( resolved, everyItem( equalTo( address ) ) );
-    }
-
-    @Test
-    void shouldResolveIPv6LocalhostDNSToIPs() throws Exception
-    {
-        BoltServerAddress address = new BoltServerAddress( "[::1]", 80 );
-        List<BoltServerAddress> resolved = address.resolveAll();
-        assertThat( resolved, hasSize( greaterThanOrEqualTo( 1 ) ) );
-        assertThat( resolved, everyItem( equalTo( address ) ) );
-    }
-
-    @Test
     void shouldIncludeHostAndPortInToString()
     {
         BoltServerAddress address = new BoltServerAddress( "localhost", 8081 );
         assertThat( address.toString(), equalTo( "localhost:8081" ) );
-    }
-
-    @Test
-    void shouldIncludeHostResolvedIPAndPortInToStringWhenResolved() throws Exception
-    {
-        BoltServerAddress address = new BoltServerAddress( "localhost", 8081 );
-        BoltServerAddress resolved = address.resolve();
-
-        assertThat( resolved.toString(), not( equalTo( "localhost:8081" ) ) );
-        assertThat( resolved.toString(), anyOf( containsString( "(127.0.0.1)" ), containsString( "(::1)" ) ) );
-        assertThat( resolved.toString(), startsWith( "localhost" ) );
-        assertThat( resolved.toString(), endsWith( "8081" ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ClusterCompositionUtil.java
@@ -29,16 +29,18 @@ import org.neo4j.driver.internal.cluster.ClusterComposition;
 
 public final class ClusterCompositionUtil
 {
-    private ClusterCompositionUtil() {}
+    private ClusterCompositionUtil()
+    {
+    }
 
     public static final long NEVER_EXPIRE = System.currentTimeMillis() + TimeUnit.HOURS.toMillis( 1 );
 
-    public static final BoltServerAddress A = new BoltServerAddress( "1111:11" );
-    public static final BoltServerAddress B = new BoltServerAddress( "2222:22" );
-    public static final BoltServerAddress C = new BoltServerAddress( "3333:33" );
-    public static final BoltServerAddress D = new BoltServerAddress( "4444:44" );
-    public static final BoltServerAddress E = new BoltServerAddress( "5555:55" );
-    public static final BoltServerAddress F = new BoltServerAddress( "6666:66" );
+    public static final BoltServerAddress A = new BoltServerAddress( "192.168.100.100:11" );
+    public static final BoltServerAddress B = new BoltServerAddress( "192.168.100.101:22" );
+    public static final BoltServerAddress C = new BoltServerAddress( "192.168.100.102:33" );
+    public static final BoltServerAddress D = new BoltServerAddress( "192.168.100.103:44" );
+    public static final BoltServerAddress E = new BoltServerAddress( "192.168.100.104:55" );
+    public static final BoltServerAddress F = new BoltServerAddress( "192.168.100.105:66" );
 
     public static final List<BoltServerAddress> EMPTY = new ArrayList<>();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
@@ -28,7 +28,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
@@ -39,8 +42,6 @@ import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.security.SecurityPlan;
-import org.neo4j.driver.Config;
-import org.neo4j.driver.Logging;
 
 public class MessageRecordingDriverFactory extends DriverFactory
 {
@@ -56,7 +57,8 @@ public class MessageRecordingDriverFactory extends DriverFactory
                                                 RoutingContext routingContext )
     {
         ChannelPipelineBuilder pipelineBuilder = new MessageRecordingChannelPipelineBuilder();
-        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext );
+        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext,
+                                         DefaultDomainNameResolver.getInstance() );
     }
 
     private class MessageRecordingChannelPipelineBuilder extends ChannelPipelineBuilderImpl

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
@@ -18,14 +18,15 @@
  */
 package org.neo4j.driver.internal.util.io;
 
+import org.neo4j.driver.Config;
 import org.neo4j.driver.internal.ConnectionSettings;
+import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.FailingMessageFormat;
-import org.neo4j.driver.Config;
 
 public class ChannelTrackingDriverFactoryWithFailingMessageFormat extends ChannelTrackingDriverFactory
 {
@@ -40,7 +41,8 @@ public class ChannelTrackingDriverFactoryWithFailingMessageFormat extends Channe
     protected ChannelConnector createRealConnector( ConnectionSettings settings, SecurityPlan securityPlan,
                                                     Config config, Clock clock, RoutingContext routingContext )
     {
-        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext );
+        return new ChannelConnectorImpl( settings, securityPlan, pipelineBuilder, config.logging(), clock, routingContext,
+                                         DefaultDomainNameResolver.getInstance() );
     }
 
     public FailingMessageFormat getFailingMessageFormat()

--- a/driver/src/test/java/org/neo4j/driver/util/cc/Cluster.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/Cluster.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.util.cc;
 
 import java.io.FileNotFoundException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -29,10 +30,10 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.util.TestUtil;
 import org.neo4j.driver.util.cc.ClusterMemberRoleDiscoveryFactory.ClusterMemberRoleDiscovery;
 
@@ -400,7 +401,7 @@ public class Cluster implements AutoCloseable
     {
         try
         {
-            return new BoltServerAddress( uri ).resolve();
+            return new BoltServerAddress( InetAddress.getByName( uri.getHost() ).getHostAddress(), uri.getPort() );
         }
         catch ( UnknownHostException e )
         {

--- a/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMember.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMember.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.util.cc;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -111,7 +112,7 @@ public class ClusterMember
     {
         try
         {
-            return new BoltServerAddress( uri ).resolve();
+            return new BoltServerAddress( InetAddress.getByName( uri.getHost() ).getHostAddress(), uri.getPort() );
         }
         catch ( UnknownHostException e )
         {

--- a/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMemberRoleDiscoveryFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/ClusterMemberRoleDiscoveryFactory.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.util.cc;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.HashMap;
@@ -27,14 +28,14 @@ import java.util.Map;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.Session;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.util.ServerVersion;
 
-import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.SessionConfig.builder;
+import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.internal.util.Iterables.single;
 
 public class ClusterMemberRoleDiscoveryFactory
@@ -145,7 +146,7 @@ public class ClusterMemberRoleDiscoveryFactory
     {
         try
         {
-            return new BoltServerAddress( uri ).resolve();
+            return new BoltServerAddress( InetAddress.getByName( uri.getHost() ).getHostAddress(), uri.getPort() );
         }
         catch ( UnknownHostException e )
         {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
@@ -21,6 +21,7 @@ package neo4j.org.testkit.backend;
 import lombok.Getter;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 
+import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +46,7 @@ public class TestkitState
     private final Consumer<TestkitResponse> responseWriter;
     private final Supplier<Boolean> processor;
     private final Map<String,Set<ServerAddress>> idToServerAddresses = new HashMap<>();
+    private final Map<String,InetAddress[]> idToResolvedAddresses = new HashMap<>();
 
     public TestkitState( Consumer<TestkitResponse> responseWriter, Supplier<Boolean> processor )
     {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DomainNameResolutionCompleted.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DomainNameResolutionCompleted.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.requests;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class DomainNameResolutionCompleted implements TestkitRequest
+{
+    private DomainNameResolutionCompletedBody data;
+
+    @Override
+    public TestkitResponse process( TestkitState testkitState )
+    {
+        testkitState.getIdToResolvedAddresses().put(
+                data.getRequestId(),
+                data.getAddresses()
+                    .stream()
+                    .map(
+                            addr ->
+                            {
+                                try
+                                {
+                                    return InetAddress.getByName( addr );
+                                }
+                                catch ( UnknownHostException e )
+                                {
+                                    throw new RuntimeException( e );
+                                }
+                            } )
+                    .toArray( InetAddress[]::new ) );
+        return null;
+    }
+
+    @Setter
+    @Getter
+    @NoArgsConstructor
+    private static class DomainNameResolutionCompletedBody
+    {
+        private String requestId;
+        private List<String> addresses;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -33,7 +33,8 @@ import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
         @JsonSubTypes.Type( TransactionRun.class ), @JsonSubTypes.Type( RetryablePositive.class ),
         @JsonSubTypes.Type( SessionBeginTransaction.class ), @JsonSubTypes.Type( TransactionCommit.class ),
         @JsonSubTypes.Type( SessionLastBookmarks.class ), @JsonSubTypes.Type( SessionWriteTransaction.class ),
-        @JsonSubTypes.Type( ResolverResolutionCompleted.class ), @JsonSubTypes.Type( CheckMultiDBSupport.class )
+        @JsonSubTypes.Type( ResolverResolutionCompleted.class ), @JsonSubTypes.Type( CheckMultiDBSupport.class ),
+        @JsonSubTypes.Type( DomainNameResolutionCompleted.class )
 } )
 public interface TestkitRequest
 {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/DomainNameResolutionRequired.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/DomainNameResolutionRequired.java
@@ -16,19 +16,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.cluster;
+package neo4j.org.testkit.backend.messages.responses;
 
-import java.net.UnknownHostException;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
-import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.spi.ConnectionPool;
-
-public interface Rediscovery
+@Setter
+@Getter
+@Builder
+public class DomainNameResolutionRequired implements TestkitResponse
 {
-    CompletionStage<ClusterCompositionLookupResult> lookupClusterComposition( RoutingTable routingTable, ConnectionPool connectionPool, Bookmark bookmark );
+    private DomainNameResolutionRequiredBody data;
 
-    List<BoltServerAddress> resolve() throws UnknownHostException;
+    @Override
+    public String testkitName()
+    {
+        return "DomainNameResolutionRequired";
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class DomainNameResolutionRequiredBody
+    {
+        private String id;
+
+        private String name;
+    }
 }


### PR DESCRIPTION
Fix for initial routers DNS resolution

This update fixes the following issue: https://github.com/neo4j/neo4j-java-driver/issues/833

The desired behaviour for getting a routing table from the initial router (either on bootstrap or when all known routers have failed) is:
- resolve the domain name to all IPs
- attempt getting a routing table from all of them until first one succeeds by:
  - getting a connection
  - trying to get a successful routing table response

Prior to this change, the connection pools were created for host and port pairs. When domain name of the host resolves to multiple IP addresses, such pools provide connections to those IPs as a group. While this works for readers and writers, it negatively impacts the routing table fetching process as there is no guarantee which IP address the provided connection is setup for.

This update delivers the following changes:
- connection pools for routers are IP address based, which allows for deterministic connection retrieval
- the resolved IP address set is kept up-to-date (in case known router IPs change) to make sure that the unused connection pools are flushed
- the domain name resolution logic has been made configurable (it is private at the moment and is used to facilitate testing)
- the testkit backend has been updated to support the domain name resolution configuration (a new test has been added to testkit to cover the issue described above)
- the testkit backend has been updated to support connection timeout driver configuration
- several tests have been updated to adopt the new changes