### PR TITLE
Added authorization expired response handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/exceptions/AuthorizationExpiredException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/AuthorizationExpiredException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.exceptions;
+
+/**
+ * The authorization info maintained on the server has expired. The client should reconnect.
+ * <p>
+ * Error code: Neo.ClientError.Security.AuthorizationExpired
+ */
+public class AuthorizationExpiredException extends SecurityException
+{
+    public AuthorizationExpiredException( String code, String message )
+    {
+        super( code, message );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/exceptions/AuthorizationExpiredException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/AuthorizationExpiredException.java
@@ -25,6 +25,8 @@ package org.neo4j.driver.exceptions;
  */
 public class AuthorizationExpiredException extends SecurityException
 {
+    public static final String DESCRIPTION = "Authorization information kept on the server has expired, this connection is no longer valid.";
+
     public AuthorizationExpiredException( String code, String message )
     {
         super( code, message );

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/AuthorizationStateListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/AuthorizationStateListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.connection;
+
+import io.netty.channel.Channel;
+
+import org.neo4j.driver.exceptions.AuthorizationExpiredException;
+
+/**
+ * Listener for authorization info state maintained on the server side.
+ */
+public interface AuthorizationStateListener
+{
+    /**
+     * Notifies the listener that the credentials stored on the server side have expired.
+     *
+     * @param e       the {@link AuthorizationExpiredException} exception.
+     * @param channel the channel that received the error.
+     */
+    void onExpired( AuthorizationExpiredException e, Channel channel );
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
@@ -40,6 +40,7 @@ public final class ChannelAttributes
     private static final AttributeKey<Long> LAST_USED_TIMESTAMP = newInstance( "lastUsedTimestamp" );
     private static final AttributeKey<InboundMessageDispatcher> MESSAGE_DISPATCHER = newInstance( "messageDispatcher" );
     private static final AttributeKey<String> TERMINATION_REASON = newInstance( "terminationReason" );
+    private static final AttributeKey<AuthorizationStateListener> AUTHORIZATION_STATE_LISTENER = newInstance( "authorizationStateListener" );
 
     private ChannelAttributes()
     {
@@ -143,6 +144,16 @@ public final class ChannelAttributes
     public static void setTerminationReason( Channel channel, String reason )
     {
         setOnce( channel, TERMINATION_REASON, reason );
+    }
+
+    public static AuthorizationStateListener authorizationStateListener( Channel channel )
+    {
+        return get( channel, AUTHORIZATION_STATE_LISTENER );
+    }
+
+    public static void setAuthorizationStateListener( Channel channel, AuthorizationStateListener authorizationStateListener )
+    {
+        set( channel, AUTHORIZATION_STATE_LISTENER, authorizationStateListener );
     }
 
     private static <T> T get( Channel channel, AttributeKey<T> key )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListener.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.handlers;
 import java.util.Map;
 
 import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.AuthorizationExpiredException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.MetadataExtractor;
@@ -48,7 +49,14 @@ public class SessionPullResponseCompletionListener implements PullResponseComple
     @Override
     public void afterFailure( Throwable error )
     {
-        releaseConnection();
+        if ( error instanceof AuthorizationExpiredException )
+        {
+            connection.terminateAndRelease( AuthorizationExpiredException.DESCRIPTION );
+        }
+        else
+        {
+            releaseConnection();
+        }
     }
 
     private void releaseConnection()

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal.messaging.v3;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -29,7 +28,6 @@ import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
-import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
@@ -123,19 +121,10 @@ public class BoltProtocolV3 implements BoltProtocol
             return Futures.failedFuture( error );
         }
 
+        CompletableFuture<Void> beginTxFuture = new CompletableFuture<>();
         BeginMessage beginMessage = new BeginMessage( bookmark, config, connection.databaseName(), connection.mode() );
-
-        if ( bookmark.isEmpty() )
-        {
-            connection.write( beginMessage, NoOpResponseHandler.INSTANCE );
-            return Futures.completedWithNull();
-        }
-        else
-        {
-            CompletableFuture<Void> beginTxFuture = new CompletableFuture<>();
-            connection.writeAndFlush( beginMessage, new BeginTxResponseHandler( beginTxFuture ) );
-            return beginTxFuture;
-        }
+        connection.writeAndFlush( beginMessage, new BeginTxResponseHandler( beginTxFuture ) );
+        return beginTxFuture;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
+import org.neo4j.driver.exceptions.AuthorizationExpiredException;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
@@ -155,7 +156,8 @@ public class ExponentialBackoffRetryLogic implements RetryLogic
     @Experimental
     public static boolean isRetryable( Throwable error )
     {
-        return error instanceof SessionExpiredException || error instanceof ServiceUnavailableException || isTransientError( error );
+        return error instanceof SessionExpiredException || error instanceof ServiceUnavailableException || error instanceof AuthorizationExpiredException ||
+               isTransientError( error );
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.exceptions.AuthenticationException;
+import org.neo4j.driver.exceptions.AuthorizationExpiredException;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.DatabaseException;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
@@ -74,6 +75,10 @@ public final class ErrorUtil
             else if ( code.equalsIgnoreCase( "Neo.ClientError.Database.DatabaseNotFound" ) )
             {
                 return new FatalDiscoveryException( code, message );
+            }
+            else if ( code.equalsIgnoreCase( "Neo.ClientError.Security.AuthorizationExpired" ) )
+            {
+                return new AuthorizationExpiredException( code, message );
             }
             else
             {

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.logging.Level;
 
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Config;
@@ -81,6 +80,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.neo4j.driver.Config.defaultConfig;
 import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.internal.metrics.InternalAbstractMetrics.DEV_NULL_METRICS;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
@@ -102,7 +102,7 @@ class ConnectionHandlingIT
         AuthToken auth = neo4j.authToken();
         RoutingSettings routingSettings = RoutingSettings.DEFAULT;
         RetrySettings retrySettings = RetrySettings.DEFAULT;
-        driver = driverFactory.newInstance( neo4j.uri(), auth, routingSettings, retrySettings, Config.builder().withLogging( Logging.console( Level.FINE ) ).build(), SecurityPlanImpl.insecure() );
+        driver = driverFactory.newInstance( neo4j.uri(), auth, routingSettings, retrySettings, defaultConfig(), SecurityPlanImpl.insecure() );
         connectionPool = driverFactory.connectionPool;
         connectionPool.startMemorizing(); // start memorizing connections after driver creation
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -26,11 +26,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
-import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.request.PullMessage;
@@ -65,12 +65,12 @@ import static org.neo4j.driver.util.TestUtil.await;
 import static org.neo4j.driver.util.TestUtil.connectionMock;
 import static org.neo4j.driver.util.TestUtil.newSession;
 import static org.neo4j.driver.util.TestUtil.setupFailingBegin;
-import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunRx;
 import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunAndPull;
+import static org.neo4j.driver.util.TestUtil.setupSuccessfulRunRx;
 import static org.neo4j.driver.util.TestUtil.verifyBeginTx;
 import static org.neo4j.driver.util.TestUtil.verifyRollbackTx;
-import static org.neo4j.driver.util.TestUtil.verifyRunRx;
 import static org.neo4j.driver.util.TestUtil.verifyRunAndPull;
+import static org.neo4j.driver.util.TestUtil.verifyRunRx;
 
 class NetworkSessionTest
 {
@@ -271,7 +271,7 @@ class NetworkSessionTest
 
         UnmanagedTransaction tx = beginTransaction( session );
         assertNotNull( tx );
-        verifyBeginTx( connection, bookmark );
+        verifyBeginTx( connection );
     }
 
     @Test
@@ -292,7 +292,7 @@ class NetworkSessionTest
         assertEquals( bookmark1, session.lastBookmark() );
 
         UnmanagedTransaction tx2 = beginTransaction( session );
-        verifyBeginTx( connection, bookmark1 );
+        verifyBeginTx( connection, 2 );
         await( tx2.commitAsync() );
 
         assertEquals( bookmark2, session.lastBookmark() );
@@ -396,7 +396,7 @@ class NetworkSessionTest
         run( session, "RETURN 2" );
 
         verify( connectionProvider, times( 2 ) ).acquireConnection( any( ConnectionContext.class ) );
-        verifyBeginTx( connection1, bookmark );
+        verifyBeginTx( connection1 );
         verifyRunAndPull( connection2, "RETURN 2" );
     }
 
@@ -420,8 +420,8 @@ class NetworkSessionTest
         beginTransaction( session );
 
         verify( connectionProvider, times( 2 ) ).acquireConnection( any( ConnectionContext.class ) );
-        verifyBeginTx( connection1, bookmark );
-        verifyBeginTx( connection2, bookmark );
+        verifyBeginTx( connection1 );
+        verifyBeginTx( connection2 );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -126,7 +126,7 @@ class UnmanagedTransactionTest
 
         beginTx( connection, bookmark );
 
-        verifyBeginTx( connection, bookmark );
+        verifyBeginTx( connection );
         verify( connection, never() ).write( any(), any(), any(), any() );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.authorizationStateListener;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.connectionId;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.creationTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.lastUsedTimestamp;
@@ -38,6 +39,7 @@ import static org.neo4j.driver.internal.async.connection.ChannelAttributes.proto
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverAddress;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverAgent;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverVersion;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setAuthorizationStateListener;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setConnectionId;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setLastUsedTimestamp;
@@ -196,5 +198,24 @@ class ChannelAttributesTest
         setTerminationReason( channel, "Reason 1" );
 
         assertThrows( IllegalStateException.class, () -> setTerminationReason( channel, "Reason 2" ) );
+    }
+
+    @Test
+    void shouldSetAndGetAuthorizationStateListener()
+    {
+        AuthorizationStateListener listener = mock( AuthorizationStateListener.class );
+        setAuthorizationStateListener( channel, listener );
+        assertEquals( listener, authorizationStateListener( channel ) );
+    }
+
+    @Test
+    void shouldAllowOverridingAuthorizationStateListener()
+    {
+        AuthorizationStateListener listener = mock( AuthorizationStateListener.class );
+        setAuthorizationStateListener( channel, listener );
+        assertEquals( listener, authorizationStateListener( channel ) );
+        AuthorizationStateListener newListener = mock( AuthorizationStateListener.class );
+        setAuthorizationStateListener( channel, newListener );
+        assertEquals( newListener, authorizationStateListener( channel ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/TestConnectionPool.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/TestConnectionPool.java
@@ -47,11 +47,13 @@ public class TestConnectionPool extends ConnectionPoolImpl
     final Map<BoltServerAddress,ExtendedChannelPool> channelPoolsByAddress = new HashMap<>();
     private final NettyChannelTracker nettyChannelTracker;
 
-    public TestConnectionPool( Bootstrap bootstrap, NettyChannelTracker nettyChannelTracker, PoolSettings settings,
-            MetricsListener metricsListener, Logging logging, Clock clock, boolean ownsEventLoopGroup )
+    public TestConnectionPool( Bootstrap bootstrap, NettyChannelTracker nettyChannelTracker, NettyChannelHealthChecker nettyChannelHealthChecker,
+                               PoolSettings settings,
+                               MetricsListener metricsListener, Logging logging, Clock clock, boolean ownsEventLoopGroup )
     {
-        super( mock( ChannelConnector.class ), bootstrap, nettyChannelTracker, settings, metricsListener, logging, clock, ownsEventLoopGroup,
-                newConnectionFactory() );
+        super( mock( ChannelConnector.class ), bootstrap, nettyChannelTracker, nettyChannelHealthChecker, settings, metricsListener, logging, clock,
+               ownsEventLoopGroup,
+               newConnectionFactory() );
         this.nettyChannelTracker = nettyChannelTracker;
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
@@ -44,6 +44,7 @@ import org.neo4j.driver.exceptions.FatalDiscoveryException;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
+import org.neo4j.driver.internal.async.pool.NettyChannelHealthChecker;
 import org.neo4j.driver.internal.async.pool.NettyChannelTracker;
 import org.neo4j.driver.internal.async.pool.PoolSettings;
 import org.neo4j.driver.internal.async.pool.TestConnectionPool;
@@ -314,8 +315,9 @@ class RoutingTableAndConnectionPoolTest
         PoolSettings poolSettings = new PoolSettings( 10, 5000, -1, -1 );
         Bootstrap bootstrap = BootstrapFactory.newBootstrap( 1 );
         NettyChannelTracker channelTracker = new NettyChannelTracker( metrics, bootstrap.config().group().next(), logging );
+        NettyChannelHealthChecker channelHealthChecker = new NettyChannelHealthChecker( poolSettings, clock, logging );
 
-        return new TestConnectionPool( bootstrap, channelTracker, poolSettings, metrics, logging, clock, true );
+        return new TestConnectionPool( bootstrap, channelTracker, channelHealthChecker, poolSettings, metrics, logging, clock, true );
     }
 
     private RoutingTableRegistryImpl newRoutingTables( ConnectionPool connectionPool, Rediscovery rediscovery )

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -194,7 +194,8 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), TransactionConfig.empty() );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection ).writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ) ),
+                                            any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -50,7 +50,6 @@ import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
-import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -218,7 +217,8 @@ public class BoltProtocolV3Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), txConfig );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection )
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -51,7 +51,6 @@ import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
-import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -192,7 +191,8 @@ public final class BoltProtocolV41Test
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), TransactionConfig.empty() );
 
         verify( connection )
