### PR TITLE
Allow tx timeout to be 0 or null.

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
@@ -183,26 +183,33 @@ public class TransactionConfig implements Serializable
         private Duration timeout;
         private Map<String,Object> metadata = emptyMap();
 
+        /**
+         * Value used to signal {@link #withTimeout(Duration)} to use the server-side configured default timeout.
+         */
+        public static final Duration SERVER_DEFAULT_TIMEOUT = null;
+
         private Builder()
         {
         }
 
         /**
          * Set the transaction timeout. Transactions that execute longer than the configured timeout will be terminated by the database.
+         * Use {@link #SERVER_DEFAULT_TIMEOUT SERVER_DEFAULT_TIMEOUT} (default) to rely on the server-side configured timeout.
          * <p>
          * This functionality allows to limit query/transaction execution time. Specified timeout overrides the default timeout configured in the database
          * using {@code dbms.transaction.timeout} setting.
          * <p>
-         * Provided value should not be {@code null} and should not represent a duration of zero or negative duration.
+         * Provided value should not represent a negative duration.
          *
          * @param timeout the timeout.
          * @return this builder.
          */
         public Builder withTimeout( Duration timeout )
         {
-            requireNonNull( timeout, "Transaction timeout should not be null" );
-            checkArgument( !timeout.isZero(), "Transaction timeout should not be zero" );
-            checkArgument( !timeout.isNegative(), "Transaction timeout should not be negative" );
+            if (timeout != null)
+            {
+                checkArgument( !timeout.isNegative(), "Transaction timeout should not be negative" );
+            }
 
             this.timeout = timeout;
             return this;

--- a/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
@@ -180,13 +180,13 @@ public class TransactionConfig implements Serializable
      */
     public static class Builder
     {
-        private Duration timeout;
-        private Map<String,Object> metadata = emptyMap();
-
         /**
          * Value used to signal {@link #withTimeout(Duration)} to use the server-side configured default timeout.
          */
         public static final Duration SERVER_DEFAULT_TIMEOUT = null;
+
+        private Duration timeout;
+        private Map<String,Object> metadata = emptyMap();
 
         private Builder()
         {
@@ -194,7 +194,7 @@ public class TransactionConfig implements Serializable
 
         /**
          * Set the transaction timeout. Transactions that execute longer than the configured timeout will be terminated by the database.
-         * Use {@link #SERVER_DEFAULT_TIMEOUT SERVER_DEFAULT_TIMEOUT} (default) to rely on the server-side configured timeout.
+         * Use {@link #SERVER_DEFAULT_TIMEOUT} (default) to rely on the server-side configured timeout.
          * <p>
          * This functionality allows to limit query/transaction execution time. Specified timeout overrides the default timeout configured in the database
          * using {@code dbms.transaction.timeout} setting.

--- a/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
@@ -180,11 +180,6 @@ public class TransactionConfig implements Serializable
      */
     public static class Builder
     {
-        /**
-         * Value used to signal {@link #withTimeout(Duration)} to use the server-side configured default timeout.
-         */
-        public static final Duration SERVER_DEFAULT_TIMEOUT = null;
-
         private Duration timeout;
         private Map<String,Object> metadata = emptyMap();
 
@@ -194,7 +189,7 @@ public class TransactionConfig implements Serializable
 
         /**
          * Set the transaction timeout. Transactions that execute longer than the configured timeout will be terminated by the database.
-         * Use {@link #SERVER_DEFAULT_TIMEOUT} (default) to rely on the server-side configured timeout.
+         * See also {@link #withDefaultTimeout}.
          * <p>
          * This functionality allows to limit query/transaction execution time. Specified timeout overrides the default timeout configured in the database
          * using {@code dbms.transaction.timeout} setting.
@@ -206,12 +201,23 @@ public class TransactionConfig implements Serializable
          */
         public Builder withTimeout( Duration timeout )
         {
-            if (timeout != null)
-            {
-                checkArgument( !timeout.isNegative(), "Transaction timeout should not be negative" );
-            }
+            requireNonNull( timeout, "Transaction timeout should not be null" );
+            checkArgument( !timeout.isNegative(), "Transaction timeout should not be negative" );
 
             this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Set the transaction timeout to ths server-side configured default timeout. This is the default behaviour if neiter
+         * {@link #withTimeout} has not been called.
+         * See also {@link #withTimeout}.
+         *
+         * @return this builder.
+         */
+        public Builder withDefaultTimeout()
+        {
+            this.timeout = null;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/TransactionConfig.java
@@ -209,7 +209,7 @@ public class TransactionConfig implements Serializable
         }
 
         /**
-         * Set the transaction timeout to ths server-side configured default timeout. This is the default behaviour if neiter
+         * Set the transaction timeout to the server-side configured default timeout. This is the default behaviour if
          * {@link #withTimeout} has not been called.
          * See also {@link #withTimeout}.
          *

--- a/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
@@ -94,6 +94,7 @@ class TransactionConfigTest
                 .build();
 
         assertNull( config.timeout() );
+        assertEquals( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT,config.timeout() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
@@ -52,18 +52,6 @@ class TransactionConfigTest
     }
 
     @Test
-    void shouldDisallowNullTimeout()
-    {
-        assertThrows( NullPointerException.class, () -> TransactionConfig.builder().withTimeout( null ) );
-    }
-
-    @Test
-    void shouldDisallowZeroTimeout()
-    {
-        assertThrows( IllegalArgumentException.class, () -> TransactionConfig.builder().withTimeout( Duration.ZERO ) );
-    }
-
-    @Test
     void shouldDisallowNegativeTimeout()
     {
         assertThrows( IllegalArgumentException.class, () -> TransactionConfig.builder().withTimeout( Duration.ofSeconds( -1 ) ) );
@@ -96,6 +84,26 @@ class TransactionConfigTest
                 .build();
 
         assertEquals( Duration.ofSeconds( 3 ), config.timeout() );
+    }
+
+    @Test
+    void shouldAllowDefaultTimeout()
+    {
+        TransactionConfig config = TransactionConfig.builder()
+                .withTimeout( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT )
+                .build();
+
+        assertNull( config.timeout() );
+    }
+
+    @Test
+    void shouldAllowZeroTimeout()
+    {
+        TransactionConfig config = TransactionConfig.builder()
+                .withTimeout( Duration.ZERO )
+                .build();
+
+        assertEquals( Duration.ZERO, config.timeout() );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
@@ -24,10 +24,10 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.InternalPath;
 import org.neo4j.driver.internal.InternalRelationship;
-import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.util.TestUtil;
 
 import static java.util.Collections.emptyMap;
@@ -80,8 +80,8 @@ class TransactionConfigTest
     void shouldHaveTimeout()
     {
         TransactionConfig config = TransactionConfig.builder()
-                .withTimeout( Duration.ofSeconds( 3 ) )
-                .build();
+                                                    .withTimeout( Duration.ofSeconds( 3 ) )
+                                                    .build();
 
         assertEquals( Duration.ofSeconds( 3 ), config.timeout() );
     }
@@ -90,11 +90,11 @@ class TransactionConfigTest
     void shouldAllowDefaultTimeout()
     {
         TransactionConfig config = TransactionConfig.builder()
-                .withTimeout( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT )
-                .build();
+                                                    .withTimeout( Duration.ofSeconds( 3 ) )
+                                                    .withDefaultTimeout()
+                                                    .build();
 
         assertNull( config.timeout() );
-        assertEquals( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT,config.timeout() );
     }
 
     @Test

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
@@ -1,0 +1,5 @@
+package neo4j.org.testkit.backend;
+
+public class CustomDriverError extends java.lang.RuntimeException
+{
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package neo4j.org.testkit.backend;
 
 public class CustomDriverError extends java.lang.RuntimeException

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/CustomDriverError.java
@@ -18,6 +18,10 @@
  */
 package neo4j.org.testkit.backend;
 
-public class CustomDriverError extends java.lang.RuntimeException
+public class CustomDriverError extends RuntimeException
 {
+    public CustomDriverError( Throwable cause )
+    {
+        super( cause );
+    }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
@@ -21,6 +21,7 @@ package neo4j.org.testkit.backend.channel.handler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import neo4j.org.testkit.backend.CustomDriverError;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import neo4j.org.testkit.backend.messages.responses.BackendError;
@@ -134,6 +135,20 @@ public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
         }
         else if ( isConnectionPoolClosedException( throwable ) || throwable instanceof UntrustedServerException )
         {
+            String id = testkitState.newId();
+            return DriverError.builder()
+                              .data(
+                                      DriverError.DriverErrorBody.builder()
+                                                                 .id( id )
+                                                                 .errorType( throwable.getClass().getName() )
+                                                                 .msg( throwable.getMessage() )
+                                                                 .build()
+                              )
+                              .build();
+        }
+        else if ( throwable instanceof CustomDriverError )
+        {
+            throwable = throwable.getCause();
             String id = testkitState.newId();
             return DriverError.builder()
                               .data(

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionBeginTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionBeginTransaction.java
@@ -58,7 +58,7 @@ public class SessionBeginTransaction implements TestkitRequest
                 }
                 else
                 {
-                    builder.withTimeout( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT );
+                    builder.withDefaultTimeout();
                 }
             }
             catch ( IllegalArgumentException e )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionBeginTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionBeginTransaction.java
@@ -63,9 +63,7 @@ public class SessionBeginTransaction implements TestkitRequest
             }
             catch ( IllegalArgumentException e )
             {
-                CustomDriverError wrapped = new CustomDriverError();
-                wrapped.initCause( e );
-                throw wrapped;
+                throw new CustomDriverError( e );
             }
         }
     }
@@ -124,17 +122,13 @@ public class SessionBeginTransaction implements TestkitRequest
         return Transaction.builder().data( Transaction.TransactionBody.builder().id( txId ).build() ).build();
     }
 
+    @Getter
+    @Setter
     public static class SessionBeginTransactionBody
     {
-        @Getter
-        @Setter
         private String sessionId;
-        @Getter
-        @Setter
         private Map<String,Object> txMeta;
-        @Getter
         private Integer timeout;
-        @Getter
         private Boolean timeoutPresent = false;
 
         public void setTimeout( Integer timeout )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionRun.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionRun.java
@@ -62,7 +62,7 @@ public class SessionRun implements TestkitRequest
                 }
                 else
                 {
-                    builder.withTimeout( TransactionConfig.Builder.SERVER_DEFAULT_TIMEOUT );
+                    builder.withDefaultTimeout();
                 }
             }
             catch ( IllegalArgumentException e )
@@ -159,6 +159,5 @@ public class SessionRun implements TestkitRequest
             this.timeout = timeout;
             timeoutPresent = true;
         }
-
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionRun.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionRun.java
@@ -67,9 +67,7 @@ public class SessionRun implements TestkitRequest
             }
             catch ( IllegalArgumentException e )
             {
-                CustomDriverError wrapped = new CustomDriverError();
-                wrapped.initCause( e );
-                throw wrapped;
+                throw new CustomDriverError( e );
             }
         }
     }
@@ -144,25 +142,16 @@ public class SessionRun implements TestkitRequest
         return Result.builder().data( Result.ResultBody.builder().id( resultId ).build() ).build();
     }
 
+    @Setter
+    @Getter
     public static class SessionRunBody
     {
         @JsonDeserialize( using = TestkitCypherParamDeserializer.class )
-        @Setter
-        @Getter
         private Map<String,Object> params;
-
-        @Setter
-        @Getter
         private String sessionId;
-        @Setter
-        @Getter
         private String cypher;
-        @Setter
-        @Getter
         private Map<String,Object> txMeta;
-        @Getter
         private Integer timeout;
-        @Getter
         private Boolean timeoutPresent = false;
 
         public void setTimeout( Integer timeout )


### PR DESCRIPTION
Adjust TestKit back end to accept
 * `null` timeout: send `null` to server (or omit as it's the default)
 * and integer: configure as timeout in milliseconds
 * omitted timeout: don't explicitly configure the timeout (user driver default)