### PR TITLE
Decouple TestkitState from CommandProcessor.

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/BackendServer.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/BackendServer.java
@@ -50,7 +50,7 @@ public class BackendServer
             System.out.println( "Handling connection from: " + clientSocket.getRemoteSocketAddress() );
             BufferedReader in = new BufferedReader( new InputStreamReader( clientSocket.getInputStream() ) );
             BufferedWriter out = new BufferedWriter( new OutputStreamWriter( clientSocket.getOutputStream() ) );
-            CommandProcessor commandProcessor = new CommandProcessor( in, out );
+            CommandProcessor commandProcessor = new DefaultCommandProcessor( in, out );
 
             boolean cont = true;
             while ( cont )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/DefaultCommandProcessor.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/DefaultCommandProcessor.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
+import neo4j.org.testkit.backend.messages.responses.BackendError;
+import neo4j.org.testkit.backend.messages.responses.DriverError;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.neo4j.driver.exceptions.Neo4jException;
+import org.neo4j.driver.exceptions.UntrustedServerException;
+import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
+
+class DefaultCommandProcessor implements CommandProcessor
+{
+    private final TestkitState testkitState;
+
+    private final ObjectMapper objectMapper;
+
+    private final BufferedReader in;
+    private final BufferedWriter out;
+
+    DefaultCommandProcessor( BufferedReader in, BufferedWriter out )
+    {
+        this.in = in;
+        this.out = out;
+        this.objectMapper = CommandProcessor.newObjectMapperFor( this );
+        this.testkitState = new TestkitState( this::writeResponse );
+    }
+
+    private String readLine()
+    {
+        try
+        {
+            return this.in.readLine();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private void write( String s )
+    {
+        try
+        {
+            this.out.write( s );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    // Logs to frontend
+    private void log( String s )
+    {
+        try
+        {
+            this.out.write( s + "\n" );
+            this.out.flush();
+        }
+        catch ( IOException e )
+        {
+        }
+        System.out.println( s );
+    }
+
+    private void flush()
+    {
+        try
+        {
+            this.out.flush();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public boolean process()
+    {
+        boolean inRequest = false;
+        StringBuilder request = new StringBuilder();
+
+        log( "Waiting for request" );
+
+        while ( true )
+        {
+            String currentLine = readLine();
+            // End of stream
+            if ( currentLine == null )
+            {
+                return false;
+            }
+
+            if ( currentLine.equals( "#request begin" ) )
+            {
+                inRequest = true;
+            }
+            else if ( currentLine.equals( "#request end" ) )
+            {
+                if ( !inRequest )
+                {
+                    throw new RuntimeException( "Request end not expected" );
+                }
+                try
+                {
+                    processRequest( request.toString() );
+                }
+                catch ( Exception e )
+                {
+                    if ( e instanceof Neo4jException )
+                    {
+                        // Error to track
+                        String id = testkitState.newId();
+                        testkitState.getErrors().put( id, (Neo4jException) e );
+                        writeResponse( driverError( id, (Neo4jException) e ) );
+                        System.out.println( "Neo4jException: " + e );
+                    }
+                    else if ( isConnectionPoolClosedException( e ) || e instanceof UntrustedServerException )
+                    {
+                        String id = testkitState.newId();
+                        DriverError driverError = DriverError.builder()
+                                                             .data(
+                                                                     DriverError.DriverErrorBody.builder()
+                                                                                                .id( id )
+                                                                                                .errorType( e.getClass().getName() )
+                                                                                                .msg( e.getMessage() )
+                                                                                                .build()
+                                                             )
+                                                             .build();
+                        writeResponse( driverError );
+                    }
+                    else
+                    {
+                        // Unknown error, interpret this as a backend error.
+                        // Report to frontend and rethrow, note that if socket been
+                        // closed the writing will throw itself...
+                        writeResponse( BackendError.builder().data( BackendError.BackendErrorBody.builder().msg( e.toString() ).build() ).build() );
+                        // This won't print if there was an IO exception since line above will rethrow
+                        e.printStackTrace();
+                        throw e;
+                    }
+                }
+                return true;
+            }
+            else
+            {
+                if ( !inRequest )
+                {
+                    throw new RuntimeException( "Command Received whilst not in request" );
+                }
+                request.append( currentLine );
+            }
+        }
+    }
+
+    private DriverError driverError( String id, Neo4jException e )
+    {
+        return DriverError.builder().data(
+                DriverError.DriverErrorBody.builder()
+                                           .id( id )
+                                           .errorType( e.getClass().getName() )
+                                           .code( e.code() )
+                                           .msg( e.getMessage() )
+                                           .build() )
+                          .build();
+    }
+
+    public void processRequest( String request )
+    {
+        System.out.println( "request = " + request + ", in = " + in + ", out = " + out );
+        try
+        {
+            TestkitRequest testkitMessage = objectMapper.readValue( request, TestkitRequest.class );
+            TestkitResponse response = testkitMessage.process( testkitState );
+            if ( response != null )
+            {
+                writeResponse( response );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private void writeResponse( TestkitResponse response )
+    {
+        try
+        {
+            String responseStr = objectMapper.writeValueAsString( response );
+            System.out.println("response = " + responseStr + ", in = " + in + ", out = " + out);
+            write( "#response begin\n" );
+            write( responseStr + "\n" );
+            write( "#response end\n" );
+            flush();
+        }
+        catch ( JsonProcessingException ex )
+        {
+            throw new RuntimeException( "Error writing response", ex );
+        }
+    }
+
+    private boolean isConnectionPoolClosedException( Exception e )
+    {
+        return e instanceof IllegalStateException && e.getMessage() != null &&
+               e.getMessage().equals( ConnectionPoolImpl.CONNECTION_POOL_CLOSED_ERROR_MESSAGE );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
@@ -36,7 +36,7 @@ import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
 
 public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
 {
-    private final TestkitState testkitState = new TestkitState( this::writeAndFlush, () -> true );
+    private final TestkitState testkitState = new TestkitState( this::writeAndFlush );
     private Channel channel;
 
     @Override

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
@@ -19,26 +19,17 @@
 package neo4j.org.testkit.backend.channel.handler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import neo4j.org.testkit.backend.messages.TestkitModule;
+import neo4j.org.testkit.backend.CommandProcessor;
 import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 
 public class TestkitRequestResponseMapperHandler extends ChannelDuplexHandler
 {
-    private final ObjectMapper objectMapper;
-
-    public TestkitRequestResponseMapperHandler()
-    {
-        objectMapper = new ObjectMapper();
-        TestkitModule testkitModule = new TestkitModule();
-        this.objectMapper.registerModule( testkitModule );
-        this.objectMapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
-    }
+    private final ObjectMapper objectMapper = CommandProcessor.newObjectMapperFor( () -> true );
 
     @Override
     public void channelRead( ChannelHandlerContext ctx, Object msg )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionReadTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionReadTransaction.java
@@ -18,10 +18,13 @@
  */
 package neo4j.org.testkit.backend.messages.requests;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import neo4j.org.testkit.backend.AsyncSessionState;
+import neo4j.org.testkit.backend.CommandProcessor;
 import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.RetryableDone;
@@ -39,10 +42,16 @@ import org.neo4j.driver.async.AsyncTransactionWork;
 
 @Setter
 @Getter
-@NoArgsConstructor
 public class SessionReadTransaction implements TestkitRequest
 {
+    private final CommandProcessor commandProcessor;
+
     private SessionReadTransactionBody data;
+
+    public SessionReadTransaction( @JacksonInject(CommandProcessor.COMMAND_PROCESSOR_ID) CommandProcessor commandProcessor )
+    {
+        this.commandProcessor = commandProcessor;
+    }
 
     @Override
     public TestkitResponse process( TestkitState testkitState )
@@ -90,7 +99,7 @@ public class SessionReadTransaction implements TestkitRequest
             while ( true )
             {
                 // Process commands as usual but blocking in here
-                testkitState.getProcessor().get();
+                commandProcessor.process();
 
                 // Check if state changed on session
                 switch ( sessionState.retryableState )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
@@ -18,10 +18,12 @@
  */
 package neo4j.org.testkit.backend.messages.requests;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import neo4j.org.testkit.backend.AsyncSessionState;
+import neo4j.org.testkit.backend.CommandProcessor;
 import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.RetryableDone;
@@ -40,10 +42,16 @@ import org.neo4j.driver.async.AsyncTransactionWork;
 
 @Setter
 @Getter
-@NoArgsConstructor
 public class SessionWriteTransaction implements TestkitRequest
 {
+    private final CommandProcessor commandProcessor;
+
     private SessionWriteTransactionBody data;
+
+    public SessionWriteTransaction( @JacksonInject(CommandProcessor.COMMAND_PROCESSOR_ID) CommandProcessor commandProcessor )
+    {
+        this.commandProcessor = commandProcessor;
+    }
 
     @Override
     public TestkitResponse process( TestkitState testkitState )
@@ -92,7 +100,7 @@ public class SessionWriteTransaction implements TestkitRequest
             while ( true )
             {
                 // Process commands as usual but blocking in here
-                testkitState.getProcessor().get();
+                commandProcessor.process();
 
                 // Check if state changed on session
                 switch ( sessionState.retryableState )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -20,13 +20,14 @@ package neo4j.org.testkit.backend.messages.requests;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import neo4j.org.testkit.backend.CommandProcessor;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "name" )
+@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, property = "name" )
 @JsonSubTypes( {
         @JsonSubTypes.Type( NewDriver.class ), @JsonSubTypes.Type( NewSession.class ),
         @JsonSubTypes.Type( SessionRun.class ), @JsonSubTypes.Type( ResultNext.class ),

--- a/testkit-backend/src/test/java/neo4j/org/testkit/backend/MessageDeserializerTest.java
+++ b/testkit-backend/src/test/java/neo4j/org/testkit/backend/MessageDeserializerTest.java
@@ -19,14 +19,11 @@
 package neo4j.org.testkit.backend;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import neo4j.org.testkit.backend.messages.TestkitModule;
 import neo4j.org.testkit.backend.messages.requests.NewDriver;
 import neo4j.org.testkit.backend.messages.requests.NewSession;
-import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import neo4j.org.testkit.backend.messages.requests.SessionRun;
-import org.junit.jupiter.api.BeforeAll;
+import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,16 +32,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 class MessageDeserializerTest
 {
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    @BeforeAll
-    static void setUp()
-    {
-        TestkitModule tkm = new TestkitModule();
-
-        //mapper.registerModule( tkm );
-        mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
-    }
+    private static final ObjectMapper mapper = CommandProcessor.newObjectMapperFor( () -> false );
 
     @Test
     void testDeserializeNewDriver() throws JsonProcessingException

--- a/testkit-backend/src/test/java/neo4j/org/testkit/backend/MessageSerializerTest.java
+++ b/testkit-backend/src/test/java/neo4j/org/testkit/backend/MessageSerializerTest.java
@@ -19,11 +19,8 @@
 package neo4j.org.testkit.backend;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import neo4j.org.testkit.backend.messages.TestkitModule;
 import neo4j.org.testkit.backend.messages.responses.Driver;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,16 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class MessageSerializerTest
 {
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    @BeforeAll
-    static void setUp()
-    {
-        TestkitModule tkm = new TestkitModule();
-
-        mapper.registerModule( tkm );
-        mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
-    }
+    private static final ObjectMapper mapper = CommandProcessor.newObjectMapperFor( () -> false );
 
     @Test
     void shouldSerializerNewDriverResponse() throws JsonProcessingException


### PR DESCRIPTION
This commit remoces the command processor from the TestKit state. The processor is supposed to use that state, not to be part of it.
However, some requests, like `NewDriver` need the processor to trigger further state.
Therefor the processor is now provided as injectable value via Jackson, so that any request can indicate that it needs a processor via a constructor argument.