-                .write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ) ),
+                                any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -216,7 +216,8 @@ public final class BoltProtocolV41Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), txConfig );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection )
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -517,16 +518,8 @@ public final class BoltProtocolV41Test
     {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
         BeginMessage beginMessage = new BeginMessage( bookmark, config, databaseName, mode );
-
-        if ( bookmark.isEmpty() )
-        {
-            verify( connection ).write( eq( beginMessage ), eq( NoOpResponseHandler.INSTANCE ) );
-        }
-        else
-        {
-            verify( connection ).write( eq( beginMessage ), beginHandlerCaptor.capture() );
-            assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
-        }
+        verify( connection ).writeAndFlush( eq( beginMessage ), beginHandlerCaptor.capture() );
+        assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
     }
 
     private static InternalAuthToken dummyAuthToken()

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -51,7 +51,6 @@ import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
-import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -192,7 +191,8 @@ public final class BoltProtocolV42Test
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), TransactionConfig.empty() );
 
         verify( connection )
-                .write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ) ),
+                                any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -216,7 +216,8 @@ public final class BoltProtocolV42Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), txConfig );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection )
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -517,16 +518,8 @@ public final class BoltProtocolV42Test
     {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
         BeginMessage beginMessage = new BeginMessage( bookmark, config, databaseName, mode );
-
-        if ( bookmark.isEmpty() )
-        {
-            verify( connection ).write( eq( beginMessage ), eq( NoOpResponseHandler.INSTANCE ) );
-        }
-        else
-        {
-            verify( connection ).write( eq( beginMessage ), beginHandlerCaptor.capture() );
-            assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
-        }
+        verify( connection ).writeAndFlush( eq( beginMessage ), beginHandlerCaptor.capture() );
+        assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
     }
 
     private static InternalAuthToken dummyAuthToken()

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
@@ -51,7 +51,6 @@ import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
 import org.neo4j.driver.internal.handlers.CommitTxResponseHandler;
