### PR TITLE
Migrate IT test to Testkit

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
@@ -86,11 +86,6 @@ public class Neo4jSettings
         return settings;
     }
 
-    public Neo4jSettings updateWith( Neo4jSettings other )
-    {
-        return updateWith( other.settings, other.excludes );
-    }
-
     public Neo4jSettings updateWith( String key, String value )
     {
         return updateWith( map(key, value), excludes );

--- a/driver/src/test/java/org/neo4j/driver/util/cc/ClusterControl.java
+++ b/driver/src/test/java/org/neo4j/driver/util/cc/ClusterControl.java
@@ -52,19 +52,9 @@ final class ClusterControl
         executeCommand( "neoctrl-cluster", "stop", path.toString() );
     }
 
-    static void stopClusterMember( Path path )
-    {
-        executeCommand( "neoctrl-stop", path.toString() );
-    }
-
     static void killCluster( Path path )
     {
         executeCommand( "neoctrl-cluster", "stop", "--kill", path.toString() );
-    }
-
-    static void killClusterMember( Path path )
-    {
-        executeCommand( "neoctrl-stop", "--kill", path.toString() );
     }
 
 }


### PR DESCRIPTION
The following integration test has been converted to stub test:
`CausalClusteringIT.shouldRediscoverWhenConnectionsToAllCoresBreak` -> `Routing.test_should_rediscover_when_all_connections_fail_using_s_and_tx_run`