### PR TITLE
Skipping not applicable tests

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/SkipTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/SkipTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.responses;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+public class SkipTest implements TestkitResponse
+{
+    private SkipTestBody data;
+
+    @Override
+    public String testkitName()
+    {
+        return "SkipTest";
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class SkipTestBody
+    {
+        private final String reason;
+    }
+}


### PR DESCRIPTION
Skipping not applicable tests.

This PR captures the tests that are not expected to pass with 4.2 driver. This makes testing faster and more reliable. In addition, it captures the current skipped tests in VCS history.

There are 91 skipped tests in total. This includes 66 stub tests, which are the main focus on this PR. The skipped stub tests are listed below:
- ALL (tests.stub.routing.Routing) - 53 in total, the majoring was previous muted in TC
- test_should_successfully_get_server_protocol_version (tests.stub.routing.RoutingV3) - not applicable to 4.2
- test_should_successfully_get_server_protocol_version (tests.stub.routing.RoutingV4) - not applicable to 4.2
- test_should_successfully_get_server_agent (tests.stub.routing.RoutingV3) - not applicable to 4.2
- test_should_successfully_get_server_agent (tests.stub.routing.RoutingV4) - not applicable to 4.2
- test_retry_ForbiddenOnReadOnlyDatabase (tests.stub.retry.TestRetryClustering) - was previously muted in TC
- test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter (tests.stub.retry.TestRetryClustering) - was previously muted in TC
- test_retry_NotALeader (tests.stub.retry.TestRetryClustering) - was previously muted in TC
- test_retry_database_unavailable (tests.stub.retry.TestRetryClustering) - was previously muted in TC
- test_retry_made_up_transient (tests.stub.retry.TestRetryClustering) - was previously muted in TC
- test_nested (tests.stub.iteration.TxRun) - skipped in Testkit
- test_read (tests.stub.retry.TestRetryClustering) - skipped in Testkit
- test_supports_bolt_4x3 (tests.stub.versions.ProtocolVersions) - skipped in Testkit
- test_disconnect_on_commit (tests.stub.retry.TestRetry) - skipped in Testkit
