### PR TITLE
Fixed SSL handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/ResolvedBoltServerAddress.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/ResolvedBoltServerAddress.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * An explicitly resolved version of {@link BoltServerAddress} that always contains one or more resolved IP addresses.
+ */
+public class ResolvedBoltServerAddress extends BoltServerAddress
+{
+    private static final String HOST_ADDRESSES_FORMAT = "%s%s:%d";
+    private static final int MAX_HOST_ADDRESSES_IN_STRING_VALUE = 5;
+    private static final String HOST_ADDRESS_DELIMITER = ",";
+    private static final String HOST_ADDRESSES_PREFIX = "(";
+    private static final String HOST_ADDRESSES_SUFFIX = ")";
+    private static final String TRIMMED_HOST_ADDRESSES_SUFFIX = ",..." + HOST_ADDRESSES_SUFFIX;
+
+    private final Set<InetAddress> resolvedAddresses;
+    private final String stringValue;
+
+    public ResolvedBoltServerAddress( String host, int port, InetAddress[] resolvedAddressesArr )
+    {
+        super( host, port );
+        requireNonNull( resolvedAddressesArr, "resolvedAddressesArr" );
+        if ( resolvedAddressesArr.length == 0 )
+        {
+            throw new IllegalArgumentException(
+                    "The resolvedAddressesArr must not be empty, check your DomainNameResolver is compliant with the interface contract" );
+        }
+        resolvedAddresses = Collections.unmodifiableSet( new LinkedHashSet<>( Arrays.asList( resolvedAddressesArr ) ) );
+        stringValue = createStringRepresentation();
+    }
+
+    /**
+     * Create a stream of unicast addresses.
+     * <p>
+     * The stream is created from the list of resolved IP addresses. Each unicast address is given a unique IP address as the connectionHost value.
+     *
+     * @return stream of unicast addresses.
+     */
+    @Override
+    public Stream<BoltServerAddress> unicastStream()
+    {
+        return resolvedAddresses.stream().map( address -> new BoltServerAddress( host, address.getHostAddress(), port ) );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        if ( !super.equals( o ) )
+        {
+            return false;
+        }
+        ResolvedBoltServerAddress that = (ResolvedBoltServerAddress) o;
+        return resolvedAddresses.equals( that.resolvedAddresses );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( super.hashCode(), resolvedAddresses );
+    }
+
+    @Override
+    public String toString()
+    {
+        return stringValue;
+    }
+
+    private String createStringRepresentation()
+    {
+        String hostAddresses = resolvedAddresses.stream()
+                                                .limit( MAX_HOST_ADDRESSES_IN_STRING_VALUE )
+                                                .map( InetAddress::getHostAddress )
+                                                .collect( joining( HOST_ADDRESS_DELIMITER, HOST_ADDRESSES_PREFIX,
+                                                                   resolvedAddresses.size() > MAX_HOST_ADDRESSES_IN_STRING_VALUE
+                                                                   ? TRIMMED_HOST_ADDRESSES_SUFFIX
+                                                                   : HOST_ADDRESSES_SUFFIX ) );
+        return String.format( HOST_ADDRESSES_FORMAT, host, hostAddresses, port );
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/ClusterCompositionTest.java
@@ -27,10 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.InternalRecord;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.contains;
@@ -38,13 +38,13 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.neo4j.driver.Values.value;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.A;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.B;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.C;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.D;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.E;
 import static org.neo4j.driver.internal.util.ClusterCompositionUtil.F;
-import static org.neo4j.driver.Values.value;
 
 class ClusterCompositionTest
 {
@@ -150,8 +150,8 @@ class ClusterCompositionTest
         Value[] values = {
                 value( 42L ),
                 value( asList( serversEntry( "READ", A, B ),
-                        serversEntry( "WRITE", C, D ),
-                        serversEntry( "ROUTE", E, F ) ) )
+                               serversEntry( "WRITE", C, D ),
+                               serversEntry( "ROUTE", E, F ) ) )
         };
         Record record = new InternalRecord( asList( "ttl", "servers" ), values );
 
@@ -171,8 +171,8 @@ class ClusterCompositionTest
         Value[] values = {
                 value( 42L ),
                 value( asList( serversEntry( "READ", A, C, E, B, F, D ),
-                        serversEntry( "WRITE" ),
-                        serversEntry( "ROUTE" ) ) )
+                               serversEntry( "WRITE" ),
+                               serversEntry( "ROUTE" ) ) )
         };
         Record record = new InternalRecord( asList( "ttl", "servers" ), values );
 
@@ -189,8 +189,8 @@ class ClusterCompositionTest
         Value[] values = {
                 value( 42L ),
                 value( asList( serversEntry( "READ" ),
-                        serversEntry( "WRITE", C, F, D, A, B, E ),
-                        serversEntry( "ROUTE" ) ) )
+                               serversEntry( "WRITE", C, F, D, A, B, E ),
+                               serversEntry( "ROUTE" ) ) )
         };
         Record record = new InternalRecord( asList( "ttl", "servers" ), values );
 
