### PR TITLE
Update channel tracking

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/pool/NettyChannelTracker.java
@@ -90,7 +90,7 @@ public class NettyChannelTracker implements ChannelPoolHandler
         log.debug( "Channel [%s] created. Local address: %s, remote address: %s",
                 channel.id(), channel.localAddress(), channel.remoteAddress() );
 
-        incrementInUse( channel );
+        incrementIdle( channel ); // when it is created, we count it as idle as it has not been acquired out of the pool
         metricsListener.afterCreated( serverAddress( channel ), creatingEvent );
 
         allChannels.add( channel );

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -123,7 +123,7 @@ class ConnectionPoolImplIT
                 assertThrows( ServiceUnavailableException.class, () -> await( pool.acquire( neo4j.address() ) ) );
         assertThat( error.getMessage(), containsString( "closed while acquiring a connection" ) );
         assertThat( error.getCause(), instanceOf( IllegalStateException.class ) );
-        assertThat( error.getCause().getMessage(), containsString( "FixedChannelPooled was closed" ) );
+        assertThat( error.getCause().getMessage(), containsString( "FixedChannelPool was closed" ) );
     }
 
     private ConnectionPoolImpl newPool() throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.22.Final</version>
+        <version>4.1.41.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hdrhistogram</groupId>


### PR DESCRIPTION
Cherry-pick: https://github.com/neo4j/neo4j-java-driver/commit/5418cb7fd4f76f4c8827095fe944db1d76d9e02d

In the updated netty pool,
`ChannelPoolHandler#channelCreated` is called at channel creation, and then `ChannelPoolHandler#channelAcquired` is called when the connection is borrowed out of the pool. When acquiring a connection from a newly created pool, a new connection will be created and then acquired. In previous netty version, when a connection is created, then it is directly lent out of the pool without being acquired. Thus we need to change some logic regarding how to count in use and idle connections.