### PR TITLE
Add holder objects for driver, session, transaction and result objects in backend

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractResultHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractResultHolder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+public abstract class AbstractResultHolder<T1, T2 extends AbstractTransactionHolder<?,?>, T3>
+{
+    private final T1 sessionHolder;
+    private final T2 transactionHolder;
+    @Getter
+    private final T3 result;
+
+    public AbstractResultHolder( T1 sessionHolder, T3 result )
+    {
+        this.sessionHolder = sessionHolder;
+        this.transactionHolder = null;
+        this.result = result;
+    }
+
+    public AbstractResultHolder( T2 transactionHolder, T3 result )
+    {
+        this.sessionHolder = null;
+        this.transactionHolder = transactionHolder;
+        this.result = result;
+    }
+
+    public T1 getSessionHolder()
+    {
+        return transactionHolder != null ? getSessionHolder( transactionHolder ) : sessionHolder;
+    }
+
+    public Optional<T2> getTransactionHolder()
+    {
+        return Optional.ofNullable( transactionHolder );
+    }
+
+    protected abstract T1 getSessionHolder( T2 transactionHolder );
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractSessionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractSessionHolder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.neo4j.driver.SessionConfig;
+
+@RequiredArgsConstructor
+@Getter
+public abstract class AbstractSessionHolder<T>
+{
+    public final DriverHolder driverHolder;
+    public final T session;
+    public final SessionConfig config;
+    @Setter
+    public CompletableFuture<Void> txWorkFuture;
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractTransactionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AbstractTransactionHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public abstract class AbstractTransactionHolder<T1, T2>
+{
+    private final T1 sessionHolder;
+    private final T2 transaction;
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AsyncSessionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AsyncSessionHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.async.AsyncSession;
+
+public class AsyncSessionHolder extends AbstractSessionHolder<AsyncSession>
+{
+    public AsyncSessionHolder( DriverHolder driverHolder, AsyncSession session, SessionConfig config )
+    {
+        super( driverHolder, session, config );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AsyncTransactionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/AsyncTransactionHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.async.AsyncTransaction;
+
+public class AsyncTransactionHolder extends AbstractTransactionHolder<AsyncSessionHolder,AsyncTransaction>
+{
+    public AsyncTransactionHolder( AsyncSessionHolder sessionHolder, AsyncTransaction transaction )
+    {
+        super( sessionHolder, transaction );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/DriverHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/DriverHolder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+
+@RequiredArgsConstructor
+@Getter
+public class DriverHolder
+{
+    private final Driver driver;
+    private final Config config;
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ResultCursorHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ResultCursorHolder.java
@@ -16,24 +16,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package neo4j.org.testkit.backend;
+package neo4j.org.testkit.backend.holder;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.neo4j.driver.async.ResultCursor;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.neo4j.driver.reactive.RxSession;
-
-@Getter
-@Setter
-public class RxSessionState
+public class ResultCursorHolder extends AbstractResultHolder<AsyncSessionHolder,AsyncTransactionHolder,ResultCursor>
 {
-    public RxSession session;
-    public CompletableFuture<Void> txWorkFuture;
-
-    public RxSessionState( RxSession session )
+    public ResultCursorHolder( AsyncSessionHolder sessionHolder, ResultCursor result )
     {
-        this.session = session;
+        super( sessionHolder, result );
+    }
+
+    public ResultCursorHolder( AsyncTransactionHolder transactionHolder, ResultCursor result )
+    {
+        super( transactionHolder, result );
+    }
+
+    @Override
+    protected AsyncSessionHolder getSessionHolder( AsyncTransactionHolder transactionHolder )
+    {
+        return transactionHolder.getSessionHolder();
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ResultHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ResultHolder.java
@@ -16,24 +16,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package neo4j.org.testkit.backend;
+package neo4j.org.testkit.backend.holder;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.neo4j.driver.Result;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.neo4j.driver.async.AsyncSession;
-
-@Getter
-@Setter
-public class AsyncSessionState
+public class ResultHolder extends AbstractResultHolder<SessionHolder,TransactionHolder,Result>
 {
-    public AsyncSession session;
-    public CompletableFuture<Void> txWorkFuture;
-
-    public AsyncSessionState( AsyncSession session )
+    public ResultHolder( SessionHolder sessionHolder, Result result )
     {
-        this.session = session;
+        super( sessionHolder, result );
+    }
+
+    public ResultHolder( TransactionHolder transactionHolder, Result result )
+    {
+        super( transactionHolder, result );
+    }
+
+    @Override
+    protected SessionHolder getSessionHolder( TransactionHolder transactionHolder )
+    {
+        return transactionHolder.getSessionHolder();
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxResultHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxResultHolder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import lombok.Getter;
+import lombok.Setter;
+import neo4j.org.testkit.backend.RxBlockingSubscriber;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.reactive.RxResult;
+
+public class RxResultHolder extends AbstractResultHolder<RxSessionHolder,RxTransactionHolder,RxResult>
+{
+    @Setter
+    private RxBlockingSubscriber<Record> subscriber;
+    @Getter
+    private final AtomicLong requestedRecordsCounter = new AtomicLong();
+
+    public RxResultHolder( RxSessionHolder sessionHolder, RxResult result )
+    {
+        super( sessionHolder, result );
+    }
+
+    public RxResultHolder( RxTransactionHolder transactionHolder, RxResult result )
+    {
+        super( transactionHolder, result );
+    }
+
+    public Optional<RxBlockingSubscriber<Record>> getSubscriber()
+    {
+        return Optional.ofNullable( subscriber );
+    }
+
+    @Override
+    protected RxSessionHolder getSessionHolder( RxTransactionHolder transactionHolder )
+    {
+        return transactionHolder.getSessionHolder();
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxSessionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxSessionHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.reactive.RxSession;
+
+public class RxSessionHolder extends AbstractSessionHolder<RxSession>
+{
+    public RxSessionHolder( DriverHolder driverHolder, RxSession session, SessionConfig config )
+    {
+        super( driverHolder, session, config );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxTransactionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxTransactionHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.reactive.RxTransaction;
+
+public class RxTransactionHolder extends AbstractTransactionHolder<RxSessionHolder,RxTransaction>
+{
+    public RxTransactionHolder( RxSessionHolder sessionHolder, RxTransaction transaction )
+    {
+        super( sessionHolder, transaction );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/SessionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/SessionHolder.java
@@ -16,23 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package neo4j.org.testkit.backend;
-
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.concurrent.CompletableFuture;
+package neo4j.org.testkit.backend.holder;
 
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 
-@Getter
-@Setter
-public class SessionState
+public class SessionHolder extends AbstractSessionHolder<Session>
 {
-    public Session session;
-    public CompletableFuture<Void> txWorkFuture;
-
-    public SessionState(Session session) {
-        this.session = session;
+    public SessionHolder( DriverHolder driverHolder, Session session, SessionConfig config )
+    {
+        super( driverHolder, session, config );
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/TransactionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/TransactionHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.Transaction;
+
+public class TransactionHolder extends AbstractTransactionHolder<SessionHolder,Transaction>
+{
+    public TransactionHolder( SessionHolder sessionHolder, Transaction transaction )
+    {
+        super( sessionHolder, transaction );
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
@@ -37,14 +37,15 @@ public class CheckMultiDBSupport implements TestkitRequest
     public TestkitResponse process( TestkitState testkitState )
     {
         String driverId = data.getDriverId();
-        boolean available = testkitState.getDrivers().get( driverId ).supportsMultiDb();
+        boolean available = testkitState.getDriverHolder( driverId ).getDriver().supportsMultiDb();
         return createResponse( available );
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getDrivers().get( data.getDriverId() )
+        return testkitState.getDriverHolder( data.getDriverId() )
+                           .getDriver()
                            .supportsMultiDbAsync()
                            .thenApply( this::createResponse );
     }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
@@ -36,14 +36,15 @@ public class DriverClose implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        testkitState.getDrivers().get( data.getDriverId() ).close();
+        testkitState.getDriverHolder( data.getDriverId() ).getDriver().close();
         return createResponse();
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getDrivers().get( data.getDriverId() )
+        return testkitState.getDriverHolder( data.getDriverId() )
+                           .getDriver()
                            .closeAsync()
                            .thenApply( ignored -> createResponse() );
     }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.holder.DriverHolder;
 import neo4j.org.testkit.backend.messages.responses.BackendError;
 import neo4j.org.testkit.backend.messages.responses.DomainNameResolutionRequired;
 import neo4j.org.testkit.backend.messages.responses.Driver;
@@ -101,15 +102,16 @@ public class NewDriver implements TestkitRequest
                                               .map( RetrySettings::new )
                                               .orElse( RetrySettings.DEFAULT );
         org.neo4j.driver.Driver driver;
+        Config config = configBuilder.build();
         try
         {
-            driver = driver( URI.create( data.uri ), authToken, configBuilder.build(), retrySettings, domainNameResolver, testkitState, id );
+            driver = driver( URI.create( data.uri ), authToken, config, retrySettings, domainNameResolver, testkitState, id );
         }
         catch ( RuntimeException e )
         {
             return handleExceptionAsErrorResponse( testkitState, e ).orElseThrow( () -> e );
         }
-        testkitState.getDrivers().putIfAbsent( id, driver );
+        testkitState.addDriverHolder( id, new DriverHolder( driver, config ) );
         return Driver.builder().data( Driver.DriverBody.builder().id( id ).build() ).build();
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
@@ -39,14 +39,14 @@ public class ResultList implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        return createResponse( testkitState.getResults().get( data.getResultId() ).list() );
+        return createResponse( testkitState.getResultHolder( data.getResultId() ).getResult().list() );
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getResultCursors().get( data.getResultId() )
-                           .listAsync()
+        return testkitState.getAsyncResultHolder( data.getResultId() )
+                           .thenCompose( resultCursorHolder -> resultCursorHolder.getResult().listAsync() )
                            .thenApply( this::createResponse );
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
@@ -36,23 +36,24 @@ public class SessionClose implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        testkitState.getSessionStates().get( data.getSessionId() ).getSession().close();
+        testkitState.getSessionHolder( data.getSessionId() ).getSession().close();
         return createResponse();
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getAsyncSessionStates().get( data.getSessionId() ).getSession()
-                           .closeAsync()
+        return testkitState.getAsyncSessionHolder( data.getSessionId() )
+                           .thenCompose( sessionHolder -> sessionHolder.getSession().closeAsync() )
                            .thenApply( ignored -> createResponse() );
     }
 
     @Override
     public Mono<TestkitResponse> processRx( TestkitState testkitState )
     {
-        return Mono.fromDirect( testkitState.getRxSessionStates().get( data.getSessionId() ).getSession().close() )
-                   .then( Mono.just( createResponse() ) );
+        return testkitState.getRxSessionHolder( data.getSessionId() )
+                           .flatMap( sessionHolder -> Mono.fromDirect( sessionHolder.getSession().close() ) )
+                           .then( Mono.just( createResponse() ) );
     }
 
     private Session createResponse()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
@@ -20,10 +20,11 @@ package neo4j.org.testkit.backend.messages.requests;
 
 import lombok.Getter;
 import lombok.Setter;
-import neo4j.org.testkit.backend.AsyncSessionState;
-import neo4j.org.testkit.backend.RxSessionState;
-import neo4j.org.testkit.backend.SessionState;
 import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.holder.AsyncTransactionHolder;
+import neo4j.org.testkit.backend.holder.RxTransactionHolder;
+import neo4j.org.testkit.backend.holder.SessionHolder;
+import neo4j.org.testkit.backend.holder.TransactionHolder;
 import neo4j.org.testkit.backend.messages.responses.RetryableDone;
 import neo4j.org.testkit.backend.messages.responses.RetryableTry;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
@@ -31,7 +32,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -52,60 +52,64 @@ public class SessionWriteTransaction implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        return Optional.ofNullable( testkitState.getSessionStates().getOrDefault( data.getSessionId(), null ) )
-                       .map( sessionState ->
-                             {
-                                 Session session = sessionState.getSession();
-                                 session.writeTransaction( handle( testkitState, sessionState ) );
-                                 return retryableDone();
-                             } ).orElseThrow( () -> new RuntimeException( "Could not find session" ) );
+        SessionHolder sessionHolder = testkitState.getSessionHolder( data.getSessionId() );
+        Session session = sessionHolder.getSession();
+        session.writeTransaction( handle( testkitState, sessionHolder ) );
+        return retryableDone();
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        AsyncSessionState sessionState = testkitState.getAsyncSessionStates().get( data.getSessionId() );
-        AsyncSession session = sessionState.getSession();
+        return testkitState.getAsyncSessionHolder( data.getSessionId() )
+                           .thenCompose( sessionHolder ->
+                                         {
+                                             AsyncSession session = sessionHolder.getSession();
 
-        AsyncTransactionWork<CompletionStage<Void>> workWrapper =
-                tx ->
-                {
-                    String txId = testkitState.addAsyncTransaction( tx );
-                    testkitState.getResponseWriter().accept( retryableTry( txId ) );
-                    CompletableFuture<Void> tryResult = new CompletableFuture<>();
-                    sessionState.setTxWorkFuture( tryResult );
-                    return tryResult;
-                };
+                                             AsyncTransactionWork<CompletionStage<Void>> workWrapper =
+                                                     tx ->
+                                                     {
+                                                         String txId =
+                                                                 testkitState.addAsyncTransactionHolder( new AsyncTransactionHolder( sessionHolder, tx ) );
+                                                         testkitState.getResponseWriter().accept( retryableTry( txId ) );
+                                                         CompletableFuture<Void> tryResult = new CompletableFuture<>();
+                                                         sessionHolder.setTxWorkFuture( tryResult );
+                                                         return tryResult;
+                                                     };
 
-        return session.writeTransactionAsync( workWrapper )
-                      .thenApply( nothing -> retryableDone() );
+                                             return session.writeTransactionAsync( workWrapper );
+                                         } )
+                           .thenApply( nothing -> retryableDone() );
     }
 
     @Override
     public Mono<TestkitResponse> processRx( TestkitState testkitState )
     {
-        RxSessionState sessionState = testkitState.getRxSessionStates().get( data.getSessionId() );
-        RxTransactionWork<Publisher<Void>> workWrapper = tx ->
-        {
-            String txId = testkitState.addRxTransaction( tx );
-            testkitState.getResponseWriter().accept( retryableTry( txId ) );
-            CompletableFuture<Void> tryResult = new CompletableFuture<>();
-            sessionState.setTxWorkFuture( tryResult );
-            return Mono.fromCompletionStage( tryResult );
-        };
+        return testkitState.getRxSessionHolder( data.getSessionId() )
+                           .flatMap( sessionHolder ->
+                                     {
+                                         RxTransactionWork<Publisher<Void>> workWrapper = tx ->
+                                         {
+                                             String txId = testkitState.addRxTransactionHolder( new RxTransactionHolder( sessionHolder, tx ) );
+                                             testkitState.getResponseWriter().accept( retryableTry( txId ) );
+                                             CompletableFuture<Void> tryResult = new CompletableFuture<>();
+                                             sessionHolder.setTxWorkFuture( tryResult );
+                                             return Mono.fromCompletionStage( tryResult );
+                                         };
 
-        return Mono.fromDirect( sessionState.getSession().writeTransaction( workWrapper ) )
-                   .then( Mono.just( retryableDone() ) );
+                                         return Mono.fromDirect( sessionHolder.getSession().writeTransaction( workWrapper ) );
+                                     } )
+                           .then( Mono.just( retryableDone() ) );
     }
 
-    private TransactionWork<Void> handle( TestkitState testkitState, SessionState sessionState )
+    private TransactionWork<Void> handle( TestkitState testkitState, SessionHolder sessionHolder )
     {
         return tx ->
         {
-            String txId = testkitState.addTransaction( tx );
+            String txId = testkitState.addTransactionHolder( new TransactionHolder( sessionHolder, tx ) );
             testkitState.getResponseWriter().accept( retryableTry( txId ) );
             CompletableFuture<Void> txWorkFuture = new CompletableFuture<>();
-            sessionState.setTxWorkFuture( txWorkFuture );
+            sessionHolder.setTxWorkFuture( txWorkFuture );
 
             try
             {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
@@ -36,7 +36,7 @@ public class TransactionClose implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        testkitState.getTransaction( data.getTxId() ).close();
+        testkitState.getTransactionHolder( data.getTxId() ).getTransaction().close();
         return createResponse( data.getTxId() );
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
@@ -27,8 +27,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.async.AsyncTransaction;
-
 @Getter
 @Setter
 public class TransactionCommit implements TestkitRequest
@@ -38,22 +36,22 @@ public class TransactionCommit implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        testkitState.getTransaction( data.getTxId() ).commit();
+        testkitState.getTransactionHolder( data.getTxId() ).getTransaction().commit();
         return createResponse( data.getTxId() );
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getAsyncTransaction( data.getTxId() ).thenCompose( AsyncTransaction::commitAsync )
+        return testkitState.getAsyncTransactionHolder( data.getTxId() ).thenCompose( tx -> tx.getTransaction().commitAsync() )
                            .thenApply( ignored -> createResponse( data.getTxId() ) );
     }
 
     @Override
     public Mono<TestkitResponse> processRx( TestkitState testkitState )
     {
-        return testkitState.getRxTransaction( data.getTxId() )
-                           .flatMap( tx -> Mono.fromDirect( tx.commit() ) )
+        return testkitState.getRxTransactionHolder( data.getTxId() )
+                           .flatMap( tx -> Mono.fromDirect( tx.getTransaction().commit() ) )
                            .then( Mono.just( createResponse( data.getTxId() ) ) );
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
@@ -27,8 +27,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
 
-import org.neo4j.driver.async.AsyncTransaction;
-
 @Getter
 @Setter
 public class TransactionRollback implements TestkitRequest
@@ -38,22 +36,22 @@ public class TransactionRollback implements TestkitRequest
     @Override
     public TestkitResponse process( TestkitState testkitState )
     {
-        testkitState.getTransaction( data.getTxId() ).rollback();
+        testkitState.getTransactionHolder( data.getTxId() ).getTransaction().rollback();
         return createResponse( data.getTxId() );
     }
 
     @Override
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
-        return testkitState.getAsyncTransaction( data.getTxId() ).thenCompose( AsyncTransaction::rollbackAsync )
+        return testkitState.getAsyncTransactionHolder( data.getTxId() ).thenCompose( tx -> tx.getTransaction().rollbackAsync() )
                            .thenApply( ignored -> createResponse( data.getTxId() ) );
     }
 
     @Override
     public Mono<TestkitResponse> processRx( TestkitState testkitState )
     {
-        return testkitState.getRxTransaction( data.getTxId() )
-                           .flatMap( tx -> Mono.fromDirect( tx.rollback() ) )
+        return testkitState.getRxTransactionHolder( data.getTxId() )
+                           .flatMap( tx -> Mono.fromDirect( tx.getTransaction().rollback() ) )
                            .then( Mono.just( createResponse( data.getTxId() ) ) );
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
@@ -37,7 +37,7 @@ public class VerifyConnectivity implements TestkitRequest
     public TestkitResponse process( TestkitState testkitState )
     {
         String id = data.getDriverId();
-        testkitState.getDrivers().get( id ).verifyConnectivity();
+        testkitState.getDriverHolder( id ).getDriver().verifyConnectivity();
         return createResponse( id );
     }
 
@@ -45,7 +45,8 @@ public class VerifyConnectivity implements TestkitRequest
     public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
     {
         String id = data.getDriverId();
-        return testkitState.getDrivers().get( id )
+        return testkitState.getDriverHolder( id )
+                           .getDriver()
                            .verifyConnectivityAsync()
                            .thenApply( ignored -> createResponse( id ) );
     }


### PR DESCRIPTION
This update also removes hardcoded fetch size in reactive backend and adds support for sending additional PULL requests when there is more data to consume.