### PR TITLE
Call close with the appropriate flag to commit or rollback on UnmanagedTransaction where possible to avoid double state acquisition

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -134,7 +134,12 @@ public class UnmanagedTransaction
 
     public CompletionStage<Void> closeAsync()
     {
-        return closeAsync( false, true );
+        return closeAsync( false );
+    }
+
+    public CompletionStage<Void> closeAsync( boolean commit )
+    {
+        return closeAsync( commit, true );
     }
 
     public CompletionStage<Void> commitAsync()

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
@@ -130,7 +130,7 @@ public class InternalRxSession extends AbstractRxQueryRunner implements RxSessio
     private <T> Publisher<T> runTransaction( AccessMode mode, RxTransactionWork<? extends Publisher<T>> work, TransactionConfig config )
     {
         Flux<T> repeatableWork = Flux.usingWhen( beginTransaction( mode, config ), work::execute,
-                                                 InternalRxTransaction::commitIfOpen, ( tx, error ) -> tx.close(), InternalRxTransaction::close );
+                                                 tx -> tx.close( true ), ( tx, error ) -> tx.close(), InternalRxTransaction::close );
         return session.retryLogic().retryRx( repeatableWork );
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -30,7 +30,6 @@ import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxTransaction;
 
 import static org.neo4j.driver.internal.reactive.RxUtils.createEmptyPublisher;
-import static org.neo4j.driver.internal.util.Futures.completedWithNull;
 
 public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTransaction
 {
@@ -77,13 +76,13 @@ public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTr
         return createEmptyPublisher( tx::rollbackAsync );
     }
 
-    Publisher<Void> commitIfOpen()
-    {
-        return createEmptyPublisher( () -> tx.isOpen() ? tx.commitAsync() : completedWithNull() );
-    }
-
     Publisher<Void> close()
     {
-        return createEmptyPublisher( tx::closeAsync );
+        return close( false );
+    }
+
+    Publisher<Void> close( boolean commit )
+    {
+        return createEmptyPublisher( () -> tx.closeAsync( commit ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -48,7 +48,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.Values.parameters;
@@ -140,43 +139,28 @@ class InternalRxTransactionTest
     }
 
     @Test
-    void shouldCommitWhenOpen()
+    void shouldDelegateConditionalClose()
     {
         UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
-        when( tx.isOpen() ).thenReturn( true );
-        when( tx.commitAsync() ).thenReturn( Futures.completedWithNull() );
+        when( tx.closeAsync( true ) ).thenReturn( Futures.completedWithNull() );
 
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
         Publisher<Void> publisher = rxTx.close( true );
         StepVerifier.create( publisher ).verifyComplete();
 
-        verify( tx ).commitAsync();
-    }
-
-    @Test
-    void shouldNotCommitWhenNotOpen()
-    {
-        UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
-        when( tx.isOpen() ).thenReturn( false );
-        when( tx.commitAsync() ).thenReturn( Futures.completedWithNull() );
-
-        InternalRxTransaction rxTx = new InternalRxTransaction( tx );
-        Publisher<Void> publisher = rxTx.close( true );
-        StepVerifier.create( publisher ).verifyComplete();
-
-        verify( tx, never() ).commitAsync();
+        verify( tx ).closeAsync( true );
     }
 
     @Test
     void shouldDelegateClose()
     {
         UnmanagedTransaction tx = mock( UnmanagedTransaction.class );
-        when( tx.closeAsync() ).thenReturn( Futures.completedWithNull() );
+        when( tx.closeAsync( false ) ).thenReturn( Futures.completedWithNull() );
 
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
         Publisher<Void> publisher = rxTx.close();
         StepVerifier.create( publisher ).verifyComplete();
 
-        verify( tx ).closeAsync();
+        verify( tx ).closeAsync( false );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -147,7 +147,7 @@ class InternalRxTransactionTest
         when( tx.commitAsync() ).thenReturn( Futures.completedWithNull() );
 
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
-        Publisher<Void> publisher = rxTx.commitIfOpen();
+        Publisher<Void> publisher = rxTx.close( true );
         StepVerifier.create( publisher ).verifyComplete();
 
         verify( tx ).commitAsync();
@@ -161,7 +161,7 @@ class InternalRxTransactionTest
         when( tx.commitAsync() ).thenReturn( Futures.completedWithNull() );
 
         InternalRxTransaction rxTx = new InternalRxTransaction( tx );
-        Publisher<Void> publisher = rxTx.commitIfOpen();
+        Publisher<Void> publisher = rxTx.close( true );
         StepVerifier.create( publisher ).verifyComplete();
 
         verify( tx, never() ).commitAsync();


### PR DESCRIPTION
Calling `close` instead of separate `isOpen` and `commitAsync` requires less lock acquisitions and is safer.