### PR TITLE
TestKit: send error message or driver creation error

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -242,7 +242,7 @@ public class NewDriver implements TestkitRequest
             String id = testkitState.newId();
             String errorType = e.getClass().getName();
             response = Optional.of(
-                    DriverError.builder().data( DriverError.DriverErrorBody.builder().id( id ).errorType( errorType ).build() ).build()
+                    DriverError.builder().data( DriverError.DriverErrorBody.builder().id( id ).errorType( errorType ).msg( e.getMessage() ).build() ).build()
             );
         }
         return response;


### PR DESCRIPTION
Cherry-pick:  #1125

Not strictly needed for testing but might make debugging or investigating
driver behavior easier.