### PR TITLE
Add result consumption and disposal to reactive testkit backend session close

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxResultHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxResultHolder.java
@@ -38,11 +38,13 @@ public class RxResultHolder extends AbstractResultHolder<RxSessionHolder,RxTrans
     public RxResultHolder( RxSessionHolder sessionHolder, RxResult result )
     {
         super( sessionHolder, result );
+        sessionHolder.setResultHolder( this );
     }
 
     public RxResultHolder( RxTransactionHolder transactionHolder, RxResult result )
     {
         super( transactionHolder, result );
+        transactionHolder.getSessionHolder().setResultHolder( this );
     }
 
     public Optional<RxBlockingSubscriber<Record>> getSubscriber()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxSessionHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/RxSessionHolder.java
@@ -18,13 +18,25 @@
  */
 package neo4j.org.testkit.backend.holder;
 
+import lombok.Setter;
+
+import java.util.Optional;
+
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.reactive.RxSession;
 
 public class RxSessionHolder extends AbstractSessionHolder<RxSession>
 {
+    @Setter
+    private RxResultHolder resultHolder;
+
     public RxSessionHolder( DriverHolder driverHolder, RxSession session, SessionConfig config )
     {
         super( driverHolder, session, config );
+    }
+
+    public Optional<RxResultHolder> getResultHolder()
+    {
+        return Optional.ofNullable( resultHolder );
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
@@ -20,12 +20,18 @@ package neo4j.org.testkit.backend.messages.requests;
 
 import lombok.Getter;
 import lombok.Setter;
+import neo4j.org.testkit.backend.RxBlockingSubscriber;
 import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.holder.RxResultHolder;
 import neo4j.org.testkit.backend.messages.responses.Session;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import reactor.core.publisher.Mono;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.driver.Record;
 
 @Setter
 @Getter
@@ -52,13 +58,119 @@ public class SessionClose implements TestkitRequest
     public Mono<TestkitResponse> processRx( TestkitState testkitState )
     {
         return testkitState.getRxSessionHolder( data.getSessionId() )
-                           .flatMap( sessionHolder -> Mono.fromDirect( sessionHolder.getSession().close() ) )
+                           .flatMap( sessionHolder -> sessionHolder.getResultHolder()
+                                                                   .map( this::consumeRequestedDemandAndCancelIfSubscribed )
+                                                                   .orElse( Mono.empty() )
+                                                                   .then( Mono.fromDirect( sessionHolder.getSession().close() ) ) )
                            .then( Mono.just( createResponse() ) );
+    }
+
+    private Mono<Void> consumeRequestedDemandAndCancelIfSubscribed( RxResultHolder resultHolder )
+    {
+        return resultHolder.getSubscriber()
+                           .map( subscriber -> Mono.fromCompletionStage( consumeRequestedDemandAndCancelIfSubscribed( resultHolder, subscriber ) ) )
+                           .orElse( Mono.empty() );
+    }
+
+    private CompletionStage<Void> consumeRequestedDemandAndCancelIfSubscribed( RxResultHolder resultHolder, RxBlockingSubscriber<Record> subscriber )
+    {
+        if ( subscriber.getCompletionStage().toCompletableFuture().isDone() )
+        {
+            return CompletableFuture.completedFuture( null );
+        }
+
+        return new DemandConsumer<>( subscriber, resultHolder.getRequestedRecordsCounter() )
+                .getCompletedStage()
+                .thenCompose( completionReason ->
+                              {
+                                  CompletionStage<Void> result;
+                                  switch ( completionReason )
+                                  {
+                                  case REQUESTED_DEMAND_CONSUMED:
+                                      result = subscriber.getSubscriptionStage().thenApply( subscription ->
+                                                                                            {
+                                                                                                subscription.cancel();
+                                                                                                return null;
+                                                                                            } );
+                                      break;
+                                  case RECORD_STREAM_EXHAUSTED:
+                                      result = CompletableFuture.completedFuture( null );
+                                      break;
+                                  default:
+                                      result = new CompletableFuture<>();
+                                      result.toCompletableFuture()
+                                            .completeExceptionally( new RuntimeException( "Unexpected completion reason: " + completionReason ) );
+                                  }
+                                  return result;
+                              } );
     }
 
     private Session createResponse()
     {
         return Session.builder().data( Session.SessionBody.builder().id( data.getSessionId() ).build() ).build();
+    }
+
+    private static class DemandConsumer<T>
+    {
+        private final RxBlockingSubscriber<T> subscriber;
+        private final AtomicLong unfulfilledDemandCounter;
+        @Getter
+        private final CompletableFuture<CompletionReason> completedStage = new CompletableFuture<>();
+
+        private enum CompletionReason
+        {
+            REQUESTED_DEMAND_CONSUMED,
+            RECORD_STREAM_EXHAUSTED
+        }
+
+        private DemandConsumer( RxBlockingSubscriber<T> subscriber, AtomicLong unfulfilledDemandCounter )
+        {
+            this.subscriber = subscriber;
+            this.unfulfilledDemandCounter = unfulfilledDemandCounter;
+
+            subscriber.getCompletionStage().whenComplete( this::onComplete );
+            if ( this.unfulfilledDemandCounter.get() > 0 )
+            {
+                setupNextSignalConsumer();
+            }
+        }
+
+        private void setupNextSignalConsumer()
+        {
+            CompletableFuture<T> consumer = new CompletableFuture<>();
+            subscriber.setNextSignalConsumer( consumer );
+            consumer.whenComplete( this::onNext );
+        }
+
+        private void onNext( T ignored, Throwable throwable )
+        {
+            if ( throwable != null )
+            {
+                completedStage.completeExceptionally( throwable );
+                return;
+            }
+
+            if ( unfulfilledDemandCounter.decrementAndGet() > 0 )
+            {
+                setupNextSignalConsumer();
+            }
+            else
+            {
+                completedStage.complete( CompletionReason.REQUESTED_DEMAND_CONSUMED );
+            }
+        }
+
+        private void onComplete( Void ignored, Throwable throwable )
+        {
+            if ( throwable != null )
+            {
+                completedStage.completeExceptionally( throwable );
+            }
+            else
+            {
+                completedStage.complete( CompletionReason.RECORD_STREAM_EXHAUSTED );
+            }
+        }
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -61,10 +61,6 @@ public class StartTest implements TestkitRequest
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_after_hello$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_run$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_on_tx_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRetry\\..*$", "Unfinished results consumption" );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRetryClustering\\..*$", "Unfinished results consumption" );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_discard_on_session_close_unfinished_result$",
-                                             "Does not support partially consumed state" );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.NoRouting[^.]+\\.test_should_error_on_database_shutdown_using_tx_run$", "Session close throws error" );
         skipMessage = "Requires investigation";
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestProtocolVersions\\.test_server_agent", skipMessage );
@@ -81,12 +77,9 @@ public class StartTest implements TestkitRequest
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_tx_commit$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_fail_on_reset$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRunParameters\\..*$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_rollback_tx_on_session_close_unfinished_result$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_rollback_tx_on_session_close_untouched_result$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_autocommit_transactions_should_support_timeout$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_fails_on_bad_syntax$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_fails_on_missing_parameter$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_iteration_larger_than_fetch_size$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_iteration_nested$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxFuncRun\\.test_iteration_nested$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_should_not_run_valid_query_in_invalid_tx$", skipMessage );


### PR DESCRIPTION
Cherry-pick: #1010