### PR TITLE
Add reactive backend support

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
@@ -34,9 +34,24 @@ public class Runner
 {
     public static void main( String[] args ) throws InterruptedException
     {
-        boolean asyncMode = args.length > 0 && args[0].equals( "async" );
+        TestkitRequestProcessorHandler.BackendMode backendMode;
+        String modeArg = args.length > 0 ? args[0] : null;
+        if ( "async".equals( modeArg ) )
+        {
+            backendMode = TestkitRequestProcessorHandler.BackendMode.ASYNC;
+        }
+        else if ( "reactive".equals( modeArg ) )
+        {
+            backendMode = TestkitRequestProcessorHandler.BackendMode.REACTIVE;
+        }
+        else
+        {
+            backendMode = TestkitRequestProcessorHandler.BackendMode.SYNC;
+        }
+
         EventLoopGroup group = new NioEventLoopGroup();
         try
+
         {
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.group( group )
@@ -50,7 +65,7 @@ public class Runner
                              channel.pipeline().addLast( new TestkitMessageInboundHandler() );
                              channel.pipeline().addLast( new TestkitMessageOutboundHandler() );
                              channel.pipeline().addLast( new TestkitRequestResponseMapperHandler() );
-                             channel.pipeline().addLast( new TestkitRequestProcessorHandler( asyncMode ) );
+                             channel.pipeline().addLast( new TestkitRequestProcessorHandler( backendMode ) );
                          }
                      } );
             ChannelFuture server = bootstrap.bind().sync();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/RxBlockingSubscriber.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/RxBlockingSubscriber.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend;