-import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.handlers.PullAllResponseHandler;
 import org.neo4j.driver.internal.handlers.RollbackTxResponseHandler;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -191,7 +190,8 @@ public final class BoltProtocolV43Test
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), TransactionConfig.empty() );
 
         verify( connection )
-                .write( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE ) ),
+                                any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -215,7 +215,8 @@ public final class BoltProtocolV43Test
 
         CompletionStage<Void> stage = protocol.beginTransaction( connection, InternalBookmark.empty(), txConfig );
 
-        verify( connection ).write( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ), NoOpResponseHandler.INSTANCE );
+        verify( connection )
+                .writeAndFlush( eq( new BeginMessage( InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE ) ), any( BeginTxResponseHandler.class ) );
         assertNull( await( stage ) );
     }
 
@@ -516,16 +517,8 @@ public final class BoltProtocolV43Test
     {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass( ResponseHandler.class );
         BeginMessage beginMessage = new BeginMessage( bookmark, config, databaseName, mode );
-
-        if ( bookmark.isEmpty() )
-        {
-            verify( connection ).write( eq( beginMessage ), eq( NoOpResponseHandler.INSTANCE ) );
-        }
-        else
-        {
-            verify( connection ).write( eq( beginMessage ), beginHandlerCaptor.capture() );
-            assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
-        }
+        verify( connection ).writeAndFlush( eq( beginMessage ), beginHandlerCaptor.capture() );
+        assertThat( beginHandlerCaptor.getValue(), instanceOf( BeginTxResponseHandler.class ) );
     }
 
     private static InternalAuthToken dummyAuthToken()

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ErrorUtilTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import org.neo4j.driver.exceptions.AuthenticationException;
+import org.neo4j.driver.exceptions.AuthorizationExpiredException;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.DatabaseException;
 import org.neo4j.driver.exceptions.Neo4jException;
