### PR TITLE
Remove stacktrace from connection acquisition attempts in LoadBalancer

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -60,6 +60,9 @@ public class RediscoveryImpl implements Rediscovery
 {
     private static final String NO_ROUTERS_AVAILABLE = "Could not perform discovery for database '%s'. No routing server available.";
     private static final String RECOVERABLE_ROUTING_ERROR = "Failed to update routing table with server '%s'.";
+    private static final String RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER = "Received a recoverable discovery error with server '%s', " +
+                                                                          "will continue discovery with other routing servers if available. " +
+                                                                          "Complete failure is reported separately from this entry.";
 
     private final BoltServerAddress initialRouter;
     private final RoutingSettings settings;
@@ -291,8 +294,9 @@ public class RediscoveryImpl implements Rediscovery
         // Retriable error happened during discovery.
         DiscoveryException discoveryError = new DiscoveryException( format( RECOVERABLE_ROUTING_ERROR, routerAddress ), error );
         Futures.combineErrors( baseError, discoveryError ); // we record each failure here
-        logger.warn( format( "Received a recoverable discovery error with server '%s', will continue discovery with other routing servers if available.",
-                routerAddress ), discoveryError );
+        String warningMessage = format( RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER, routerAddress );
+        logger.warn( warningMessage );
+        logger.debug( warningMessage, discoveryError );
         routingTable.forget( routerAddress );
         return null;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -57,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.startsWith;
@@ -187,9 +186,14 @@ class RediscoveryTest
         ClusterComposition composition = await( rediscovery.lookupClusterComposition( table, pool, empty() ) ).getClusterComposition();
         assertEquals( validComposition, composition );
 
-        ArgumentCaptor<DiscoveryException> argument = ArgumentCaptor.forClass( DiscoveryException.class );
-        verify( logger ).warn( anyString(), argument.capture() );
-        assertThat( argument.getValue().getCause(), equalTo( protocolError ) );
+        ArgumentCaptor<String> warningMessageCaptor = ArgumentCaptor.forClass( String.class );
+        ArgumentCaptor<String> debugMessageCaptor = ArgumentCaptor.forClass( String.class );
+        ArgumentCaptor<DiscoveryException> debugThrowableCaptor = ArgumentCaptor.forClass( DiscoveryException.class );
+        verify( logger ).warn( warningMessageCaptor.capture() );
+        verify( logger ).debug( debugMessageCaptor.capture(), debugThrowableCaptor.capture() );
+        assertNotNull( warningMessageCaptor.getValue() );
+        assertEquals( warningMessageCaptor.getValue(), debugMessageCaptor.getValue() );
+        assertThat( debugThrowableCaptor.getValue().getCause(), equalTo( protocolError ) );
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of #944.

This is to reduce the noise in the logs on connection acquisition errors. Complete failures are reported separately.