+
+import lombok.Getter;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.CompletableFuture;
+
+public class RxBlockingSubscriber<T> implements Subscriber<T>
+{
+    @Getter
+    private final CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
+    private CompletableFuture<CompletableFuture<T>> nextSignalConsumerFuture;
+
+    public void setNextSignalConsumer( CompletableFuture<T> nextSignalConsumer )
+    {
+        nextSignalConsumerFuture.complete( nextSignalConsumer );
+    }
+
+    @Override
+    public void onSubscribe( Subscription s )
+    {
+        nextSignalConsumerFuture = new CompletableFuture<>();
+        subscriptionFuture.complete( s );
+    }
+
+    @Override
+    public void onNext( T t )
+    {
+        blockUntilNextSignalConsumer().complete( t );
+    }
+
+    @Override
+    public void onError( Throwable t )
+    {
+        blockUntilNextSignalConsumer().completeExceptionally( t );
+    }
+
+    @Override
+    public void onComplete()
+    {
+        blockUntilNextSignalConsumer().complete( null );
+    }
+
+    private CompletableFuture<T> blockUntilNextSignalConsumer()
+    {
+        CompletableFuture<T> nextSignalConsumer;
+        try
+        {
+            nextSignalConsumer = nextSignalConsumerFuture.get();
+        }
+        catch ( Throwable throwable )
+        {
+            throw new RuntimeException( "Failed waiting for next signal consumer", throwable );
+        }
+        nextSignalConsumerFuture = new CompletableFuture<>();
+        return nextSignalConsumer;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/RxSessionState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/RxSessionState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.neo4j.driver.reactive.RxSession;
+
+@Getter
+@Setter
+public class RxSessionState
+{
+    public RxSession session;
+    public CompletableFuture<Void> txWorkFuture;
+
+    public RxSessionState( RxSession session )
+    {
+        this.session = session;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
@@ -30,6 +30,8 @@ import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
 
 import org.neo4j.driver.exceptions.Neo4jException;
@@ -39,15 +41,24 @@ import org.neo4j.driver.internal.async.pool.ConnectionPoolImpl;
 public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
 {
     private final TestkitState testkitState = new TestkitState( this::writeAndFlush );
-    private final BiFunction<TestkitRequest, TestkitState, CompletionStage<TestkitResponse>> processorImpl;
+    private final BiFunction<TestkitRequest,TestkitState,CompletionStage<TestkitResponse>> processorImpl;
+    // Some requests require multiple threads
+    private final Executor requestExecutorService = Executors.newFixedThreadPool( 10 );
     private Channel channel;
 
-    public TestkitRequestProcessorHandler( boolean asyncMode )
+    public TestkitRequestProcessorHandler( BackendMode backendMode )
     {
-        if (asyncMode) {
-            processorImpl = (request, state) -> request.processAsync( state );
-        } else {
+        switch ( backendMode )
+        {
+        case ASYNC:
             processorImpl = TestkitRequestProcessorHandler::wrapSyncRequest;
+            break;
+        case REACTIVE:
+            processorImpl = ( request, state ) -> request.processRx( state ).toFuture();
+            break;
+        default:
+            processorImpl = TestkitRequest::processAsync;
+            break;
         }
     }
 
@@ -62,20 +73,29 @@ public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
     public void channelRead( ChannelHandlerContext ctx, Object msg )
     {
         // Processing is done in a separate thread to avoid blocking EventLoop because some testing logic, like resolvers support, is blocking.
-        CompletableFuture.supplyAsync( () -> (TestkitRequest) msg )
-                .thenCompose( request -> processorImpl.apply( request, testkitState ) )
-                .thenApply( response ->
-                {
-                    if ( response != null )
-                    {
-                        ctx.writeAndFlush( response );
-                    }
-                    return null;
-                } ).exceptionally( throwable ->
-        {
-            ctx.writeAndFlush( createErrorResponse( throwable ) );
-            return null;
-        } );
+        requestExecutorService.execute( () ->
+                                        {
+                                            try
+                                            {
+                                                TestkitRequest request = (TestkitRequest) msg;
+                                                CompletionStage<TestkitResponse> responseStage = processorImpl.apply( request, testkitState );
+                                                responseStage.whenComplete( ( response, throwable ) ->
+                                                                            {
+                                                                                if ( throwable != null )
+                                                                                {
+                                                                                    ctx.writeAndFlush( createErrorResponse( throwable ) );
+                                                                                }
+                                                                                else if ( response != null )
+                                                                                {
+                                                                                    ctx.writeAndFlush( response );
+                                                                                }
+                                                                            } );
+                                            }
+                                            catch ( Throwable throwable )
+                                            {
+                                                ctx.writeAndFlush( createErrorResponse( throwable ) );
+                                            }
+                                        } );
     }
 
     private static CompletionStage<TestkitResponse> wrapSyncRequest( TestkitRequest testkitRequest, TestkitState testkitState )
@@ -144,5 +164,12 @@ public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
             throw new IllegalStateException( "Called before channel is initialized" );
         }
         channel.writeAndFlush( response );
+    }
+
+    public enum BackendMode
+    {
+        SYNC,
+        ASYNC,
+        REACTIVE
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.MultiDBSupport;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -46,6 +47,12 @@ public class CheckMultiDBSupport implements TestkitRequest
         return testkitState.getDrivers().get( data.getDriverId() )
                            .supportsMultiDbAsync()
                            .thenApply( this::createResponse );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.fromCompletionStage( processAsync( testkitState ) );
     }
 
     private MultiDBSupport createResponse( boolean available )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.Driver;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -45,6 +46,12 @@ public class DriverClose implements TestkitRequest
         return testkitState.getDrivers().get( data.getDriverId() )
                            .closeAsync()
                            .thenApply( ignored -> createResponse() );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.fromCompletionStage( processAsync( testkitState ) );
     }
 
     private Driver createResponse()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.FeatureList;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,6 +61,12 @@ public class GetFeatures implements TestkitRequest
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
         return CompletableFuture.completedFuture( createResponse( COMMON_FEATURES ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.just( createResponse( COMMON_FEATURES ) );
     }
 
     private FeatureList createResponse( Set<String> features )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.RoutingTable;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
 import java.util.List;
@@ -78,7 +79,13 @@ public class GetRoutingTable implements TestkitRequest
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return CompletableFuture.completedFuture( process( testkitState ) ) ;
+        return CompletableFuture.completedFuture( process( testkitState ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.just( process( testkitState ) );
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -29,6 +29,7 @@ import neo4j.org.testkit.backend.messages.responses.DriverError;
 import neo4j.org.testkit.backend.messages.responses.ResolverResolutionRequired;
 import neo4j.org.testkit.backend.messages.responses.TestkitCallback;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -116,6 +117,12 @@ public class NewDriver implements TestkitRequest
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
         return CompletableFuture.completedFuture( process( testkitState ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.fromCompletionStage( processAsync( testkitState ) );
     }
 
     private ServerAddressResolver callbackResolver( TestkitState testkitState )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
@@ -24,11 +24,13 @@ import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.NullRecord;
 import neo4j.org.testkit.backend.messages.responses.Summary;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.reactive.RxResult;
 
 @Setter
 @Getter
@@ -56,6 +58,14 @@ public class ResultConsume implements TestkitRequest
         return testkitState.getResultCursors().get( data.getResultId() )
                            .consumeAsync()
                            .thenApply( this::createResponse );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        RxResult result = testkitState.getRxResults().get( data.getResultId() );
+        return Mono.fromDirect( result.consume() )
+                   .map( this::createResponse );
     }
 
     private Summary createResponse( org.neo4j.driver.summary.ResultSummary summary )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
@@ -24,6 +24,7 @@ import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.Record;
 import neo4j.org.testkit.backend.messages.responses.RecordList;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -47,6 +48,12 @@ public class ResultList implements TestkitRequest
         return testkitState.getResultCursors().get( data.getResultId() )
                            .listAsync()
                            .thenApply( this::createResponse );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        throw new UnsupportedOperationException( "Operation not supported" );
     }
 
     private RecordList createResponse( List<org.neo4j.driver.Record> records )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultNext.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultNext.java
@@ -20,15 +20,20 @@ package neo4j.org.testkit.backend.messages.requests;
 
 import lombok.Getter;
 import lombok.Setter;
+import neo4j.org.testkit.backend.RxBlockingSubscriber;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.NullRecord;
 import neo4j.org.testkit.backend.messages.responses.Record;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.reactive.RxResult;
 
 @Setter
 @Getter
@@ -56,6 +61,44 @@ public class ResultNext implements TestkitRequest
         return testkitState.getResultCursors().get( data.getResultId() )
                            .nextAsync()
                            .thenApply( record -> record != null ? createResponse( record ) : NullRecord.builder().build() );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        CompletableFuture<RxBlockingSubscriber<org.neo4j.driver.Record>> subscriberFuture;
+        String resultId = data.getResultId();
+        RxBlockingSubscriber<org.neo4j.driver.Record> currentSubscriber = testkitState.getRxResultIdToRecordSubscriber().get( resultId );
+
+        if ( currentSubscriber == null )
+        {
+            RxBlockingSubscriber<org.neo4j.driver.Record> subscriber = new RxBlockingSubscriber<>();
+            subscriberFuture = subscriber.getSubscriptionFuture().thenApply( subscription ->
+                                                                             {
+                                                                                 subscription.request( 1000 );
+                                                                                 return subscriber;
+                                                                             } );
+            testkitState.getRxResultIdToRecordSubscriber().put( resultId, subscriber );
+            RxResult result = testkitState.getRxResults().get( resultId );
+            result.records().subscribe( subscriber );
+        }
+        else
+        {
+            subscriberFuture = CompletableFuture.completedFuture( currentSubscriber );
+        }
+
+        CompletableFuture<TestkitResponse> responseFuture = subscriberFuture
+                .thenApply( recordsSubscriber ->
+                            {
+                                CompletableFuture<org.neo4j.driver.Record> recordConsumer =
+                                        new CompletableFuture<>();
+                                recordsSubscriber.setNextSignalConsumer( recordConsumer );
+                                return recordConsumer;
+                            } )
+                .thenCompose( Function.identity() )
+                .thenApply( record -> record != null ? createResponse( record ) : NullRecord.builder().build() );
+
+        return Mono.fromCompletionStage( responseFuture );
     }
 
     private Record createResponse( org.neo4j.driver.Record record )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryableNegative.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryableNegative.java
@@ -21,9 +21,11 @@ package neo4j.org.testkit.backend.messages.requests;
 import lombok.Getter;
 import lombok.Setter;
 import neo4j.org.testkit.backend.AsyncSessionState;
+import neo4j.org.testkit.backend.RxSessionState;
 import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -70,6 +72,23 @@ public class RetryableNegative implements TestkitRequest
         }
         sessionState.getTxWorkFuture().completeExceptionally( throwable );
         return CompletableFuture.completedFuture( null );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        RxSessionState sessionState = testkitState.getRxSessionStates().get( data.getSessionId() );
+        Throwable throwable;
+        if ( !"".equals( data.getErrorId() ) )
+        {
+            throwable = testkitState.getErrors().get( data.getErrorId() );
+        }
+        else
+        {
+            throwable = new RuntimeException( "Error from client in retryable tx" );
+        }
+        sessionState.getTxWorkFuture().completeExceptionally( throwable );
+        return Mono.empty();
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryablePositive.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryablePositive.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -50,6 +51,13 @@ public class RetryablePositive implements TestkitRequest
     {
         testkitState.getAsyncSessionStates().get( data.getSessionId() ).getTxWorkFuture().complete( null );
         return CompletableFuture.completedFuture( null );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        testkitState.getRxSessionStates().get( data.getSessionId() ).getTxWorkFuture().complete( null );
+        return Mono.empty();
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.Session;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -45,6 +46,13 @@ public class SessionClose implements TestkitRequest
         return testkitState.getAsyncSessionStates().get( data.getSessionId() ).getSession()
                            .closeAsync()
                            .thenApply( ignored -> createResponse() );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.fromDirect( testkitState.getRxSessionStates().get( data.getSessionId() ).getSession().close() )
+                   .then( Mono.just( createResponse() ) );
     }
 
     private Session createResponse()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionLastBookmarks.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionLastBookmarks.java
@@ -24,6 +24,7 @@ import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.Bookmarks;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +56,13 @@ public class SessionLastBookmarks implements TestkitRequest
     {
         Bookmark bookmark = testkitState.getAsyncSessionStates().get( data.getSessionId() ).getSession().lastBookmark();
         return CompletableFuture.completedFuture( createResponse( bookmark ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        Bookmark bookmark = testkitState.getRxSessionStates().get( data.getSessionId() ).getSession().lastBookmark();
+        return Mono.just( createResponse( bookmark ) );
     }
 
     private Bookmarks createResponse( Bookmark bookmark )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
@@ -21,11 +21,14 @@ package neo4j.org.testkit.backend.messages.requests;
 import lombok.Getter;
 import lombok.Setter;
 import neo4j.org.testkit.backend.AsyncSessionState;
+import neo4j.org.testkit.backend.RxSessionState;
 import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.RetryableDone;
 import neo4j.org.testkit.backend.messages.responses.RetryableTry;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +41,7 @@ import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransactionWork;
 import org.neo4j.driver.exceptions.Neo4jException;
+import org.neo4j.driver.reactive.RxTransactionWork;
 
 @Setter
 @Getter
@@ -75,6 +79,23 @@ public class SessionWriteTransaction implements TestkitRequest
 
         return session.writeTransactionAsync( workWrapper )
                       .thenApply( nothing -> retryableDone() );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        RxSessionState sessionState = testkitState.getRxSessionStates().get( data.getSessionId() );
+        RxTransactionWork<Publisher<Void>> workWrapper = tx ->
+        {
+            String txId = testkitState.addRxTransaction( tx );
+            testkitState.getResponseWriter().accept( retryableTry( txId ) );
+            CompletableFuture<Void> tryResult = new CompletableFuture<>();
+            sessionState.setTxWorkFuture( tryResult );
+            return Mono.fromCompletionStage( tryResult );
+        };
+
+        return Mono.fromDirect( sessionState.getSession().writeTransaction( workWrapper ) )
+                   .then( Mono.just( retryableDone() ) );
     }
 
     private TransactionWork<Void> handle( TestkitState testkitState, SessionState sessionState )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -24,6 +24,7 @@ import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.RunTest;
 import neo4j.org.testkit.backend.messages.responses.SkipTest;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,10 +36,75 @@ import java.util.concurrent.CompletionStage;
 public class StartTest implements TestkitRequest
 {
     private static final Map<String,String> ASYNC_SKIP_PATTERN_TO_REASON = new HashMap<>();
+    private static final Map<String,String> REACTIVE_SKIP_PATTERN_TO_REASON = new HashMap<>();
 
     static
     {
-        ASYNC_SKIP_PATTERN_TO_REASON.put( "^.*.test_should_reject_server_using_verify_connectivity_bolt_3x0$", "Does not error as expected" );
+        ASYNC_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_should_reject_server_using_verify_connectivity_bolt_3x0$", "Does not error as expected" );
+
+        // V3 tests
+        String skipMessage = "v3 is not applicable to reactive";
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthorizationV3\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestBookmarksV3\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRoutingV3\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.RoutingV3\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestProtocolVersions\\.test_should_reject_server_using_verify_connectivity_bolt_3x0$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestProtocolVersions\\.test_supports_bolt_3x0", skipMessage );
+
+        // Current limitations (require further investigation or bug fixing)
+        skipMessage = "Does not report RUN FAILURE";
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_write_successfully_on_leader_switch_using_tx_function$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_after_hello$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_run$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_on_tx_run$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRetry\\..*$", "Unfinished results consumption" );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRetryClustering\\..*$", "Unfinished results consumption" );
+        skipMessage = "Does not support PULL pipelining";
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_and_rediscovery_until_success$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_until_success_on_error$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_and_rediscovery_until_success$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_until_success_on_error$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run$",
+                                             skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run$",
+                                             skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run$",
+                                             skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_readers_using_tx_function$",
+                                             skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_fail_when_writing_to_unexpectedly_interrupting_writers_using_tx_function$",
+                                             skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_write_until_success_with_leader_change_using_tx_function$",
+                                             skipMessage );
+        skipMessage = "Custom fetch size not supported";
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_accept_custom_fetch_size_using_driver_configuration$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_pull_all_when_fetch_is_minus_one_using_driver_configuration", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_pull_custom_size_and_then_all_using_session_configuration$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_accept_custom_fetch_size_using_session_configuration$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestIterationSessionRun\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestIterationTxRun\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_rollback_tx_on_session_close_consumed_result$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_error_on_database_shutdown_using_tx_run$", "Session close throws error" );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function$",
+                                             "Commit failure leaks outside function" );
+        skipMessage = "Requires investigation";
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestProtocolVersions\\.test_server_agent", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestProtocolVersions\\.test_server_version", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthorizationV4x1\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthorizationV4x3\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestNoRoutingAuthorization\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestOptimizations\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDirectConnectionRecvTimeout\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_successfully_acquire_rt_when_router_ip_changes$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout_unmanaged_tx$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_tx_commit$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRunParameters\\..*$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_rollback_tx_on_session_close_unfinished_result$", skipMessage );
+        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_rollback_tx_on_session_close_untouched_result$", skipMessage );
     }
 
     private StartTestBody data;
@@ -65,6 +131,24 @@ public class StartTest implements TestkitRequest
                 .orElseGet( () -> RunTest.builder().build() );
 
         return CompletableFuture.completedFuture( testkitResponse );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        TestkitResponse testkitResponse = REACTIVE_SKIP_PATTERN_TO_REASON
+                .entrySet()
+                .stream()
+                .filter( entry -> data.getTestName().matches( entry.getKey() ) )
+                .findFirst()
+                .map( entry -> (TestkitResponse) SkipTest.builder()
+                                                         .data( SkipTest.SkipTestBody.builder()
+                                                                                     .reason( entry.getValue() )
+                                                                                     .build() )
+                                                         .build() )
+                .orElseGet( () -> RunTest.builder().build() );
+
+        return Mono.fromCompletionStage( CompletableFuture.completedFuture( testkitResponse ) );
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitCallbackResult.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitCallbackResult.java
@@ -21,6 +21,7 @@ package neo4j.org.testkit.backend.messages.requests;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitCallback;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -44,5 +45,12 @@ public interface TestkitCallbackResult extends TestkitRequest
     {
         testkitState.getCallbackIdToFuture().get( getCallbackId() ).complete( this );
         return CompletableFuture.completedFuture( null );
+    }
+
+    @Override
+    default Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        testkitState.getCallbackIdToFuture().get( getCallbackId() ).complete( this );
+        return Mono.empty();
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -46,4 +47,6 @@ public interface TestkitRequest
     TestkitResponse process( TestkitState testkitState );
 
     CompletionStage<TestkitResponse> processAsync( TestkitState testkitState );
+
+    Mono<TestkitResponse> processRx( TestkitState testkitState );
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import neo4j.org.testkit.backend.messages.responses.Transaction;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -43,6 +44,12 @@ public class TransactionClose implements TestkitRequest
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        throw new UnsupportedOperationException( "Operation not supported" );
     }
 
     private Transaction createResponse( String txId )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
