### PR TITLE
Deprecated and replaced ServerInfo.version()

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -1,3 +1,22 @@
 <differences>
-<!--4.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 4.0.0-->
+    <!--4.0 drivers is not API compatible with 1.0 drivers, as a result we reset API differences from 4.0.0-->
+
+    <difference>
+        <className>org/neo4j/driver/summary/ServerInfo</className>
+        <differenceType>7007</differenceType>
+        <method>java.lang.String version()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/ServerInfo</className>
+        <differenceType>7012</differenceType>
+        <method>java.lang.String protocolVersion()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/ServerInfo</className>
+        <differenceType>7012</differenceType>
+        <method>java.lang.String agent()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
@@ -54,6 +54,7 @@ public class NetworkConnection implements Connection
 {
     private final Channel channel;
     private final InboundMessageDispatcher messageDispatcher;
+    private final String serverAgent;
     private final BoltServerAddress serverAddress;
     private final ServerVersion serverVersion;
     private final BoltProtocol protocol;
@@ -69,6 +70,7 @@ public class NetworkConnection implements Connection
     {
         this.channel = channel;
         this.messageDispatcher = ChannelAttributes.messageDispatcher( channel );
+        this.serverAgent = ChannelAttributes.serverAgent( channel );
         this.serverAddress = ChannelAttributes.serverAddress( channel );
         this.serverVersion = ChannelAttributes.serverVersion( channel );
         this.protocol = BoltProtocol.forChannel( channel );
@@ -183,6 +185,12 @@ public class NetworkConnection implements Connection
             releaseFuture.complete( null );
             metricsListener.afterConnectionReleased( poolId( this.channel ), this.inUseEvent );
         }
+    }
+
+    @Override
+    public String serverAgent()
+    {
+        return serverAgent;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
@@ -33,6 +33,7 @@ public final class ChannelAttributes
     private static final AttributeKey<String> CONNECTION_ID = newInstance( "connectionId" );
     private static final AttributeKey<String> POOL_ID = newInstance( "poolId" );
     private static final AttributeKey<BoltProtocolVersion> PROTOCOL_VERSION = newInstance( "protocolVersion" );
+    private static final AttributeKey<String> SERVER_AGENT = newInstance( "serverAgent" );
     private static final AttributeKey<BoltServerAddress> ADDRESS = newInstance( "serverAddress" );
     private static final AttributeKey<ServerVersion> SERVER_VERSION = newInstance( "serverVersion" );
     private static final AttributeKey<Long> CREATION_TIMESTAMP = newInstance( "creationTimestamp" );
@@ -72,6 +73,16 @@ public final class ChannelAttributes
     public static void setProtocolVersion( Channel channel, BoltProtocolVersion version )
     {
         setOnce( channel, PROTOCOL_VERSION, version );
+    }
+
+    public static void setServerAgent( Channel channel, String serverAgent )
+    {
+        setOnce( channel, SERVER_AGENT, serverAgent );
+    }
+
+    public static String serverAgent( Channel channel )
+    {
+        return get( channel, SERVER_AGENT );
     }
 
     public static BoltServerAddress serverAddress( Channel channel )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async.connection;
 
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.DirectConnectionProvider;
@@ -28,7 +29,6 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.ServerVersion;
-import org.neo4j.driver.AccessMode;
 
 /**
  * This is a connection used by {@link DirectConnectionProvider} to connect to a remote database.
@@ -109,6 +109,12 @@ public class DirectConnection implements Connection
     public void terminateAndRelease( String reason )
     {
         delegate.terminateAndRelease( reason );
+    }
+
+    @Override
+    public String serverAgent()
+    {
+        return delegate.serverAgent();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async.connection;
 
 import java.util.concurrent.CompletionStage;
 
+import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.RoutingErrorHandler;
@@ -29,7 +30,6 @@ import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 import org.neo4j.driver.internal.util.ServerVersion;
-import org.neo4j.driver.AccessMode;
 
 /**
  * A connection used by the routing driver.
@@ -107,6 +107,12 @@ public class RoutingConnection implements Connection
     public void terminateAndRelease( String reason )
     {
         delegate.terminateAndRelease( reason );
+    }
+
+    @Override
+    public String serverAgent()
+    {
+        return delegate.serverAgent();
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/HelloResponseHandler.java
@@ -23,14 +23,16 @@ import io.netty.channel.ChannelPromise;
 
 import java.util.Map;
 
+import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
 import org.neo4j.driver.internal.spi.ResponseHandler;
-import org.neo4j.driver.Value;
 
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setConnectionId;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerAgent;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerVersion;
 import static org.neo4j.driver.internal.util.MetadataExtractor.extractNeo4jServerVersion;
+import static org.neo4j.driver.internal.util.MetadataExtractor.extractServer;
 import static org.neo4j.driver.internal.util.ServerVersion.fromBoltProtocolVersion;
 
 public class HelloResponseHandler implements ResponseHandler
@@ -53,6 +55,9 @@ public class HelloResponseHandler implements ResponseHandler
     {
         try
         {
+            Value serverValue = extractServer( metadata );
+            setServerAgent( channel, serverValue.asString() );
+
             // From Server V4 extracting server from metadata in the success message is unreliable
             // so we fix the Server version against the Bolt Protocol version for Server V4 and above.
             if ( BoltProtocolV3.VERSION.equals( protocolVersion ) )

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -51,6 +51,8 @@ public interface Connection
 
     void terminateAndRelease( String reason );
 
+    String serverAgent();
+
     BoltServerAddress serverAddress();
 
     ServerVersion serverVersion();

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalServerInfo.java
@@ -21,18 +21,29 @@ package org.neo4j.driver.internal.summary;
 import java.util.Objects;
 
 import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.summary.ServerInfo;
 
 public class InternalServerInfo implements ServerInfo
 {
+    private final String agent;
     private final String address;
     private final String version;
+    private final String protocolVersion;
 
-    public InternalServerInfo( BoltServerAddress address, ServerVersion version )
+    public InternalServerInfo( String agent, BoltServerAddress address, ServerVersion version, BoltProtocolVersion protocolVersion )
     {
+        this.agent = agent;
         this.address = address.toString();
         this.version = version.toString();
+        this.protocolVersion = protocolVersion.toString();
+    }
+
+    @Override
+    public String agent()
+    {
+        return agent;
     }
 
     @Override
@@ -45,6 +56,12 @@ public class InternalServerInfo implements ServerInfo
     public String version()
     {
         return version;
+    }
+
+    @Override
+    public String protocolVersion()
+    {
+        return protocolVersion;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/summary/ServerInfo.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/ServerInfo.java
@@ -31,9 +31,27 @@ public interface ServerInfo
     String address();
 
     /**
-     * Returns a string telling which version of the server the query was executed.
-     * Supported since neo4j 3.1.
+     * Returns a string telling which version of the server the query was executed. Supported since neo4j 3.1.
+     *
      * @return The server version.
+     * @deprecated in 4.3, please use {@link ServerInfo#agent()}, {@link ServerInfo#protocolVersion()}, or call the <i>dbms.components</i> procedure instead.
+     * <b>Method might be removed in the next major release.</b>
      */
+    @Deprecated
     String version();
+
+    /**
+     * Returns Bolt protocol version with which the remote server communicates. This is returned as a string in format X.Y where X is the major version and Y is
+     * the minor version.
+     *
+     * @return The Bolt protocol version.
+     */
+    String protocolVersion();
+
+    /**
+     * Returns server agent string by which the remote server identifies itself.
+     *
+     * @return The agent string.
+     */
+    String agent();
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.util.Pair;
@@ -360,6 +361,8 @@ class InternalResultTest
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
+        when( connection.protocol() ).thenReturn( BoltProtocolV43.INSTANCE );
+        when( connection.serverAgent() ).thenReturn( "Neo4j/4.2.5" );
         PullAllResponseHandler pullAllHandler =
                 new LegacyPullAllResponseHandler( query, runHandler, connection, BoltProtocolV3.METADATA_EXTRACTOR,
                                                   mock( PullResponseCompletionListener.class ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
@@ -37,6 +37,7 @@ import org.neo4j.driver.internal.cursor.AsyncResultCursorImpl;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.summary.InternalResultSummary;
 import org.neo4j.driver.internal.summary.InternalServerInfo;
 import org.neo4j.driver.internal.summary.InternalSummaryCounters;
@@ -86,10 +87,13 @@ class AsyncResultCursorImplTest
     {
         PullAllResponseHandler pullAllHandler = mock( PullAllResponseHandler.class );
 
-        ResultSummary summary = new InternalResultSummary( new Query( "RETURN 42" ),
-                new InternalServerInfo( BoltServerAddress.LOCAL_DEFAULT, anyServerVersion() ), DEFAULT_DATABASE_INFO, QueryType.SCHEMA_WRITE,
+        ResultSummary summary = new InternalResultSummary(
+                new Query( "RETURN 42" ),
+                new InternalServerInfo( "Neo4j/4.2.5", BoltServerAddress.LOCAL_DEFAULT, anyServerVersion(), BoltProtocolV43.VERSION ),
+                DEFAULT_DATABASE_INFO, QueryType.SCHEMA_WRITE,
                 new InternalSummaryCounters( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 ),
-                null, null, emptyList(), 42, 42 );
+                null, null, emptyList(), 42, 42
+        );
         when( pullAllHandler.consumeAsync() ).thenReturn( completedFuture( summary ) );
 
         AsyncResultCursorImpl cursor = newCursor( pullAllHandler );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
@@ -349,6 +349,31 @@ class NetworkConnectionTest
     }
 
     @Test
+    void shouldReturnServerAgentWhenCreated()
+    {
+        EmbeddedChannel channel = newChannel();
+        String agent = "Neo4j/4.2.5";
+        ChannelAttributes.setServerAgent( channel, agent );
+
+        NetworkConnection connection = newConnection( channel );
+
+        assertEquals( agent, connection.serverAgent() );
+    }
+
+    @Test
+    void shouldReturnServerAgentWhenReleased()
+    {
+        EmbeddedChannel channel = newChannel();
+        String agent = "Neo4j/4.2.5";
+        ChannelAttributes.setServerAgent( channel, agent );
+
+        NetworkConnection connection = newConnection( channel );
+        connection.release();
+
+        assertEquals( agent, connection.serverAgent() );
+    }
+
+    @Test
     void shouldReturnServerAddressWhenReleased()
     {
         EmbeddedChannel channel = newChannel();

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
@@ -36,6 +36,7 @@ import static org.neo4j.driver.internal.async.connection.ChannelAttributes.lastU
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.messageDispatcher;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.protocolVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverAddress;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverAgent;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setConnectionId;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setCreationTimestamp;
@@ -43,6 +44,7 @@ import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setLa
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setMessageDispatcher;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setProtocolVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerAddress;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerAgent;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setServerVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setTerminationReason;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.terminationReason;
@@ -80,6 +82,23 @@ class ChannelAttributesTest
         setProtocolVersion( channel, new BoltProtocolVersion( 42, 0 ) );
 
         assertThrows( IllegalStateException.class, () -> setProtocolVersion( channel, new BoltProtocolVersion( 43, 0 ) ) );
+    }
+
+    @Test
+    void shouldSetAndGetServerAgent()
+    {
+        String agent = "Neo4j/4.2.5";
+        setServerAgent( channel, agent );
+        assertEquals( agent, serverAgent( channel ) );
+    }
+
+    @Test
+    void shouldFailToSetServerAgentTwice()
+    {
+        String agent = "Neo4j/4.2.5";
+        setServerAgent( channel, agent );
+
+        assertThrows( IllegalStateException.class, () -> setServerAgent( channel, agent ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/DirectConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/DirectConnectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.connection;
+
+import org.junit.jupiter.api.Test;
+
+import org.neo4j.driver.internal.spi.Connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.driver.AccessMode.READ;
+import static org.neo4j.driver.internal.DatabaseNameUtil.defaultDatabase;
+
+public class DirectConnectionTest
+{
+    @Test
+    void shouldReturnServerAgent()
+    {
+        // given
+        Connection connection = mock( Connection.class );
+        DirectConnection directConnection = new DirectConnection( connection, defaultDatabase(), READ );
+        String agent = "Neo4j/4.2.5";
+        given( connection.serverAgent() ).willReturn( agent );
+
+        // when
+        String actualAgent = directConnection.serverAgent();
+
+        // then
+        assertEquals( agent, actualAgent );
+        then( connection ).should().serverAgent();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/RoutingConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/RoutingConnectionTest.java
@@ -28,6 +28,9 @@ import org.neo4j.driver.internal.spi.ResponseHandler;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -60,6 +63,24 @@ class RoutingConnectionTest
     void shouldWrapHandlersWhenWritingAndFlushingMultipleMessages()
     {
         testHandlersWrappingWithMultipleMessages( true );
+    }
+
+    @Test
+    void shouldReturnServerAgent()
+    {
+        // given
+        Connection connection = mock( Connection.class );
+        RoutingErrorHandler errorHandler = mock( RoutingErrorHandler.class );
+        RoutingConnection routingConnection = new RoutingConnection( connection, defaultDatabase(), READ, errorHandler );
+        String agent = "Neo4j/4.2.5";
+        given( connection.serverAgent() ).willReturn( agent );
+
+        // when
+        String actualAgent = routingConnection.serverAgent();
+
+        // then
+        assertEquals( agent, actualAgent );
+        then( connection ).should().serverAgent();
     }
 
     private static void testHandlersWrappingWithSingleMessage( boolean flush )

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/HelloResponseHandlerTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.Values.value;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.connectionId;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverAgent;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setMessageDispatcher;
 import static org.neo4j.driver.internal.async.outbound.OutboundMessageHandler.NAME;
@@ -84,6 +85,20 @@ class HelloResponseHandlerTest
 
         assertTrue( channelPromise.isSuccess() );
         assertEquals( anyServerVersion(), serverVersion( channel ) );
+    }
+
+    @Test
+    void shouldSetServerAgentOnChannel()
+    {
+        ChannelPromise channelPromise = channel.newPromise();
+        HelloResponseHandler handler = new HelloResponseHandler( channelPromise, BoltProtocolV3.VERSION );
+
+        String agent = "Neo4j/4.2.5";
+        Map<String,Value> metadata = metadata( agent, "bolt-1" );
+        handler.onSuccess( metadata );
+
+        assertTrue( channelPromise.isSuccess() );
+        assertEquals( agent, serverAgent( channel ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/PullAllResponseHandlerTestBase.java
@@ -22,9 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -36,10 +34,10 @@ import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.spi.Connection;
-import org.neo4j.driver.internal.value.BooleanValue;
-import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.QueryType;
+import org.neo4j.driver.summary.ResultSummary;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -714,6 +712,8 @@ public abstract class PullAllResponseHandlerTestBase<T extends PullAllResponseHa
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
+        when( connection.protocol() ).thenReturn( BoltProtocolV43.INSTANCE );
+        when( connection.serverAgent() ).thenReturn( "Neo4j/4.2.5" );
         return connection;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListenerTest.java
@@ -28,6 +28,7 @@ import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.handlers.pulln.BasicPullResponseHandler;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 
@@ -94,6 +95,8 @@ class SessionPullResponseCompletionListenerTest
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
+        when( connection.protocol() ).thenReturn( BoltProtocolV43.INSTANCE );
+        when( connection.serverAgent() ).thenReturn( "Neo4j/4.2.5" );
         return connection;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/TransactionPullResponseCompletionListenerTest.java
@@ -32,6 +32,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.handlers.pulln.BasicPullResponseHandler;
 import org.neo4j.driver.internal.handlers.pulln.PullResponseHandler;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.spi.Connection;
 
 import static org.mockito.Mockito.mock;
@@ -63,13 +64,19 @@ class TransactionPullResponseCompletionListenerTest
         Connection connection = mock( Connection.class );
         when( connection.serverAddress() ).thenReturn( BoltServerAddress.LOCAL_DEFAULT );
         when( connection.serverVersion() ).thenReturn( anyServerVersion() );
+        when( connection.protocol() ).thenReturn( BoltProtocolV43.INSTANCE );
+        when( connection.serverAgent() ).thenReturn( "Neo4j/4.2.5" );
         UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
         TransactionPullResponseCompletionListener listener = new TransactionPullResponseCompletionListener( tx );
         RunResponseHandler runHandler = new RunResponseHandler( new CompletableFuture<>(), METADATA_EXTRACTOR );
         PullResponseHandler handler = new BasicPullResponseHandler( new Query( "RETURN 1" ), runHandler,
-                connection, METADATA_EXTRACTOR, listener );
-        handler.installRecordConsumer( ( record, throwable ) -> {} );
-        handler.installSummaryConsumer( ( resultSummary, throwable ) -> {} );
+                                                                    connection, METADATA_EXTRACTOR, listener );
+        handler.installRecordConsumer( ( record, throwable ) ->
+                                       {
+                                       } );
+        handler.installSummaryConsumer( ( resultSummary, throwable ) ->
+                                        {
+                                        } );
 
         handler.onFailure( error );
 

--- a/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandlerTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandlerTestBase.java
@@ -26,14 +26,15 @@ import java.util.HashMap;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.messaging.request.DiscardMessage;
 import org.neo4j.driver.internal.messaging.request.PullMessage;
+import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.internal.value.BooleanValue;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.Value;
 import org.neo4j.driver.summary.ResultSummary;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -241,6 +242,8 @@ abstract class BasicPullResponseHandlerTestBase
         Connection conn = mock( Connection.class );
         when( conn.serverAddress() ).thenReturn( mock( BoltServerAddress.class ) );
         when( conn.serverVersion() ).thenReturn( mock( ServerVersion.class ) );
+        when( conn.protocol() ).thenReturn( BoltProtocolV43.INSTANCE );
+        when( conn.serverAgent() ).thenReturn( "Neo4j/4.2.5" );
         return conn;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Config;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -35,8 +37,6 @@ import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ResponseHandler;
-import org.neo4j.driver.AuthToken;
-import org.neo4j.driver.Config;
 
 public class FailingConnectionDriverFactory extends DriverFactory
 {
@@ -192,6 +192,12 @@ public class FailingConnectionDriverFactory extends DriverFactory
         public void terminateAndRelease( String reason )
         {
             delegate.terminateAndRelease( reason );
+        }
+
+        @Override
+        public String serverAgent()
+        {
+            return delegate.serverAgent();
         }
 
         @Override

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.NullRecord;
-import neo4j.org.testkit.backend.messages.responses.ResultSummary;
+import neo4j.org.testkit.backend.messages.responses.Summary;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 
 import org.neo4j.driver.Result;
@@ -42,8 +42,17 @@ public class ResultConsume implements TestkitRequest
         try
         {
             Result result = testkitState.getResults().get( data.getResultId() );
-            result.consume();
-            return ResultSummary.builder().build();
+            org.neo4j.driver.summary.ResultSummary summary = result.consume();
+            Summary.ServerInfo serverInfo = Summary.ServerInfo.builder()
+                                                              .protocolVersion( summary.server().protocolVersion() )
+                                                              .agent( summary.server().agent() )
+                                                              .build();
+            Summary.SummaryBody data = Summary.SummaryBody.builder()
+                                                          .serverInfo( serverInfo )
+                                                          .build();
+            return Summary.builder()
+                          .data( data )
+                          .build();
         }
         catch ( NoSuchRecordException ignored )
         {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
@@ -25,11 +25,31 @@ import lombok.Setter;
 @Setter
 @Getter
 @Builder
-public class ResultSummary implements TestkitResponse
+public class Summary implements TestkitResponse
 {
+    private SummaryBody data;
+
     @Override
     public String testkitName()
     {
-        return "ResultSummary";
+        return "Summary";
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class SummaryBody
+    {
+        private ServerInfo serverInfo;
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class ServerInfo
+    {
+        private String protocolVersion;
+
+        private String agent;
     }
 }


### PR DESCRIPTION
This update deprecates ServerInfo.version() and introduces 2 alternative methods:
- protocolVersion()
- agent()