### PR TITLE
TestKit backend output goes to stdout/stderr

### DIFF
--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -3,12 +3,15 @@ Executed in Java driver container.
 Assumes driver and backend has been built.
 Responsible for starting the test backend.
 """
-import os, subprocess
+import os
+import subprocess
+import sys
 
 
 if __name__ == "__main__":
-    err = open("/artifacts/backenderr.log", "w")
-    out = open("/artifacts/backendout.log", "w")
     subprocess.check_call(
-        ["java", "-jar", "testkit-backend/target/testkit-backend.jar", os.getenv('TEST_BACKEND_SERVER', '')], stdout=out, stderr=err)
+        ["java", "-jar", "testkit-backend/target/testkit-backend.jar",
+        os.getenv('TEST_BACKEND_SERVER', '')],
+        stdout=sys.stdout, stderr=sys.stderr
+    )
 


### PR DESCRIPTION
From there, TestKit can pick it up and write it into logfiles if desired.
https://github.com/neo4j-drivers/testkit/pull/309