### PR TITLE
Upgrade to Logback Classic 1.2.8 for test dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <junit.version>5.8.2</junit.version>
     <jarchivelib.version>1.2.0</jarchivelib.version>
     <bouncycastle-jdk15on.version>1.70</bouncycastle-jdk15on.version>
-    <logback-classic.version>1.2.7</logback-classic.version>
+    <logback-classic.version>1.2.8</logback-classic.version>
     <jackson.version>2.13.0</jackson.version>
     <lombok.version>1.18.22</lombok.version>
     <svm.version>20.3.4</svm.version>


### PR DESCRIPTION
Forward cherry-picked from #1103. Forward because the 5.0 build was still broken yesterday and I wanted to have this in the 4.4 branch in case we do put out another (bug) fix release for it in time.