### PR TITLE
Remove stacktrace from recoverable discovery log warnings

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -53,13 +53,15 @@ import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 import static org.neo4j.driver.internal.util.Futures.failedFuture;
 
 /**
- * This class is used by all router tables to perform discovery.
- * In other words, the methods in this class could be called by multiple threads concurrently.
+ * This class is used by all router tables to perform discovery. In other words, the methods in this class could be called by multiple threads concurrently.
  */
 public class RediscoveryImpl implements Rediscovery
 {
     private static final String NO_ROUTERS_AVAILABLE = "Could not perform discovery for database '%s'. No routing server available.";
     private static final String RECOVERABLE_ROUTING_ERROR = "Failed to update routing table with server '%s'.";
+    private static final String RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER = "Received a recoverable discovery error with server '%s', " +
+                                                                          "will continue discovery with other routing servers if available. " +
+                                                                          "Complete routing failures will be captured separately from this warning.";
 
     private final BoltServerAddress initialRouter;
     private final RoutingSettings settings;
@@ -291,8 +293,15 @@ public class RediscoveryImpl implements Rediscovery
         // Retriable error happened during discovery.
         DiscoveryException discoveryError = new DiscoveryException( format( RECOVERABLE_ROUTING_ERROR, routerAddress ), error );
         Futures.combineErrors( baseError, discoveryError ); // we record each failure here
-        logger.warn( format( "Received a recoverable discovery error with server '%s', will continue discovery with other routing servers if available.",
-                routerAddress ), discoveryError );
+        String warningMessage = format( RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER, routerAddress );
+        if ( logger.isDebugEnabled() )
+        {
+            logger.warn( warningMessage, discoveryError ); // print the same warning, just with the stacktrace included
+        }
+        else
+        {
+            logger.warn( warningMessage );
+        }
         routingTable.forget( routerAddress );
         return null;
     }


### PR DESCRIPTION
This is to reduce the noise in the logs when recoverable discovery exceptions occur. Complete discovery failures are expected to be reported separately.