@@ -23,8 +23,11 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import neo4j.org.testkit.backend.messages.responses.Transaction;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.async.AsyncTransaction;
 
 @Getter
 @Setter
@@ -42,7 +45,16 @@ public class TransactionCommit implements TestkitRequest
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getAsyncTransaction( data.getTxId() ).thenCompose( tx -> tx.commitAsync() ).thenApply( ignored -> createResponse( data.getTxId() ) );
+        return testkitState.getAsyncTransaction( data.getTxId() ).thenCompose( AsyncTransaction::commitAsync )
+                           .thenApply( ignored -> createResponse( data.getTxId() ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return testkitState.getRxTransaction( data.getTxId() )
+                           .flatMap( tx -> Mono.fromDirect( tx.commit() ) )
+                           .then( Mono.just( createResponse( data.getTxId() ) ) );
     }
 
     private Transaction createResponse( String txId )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.responses.Driver;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
@@ -47,6 +48,12 @@ public class VerifyConnectivity implements TestkitRequest
         return testkitState.getDrivers().get( id )
                            .verifyConnectivityAsync()
                            .thenApply( ignored -> createResponse( id ) );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return Mono.fromCompletionStage( processAsync( testkitState ) );
     }
 
     private Driver createResponse( String id )

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -24,6 +24,9 @@
         <testkit.args>--tests TESTKIT_TESTS INTEGRATION_TESTS STUB_TESTS STRESS_TESTS TLS_TESTS</testkit.args>
         <testkit.timeout>7200000</testkit.timeout>
         <testkit.async.name.pattern>%a-async</testkit.async.name.pattern>
