### PR TITLE
Include bookmarks in the ROUTE message.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunner.java
@@ -71,7 +71,7 @@ public class RouteMessageRoutingProcedureRunner implements RoutingProcedureRunne
         CompletableFuture<Map<String,Value>> completableFuture = createCompletableFuture.get();
 
         DirectConnection directConnection = toDirectConnection( connection, databaseName );
-        directConnection.writeAndFlush( new RouteMessage( routingContext, databaseName.databaseName().orElse( null ) ),
+        directConnection.writeAndFlush( new RouteMessage( routingContext, bookmark, databaseName.databaseName().orElse( null ) ),
                                         new RouteMessageResponseHandler( completableFuture ) );
         return completableFuture
                 .thenApply( routingTable -> new RoutingProcedureResponse( getQuery( databaseName ), singletonList( toRecord( routingTable ) ) ) )

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RouteMessageEncoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RouteMessageEncoder.java
@@ -19,12 +19,14 @@
 package org.neo4j.driver.internal.messaging.encode;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageEncoder;
 import org.neo4j.driver.internal.messaging.ValuePacker;
 import org.neo4j.driver.internal.messaging.request.RouteMessage;
 
+import static org.neo4j.driver.Values.value;
 import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
 
 /**
@@ -37,8 +39,9 @@ public class RouteMessageEncoder implements MessageEncoder
     {
         checkArgument( message, RouteMessage.class );
         RouteMessage routeMessage = (RouteMessage) message;
-        packer.packStructHeader( 2, message.signature() );
+        packer.packStructHeader( 3, message.signature() );
         packer.pack( routeMessage.getRoutingContext() );
+        packer.pack( routeMessage.getBookmark() != null ? value( routeMessage.getBookmark().values() ) : value( Collections.emptyList() ) );
         packer.pack( routeMessage.getDatabaseName() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RouteMessageEncoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/RouteMessageEncoder.java
@@ -41,7 +41,7 @@ public class RouteMessageEncoder implements MessageEncoder
         RouteMessage routeMessage = (RouteMessage) message;
         packer.packStructHeader( 3, message.signature() );
         packer.pack( routeMessage.getRoutingContext() );
-        packer.pack( routeMessage.getBookmark() != null ? value( routeMessage.getBookmark().values() ) : value( Collections.emptyList() ) );
+        packer.pack( routeMessage.getBookmark().isPresent() ? value( routeMessage.getBookmark().get().values() ) : value( Collections.emptyList() ) );
         packer.pack( routeMessage.getDatabaseName() );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RouteMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RouteMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging.request;
 import java.util.Map;
 import java.util.Objects;
 
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.messaging.Message;
 
@@ -36,23 +37,31 @@ public class RouteMessage implements Message
 {
     public final static byte SIGNATURE = 0x66;
     private final Map<String,Value> routingContext;
+    private final Bookmark bookmark;
     private final String databaseName;
 
     /**
      * Constructor
      *
      * @param routingContext The routing context used to define the routing table. Multi-datacenter deployments is one of its use cases.
+     * @param bookmark      The bookmark used when getting the routing table.
      * @param databaseName   The name of the database to get the routing table for.
      */
-    public RouteMessage( Map<String,Value> routingContext, String databaseName )
+    public RouteMessage( Map<String,Value> routingContext, Bookmark bookmark, String databaseName )
     {
         this.routingContext = unmodifiableMap( routingContext );
+        this.bookmark = bookmark;
         this.databaseName = databaseName;
     }
 
     public Map<String,Value> getRoutingContext()
     {
         return routingContext;
+    }
+
+    public Bookmark getBookmark()
+    {
+        return bookmark;
     }
 
     public String getDatabaseName()
@@ -69,7 +78,7 @@ public class RouteMessage implements Message
     @Override
     public String toString()
     {
-        return String.format( "ROUTE %s %s", routingContext, databaseName );
+        return String.format( "ROUTE %s %s %s", routingContext, bookmark, databaseName );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RouteMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RouteMessage.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.messaging.request;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Value;
@@ -59,9 +60,9 @@ public class RouteMessage implements Message
         return routingContext;
     }
 
-    public Bookmark getBookmark()
+    public Optional<Bookmark> getBookmark()
     {
-        return bookmark;
+        return Optional.ofNullable( bookmark );
     }
 
     public String getDatabaseName()

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -147,6 +147,6 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase
     {
         Map<String,Value> routeContext = new HashMap<>();
         routeContext.put( "someContext", Values.value( 124 ) );
-        return new RouteMessage( routeContext, "dbName" );
+        return new RouteMessage( routeContext, InternalBookmark.empty(), "dbName" );
     }
 }


### PR DESCRIPTION
Adding bookmarks to ROUTE message

The new format is: `ROUTE {routingContext} [listOfBookmarks] dbname`
 where (in order of occurrence):
- `routingContext` provided by the driver.
- A list of bookmarks. If none are provided then an empty list should be supplied.
- the `dbname` of the database for which a new routing table is being requested. This is a string value and can be replaced with `null` to return the default database's routing table.