### PR TITLE
Abort discovery on bookmark failures and continue on authorization expired error

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -31,6 +31,7 @@ import org.neo4j.driver.exceptions.DatabaseException;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.ResultConsumedException;
+import org.neo4j.driver.exceptions.SecurityException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.TokenExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
@@ -65,29 +66,38 @@ public final class ErrorUtil
 
     public static Neo4jException newNeo4jError( String code, String message )
     {
-        String classification = extractClassification( code );
-        switch ( classification )
+        switch ( extractErrorClass( code ) )
         {
         case "ClientError":
-            if ( code.equalsIgnoreCase( "Neo.ClientError.Security.Unauthorized" ) )
+            if ( "Security".equals( extractErrorSubClass( code ) ) )
             {
-                return new AuthenticationException( code, message );
-            }
-            else if ( code.equalsIgnoreCase( "Neo.ClientError.Database.DatabaseNotFound" ) )
-            {
-                return new FatalDiscoveryException( code, message );
-            }
-            else if ( code.equalsIgnoreCase( "Neo.ClientError.Security.AuthorizationExpired" ) )
-            {
-                return new AuthorizationExpiredException( code, message );
-            }
-            else if ( code.equalsIgnoreCase( "Neo.ClientError.Security.TokenExpired" ) )
-            {
-                return new TokenExpiredException( code, message );
+                if ( code.equalsIgnoreCase( "Neo.ClientError.Security.Unauthorized" ) )
+                {
+                    return new AuthenticationException( code, message );
+                }
+                else if ( code.equalsIgnoreCase( "Neo.ClientError.Security.AuthorizationExpired" ) )
+                {
+                    return new AuthorizationExpiredException( code, message );
+                }
+                else if ( code.equalsIgnoreCase( "Neo.ClientError.Security.TokenExpired" ) )
+                {
+                    return new TokenExpiredException( code, message );
+                }
+                else
+                {
+                    return new SecurityException( code, message );
+                }
             }
             else
             {
-                return new ClientException( code, message );
+                if ( code.equalsIgnoreCase( "Neo.ClientError.Database.DatabaseNotFound" ) )
+                {
+                    return new FatalDiscoveryException( code, message );
+                }
+                else
+                {
+                    return new ClientException( code, message );
+                }
             }
         case "TransientError":
             return new TransientException( code, message );
@@ -140,7 +150,7 @@ public final class ErrorUtil
         return errorCode != null && (errorCode.contains( "ClientError" ) || errorCode.contains( "TransientError" ));
     }
 
-    private static String extractClassification( String code )
+    private static String extractErrorClass( String code )
     {
         String[] parts = code.split( "\\." );
         if ( parts.length < 2 )
@@ -148,6 +158,16 @@ public final class ErrorUtil
             return "";
         }
         return parts[1];
+    }
+
+    private static String extractErrorSubClass( String code )
+    {
+        String[] parts = code.split( "\\." );
+        if ( parts.length < 3 )
+        {
+            return "";
+        }
+        return parts[2];
     }
 
     public static void addSuppressed( Throwable mainError, Throwable error )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -44,7 +44,8 @@ public class GetFeatures implements TestkitRequest
             "Feature:Auth:Kerberos",
             "Feature:Auth:Custom",
             "Feature:Bolt:4.4",
-            "Feature:Impersonation"
+            "Feature:Impersonation",
+            "Temporary:FastFailingDiscovery"
     ) );
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>( Arrays.asList(


### PR DESCRIPTION
This update ensures that discovery gets aborted on `ClientException` with the following codes:
- `Neo.ClientError.Transaction.InvalidBookmark`
- `Neo.ClientError.Transaction.InvalidBookmarkMixture`

In addition, it makes sure that it continues on `AuthorizationExpiredException`.

All security exceptions are mapped to `SecurityException`.
