### PR TITLE
Make default driver logging quiet

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -34,7 +34,7 @@ import org.neo4j.driver.net.ServerAddressResolver;
 import org.neo4j.driver.util.Immutable;
 
 import static java.lang.String.format;
-import static org.neo4j.driver.Logging.javaUtilLogging;
+import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 /**
  * A configuration class to config driver properties.
@@ -269,7 +269,7 @@ public class Config
      */
     public static class ConfigBuilder
     {
-        private Logging logging = javaUtilLogging( Level.INFO );
+        private Logging logging = DEV_NULL_LOGGING;
         private boolean logLeakedSessions;
         private int maxConnectionPoolSize = PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;


### PR DESCRIPTION
This update objective is to align the default logging setting with other Neo4j drivers.

Users can change the level according to their needs.
