### PR TITLE
Daemonize event loop threads.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/EventLoopGroupFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/EventLoopGroupFactory.java
@@ -40,6 +40,7 @@ public final class EventLoopGroupFactory
 {
     private static final String THREAD_NAME_PREFIX = "Neo4jDriverIO";
     private static final int THREAD_PRIORITY = Thread.MAX_PRIORITY;
+    private static final boolean THREAD_IS_DAEMON = true;
 
     private EventLoopGroupFactory()
     {
@@ -127,7 +128,7 @@ public final class EventLoopGroupFactory
     {
         DriverThreadFactory()
         {
-            super( THREAD_NAME_PREFIX, THREAD_PRIORITY );
+            super( THREAD_NAME_PREFIX, THREAD_IS_DAEMON, THREAD_PRIORITY );
         }
 
         @Override


### PR DESCRIPTION
This instructs the `EventLoopGroupFactory` to daemonize newly created
event loop group threads as per Netty's `DefaultThreadFactory`. This
allows applications to shutdown when the last user thread ends, without
explicitly calling `close` to the Neo4j driver instance, which is in
line with other database drivers such as Postgres JDBC or MySQL JDBC.

In addition, this might become relevant with Netty 5 at some point in
the future, too. See: https://github.com/netty/netty/issues/2832.