### PR TITLE
Remove circular references in exceptions during the commit

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
@@ -18,20 +18,17 @@
  */
 package org.neo4j.driver.integration;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.UUID;
 
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
-import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.Neo4jFeature;
@@ -47,6 +44,7 @@ import static org.neo4j.driver.internal.InternalBookmark.parse;
 import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkContainsSingleValue;
 import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkIsEmpty;
 import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarksContainsSingleUniqueValues;
+import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
 
 @ParallelizableIT
 class BookmarkIT
@@ -137,7 +135,8 @@ class BookmarkIT
         Transaction tx = session.beginTransaction();
         tx.run( "RETURN" );
 
-        assertThrows( ClientException.class, tx::commit );
+        ClientException e = assertThrows( ClientException.class, tx::commit );
+        assertNoCircularReferences( e );
         assertEquals( bookmark, session.lastBookmark() );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
@@ -18,9 +18,13 @@
  */
 package org.neo4j.driver.integration;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -36,8 +40,10 @@ import org.neo4j.driver.util.SessionExtension;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
 
 @ParallelizableIT
 class QueryIT
@@ -181,5 +187,19 @@ class QueryIT
     {
         assertThrows( IllegalArgumentException.class, () -> session.run( (String) null ) );
         assertThrows( IllegalArgumentException.class, () -> session.run( "" ) );
+    }
+
+    @Test
+    void shouldBeAbleToLogSemanticWrongExceptions() {
+        try {
+            // When I run a query with the old syntax
+            session.writeTransaction(tx ->
+                                             tx.run( "MATCH (n:Element) WHERE n.name = {param} RETURN n",
+                                                     parameters("param", "Luke" )).list());
+        } catch ( Exception ex ) {
+            // And exception happens
+            // Then it should not have circular reference
+            assertNoCircularReferences(ex);
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncQueryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncQueryIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration.async;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+
+import org.neo4j.driver.async.AsyncSession;
+import org.neo4j.driver.util.DatabaseExtension;
+import org.neo4j.driver.util.ParallelizableIT;
+
+import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
+
+@ParallelizableIT
+public class AsyncQueryIT
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger( AsyncQueryIT.class );
+
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    private AsyncSession session;
+
+    @BeforeEach
+    void setUp()
+    {
+        session = neo4j.driver().asyncSession();
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        session.closeAsync();
+    }
+
+    @Test
+    void shouldBeAbleToLogSemanticWrongExceptions() throws ExecutionException, InterruptedException
+    {
+        session.writeTransactionAsync( tx -> Flux.from(
+                Mono.fromCompletionStage(
+                        tx.runAsync( "MATCH (n:Element) WHERE n.name = {param} RETURN n", parameters("param", "Luke") )
+                )).collectList().toFuture())
+
+               .toCompletableFuture()
+               .exceptionally( ex -> {
+                   assertNoCircularReferences(ex);
+                   return new ArrayList<>();
+               } )
+               .get();
+    }
+
+}

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
@@ -83,6 +83,7 @@ import static org.neo4j.driver.internal.util.Matchers.containsResultAvailableAft
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V3;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
+import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
 import static org.neo4j.driver.util.TestUtil.await;
 import static org.neo4j.driver.util.TestUtil.awaitAll;
 
@@ -381,7 +382,8 @@ class AsyncSessionIT
         InvocationTrackingWork work = new InvocationTrackingWork( "UNWIND [10, 5, 0] AS x CREATE (:Hi) RETURN 10/x" );
         CompletionStage<Record> txStage = session.writeTransactionAsync( work );
 
-        assertThrows( ClientException.class, () -> await( txStage ) );
+        ClientException e = assertThrows( ClientException.class, () -> await( txStage ) );
+        assertNoCircularReferences( e );
         assertEquals( 1, work.invocationCount() );
         assertEquals( 0, countNodesByLabel( "Hi" ) );
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -69,6 +69,7 @@ import static org.neo4j.driver.internal.InternalBookmark.parse;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.internal.util.Matchers.containsResultAvailableAfterAndResultConsumedAfter;
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
+import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
 import static org.neo4j.driver.util.TestUtil.await;
 
 @ParallelizableIT
@@ -677,6 +678,7 @@ class AsyncTransactionIT
         tx.runAsync( "CREATE (:TestNode)" );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertNoCircularReferences( e );
         assertEquals( "/ by zero", e.getMessage() );
     }
 
@@ -688,6 +690,7 @@ class AsyncTransactionIT
         tx.runAsync( "RETURN ILLEGAL" );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertNoCircularReferences( e );
         assertThat( e.getMessage(), containsString( "ILLEGAL" ) );
     }
 
@@ -699,6 +702,7 @@ class AsyncTransactionIT
         await( tx.runAsync( "RETURN 42 / 0" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertNoCircularReferences( e );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );
     }
 
@@ -732,6 +736,7 @@ class AsyncTransactionIT
         tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertNoCircularReferences( e );
         assertThat( e.code(), containsString( "TypeError" ) );
     }
 
@@ -743,6 +748,7 @@ class AsyncTransactionIT
         await( tx.runAsync( "UNWIND [1, 2, 3, 'Hi'] AS x RETURN 10 / x" ) );
 
         ClientException e = assertThrows( ClientException.class, () -> await( tx.commitAsync() ) );
+        assertNoCircularReferences( e );
         assertThat( e.code(), containsString( "TypeError" ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/util/TestUtil.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -642,6 +643,29 @@ public final class TestUtil
     public static ServerVersion anyServerVersion()
     {
         return ServerVersion.v4_0_0;
+    }
+
+    public static void assertNoCircularReferences(Throwable ex)
+    {
+        assertNoCircularReferences( ex, new ArrayList<>() );
+    }
+
+    private static void assertNoCircularReferences(Throwable ex, List<Throwable> list)
+    {
+        list.add( ex );
+        if (ex.getCause() != null ) {
+            if (list.contains( ex.getCause() )) {
+                throw new AssertionError("Circular reference detected", ex.getCause());
+            }
+            assertNoCircularReferences(ex.getCause(), list);
+        }
+        for ( Throwable suppressed: ex.getSuppressed()  )
+        {
+            if(list.contains( suppressed )) {
+                throw new AssertionError("Circular reference detected", suppressed);
+            }
+            assertNoCircularReferences( suppressed, list );
+        }
     }
 
     private static void setupSuccessfulPullAll( Connection connection, String query )


### PR DESCRIPTION
The error issue happened because the cursor failure is already the cause of the commit or rollback failure. This generates a circular reference when both of the exceptions are combined.

This situation can create stack overflow when the exception is logged in some logging libraries.

The solution don't add the cursor exception as the cause of the exception, this way it will not be wrongly combined creating a circular reference.