### PR TITLE
Update backend to report no routing context as DriverError

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -61,14 +61,16 @@ import static org.neo4j.driver.internal.util.ErrorUtil.addSuppressed;
 
 public class DriverFactory
 {
+    public static final String NO_ROUTING_CONTEXT_ERROR_MESSAGE = "Routing parameters are not supported with scheme 'bolt'. Given URI: ";
+
     public final Driver newInstance( URI uri, AuthToken authToken, RoutingSettings routingSettings,
                                      RetrySettings retrySettings, Config config, SecurityPlan securityPlan )
     {
         return newInstance( uri, authToken, routingSettings, retrySettings, config, null, securityPlan );
     }
 
-    public final Driver newInstance ( URI uri, AuthToken authToken, RoutingSettings routingSettings,
-            RetrySettings retrySettings, Config config,  EventLoopGroup eventLoopGroup, SecurityPlan securityPlan )
+    public final Driver newInstance( URI uri, AuthToken authToken, RoutingSettings routingSettings,
+                                     RetrySettings retrySettings, Config config, EventLoopGroup eventLoopGroup, SecurityPlan securityPlan )
     {
         Bootstrap bootstrap;
         boolean ownsEventLoopGroup;
@@ -288,8 +290,7 @@ public class DriverFactory
         RoutingContext routingContext = routingSettings.routingContext();
         if ( routingContext.isDefined() )
         {
-            throw new IllegalArgumentException(
-                    "Routing parameters are not supported with scheme 'bolt'. Given URI: '" + uri + "'" );
+            throw new IllegalArgumentException( NO_ROUTING_CONTEXT_ERROR_MESSAGE + "'" + uri + "'" );
         }
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.DomainNameResolutionRequired;
 import neo4j.org.testkit.backend.messages.responses.Driver;
+import neo4j.org.testkit.backend.messages.responses.DriverError;
 import neo4j.org.testkit.backend.messages.responses.ResolverResolutionRequired;
 import neo4j.org.testkit.backend.messages.responses.TestkitErrorResponse;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
@@ -82,7 +83,16 @@ public class NewDriver implements TestkitRequest
         }
         Optional.ofNullable( data.userAgent ).ifPresent( configBuilder::withUserAgent );
         Optional.ofNullable( data.connectionTimeoutMs ).ifPresent( timeout -> configBuilder.withConnectionTimeout( timeout, TimeUnit.MILLISECONDS ) );
-        testkitState.getDrivers().putIfAbsent( id, driver( URI.create( data.uri ), authToken, configBuilder.build(), domainNameResolver ) );
+        org.neo4j.driver.Driver driver;
+        try
+        {
+            driver = driver( URI.create( data.uri ), authToken, configBuilder.build(), domainNameResolver );
+        }
+        catch ( RuntimeException e )
+        {
+            return handleExceptionAsErrorResponse( testkitState, e ).orElseThrow( () -> e );
+        }
+        testkitState.getDrivers().putIfAbsent( id, driver );
         return Driver.builder().data( Driver.DriverBody.builder().id( id ).build() ).build();
     }
 
@@ -135,6 +145,20 @@ public class NewDriver implements TestkitRequest
         SecurityPlan securityPlan = securitySettings.createSecurityPlan( uri.getScheme() );
         return new DriverFactoryWithDomainNameResolver( domainNameResolver )
                 .newInstance( uri, authToken, routingSettings, retrySettings, config, securityPlan );