+        <testkit.rx.name.pattern>%a-rx</testkit.rx.name.pattern>
+        <!-- Debug logging for backend messages. Empty string - off, Non-empty string - on. -->
+        <testkit.debug.reqres></testkit.debug.reqres>
 
         <docker-maven-plugin.version>0.36.1</docker-maven-plugin.version>
         <docker.showLogs>true</docker.showLogs>
@@ -73,6 +76,7 @@
                                         <TEST_DRIVER_NAME>java</TEST_DRIVER_NAME>
                                         <TEST_DRIVER_REPO>${rootDir}</TEST_DRIVER_REPO>
                                         <TEST_SKIP_BUILD>true</TEST_SKIP_BUILD>
+                                        <TEST_DEBUG_REQRES>${testkit.debug.reqres}</TEST_DEBUG_REQRES>
                                     </env>
                                     <volumes>
                                         <bind>
@@ -131,6 +135,34 @@
                                             </env>
                                             <log>
                                                 <prefix xml:space="preserve">${testkit.async.name.pattern}> </prefix>
+                                            </log>
+                                        </run>
+                                    </image>
+                                </images>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- Use reactive backend to test reactive driver. -->
+                            <id>run-testkit-rx</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <!-- Testkit is expected to exit automatically. -->
+                                <goal>start</goal>
+                            </goals>
+                            <configuration>
+                                <images>
+                                    <image>
+                                        <alias>tklnchr</alias>
+                                        <run>
+                                            <containerNamePattern>${testkit.rx.name.pattern}</containerNamePattern>
+                                            <env>
+                                                <TESTKIT_CHECKOUT_PATH>${project.build.directory}/testkit-rx</TESTKIT_CHECKOUT_PATH>
+                                                <TEST_BACKEND_SERVER>reactive</TEST_BACKEND_SERVER>
+                                                <!-- Excludes 3.5 -->
+                                                <TESTKIT_ARGS>--configs 4.2-cluster,4.0-community,4.1-enterprise ${testkit.args}</TESTKIT_ARGS>
+                                            </env>
+                                            <log>
+                                                <prefix xml:space="preserve">${testkit.rx.name.pattern}> </prefix>
                                             </log>
                                         </run>
                                     </image>


### PR DESCRIPTION
This update brings reactive backend support.

Its scope is limited to providing partial transparent support for existing test cases. More updates are expected in future PRs.