### PR TITLE
Skip test test_disconnect_on_hello

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -52,6 +52,7 @@ public class StartTest implements TestkitRequest
                 .put( "^.+routing.Routing.*\\.test_should_successfully_get_server_protocol_version$", "The test is not applicable to 4.2 driver" );
         SKIP_PATTERN_TO_REASON.put( "^.+routing.Routing.*\\.test_should_successfully_get_server_agent$", "The test is not applicable to 4.2 driver" );
         SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.test_client_says_goodbye$", "This test uses 4.3 Bolt" );
+        SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.test_disconnect_on_hello", "This test uses 4.3 Bolt" );
         SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.test_disconnect_after_hello", "This test uses 4.3 Bolt" );
         SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.test_disconnect_on_tx_begin", "The 4.2 driver disconnects after first next" );
         SKIP_PATTERN_TO_REASON.put( "^.+disconnects.TestDisconnects.test_disconnect_on_tx_run", "The 4.2 driver disconnects after first next" );


### PR DESCRIPTION
The test requires bolt version 4.3

It didn't fail until I fixed the stub server https://github.com/neo4j-drivers/testkit/pull/159