### PR TITLE
Make Maven skip deployment by default and enable it for specific artifacts only

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -21,6 +21,7 @@
     <maven.build.timestamp.format>'v'yyyyMMdd-HHmm</maven.build.timestamp.format>
     <moduleName>org.neo4j.driver</moduleName>
     <rootDir>${project.basedir}/..</rootDir>
+    <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
 
   <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -83,17 +83,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-deploy</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <!-- All tests tagged are to be executed in parallel -->
     <parallelizable.it.tags>parallelizableIT</parallelizable.it.tags>
     <surefire.and.failsafe.version>2.22.1</surefire.and.failsafe.version>
+    <!-- Skip deployment by default for everything in this project. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
     <reactive-streams.version>1.0.3</reactive-streams.version>
@@ -423,6 +425,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <!-- Explicit deployment override for this artifact only. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This is intended to prevent current and future modules from being deployed without explicit configuration.