@@ -207,8 +207,8 @@ class ClusterCompositionTest
         Value[] values = {
                 value( 42L ),
                 value( asList( serversEntry( "READ" ),
-                        serversEntry( "WRITE" ),
-                        serversEntry( "ROUTE", F, D, A, B, C, E ) ) )
+                               serversEntry( "WRITE" ),
+                               serversEntry( "ROUTE", F, D, A, B, C, E ) ) )
         };
         Record record = new InternalRecord( asList( "ttl", "servers" ), values );
 
@@ -220,7 +220,7 @@ class ClusterCompositionTest
     }
 
     private static ClusterComposition newComposition( long expirationTimestamp, Set<BoltServerAddress> readers,
-            Set<BoltServerAddress> writers, Set<BoltServerAddress> routers )
+                                                      Set<BoltServerAddress> writers, Set<BoltServerAddress> routers )
     {
         return new ClusterComposition( expirationTimestamp, readers, writers, routers );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -430,7 +430,7 @@ class RediscoveryTest
         verify( resolver, times( 1 ) ).resolve( A );
         verify( domainNameResolver, times( 1 ) ).resolve( A.host() );
         assertEquals( 1, addresses.size() );
-        assertEquals( addresses.get( 0 ), new BoltServerAddress( localhost.getHostAddress(), A.port() ) );
+        assertEquals( new BoltServerAddress( A.host(), localhost.getHostAddress(), A.port() ), addresses.get( 0 ) );
     }
 
     private Rediscovery newRediscovery( BoltServerAddress initialRouter, ClusterCompositionProvider compositionProvider,

--- a/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/net/BoltServerAddressTest.java
@@ -20,7 +20,6 @@ package org.neo4j.driver.internal.net;
 
 import org.junit.jupiter.api.Test;
 
-import java.net.SocketAddress;
 import java.net.URI;
 
 import org.neo4j.driver.internal.BoltServerAddress;
@@ -29,7 +28,6 @@ import org.neo4j.driver.net.ServerAddress;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -48,17 +46,6 @@ class BoltServerAddressTest
     void portShouldUseDefaultIfNotSupplied()
     {
         assertThat( new BoltServerAddress( "localhost" ).port(), equalTo( BoltServerAddress.DEFAULT_PORT ) );
-    }
-
-    @Test
-    void shouldAlwaysResolveAddress()
-    {
-        BoltServerAddress boltAddress = new BoltServerAddress( "localhost" );
-
-        SocketAddress socketAddress1 = boltAddress.toSocketAddress();
-        SocketAddress socketAddress2 = boltAddress.toSocketAddress();
-
-        assertNotSame( socketAddress1, socketAddress2 );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jRunner.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.util;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.StandardSocketOptions;
 import java.net.URI;
 import java.nio.channels.SocketChannel;
@@ -286,7 +287,8 @@ public class Neo4jRunner
         {
             SocketChannel soChannel = SocketChannel.open();
             soChannel.setOption( StandardSocketOptions.SO_REUSEADDR, true );
-            soChannel.connect( boltAddress().toSocketAddress() );
+            BoltServerAddress address = boltAddress();
+            soChannel.connect( new InetSocketAddress( address.connectionHost(), address.port() ) );
             soChannel.close();
             return ServerStatus.ONLINE;
         }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -39,9 +39,10 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.DomainNameResolver;
 import org.neo4j.driver.internal.DriverFactory;
+import org.neo4j.driver.internal.SecuritySettings;
 import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.retry.RetrySettings;
-import org.neo4j.driver.internal.security.SecurityPlanImpl;
+import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.net.ServerAddressResolver;
 
 @Setter
@@ -93,7 +94,7 @@ public class NewDriver implements TestkitRequest
             ResolverResolutionRequired.ResolverResolutionRequiredBody body =
                     ResolverResolutionRequired.ResolverResolutionRequiredBody.builder()
                                                                              .id( callbackId )
-                                                                             .address( address.toString() )
+                                                                             .address( String.format( "%s:%d", address.host(), address.port() ) )
                                                                              .build();
             ResolverResolutionRequired response =
                     ResolverResolutionRequired.builder()
@@ -129,8 +130,11 @@ public class NewDriver implements TestkitRequest
     {
         RoutingSettings routingSettings = RoutingSettings.DEFAULT;
         RetrySettings retrySettings = RetrySettings.DEFAULT;
+        SecuritySettings.SecuritySettingsBuilder securitySettingsBuilder = new SecuritySettings.SecuritySettingsBuilder();
+        SecuritySettings securitySettings = securitySettingsBuilder.build();
+        SecurityPlan securityPlan = securitySettings.createSecurityPlan( uri.getScheme() );
         return new DriverFactoryWithDomainNameResolver( domainNameResolver )
-                .newInstance( uri, authToken, routingSettings, retrySettings, config, SecurityPlanImpl.insecure() );
+                .newInstance( uri, authToken, routingSettings, retrySettings, config, securityPlan );
     }
 
     @Setter


### PR DESCRIPTION
This update fixes a number of SSL-related tests in testkit and CausalClusteringIT.shouldDropBrokenOldConnections test.
The connection pooling strategy has been updated to use the same connection pool when the connection host is unambiguous.
Removed hardcoded domain name resolution from the BoltServerAddress and moved the logic to ChannelConnectorImpl that uses the DomainNameResolver.