### PR TITLE
Add support for multiple certificate files

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -79,4 +79,11 @@
         <method>org.neo4j.driver.Config$ConfigBuilder withRoutingRetryDelay(long, java.util.concurrent.TimeUnit)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Config$TrustStrategy</className>
+        <differenceType>7005</differenceType>
+        <method>org.neo4j.driver.Config$TrustStrategy trustCustomCertificateSignedBy(java.io.File)</method>
+        <to>org.neo4j.driver.Config$TrustStrategy trustCustomCertificateSignedBy(java.io.File[])</to>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -21,6 +21,7 @@ package org.neo4j.driver;
 import java.io.File;
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -728,7 +729,7 @@ public class Config implements Serializable
         {
             Objects.requireNonNull( certFiles, "certFiles can't be null" );
             this.strategy = strategy;
-            this.certFiles = certFiles;
+            this.certFiles = Collections.unmodifiableList( new ArrayList<>( certFiles ) );
         }
 
         /**

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -21,6 +21,9 @@ package org.neo4j.driver;
 import java.io.File;
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -463,7 +466,7 @@ public class Config implements Serializable
 
         /**
          * Specify how to determine the authenticity of an encryption certificate provided by the Neo4j instance we are connecting to. This defaults to {@link
-         * TrustStrategy#trustSystemCertificates()}. See {@link TrustStrategy#trustCustomCertificateSignedBy(File)} for using certificate signatures instead to
+         * TrustStrategy#trustSystemCertificates()}. See {@link TrustStrategy#trustCustomCertificateSignedBy(File...)} for using certificate signatures instead to
          * verify trust.
          * <p>
          * This is an important setting to understand, because unless we know that the remote server we have an encrypted connection to is really Neo4j, there
@@ -712,19 +715,20 @@ public class Config implements Serializable
         }
 
         private final Strategy strategy;
-        private final File certFile;
+        private final List<File> certFiles;
         private boolean hostnameVerificationEnabled = true;
         private RevocationStrategy revocationStrategy = RevocationStrategy.NO_CHECKS;
 
         private TrustStrategy( Strategy strategy )
         {
-            this( strategy, null );
+            this( strategy, Collections.emptyList() );
         }
 
-        private TrustStrategy( Strategy strategy, File certFile )
+        private TrustStrategy( Strategy strategy, List<File> certFiles )
         {
+            Objects.requireNonNull( certFiles, "certFiles can't be null" );
             this.strategy = strategy;
-            this.certFile = certFile;
+            this.certFiles = certFiles;
         }
 
         /**
@@ -741,10 +745,22 @@ public class Config implements Serializable
          * Return the configured certificate file.
          *
          * @return configured certificate or {@code null} if trust strategy does not require a certificate.
+         * @deprecated superseded by {@link TrustStrategy#certFiles()}
          */
+        @Deprecated
         public File certFile()
         {
-            return certFile;
+            return certFiles.isEmpty() ? null : certFiles.get( 0 );
+        }
+
+        /**
+         * Return the configured certificate files.
+         *
+         * @return configured certificate files or empty list if trust strategy does not require certificates.
+         */
+        public List<File> certFiles()
+        {
+            return certFiles;
         }
 
         /**
@@ -780,18 +796,18 @@ public class Config implements Serializable
         }
 
         /**
-         * Only encrypted connections to Neo4j instances with certificates signed by a trusted certificate will be accepted.
-         * The file specified should contain one or more trusted X.509 certificates.
+         * Only encrypted connections to Neo4j instances with certificates signed by a trusted certificate will be accepted. The file(s) specified should
+         * contain one or more trusted X.509 certificates.
          * <p>
-         * The certificate(s) in the file must be encoded using PEM encoding, meaning the certificates in the file should be encoded using Base64,
-         * and each certificate is bounded at the beginning by "-----BEGIN CERTIFICATE-----", and bounded at the end by "-----END CERTIFICATE-----".
+         * The certificate(s) in the file(s) must be encoded using PEM encoding, meaning the certificates in the file(s) should be encoded using Base64, and
+         * each certificate is bounded at the beginning by "-----BEGIN CERTIFICATE-----", and bounded at the end by "-----END CERTIFICATE-----".
          *
-         * @param certFile the trusted certificate file
+         * @param certFiles the trusted certificate files
          * @return an authentication config
          */
