### PR TITLE
Add support for `connection.recv_timeout_seconds` connection hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Make sure to run build for the whole project and not just for `testkit-tests` mo
 - `mvn clean verify -DtestkitArgs='--tests STUB_TESTS'` - runs all project tests and Testkit stub tests.
 - `mvn clean verify -DskipTests -P testkit-tests` - skips all project tests and runs Testkit tests.
 - `mvn clean verify -DskipTests -DtestkitArgs='--tests STUB_TESTS'` - skips all project tests and runs Testkit stub tests.
+- `mvn clean verify -DskipITs -DtestkitArgs='--tests STUB_TESTS'` - skips all integration tests and runs Testkit stub tests.
+
+If you interrupt Maven build, you have to remove Testkit containers manually.
 
 ##### Running Testkit manually
 

--- a/driver/src/main/java/org/neo4j/driver/exceptions/ConnectionReadTimeoutException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/ConnectionReadTimeoutException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.exceptions;
+
+/**
+ * Indicates that read timed out due to it taking longer than the server-supplied timeout value via the {@code connection.recv_timeout_seconds} configuration
+ * hint. The server might provide this value to clients to let them know when a given connection may be considered broken if client does not get any
+ * communication from the server within the specified timeout period. This results in the server being removed from the routing table.
+ */
+public class ConnectionReadTimeoutException extends ServiceUnavailableException
+{
+    public static final ConnectionReadTimeoutException INSTANCE = new ConnectionReadTimeoutException(
+            "Connection read timed out due to it taking longer than the server-supplied timeout value via configuration hint." );
+
+    public ConnectionReadTimeoutException( String message )
+    {
+        super( message );
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -207,12 +207,25 @@ public class DriverFactory
      * <b>This method is protected only for testing</b>
      */
     protected LoadBalancer createLoadBalancer( BoltServerAddress address, ConnectionPool connectionPool,
-            EventExecutorGroup eventExecutorGroup, Config config, RoutingSettings routingSettings )
+                                               EventExecutorGroup eventExecutorGroup, Config config, RoutingSettings routingSettings )
     {
         LoadBalancingStrategy loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy( connectionPool, config.logging() );
         ServerAddressResolver resolver = createResolver( config );
-        return new LoadBalancer( address, routingSettings, connectionPool, eventExecutorGroup, createClock(),
-                                 config.logging(), loadBalancingStrategy, resolver, getDomainNameResolver() );
+        LoadBalancer loadBalancer = new LoadBalancer( address, routingSettings, connectionPool, eventExecutorGroup, createClock(),
+                                                      config.logging(), loadBalancingStrategy, resolver, getDomainNameResolver() );
+        handleNewLoadBalancer( loadBalancer );
+        return loadBalancer;
+    }
+
+    /**
+     * Handles new {@link LoadBalancer} instance.
+     * <p>
+     * <b>This method is protected for Testkit backend usage only.</b>
+     *
+     * @param loadBalancer the new load balancer instance.
+     */
+    protected void handleNewLoadBalancer( LoadBalancer loadBalancer )
+    {
     }
 
     private static ServerAddressResolver createResolver( Config config )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.AuthorizationExpiredException;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.RxResultCursor;
@@ -146,6 +147,10 @@ public class UnmanagedTransaction
                                         if ( beginError instanceof AuthorizationExpiredException )
                                         {
                                             connection.terminateAndRelease( AuthorizationExpiredException.DESCRIPTION );
+                                        }
+                                        else if ( beginError instanceof ConnectionReadTimeoutException )
+                                        {
+                                            connection.terminateAndRelease( beginError.getMessage() );
                                         }
                                         else
                                         {
@@ -324,6 +329,10 @@ public class UnmanagedTransaction
         if ( throwable instanceof AuthorizationExpiredException )
         {
             connection.terminateAndRelease( AuthorizationExpiredException.DESCRIPTION );
+        }
+        else if ( throwable instanceof ConnectionReadTimeoutException )
+        {
+            connection.terminateAndRelease( throwable.getMessage() );
         }
         else
         {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
@@ -21,6 +21,8 @@ package org.neo4j.driver.internal.async.connection;
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
 
+import java.util.Optional;
+
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
@@ -41,6 +43,9 @@ public final class ChannelAttributes
     private static final AttributeKey<InboundMessageDispatcher> MESSAGE_DISPATCHER = newInstance( "messageDispatcher" );
     private static final AttributeKey<String> TERMINATION_REASON = newInstance( "terminationReason" );
     private static final AttributeKey<AuthorizationStateListener> AUTHORIZATION_STATE_LISTENER = newInstance( "authorizationStateListener" );
+
+    // configuration hints provided by the server
+    private static final AttributeKey<Long> CONNECTION_READ_TIMEOUT = newInstance( "connectionReadTimeout" );
 
     private ChannelAttributes()
     {
@@ -154,6 +159,16 @@ public final class ChannelAttributes
     public static void setAuthorizationStateListener( Channel channel, AuthorizationStateListener authorizationStateListener )
     {
         set( channel, AUTHORIZATION_STATE_LISTENER, authorizationStateListener );
+    }
+
+    public static Optional<Long> connectionReadTimeout( Channel channel )
+    {
+        return Optional.ofNullable( get( channel, CONNECTION_READ_TIMEOUT ) );
+    }
+
+    public static void setConnectionReadTimeout( Channel channel, Long connectionReadTimeout )
+    {
+        setOnce( channel, CONNECTION_READ_TIMEOUT, connectionReadTimeout );
     }
 
     private static <T> T get( Channel channel, AttributeKey<T> key )

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ChannelErrorHandler.java
@@ -24,11 +24,12 @@ import io.netty.handler.codec.CodecException;
 
 import java.io.IOException;
 
-import org.neo4j.driver.internal.logging.ChannelActivityLogger;
-import org.neo4j.driver.internal.util.ErrorUtil;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.internal.logging.ChannelActivityLogger;
+import org.neo4j.driver.internal.util.ErrorUtil;
 
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.messageDispatcher;
@@ -94,8 +95,16 @@ public class ChannelErrorHandler extends ChannelInboundHandlerAdapter
         else
         {
             failed = true;
-            log.warn( "Fatal error occurred in the pipeline", error );
+            logUnexpectedErrorWarning( error );
             fail( error );
+        }
+    }
+
+    private void logUnexpectedErrorWarning( Throwable error )
+    {
+        if ( !(error instanceof ConnectionReadTimeoutException) )
+        {
+            log.warn( "Fatal error occurred in the pipeline", error );
         }
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ConnectionReadTimeoutHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/inbound/ConnectionReadTimeoutHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.inbound;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
+
+public class ConnectionReadTimeoutHandler extends ReadTimeoutHandler
+{
+    private boolean triggered;
+
+    public ConnectionReadTimeoutHandler( long timeout, TimeUnit unit )
+    {
+        super( timeout, unit );
+    }
+
+    @Override
+    protected void readTimedOut( ChannelHandlerContext ctx )
+    {
+        if ( !triggered )
+        {
+            ctx.fireExceptionCaught( ConnectionReadTimeoutException.INSTANCE );
+            ctx.close();
+            triggered = true;
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImpl.java
@@ -71,7 +71,7 @@ public class ConnectionPoolImpl implements ConnectionPool
     {
         this( connector, bootstrap, new NettyChannelTracker( metricsListener, bootstrap.config().group().next(), logging ),
               new NettyChannelHealthChecker( settings, clock, logging ), settings, metricsListener, logging,
-              clock, ownsEventLoopGroup, new NetworkConnectionFactory( clock, metricsListener ) );
+              clock, ownsEventLoopGroup, new NetworkConnectionFactory( clock, metricsListener, logging ) );
     }
 
     protected ConnectionPoolImpl( ChannelConnector connector, Bootstrap bootstrap, NettyChannelTracker nettyChannelTracker,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NetworkConnectionFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NetworkConnectionFactory.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async.pool;
 
 import io.netty.channel.Channel;
 
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.internal.async.NetworkConnection;
 import org.neo4j.driver.internal.metrics.MetricsListener;
 import org.neo4j.driver.internal.spi.Connection;
@@ -29,16 +30,18 @@ public class NetworkConnectionFactory implements ConnectionFactory
 {
     private final Clock clock;
     private final MetricsListener metricsListener;
+    private final Logging logging;
 
-    public NetworkConnectionFactory( Clock clock, MetricsListener metricsListener )
+    public NetworkConnectionFactory( Clock clock, MetricsListener metricsListener, Logging logging )
     {
         this.clock = clock;
         this.metricsListener = metricsListener;
+        this.logging = logging;
     }
 
     @Override
     public Connection createConnection( Channel channel, ExtendedChannelPool pool )
     {
-        return new NetworkConnection( channel, pool, clock, metricsListener );
+        return new NetworkConnection( channel, pool, clock, metricsListener, logging );
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistry.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistry.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.cluster;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -52,4 +53,12 @@ public interface RoutingTableRegistry
      * Removes all routing tables that has been not used for a long time.
      */
     void removeAged();
+
+    /**
+     * Returns routing table handler for the given database name if it exists in the registry.
+     *
+     * @param databaseName the database name
+     * @return the routing table handler for the requested database name
+     */
+    Optional<RoutingTableHandler> getRoutingTableHandler( DatabaseName databaseName );
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableRegistryImpl.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.cluster;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,14 +80,23 @@ public class RoutingTableRegistryImpl implements RoutingTableRegistry
     @Override
     public void removeAged()
     {
-        routingTableHandlers.forEach( ( databaseName, handler ) -> {
-            if ( handler.isRoutingTableAged() )
-            {
-                logger.info( "Routing table handler for database '%s' is removed because it has not been used for a long time. Routing table: %s",
-                        databaseName.description(), handler.routingTable() );
-                routingTableHandlers.remove( databaseName );
-            }
-        } );
+        routingTableHandlers.forEach(
+                ( databaseName, handler ) ->
+                {
+                    if ( handler.isRoutingTableAged() )
+                    {
+                        logger.info(
+                                "Routing table handler for database '%s' is removed because it has not been used for a long time. Routing table: %s",
+                                databaseName.description(), handler.routingTable() );
+                        routingTableHandlers.remove( databaseName );
+                    }
+                } );
+    }
+
+    @Override
+    public Optional<RoutingTableHandler> getRoutingTableHandler( DatabaseName databaseName )
+    {
+        return Optional.ofNullable( routingTableHandlers.get( databaseName ) );
     }
 
     // For tests
@@ -97,11 +107,13 @@ public class RoutingTableRegistryImpl implements RoutingTableRegistry
 
     private RoutingTableHandler getOrCreate( DatabaseName databaseName )
     {
-        return routingTableHandlers.computeIfAbsent( databaseName, name -> {
-            RoutingTableHandler handler = factory.newInstance( name, this );
-            logger.debug( "Routing table handler for database '%s' is added.", databaseName.description() );
-            return handler;
-        } );
+        return routingTableHandlers.computeIfAbsent(
+                databaseName, name ->
+                {
+                    RoutingTableHandler handler = factory.newInstance( name, this );
+                    logger.debug( "Routing table handler for database '%s' is added.", databaseName.description() );
+                    return handler;
+                } );
     }
 
     static class RoutingTableHandlerFactory

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
@@ -175,12 +175,19 @@ public class LoadBalancer implements ConnectionProvider
         } );
     }
 
+    public RoutingTableRegistry getRoutingTableRegistry()
+    {
+        return routingTables;
+    }
+
     private CompletionStage<Boolean> supportsMultiDb( BoltServerAddress address )
     {
-        return connectionPool.acquire( address ).thenCompose( conn -> {
-            boolean supportsMultiDatabase = supportsMultiDatabase( conn );
-            return conn.release().thenApply( ignored -> supportsMultiDatabase );
-        } );
+        return connectionPool.acquire( address ).thenCompose(
+                conn ->
+                {
+                    boolean supportsMultiDatabase = supportsMultiDatabase( conn );
+                    return conn.release().thenApply( ignored -> supportsMultiDatabase );
+                } );
     }
 
     private CompletionStage<Connection> acquire( AccessMode mode, RoutingTable routingTable )

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RoutingResponseHandler.java
@@ -21,16 +21,16 @@ package org.neo4j.driver.internal.handlers;
 import java.util.Map;
 import java.util.Objects;
 
-import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.RoutingErrorHandler;
-import org.neo4j.driver.internal.spi.ResponseHandler;
-import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.RoutingErrorHandler;
+import org.neo4j.driver.internal.spi.ResponseHandler;
+import org.neo4j.driver.internal.util.Futures;
 
 import static java.lang.String.format;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/RunResponseHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.AuthorizationExpiredException;
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
@@ -69,6 +70,10 @@ public class RunResponseHandler implements ResponseHandler
         else if ( error instanceof AuthorizationExpiredException )
         {
             connection.terminateAndRelease( AuthorizationExpiredException.DESCRIPTION );
+        }
+        else if ( error instanceof ConnectionReadTimeoutException )
+        {
+            connection.terminateAndRelease( error.getMessage() );
         }
         runFuture.completeExceptionally( error );
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/SessionPullResponseCompletionListener.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.AuthorizationExpiredException;
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.MetadataExtractor;
@@ -52,6 +53,10 @@ public class SessionPullResponseCompletionListener implements PullResponseComple
         if ( error instanceof AuthorizationExpiredException )
         {
             connection.terminateAndRelease( AuthorizationExpiredException.DESCRIPTION );
+        }
+        else if ( error instanceof ConnectionReadTimeoutException )
+        {
+            connection.terminateAndRelease( error.getMessage() );
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
@@ -641,7 +641,7 @@ class NetworkConnectionTest
 
     private static NetworkConnection newConnection( Channel channel, ExtendedChannelPool pool )
     {
-        return new NetworkConnection( channel, pool, new FakeClock(), DEV_NULL_METRICS );
+        return new NetworkConnection( channel, pool, new FakeClock(), DEV_NULL_METRICS, DEV_NULL_LOGGING );
     }
 
     private static void assertConnectionReleasedError( IllegalStateException e )

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/ChannelAttributesTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.authorizationStateListener;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.connectionId;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.connectionReadTimeout;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.creationTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.lastUsedTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.messageDispatcher;
@@ -41,6 +42,7 @@ import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serve
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.serverVersion;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setAuthorizationStateListener;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setConnectionId;
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setConnectionReadTimeout;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setCreationTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setLastUsedTimestamp;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setMessageDispatcher;
@@ -217,5 +219,21 @@ class ChannelAttributesTest
         AuthorizationStateListener newListener = mock( AuthorizationStateListener.class );
         setAuthorizationStateListener( channel, newListener );
         assertEquals( newListener, authorizationStateListener( channel ) );
+    }
+
+    @Test
+    void shouldSetAndGetConnectionReadTimeout()
+    {
+        long timeout = 15L;
+        setConnectionReadTimeout( channel, timeout );
+        assertEquals( timeout, connectionReadTimeout( channel ).orElse( null ) );
+    }
+
+    @Test
+    void shouldFailToSetConnectionReadTimeoutTwice()
+    {
+        long timeout = 15L;
+        setConnectionReadTimeout( channel, timeout );
+        assertThrows( IllegalStateException.class, () -> setConnectionReadTimeout( channel, timeout ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ConnectionReadTimeoutHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/ConnectionReadTimeoutHandlerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.async.inbound;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.Mockito.mock;
+
+public class ConnectionReadTimeoutHandlerTest
+{
+    ConnectionReadTimeoutHandler handler = new ConnectionReadTimeoutHandler( 15L, TimeUnit.SECONDS );
+    ChannelHandlerContext context = mock( ChannelHandlerContext.class );
+
+    @Test
+    void shouldFireConnectionReadTimeoutExceptionAndCloseChannelOnReadTimeOutOnce()
+    {
+        // WHEN
+        IntStream.range( 0, 10 ).forEach( i -> handler.readTimedOut( context ) );
+
+        // THEN
+        then( context ).should( times( 1 ) ).fireExceptionCaught( any( ConnectionReadTimeoutException.class ) );
+        then( context ).should( times( 1 ) ).close();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -183,6 +184,12 @@ class RoutingTableHandlerTest
             @Override
             public void removeAged()
             {
+            }
+
+            @Override
+            public Optional<RoutingTableHandler> getRoutingTableHandler( DatabaseName databaseName )
+            {
+                return Optional.empty();
             }
         };
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
@@ -32,12 +32,14 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.Neo4jException;
+import org.neo4j.driver.internal.cluster.RoutingTableRegistry;
 import org.neo4j.driver.net.ServerAddress;
 
 @Getter
 public class TestkitState
 {
     private final Map<String,Driver> drivers = new HashMap<>();
+    private final Map<String,RoutingTableRegistry> routingTableRegistry = new HashMap<>();
     private final Map<String,SessionState> sessionStates = new HashMap<>();
     private final Map<String,Result> results = new HashMap<>();
     private final Map<String,Transaction> transactions = new HashMap<>();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -36,7 +36,8 @@ public class GetFeatures implements TestkitRequest
 {
     private static final Set<String> FEATURES = new HashSet<>( Arrays.asList(
             "AuthorizationExpiredTreatment",
-            "Optimization:PullPipelining"
+            "Optimization:PullPipelining",
+            "ConfHint:connection.recv_timeout_seconds"
     ) );
 
     @Override

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.requests;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.messages.responses.RoutingTable;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.DatabaseName;
+import org.neo4j.driver.internal.DatabaseNameUtil;
+import org.neo4j.driver.internal.cluster.AddressSet;
+import org.neo4j.driver.internal.cluster.RoutingTableHandler;
+import org.neo4j.driver.internal.cluster.RoutingTableRegistry;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class GetRoutingTable implements TestkitRequest
+{
+    private GetRoutingTableBody data;
+
+    @Override
+    public TestkitResponse process( TestkitState testkitState )
+    {
+        RoutingTableRegistry routingTableRegistry = testkitState.getRoutingTableRegistry().get( data.getDriverId() );
+        if ( routingTableRegistry == null )
+        {
+            throw new IllegalStateException(
+                    String.format( "There is no routing table registry for '%s' driver. (It might be a direct driver)", data.getDriverId() ) );
+        }
+
+        DatabaseName databaseName = DatabaseNameUtil.database( data.getDatabase() );
+        RoutingTableHandler routingTableHandler = routingTableRegistry.getRoutingTableHandler( databaseName ).orElseThrow(
+                () -> new IllegalStateException(
+                        String.format( "There is no routing table handler for the '%s' database.", databaseName.databaseName().orElse( "null" ) ) ) );
+
+        org.neo4j.driver.internal.cluster.RoutingTable routingTable = routingTableHandler.routingTable();
+        Function<AddressSet,List<String>> addressesToStrings = ( addresses ) -> Arrays.stream( addresses.toArray() )
+                                                                                      .map( BoltServerAddress::toString ).collect( Collectors.toList() );
+
+        return RoutingTable
+                .builder()
+                .data( RoutingTable.RoutingTableBody
+                               .builder()
+                               .database( databaseName.databaseName().orElse( null ) )
+                               .routers( addressesToStrings.apply( routingTable.routers() ) )
+                               .readers( addressesToStrings.apply( routingTable.readers() ) )
+                               .writers( addressesToStrings.apply( routingTable.writers() ) )
+                               .build()
+                ).build();
+    }
+
+    @Setter
+    @Getter
+    @NoArgsConstructor
+    public static class GetRoutingTableBody
+    {
+        private String driverId;
+        private String database;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -35,7 +35,8 @@ import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
         @JsonSubTypes.Type( SessionLastBookmarks.class ), @JsonSubTypes.Type( SessionWriteTransaction.class ),
         @JsonSubTypes.Type( ResolverResolutionCompleted.class ), @JsonSubTypes.Type( CheckMultiDBSupport.class ),
         @JsonSubTypes.Type( DomainNameResolutionCompleted.class ), @JsonSubTypes.Type( StartTest.class ),
-        @JsonSubTypes.Type( TransactionRollback.class ), @JsonSubTypes.Type( GetFeatures.class )
+        @JsonSubTypes.Type( TransactionRollback.class ), @JsonSubTypes.Type( GetFeatures.class ),
+        @JsonSubTypes.Type( GetRoutingTable.class )
 } )
 public interface TestkitRequest
 {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/RoutingTable.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/RoutingTable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.responses;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+@Builder
+public class RoutingTable implements TestkitResponse
+{
+    private RoutingTableBody data;
+
+    @Override
+    public String testkitName()
+    {
+        return "RoutingTable";
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class RoutingTableBody
+    {
+        private String database;
+        private long ttl;
+        private List<String> routers;
+        private List<String> readers;
+        private List<String> writers;
+    }
+}


### PR DESCRIPTION
This update brings support for the `connection.recv_timeout_seconds` connection hint that the server may provide in response to the `HELLO` Bolt message.

By providing this value, the server instructs the client on when it may consider connection broken when the client does not hear anything from the server for the specified duration. The client should drop the connection and remove the server from its routing table when it is running with routing enabled. The timeout is considered retryable by the transaction functions.

In addition, this update adds support for the `GetRoutingTable` Testkit request. The `ttl` field is not currently populated.