### PR TITLE
Added value conversion for char[] and short[]

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/v1/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/v1/Values.java
@@ -117,11 +117,13 @@ public abstract class Values
         if ( value instanceof Iterable<?> ) { return value( (Iterable<Object>) value ); }
         if ( value instanceof Iterator<?> ) { return value( (Iterator<Object>) value ); }
 
+        if ( value instanceof char[] ) { return value( (char[]) value ); }
         if ( value instanceof byte[] ) { return value( (byte[]) value ); }
         if ( value instanceof boolean[] ) { return value( (boolean[]) value ); }
         if ( value instanceof String[] ) { return value( (String[]) value ); }
         if ( value instanceof long[] ) { return value( (long[]) value ); }
         if ( value instanceof int[] ) { return value( (int[]) value ); }
+        if ( value instanceof short[] ) { return value( (short[]) value ); }
         if ( value instanceof double[] ) { return value( (double[]) value ); }
         if ( value instanceof float[] ) { return value( (float[]) value ); }
         if ( value instanceof Value[] ) { return value( (Value[]) value ); }
@@ -194,6 +196,16 @@ public abstract class Values
     }
 
     public static Value value( int... input )
+    {
+        Value[] values = new Value[input.length];
+        for ( int i = 0; i < input.length; i++ )
+        {
+            values[i] = value( input[i] );
+        }
+        return new ListValue( values );
+    }
+
+    public static Value value( short... input )
     {
         Value[] values = new Value[input.length];
         for ( int i = 0; i < input.length; i++ )

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -92,25 +92,52 @@ public class ValuesTest
     @Test
     public void shouldConvertPrimitiveArrays() throws Throwable
     {
+        assertThat( value( new short[]{1, 2, 3} ),
+                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+
+        assertThat( value( (Object) new short[]{1, 2, 3} ),
+                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+
         assertThat( value( new int[]{1, 2, 3} ),
+                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+
+        assertThat( value( (Object) new int[]{1, 2, 3} ),
                 equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
 
         assertThat( value( new long[]{1, 2, 3} ),
                 equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
 
+        assertThat( value( (Object) new long[]{1, 2, 3} ),
+                equalTo( (Value) new ListValue( values( 1, 2, 3 ) ) ) );
+
         assertThat( value( new float[]{1.1f, 2.2f, 3.3f} ),
+                equalTo( (Value) new ListValue( values( 1.1f, 2.2f, 3.3f ) ) ) );
+
+        assertThat( value( (Object) new float[]{1.1f, 2.2f, 3.3f} ),
                 equalTo( (Value) new ListValue( values( 1.1f, 2.2f, 3.3f ) ) ) );
 
         assertThat( value( new double[]{1.1, 2.2, 3.3} ),
                 equalTo( (Value) new ListValue( values( 1.1, 2.2, 3.3 ) ) ) );
 
+        assertThat( value( (Object) new double[]{1.1, 2.2, 3.3} ),
+                equalTo( (Value) new ListValue( values( 1.1, 2.2, 3.3 ) ) ) );
+
         assertThat( value( new boolean[]{true, false, true} ),
+                equalTo( (Value) new ListValue( values( true, false, true ) ) ) );
+
+        assertThat( value( (Object) new boolean[]{true, false, true} ),
                 equalTo( (Value) new ListValue( values( true, false, true ) ) ) );
 
         assertThat( value( new char[]{'a', 'b', 'c'} ),
                 equalTo( (Value) new ListValue( values( 'a', 'b', 'c' ) ) ) );
 
+        assertThat( value( (Object) new char[]{'a', 'b', 'c'} ),
+                equalTo( (Value) new ListValue( values( 'a', 'b', 'c' ) ) ) );
+
         assertThat( value( new String[]{"a", "b", "c"} ),
+                equalTo( (Value) new ListValue( values( "a", "b", "c" ) ) ) );
+
+        assertThat( (Object) value( new String[]{"a", "b", "c"} ),
                 equalTo( (Value) new ListValue( values( "a", "b", "c" ) ) ) );
     }
 


### PR DESCRIPTION
A user of jQAssistant reported a problem when using a dedicated Neo4j instance (https://github.com/jQAssistant/jqa-core-framework/issues/60). 

The mapping framework behind jQAssistant (XO) sets properties of a node/relation using `Value.parameters` where the value is a Map of properties. In the described case one of the properties is of type `char[]` but testing revealed that `short[]` is not covered as well.

Creating the pull request against 1.6, the version used by jQAssistant actually is 4.3.