+    }
+
+    private Optional<TestkitResponse> handleExceptionAsErrorResponse( TestkitState testkitState, RuntimeException e )
+    {
+        Optional<TestkitResponse> response = Optional.empty();
+        if ( e instanceof IllegalArgumentException && e.getMessage().startsWith( DriverFactory.NO_ROUTING_CONTEXT_ERROR_MESSAGE ) )
+        {
+            String id = testkitState.newId();
+            String errorType = e.getClass().getName();
+            response = Optional.of(
+                    DriverError.builder().data( DriverError.DriverErrorBody.builder().id( id ).errorType( errorType ).build() ).build()
+            );
+        }
+        return response;
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -36,6 +36,9 @@ public class StartTest implements TestkitRequest
 {
     private static final Map<String,String> SKIP_PATTERN_TO_REASON = new LinkedHashMap<>();
 
+    private static final String SERVER_INFO_SKIP_REASON_MESSAGE =
+            "The 4.2 driver backend does not provide server info and its properties were changed in 4.3 drivers";
+
     static
     {
         SKIP_PATTERN_TO_REASON.put( "^.*retry.TestRetryClustering.test_retry_database_unavailable$", "The test is not applicable to 4.2 driver" );
@@ -44,10 +47,37 @@ public class StartTest implements TestkitRequest
         SKIP_PATTERN_TO_REASON.put( "^.*retry.TestRetryClustering.test_retry_NotALeader$", "The test is not applicable to 4.2 driver" );
         SKIP_PATTERN_TO_REASON
                 .put( "^.*retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter$", "The test is not applicable to 4.2 driver" );
-        SKIP_PATTERN_TO_REASON.put( "^.*routing.Routing\\..+$", "The tests are not applicable to 4.2 driver" );
+        SKIP_PATTERN_TO_REASON.put( "^.*test_routing_v4x3.RoutingV4x3\\..+$", "The tests are not applicable to 4.2 driver" );
         SKIP_PATTERN_TO_REASON
                 .put( "^.+routing.Routing.*\\.test_should_successfully_get_server_protocol_version$", "The test is not applicable to 4.2 driver" );
         SKIP_PATTERN_TO_REASON.put( "^.+routing.Routing.*\\.test_should_successfully_get_server_agent$", "The test is not applicable to 4.2 driver" );
+        SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.*\\.test_client_says_goodbye$", "This test uses 4.3 Bolt" );
+        SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.*\\.test_disconnect_after_hello", "This test uses 4.3 Bolt" );
+        SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.*\\.test_disconnect_on_tx_begin", "The 4.2 driver disconnects after first next" );
+        SKIP_PATTERN_TO_REASON.put( "^.+test_no_routing.NoRouting.test_should_read_successfully_using_session_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v3.RoutingV3.test_should_read_successfully_from_reader_using_session_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON.put( "^.+test_routing_v3.RoutingV3.test_should_read_successfully_from_reader_using_session_run_with_default_db_driver",
+                                    SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v3.RoutingV3.test_should_read_successfully_from_reader_using_tx_function", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON.put( "^.+test_routing_v3.RoutingV3.test_should_read_successfully_from_reader_using_tx_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v3.RoutingV3.test_should_write_successfully_on_writer_using_session_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v3.RoutingV3.test_should_write_successfully_on_writer_using_tx_function", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON.put( "^.+test_routing_v3.RoutingV3.test_should_write_successfully_on_writer_using_tx_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v4x1.RoutingV4x1.test_should_read_successfully_from_reader_using_session_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v4x1.RoutingV4x1.test_should_read_successfully_from_reader_using_tx_function", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v4x1.RoutingV4x1.test_should_read_successfully_from_reader_using_tx_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v4x1.RoutingV4x1.test_should_write_successfully_on_writer_using_session_run", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON
+                .put( "^.+test_routing_v4x1.RoutingV4x1.test_should_write_successfully_on_writer_using_tx_function", SERVER_INFO_SKIP_REASON_MESSAGE );
+        SKIP_PATTERN_TO_REASON.put( "^.+test_routing_v4x1.RoutingV4x1.test_should_write_successfully_on_writer_using_tx_run", SERVER_INFO_SKIP_REASON_MESSAGE );
     }
 
     private StartTestBody data;


### PR DESCRIPTION
Cherry-pick of #915

In addition, some tests are skipped due to incompatibility with 4.3 testkit.