-        public static TrustStrategy trustCustomCertificateSignedBy( File certFile )
+        public static TrustStrategy trustCustomCertificateSignedBy( File... certFiles )
         {
-            return new TrustStrategy( Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, certFile );
+            return new TrustStrategy( Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, Arrays.asList( certFiles ) );
         }
 
         /**

--- a/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
@@ -21,7 +21,6 @@ package org.neo4j.driver.internal;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
-import java.util.Objects;
 
 import org.neo4j.driver.Config;
 import org.neo4j.driver.exceptions.ClientException;
@@ -73,7 +72,7 @@ public class SecuritySettings implements Serializable
         }
 
         return t1.isHostnameVerificationEnabled() == t2.isHostnameVerificationEnabled() && t1.strategy() == t2.strategy() &&
-                Objects.equals( t1.certFile(), t2.certFile() ) && t1.revocationStrategy() == t2.revocationStrategy();
+               t1.certFiles().equals( t2.certFiles() ) && t1.revocationStrategy() == t2.revocationStrategy();
     }
 
     public SecurityPlan createSecurityPlan( String uriScheme )
@@ -131,7 +130,7 @@ public class SecuritySettings implements Serializable
             switch ( trustStrategy.strategy() )
             {
             case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
-                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFile(), hostnameVerificationEnabled, revocationStrategy );
+                return SecurityPlanImpl.forCustomCASignedCertificates( trustStrategy.certFiles(), hostnameVerificationEnabled, revocationStrategy );
             case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
                 return SecurityPlanImpl.forSystemCASignedCertificates( hostnameVerificationEnabled, revocationStrategy );
             case TRUST_ALL_CERTIFICATES:

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
@@ -27,6 +27,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
 import javax.net.ssl.CertPathTrustManagerParameters;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -53,31 +55,31 @@ public class SecurityPlanImpl implements SecurityPlan
         return new SecurityPlanImpl( true, sslContext, requiresHostnameVerification, revocationStrategy );
     }
 
-    public static SecurityPlan forCustomCASignedCertificates( File certFile, boolean requiresHostnameVerification,
+    public static SecurityPlan forCustomCASignedCertificates( List<File> certFiles, boolean requiresHostnameVerification,
                                                               RevocationStrategy revocationStrategy )
             throws GeneralSecurityException, IOException
     {
-        SSLContext sslContext = configureSSLContext( certFile, revocationStrategy );
+        SSLContext sslContext = configureSSLContext( certFiles, revocationStrategy );
         return new SecurityPlanImpl( true, sslContext, requiresHostnameVerification, revocationStrategy );
     }
 
     public static SecurityPlan forSystemCASignedCertificates( boolean requiresHostnameVerification, RevocationStrategy revocationStrategy )
             throws GeneralSecurityException, IOException
     {
-        SSLContext sslContext = configureSSLContext( null, revocationStrategy );
+        SSLContext sslContext = configureSSLContext( Collections.emptyList(), revocationStrategy );
         return new SecurityPlanImpl( true, sslContext, requiresHostnameVerification, revocationStrategy );
     }
 
-    private static SSLContext configureSSLContext( File customCertFile, RevocationStrategy revocationStrategy )
+    private static SSLContext configureSSLContext( List<File> customCertFiles, RevocationStrategy revocationStrategy )
             throws GeneralSecurityException, IOException
     {
         KeyStore trustedKeyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
         trustedKeyStore.load( null, null );
 
-        if ( customCertFile != null )
+        if ( !customCertFiles.isEmpty() )
         {
-            // A certificate file is specified so we will load the certificates in the file
-            loadX509Cert( customCertFile, trustedKeyStore );
+            // Certificate files are specified, so we will load the certificates in the file
+            loadX509Cert( customCertFiles, trustedKeyStore );
         }
         else
         {

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -80,7 +80,7 @@ class ConfigTest
 
         // Then
         assertEquals( authConfig.strategy(), Config.TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES );
-        assertEquals( trustedCert.getAbsolutePath(), authConfig.certFile().getAbsolutePath() );
+        assertEquals( trustedCert.getAbsolutePath(), authConfig.certFiles().get( 0 ).getAbsolutePath() );
     }
 
     @Test
@@ -401,7 +401,7 @@ class ConfigTest
             assertEquals( config.eventLoopThreads(), verify.eventLoopThreads() );
             assertEquals( config.encrypted(), verify.encrypted() );
             assertEquals( config.trustStrategy().strategy(), verify.trustStrategy().strategy() );
-            assertEquals( config.trustStrategy().certFile(), verify.trustStrategy().certFile() );
+            assertEquals( config.trustStrategy().certFiles(), verify.trustStrategy().certFiles() );
             assertEquals( config.trustStrategy().isHostnameVerificationEnabled(), verify.trustStrategy().isHostnameVerificationEnabled() );
             assertEquals( config.trustStrategy().revocationStrategy(), verify.trustStrategy().revocationStrategy() );
             assertEquals( config.userAgent(), verify.userAgent() );

--- a/driver/src/test/java/org/neo4j/driver/util/CertificateUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/util/CertificateUtilTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.Enumeration;
 
 import org.neo4j.driver.internal.util.CertificateTool;
@@ -52,7 +53,7 @@ public class CertificateUtilTest
         keyStore.load( null, null );
 
         // When
-        CertificateTool.loadX509Cert( certFile, keyStore );
+        CertificateTool.loadX509Cert( Collections.singletonList( certFile ), keyStore );
 
         // Then
         Enumeration<String> aliases = keyStore.aliases();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -62,7 +62,9 @@ public class GetFeatures implements TestkitRequest
             "Temporary:ResultKeys",
             "Temporary:TransactionClose",
             "Optimization:EagerTransactionBegin",
-            "Feature:API:Driver.IsEncrypted"
+            "Feature:API:Driver.IsEncrypted",
+            "Feature:API:SSLConfig",
+            "Detail:DefaultSecurityConfigValueEquality"
     ) );
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>( Arrays.asList(

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -53,12 +53,15 @@ public class StartTest implements TestkitRequest
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_partial_summary_contains_system_updates$", "Does not contain updates because value is zero" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_partial_summary_contains_updates$", "Does not contain updates because value is zero" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_supports_multi_db$", "Database is None" );
+        String skipMessage = "This test expects hostname verification to be turned off when all certificates are trusted";
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTrustAllCertsConfig\\.test_trusted_ca_wrong_hostname$", skipMessage );
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTrustAllCertsConfig\\.test_untrusted_ca_wrong_hostname$", skipMessage );
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll( COMMON_SKIP_PATTERN_TO_REASON );
 
         REACTIVE_SKIP_PATTERN_TO_REASON.putAll( COMMON_SKIP_PATTERN_TO_REASON );
         // Current limitations (require further investigation or bug fixing)
-        String skipMessage = "Does not report RUN FAILURE";
+        skipMessage = "Does not report RUN FAILURE";
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_write_successfully_on_leader_switch_using_tx_function$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_after_hello$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_run$", skipMessage );

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -13,4 +13,5 @@ ENV PATH=$JAVA_HOME/bin:$PATH
 # Assumes Linux Debian based image.
 # JAVA_HOME needed by update-ca-certificates hook to update Java with changed system CAs.
 COPY CAs/* /usr/local/share/ca-certificates/
+COPY CustomCAs/* /usr/local/share/custom-ca-certificates/
 RUN update-ca-certificates


### PR DESCRIPTION
This update brings support for specifying multiple certificate files via `TrustStrategy#trustCustomCertificateSignedBy(File...)`. Also, it deprecates `TrustStrategy#certFiles()` that is superseded by `TrustStrategy#certFiles()`.

In addition, it adds support for the following Testkit feature flags:
- `Feature:API:SSLConfig`
- `Detail:DefaultSecurityConfigValueEquality`