### PR TITLE
Added value conversion for char[] and short[]

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/Values.java
@@ -121,11 +121,13 @@ public abstract class Values
         if ( value instanceof Iterator<?> ) { return value( (Iterator<Object>) value ); }
         if ( value instanceof Stream<?> ) { return value( (Stream<Object>) value ); }
 
+        if ( value instanceof char[] ) { return value( (char[]) value ); }
         if ( value instanceof byte[] ) { return value( (byte[]) value ); }
         if ( value instanceof boolean[] ) { return value( (boolean[]) value ); }
         if ( value instanceof String[] ) { return value( (String[]) value ); }
         if ( value instanceof long[] ) { return value( (long[]) value ); }
         if ( value instanceof int[] ) { return value( (int[]) value ); }
+        if ( value instanceof short[] ) { return value( (short[]) value ); }
         if ( value instanceof double[] ) { return value( (double[]) value ); }
         if ( value instanceof float[] ) { return value( (float[]) value ); }
         if ( value instanceof Value[] ) { return value( (Value[]) value ); }
@@ -188,6 +190,16 @@ public abstract class Values
     }
 
     public static Value value( long... input )
+    {
+        Value[] values = new Value[input.length];
+        for ( int i = 0; i < input.length; i++ )
+        {
+            values[i] = value( input[i] );
+        }
+        return new ListValue( values );
+    }
+
+    public static Value value( short... input )
     {
         Value[] values = new Value[input.length];
         for ( int i = 0; i < input.length; i++ )

--- a/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ValuesTest.java
@@ -90,6 +90,9 @@ class ValuesTest
     @Test
     void shouldConvertPrimitiveArrays()
     {
+        assertThat( value( new short[]{1, 2, 3} ),
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
+
         assertThat( value( new int[]{1, 2, 3} ),
                 equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
 
@@ -109,6 +112,34 @@ class ValuesTest
                 equalTo( new ListValue( values( 'a', 'b', 'c' ) ) ) );
 
         assertThat( value( new String[]{"a", "b", "c"} ),
+                equalTo( new ListValue( values( "a", "b", "c" ) ) ) );
+    }
+
+    @Test
+    void shouldConvertPrimitiveArraysFromObject()
+    {
+        assertThat( value( (Object) new short[]{1, 2, 3} ),
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
+
+        assertThat( value( (Object) new int[]{1, 2, 3} ),
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
+
+        assertThat( value( (Object) new long[]{1, 2, 3} ),
+                equalTo( new ListValue( values( 1, 2, 3 ) ) ) );
+
+        assertThat( value( (Object) new float[]{1.1f, 2.2f, 3.3f} ),
+                equalTo( new ListValue( values( 1.1f, 2.2f, 3.3f ) ) ) );
+
+        assertThat( value( (Object) new double[]{1.1, 2.2, 3.3} ),
+                equalTo( new ListValue( values( 1.1, 2.2, 3.3 ) ) ) );
+
+        assertThat( value( (Object) new boolean[]{true, false, true} ),
+                equalTo( new ListValue( values( true, false, true ) ) ) );
+
+        assertThat( value( (Object) new char[]{'a', 'b', 'c'} ),
+                equalTo( new ListValue( values( 'a', 'b', 'c' ) ) ) );
+
+        assertThat( value( (Object) new String[]{"a", "b", "c"} ),
                 equalTo( new ListValue( values( "a", "b", "c" ) ) ) );
     }
 


### PR DESCRIPTION
A user of jQAssistant reported a problem when using a dedicated Neo4j instance (jQAssistant/jqa-core-framework#60).

The mapping framework behind jQAssistant (XO) sets properties of a node/relation using Value.parameters where the value is a Map of properties. In the described case one of the properties is of type char[] but testing revealed that short[] is not covered as well.

This PR replaces #964 .