### PR TITLE
Add channel error logger for channel errors

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ChannelErrorLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ChannelErrorLogger.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import io.netty.channel.Channel;
+
+import org.neo4j.driver.Logging;
+
+/**
+ * Dedicated logger for channel error logging.
+ * <p>
+ * It keeps messages shorter in debug mode and provides more details in trace mode.
+ */
+public class ChannelErrorLogger extends ChannelActivityLogger
+{
+    private static final String DEBUG_MESSAGE_FORMAT = "%s (%s)";
+
+    public ChannelErrorLogger( Channel channel, Logging logging )
+    {
+        super( channel, logging, ChannelErrorLogger.class );
+    }
+
+    public void traceOrDebug( String message, Throwable error )
+    {
+        if ( isTraceEnabled() )
+        {
+            trace( message, error );
+        }
+        else
+        {
+            debug( String.format( DEBUG_MESSAGE_FORMAT, message, error.getClass() ) );
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/inbound/InboundMessageDispatcherTest.java
@@ -38,6 +38,7 @@ import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.logging.ChannelActivityLogger;
+import org.neo4j.driver.internal.logging.ChannelErrorLogger;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.response.FailureMessage;
 import org.neo4j.driver.internal.messaging.response.IgnoredMessage;
@@ -56,6 +57,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -378,6 +380,8 @@ class InboundMessageDispatcherTest
         Logger logger = mock( Logger.class );
         when( logger.isDebugEnabled() ).thenReturn( true );
         when( logging.getLog( InboundMessageDispatcher.class.getSimpleName() ) ).thenReturn( logger );
+        ChannelErrorLogger errorLogger = mock( ChannelErrorLogger.class );
+        when( logging.getLog( ChannelErrorLogger.class.getSimpleName() ) ).thenReturn( errorLogger );
         InboundMessageDispatcher dispatcher = new InboundMessageDispatcher( channel, logging );
         ResponseHandler handler = mock( ResponseHandler.class );
         dispatcher.enqueue( handler );
@@ -406,11 +410,12 @@ class InboundMessageDispatcherTest
 
         // THEN
         assertTrue( dispatcher.getLog() instanceof ChannelActivityLogger );
+        assertTrue( dispatcher.getErrorLog() instanceof ChannelErrorLogger );
         verify( logger ).debug( anyString(), any( Object.class ) );
     }
 
     @Test
-    void shouldCreateChannelActivityLoggerAndLogDebugMessageOnChannelError()
+    void shouldCreateChannelErrorLoggerAndLogDebugMessageOnChannelError()
     {
         // GIVEN
         Channel channel = newChannelMock();
@@ -418,6 +423,9 @@ class InboundMessageDispatcherTest
         Logger logger = mock( Logger.class );
         when( logger.isDebugEnabled() ).thenReturn( true );
         when( logging.getLog( InboundMessageDispatcher.class.getSimpleName() ) ).thenReturn( logger );
+        ChannelErrorLogger errorLogger = mock( ChannelErrorLogger.class );
+        when( errorLogger.isDebugEnabled() ).thenReturn( true );
+        when( logging.getLog( ChannelErrorLogger.class.getSimpleName() ) ).thenReturn( errorLogger );
         InboundMessageDispatcher dispatcher = new InboundMessageDispatcher( channel, logging );
         ResponseHandler handler = mock( ResponseHandler.class );
         dispatcher.enqueue( handler );
@@ -428,7 +436,8 @@ class InboundMessageDispatcherTest
 
         // THEN
         assertTrue( dispatcher.getLog() instanceof ChannelActivityLogger );
-        verify( logger ).debug( anyString(), eq( throwable ) );
+        assertTrue( dispatcher.getErrorLog() instanceof ChannelErrorLogger );
+        verify( errorLogger ).debug( contains( throwable.getClass().toString() ) );
     }
 
     private static void verifyFailure( ResponseHandler handler )


### PR DESCRIPTION
Cherry-pick: #1039

The new logger provides a dedicated facility for channel error logging in debug and trace modes.