@@ -160,5 +161,18 @@ class ErrorUtilTest
         ServiceUnavailableException error = newConnectionTerminatedError( reason );
         assertThat( error.getMessage(), startsWith( "Connection to the database terminated" ) );
         assertThat( error.getMessage(), containsString( reason ) );
+    }
+
+    @Test
+    void shouldCreateAuthorizationExpiredException()
+    {
+        String code = "Neo.ClientError.Security.AuthorizationExpired";
+        String message = "Expired authorization info";
+
+        Neo4jException error = newNeo4jError( code, message );
+
+        assertThat( error, instanceOf( AuthorizationExpiredException.class ) );
+        assertEquals( code, error.code() );
+        assertEquals( message, error.getMessage() );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -57,7 +57,6 @@ import org.neo4j.driver.internal.DefaultBookmarkHolder;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.async.connection.EventLoopGroupFactory;
 import org.neo4j.driver.internal.handlers.BeginTxResponseHandler;
-import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
 import org.neo4j.driver.internal.messaging.Message;
@@ -88,7 +87,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -353,19 +351,12 @@ public final class TestUtil
 
     public static void verifyBeginTx( Connection connectionMock )
     {
-        verifyBeginTx( connectionMock, empty() );
+        verifyBeginTx( connectionMock, 1 );
     }
 
-    public static void verifyBeginTx( Connection connectionMock, Bookmark bookmark )
+    public static void verifyBeginTx( Connection connectionMock, int times )
     {
-        if ( bookmark.isEmpty() )
-        {
-            verify( connectionMock ).write( any( BeginMessage.class ), eq( NoOpResponseHandler.INSTANCE ) );
-        }
-        else
-        {
-            verify( connectionMock ).writeAndFlush( any( BeginMessage.class ), any( BeginTxResponseHandler.class ) );
-        }
+        verify( connectionMock, times( times ) ).writeAndFlush( any( BeginMessage.class ), any( BeginTxResponseHandler.class ) );
     }
 
     public static void setupFailingRun( Connection connection, Throwable error )

--- a/driver/src/test/resources/database_shutdown_at_commit.script
+++ b/driver/src/test/resources/database_shutdown_at_commit.script
@@ -4,10 +4,10 @@
 !: AUTO GOODBYE
 
 C: BEGIN {}
-   RUN "CREATE (n {name:'Bob'})" {} {}
+S: SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {}
    SUCCESS {}
 C: COMMIT
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database shut down."}

--- a/driver/src/test/resources/read_tx_v4_discard.script
+++ b/driver/src/test/resources/read_tx_v4_discard.script
@@ -4,9 +4,9 @@
 !: AUTO GOODBYE
 
 C: BEGIN { "mode": "r" }
-   RUN "UNWIND [1,2,3,4] AS a RETURN a" {} {}
 S: SUCCESS {}
-   SUCCESS {"t_first": 110, "fields": ["a"], "qid": 0}
+C: RUN "UNWIND [1,2,3,4] AS a RETURN a" {} {}
+S: SUCCESS {"t_first": 110, "fields": ["a"], "qid": 0}
 C: DISCARD {"qid": 0, "n": -1}
 S: SUCCESS {"type": "r", "t_last": 3, "db": "neo4j"}
 C: COMMIT

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -34,7 +34,8 @@ import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
         @JsonSubTypes.Type( SessionBeginTransaction.class ), @JsonSubTypes.Type( TransactionCommit.class ),
         @JsonSubTypes.Type( SessionLastBookmarks.class ), @JsonSubTypes.Type( SessionWriteTransaction.class ),
         @JsonSubTypes.Type( ResolverResolutionCompleted.class ), @JsonSubTypes.Type( CheckMultiDBSupport.class ),
-        @JsonSubTypes.Type( DomainNameResolutionCompleted.class ), @JsonSubTypes.Type( StartTest.class )
+        @JsonSubTypes.Type( DomainNameResolutionCompleted.class ), @JsonSubTypes.Type( StartTest.class ),
+        @JsonSubTypes.Type( TransactionRollback.class )
 } )
 public interface TestkitRequest
 {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.requests;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import neo4j.org.testkit.backend.messages.responses.Transaction;
+
+import java.util.Optional;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class TransactionRollback implements TestkitRequest
+{
+    private TransactionRollbackBody data;
+
+    @Override
+    public TestkitResponse process( TestkitState testkitState )
+    {
+        return Optional.ofNullable( testkitState.getTransactions().get( data.txId ) )
+                       .map( tx ->
+                             {
+                                 tx.rollback();
+                                 return transaction( data.txId );
+                             } )
+                       .orElseThrow( () -> new RuntimeException( "Could not find transaction" ) );
+    }
+
+    private Transaction transaction( String txId )
+    {
+        return Transaction.builder().data( Transaction.TransactionBody.builder().id( txId ).build() ).build();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Setter
+    public static class TransactionRollbackBody
+    {
+        private String txId;
+    }
+}


### PR DESCRIPTION
This update adds support for authorization expired response handling. When such error arrives the driver will mark all connections that were created on or before the creation timestamp of the receiving connection for disposal. The connections will be allowed to finish what they are doing and released back to the pool and will be disposed on the next acquire call.

This update also makes sure that we always register the HELLO response handler so that we can handle the response appropriately.

In addition, it adds the ROLLBACK message support to the driver backend.