### PR TITLE
Add exceptions to numeric id accessors in nodes and relationships

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalEntity.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalEntity.java
@@ -32,7 +32,8 @@ import static org.neo4j.driver.Values.ofObject;
 
 public abstract class InternalEntity implements Entity, AsValue
 {
-    public static final String INVALID_ID_ERROR = "Numeric id is not available, please use string based element id alternative";
+    public static final String INVALID_ID_ERROR =
+            "Numeric id is not available with this server deployment, please use the new string based element id alternative";
 
     private final long id;
     private final String elementId;

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalEntity.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalEntity.java
@@ -32,20 +32,25 @@ import static org.neo4j.driver.Values.ofObject;
 
 public abstract class InternalEntity implements Entity, AsValue
 {
+    public static final String INVALID_ID_ERROR = "Numeric id is not available, please use string based element id alternative";
+
     private final long id;
     private final String elementId;
     private final Map<String,Value> properties;
+    private final boolean numericIdAvailable;
 
-    public InternalEntity( long id, String elementId, Map<String,Value> properties )
+    public InternalEntity( long id, String elementId, Map<String,Value> properties, boolean numericIdAvailable )
     {
         this.id = id;
         this.elementId = elementId;
         this.properties = properties;
+        this.numericIdAvailable = numericIdAvailable;
     }
 
     @Override
     public long id()
     {
+        assertNumericIdAvailable();
         return id;
     }
 
@@ -141,5 +146,18 @@ public abstract class InternalEntity implements Entity, AsValue
     public <T> Iterable<T> values( Function<Value,T> mapFunction )
     {
         return Iterables.map( properties.values(), mapFunction );
+    }
+
+    protected void assertNumericIdAvailable()
+    {
+        if ( !numericIdAvailable )
+        {
+            throw new IllegalStateException( INVALID_ID_ERROR );
+        }
+    }
+
+    public boolean isNumericIdAvailable()
+    {
+        return numericIdAvailable;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalNode.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalNode.java
@@ -35,12 +35,17 @@ public class InternalNode extends InternalEntity implements Node
 
     public InternalNode( long id )
     {
-        this( id, String.valueOf( id ), Collections.emptyList(), Collections.emptyMap() );
+        this( id, Collections.emptyList(), Collections.emptyMap() );
     }
 
-    public InternalNode( long id, String elementId, Collection<String> labels, Map<String,Value> properties )
+    public InternalNode( long id, Collection<String> labels, Map<String,Value> properties )
     {
-        super( id, elementId, properties );
+        this( id, String.valueOf( id ), labels, properties, true );
+    }
+
+    public InternalNode( long id, String elementId, Collection<String> labels, Map<String,Value> properties, boolean numericIdAvailable )
+    {
+        super( id, elementId, properties, numericIdAvailable );
         this.labels = labels;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalRelationship.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalRelationship.java
@@ -36,15 +36,20 @@ public class InternalRelationship extends InternalEntity implements Relationship
     private String endElementId;
     private final String type;
 
-    public InternalRelationship( long id, String elementId, long start, String startElementId, long end, String endElementId, String type )
+    public InternalRelationship( long id, long start, long end, String type )
     {
-        this( id, elementId, start, startElementId, end, endElementId, type, Collections.emptyMap() );
+        this( id, start, end, type, Collections.emptyMap() );
+    }
+
+    public InternalRelationship( long id, long start, long end, String type, Map<String,Value> properties )
+    {
+        this( id, String.valueOf( id ), start, String.valueOf( start ), end, String.valueOf( end ), type, properties, true );
     }
 
     public InternalRelationship( long id, String elementId, long start, String startElementId, long end, String endElementId, String type,
-                                 Map<String,Value> properties )
+                                 Map<String,Value> properties, boolean numericIdAvailable )
     {
-        super( id, elementId, properties );
+        super( id, elementId, properties, numericIdAvailable );
         this.start = start;
         this.startElementId = startElementId;
         this.end = end;
@@ -72,6 +77,7 @@ public class InternalRelationship extends InternalEntity implements Relationship
     @Override
     public long startNodeId()
     {
+        assertNumericIdAvailable();
         return start;
     }
 
@@ -84,6 +90,7 @@ public class InternalRelationship extends InternalEntity implements Relationship
     @Override
     public long endNodeId()
     {
+        assertNumericIdAvailable();
         return end;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
@@ -237,8 +237,8 @@ public class CommonValueUnpacker implements ValueUnpacker
         String relType = unpacker.unpackString();
         Map<String,Value> props = unpackMap();
 
-        InternalRelationship adapted =
-                new InternalRelationship( urn, String.valueOf( urn ), startUrn, String.valueOf( startUrn ), endUrn, String.valueOf( endUrn ), relType, props );
+        InternalRelationship adapted = new InternalRelationship( urn, String.valueOf( urn ), startUrn, String.valueOf( startUrn ), endUrn,
+                                                                 String.valueOf( endUrn ), relType, props, true );
         return new RelationshipValue( adapted );
     }
 
@@ -260,7 +260,7 @@ public class CommonValueUnpacker implements ValueUnpacker
             props.put( key, unpack() );
         }
 
-        return new InternalNode( urn, String.valueOf( urn ), labels, props );
+        return new InternalNode( urn, String.valueOf( urn ), labels, props, true );
     }
 
     protected Value unpackPath() throws IOException
@@ -283,7 +283,7 @@ public class CommonValueUnpacker implements ValueUnpacker
             long id = unpacker.unpackLong();
             String relType = unpacker.unpackString();
             Map<String,Value> props = unpackMap();
-            uniqRels[i] = new InternalRelationship( id, String.valueOf( id ), -1, String.valueOf( -1 ), -1, String.valueOf( -1 ), relType, props );
+            uniqRels[i] = new InternalRelationship( id, String.valueOf( id ), -1, String.valueOf( -1 ), -1, String.valueOf( -1 ), relType, props, true );
         }
 
         // Path sequence

--- a/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/packstream/PackStream.java
@@ -467,7 +467,7 @@ public class PackStream
             }
         }
 
-        public Long unpackLongOrDefaultOnNull( long defaultValue ) throws IOException
+        public Long unpackLongOrNull() throws IOException
         {
             final byte markerByte = in.readByte();
             if ( markerByte >= MINUS_2_TO_THE_4 )
@@ -485,7 +485,7 @@ public class PackStream
             case INT_64:
                 return in.readLong();
             case NULL:
-                return defaultValue;
+                return null;
             default:
                 throw new Unexpected( "Expected an integer, but got: " + toHexString( markerByte ) );
             }

--- a/driver/src/main/java/org/neo4j/driver/types/Entity.java
+++ b/driver/src/main/java/org/neo4j/driver/types/Entity.java
@@ -31,9 +31,10 @@ public interface Entity extends MapAccessor
      * A unique id for this Entity. Ids are guaranteed to remain stable for the duration of the session they were found in, but may be re-used for other
      * entities after that. As such, if you want a public identity to use for your entities, attaching an explicit 'id' property or similar persistent and
      * unique identifier is a better choice.
+     * <p>
+     * Please note that depending on server configuration numeric id might not be available and accessing it will result in {@link IllegalStateException}.
      *
-     * @return the id of this entity, please note that negative values are considered to be invalid and may be returned when storage engine can only provide the
-     * {@link #elementId()}
+     * @return the id of this entity
      * @deprecated superseded by {@link #elementId()}
      */
     @Deprecated

--- a/driver/src/main/java/org/neo4j/driver/types/Relationship.java
+++ b/driver/src/main/java/org/neo4j/driver/types/Relationship.java
@@ -26,6 +26,8 @@ public interface Relationship extends Entity
 {
     /**
      * Id of the node where this relationship starts.
+     * <p>
+     * Please note that depending on server configuration numeric id might not be available and accessing it will result in {@link IllegalStateException}.
      *
      * @return the node id
      * @deprecated superseded by {@link #startNodeElementId()}
@@ -42,6 +44,8 @@ public interface Relationship extends Entity
 
     /**
      * Id of the node where this relationship ends.
+     * <p>
+     * Please note that depending on server configuration numeric id might not be available and accessing it will result in {@link IllegalStateException}.
      *
      * @return the node id
      * @deprecated superseded by {@link #endNodeElementId()}

--- a/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/TransactionConfigTest.java
@@ -71,7 +71,7 @@ class TransactionConfigTest
 
         assertThrows( ClientException.class,
                       () -> TransactionConfig.builder().withMetadata(
-                              singletonMap( "key", new InternalRelationship( 1, String.valueOf( 1 ), 1, String.valueOf( 1 ), 1, String.valueOf( 1 ), "" ) ) ) );
+                              singletonMap( "key", new InternalRelationship( 1, 1, 1, "" ) ) ) );
 
         assertThrows( ClientException.class,
                 () -> TransactionConfig.builder().withMetadata( singletonMap( "key", new InternalPath( new InternalNode( 1 ) ) ) ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/ExtractTest.java
@@ -127,7 +127,7 @@ class ExtractTest
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 43 ) );
         props.put( "k2", value( 42 ) );
-        InternalNode node = new InternalNode( 42L, String.valueOf( 42L ), Collections.singletonList( "L" ), props );
+        InternalNode node = new InternalNode( 42L, Collections.singletonList( "L" ), props );
 
         // WHEN
         Iterable<Pair<String,Integer>> properties = Extract.properties( node, Value::asInt );
@@ -143,7 +143,7 @@ class ExtractTest
     void testFields()
     {
         // GIVEN
-        InternalRecord record = new InternalRecord( Arrays.asList( "k1" ), new Value[]{value( 42 )} );
+        InternalRecord record = new InternalRecord( singletonList( "k1" ), new Value[]{value( 42 )} );
         // WHEN
         List<Pair<String,Integer>> fields = Extract.fields( record, Value::asInt );
 
@@ -181,11 +181,7 @@ class ExtractTest
     void shouldFailToExtractMapOfValuesFromUnsupportedValues()
     {
         assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalNode( 1 ) ) ) );
-        assertThrows( ClientException.class,
-                      () -> Extract.mapOfValues(
-                              singletonMap( "key",
-                                            new InternalRelationship( 1, String.valueOf( 1 ), 1, String.valueOf( 1 ),
-                                                                      1, String.valueOf( 1 ), "HI" ) ) ) );
+        assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalRelationship( 1, 1, 1, "HI" ) ) ) );
         assertThrows( ClientException.class, () -> Extract.mapOfValues( singletonMap( "key", new InternalPath( new InternalNode( 1 ) ) ) ) );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalMapAccessorWithDefaultValueTest.java
@@ -90,7 +90,7 @@ class InternalMapAccessorWithDefaultValueTest
         // Path
         Value defaultPathValue = new PathValue( new InternalPath(
                 new InternalNode( 0L ),
-                new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T" ),
+                new InternalRelationship( 0L, 0L, 1L, "T" ),
                 new InternalNode( 1L ) ) );
         Value realPathValue = new PathValue( createPath() );
         assertThat( record.get( "PathValue", defaultPathValue ), equalTo( realPathValue ) );
@@ -104,7 +104,7 @@ class InternalMapAccessorWithDefaultValueTest
 
         // Rel
         Value defaultRelValue =
-                new RelationshipValue( new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T" ) );
+                new RelationshipValue( new InternalRelationship( 0L, 0L, 1L, "T" ) );
         Value realRelValue = new RelationshipValue( createRel() );
         assertThat( record.get( "RelValue", defaultRelValue ), equalTo( realRelValue ) );
         assertThat( record.get( wrongKey, defaultRelValue ), equalTo( defaultRelValue ) );
@@ -136,11 +136,11 @@ class InternalMapAccessorWithDefaultValueTest
         Record record = createRecord();
 
         Entity defaultNodeEntity = new InternalNode( 0L );
-        assertThat( record.get( "NodeValue", defaultNodeEntity ), equalTo( (Entity) createNode() ) );
+        assertThat( record.get( "NodeValue", defaultNodeEntity ), equalTo( createNode() ) );
         assertThat( record.get( wrongKey, defaultNodeEntity ), equalTo( defaultNodeEntity ) );
 
-        Entity defaultRelEntity = new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T" );
-        assertThat( record.get( "RelValue", defaultRelEntity ), equalTo( (Entity) createRel() ) );
+        Entity defaultRelEntity = new InternalRelationship( 0L, 0L, 1L, "T" );
+        assertThat( record.get( "RelValue", defaultRelEntity ), equalTo( createRel() ) );
         assertThat( record.get( wrongKey, defaultRelEntity ), equalTo( defaultRelEntity ) );
     }
 
@@ -159,7 +159,7 @@ class InternalMapAccessorWithDefaultValueTest
     {
         Record record = createRecord();
 
-        Relationship defaultRel = new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T" );
+        Relationship defaultRel = new InternalRelationship( 0L, 0L, 1L, "T" );
         assertThat( record.get( "RelValue", defaultRel ), equalTo( createRel() ) );
         assertThat( record.get( wrongKey, defaultRel ), equalTo( defaultRel ) );
     }
@@ -171,7 +171,7 @@ class InternalMapAccessorWithDefaultValueTest
 
         Path defaultPath = new InternalPath(
                 new InternalNode( 0L ),
-                new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T" ),
+                new InternalRelationship( 0L, 0L, 1L, "T" ),
                 new InternalNode( 1L ) );
         assertThat( record.get( "PathValue", defaultPath ), equalTo( createPath() ) );
         assertThat( record.get( wrongKey, defaultPath ), equalTo( defaultPath ) );
@@ -271,7 +271,7 @@ class InternalMapAccessorWithDefaultValueTest
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 43 ) );
         props.put( "k2", value( "hello world" ) );
-        NodeValue nodeValue = new NodeValue( new InternalNode( 42L, String.valueOf( 42L ), Collections.singletonList( "L" ), props ) );
+        NodeValue nodeValue = new NodeValue( new InternalNode( 42L, Collections.singletonList( "L" ), props ) );
 
         assertThat( nodeValue.get( "k1", 0 ), equalTo( 43 ) );
         assertThat( nodeValue.get( "k2", "" ), equalTo( "hello world" ) );
@@ -285,7 +285,7 @@ class InternalMapAccessorWithDefaultValueTest
         props.put( "k1", value( 43 ) );
         props.put( "k2", value( "hello world" ) );
         RelationshipValue relValue =
-                new RelationshipValue( new InternalRelationship( 0L, String.valueOf( 0L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T", props ) );
+                new RelationshipValue( new InternalRelationship( 0L, 0L, 1L, "T", props ) );
 
         assertThat( relValue.get( "k1", 0 ), equalTo( 43 ) );
         assertThat( relValue.get( "k2", "" ), equalTo( "hello world" ) );
@@ -296,7 +296,7 @@ class InternalMapAccessorWithDefaultValueTest
     {
         return new InternalPath(
                 new InternalNode( 42L ),
-                new InternalRelationship( 43L, String.valueOf( 43L ), 42L, String.valueOf( 42L ), 44L, String.valueOf( 44L ), "T" ),
+                new InternalRelationship( 43L, 42L, 44L, "T" ),
                 new InternalNode( 44L ) );
     }
 
@@ -307,7 +307,7 @@ class InternalMapAccessorWithDefaultValueTest
 
     private Relationship createRel()
     {
-        return new InternalRelationship( 1L, String.valueOf( 1L ), 1L, String.valueOf( 1L ), 2L, String.valueOf( 2L ), "T" );
+        return new InternalRelationship( 1L, 1L, 2L, "T" );
     }
 
     private Map<String, Value> createMap()

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalNodeTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalNodeTest.java
@@ -30,7 +30,9 @@ import org.neo4j.driver.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.NULL;
 import static org.neo4j.driver.Values.value;
 
@@ -63,12 +65,22 @@ class InternalNodeTest
         assertThat( node.get( "k3" ), equalTo( NULL ) );
     }
 
+    @Test
+    void shouldThrowOnIdWhenNumericIdUnavailable()
+    {
+        // GIVEN
+        InternalNode node = new InternalNode( -1, "value", Collections.emptyList(), Collections.emptyMap(), false );
+
+        // WHEN & THEN
+        IllegalStateException e = assertThrows( IllegalStateException.class, node::id );
+        assertEquals( InternalEntity.INVALID_ID_ERROR, e.getMessage() );
+    }
+
     private InternalNode createNode()
     {
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 1 ) );
         props.put( "k2", value( 2 ) );
-        return new InternalNode( 42L, String.valueOf( 42L ), Collections.singletonList( "L" ), props );
+        return new InternalNode( 42L, String.valueOf( 42L ), Collections.singletonList( "L" ), props, true );
     }
-
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalPathTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalPathTest.java
@@ -40,11 +40,11 @@ class InternalPathTest
     {
         return new InternalPath(
                 new InternalNode( 1 ),
-                new InternalRelationship( -1, String.valueOf( -1 ), 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "KNOWS" ),
+                new InternalRelationship( -1, 1, 2, "KNOWS" ),
                 new InternalNode( 2 ),
-                new InternalRelationship( -2, String.valueOf( -2 ), 3, String.valueOf( 3 ), 2, String.valueOf( 2 ), "KNOWS" ),
+                new InternalRelationship( -2, 3, 2, "KNOWS" ),
                 new InternalNode( 3 ),
-                new InternalRelationship( -3, String.valueOf( -3 ), 3, String.valueOf( 3 ), 4, String.valueOf( 4 ), "KNOWS" ),
+                new InternalRelationship( -3, 3, 4, "KNOWS" ),
                 new InternalNode( 4 )
         );
     }
@@ -82,17 +82,17 @@ class InternalPathTest
         MatcherAssert.assertThat( segments, equalTo( Arrays.asList( (Path.Segment)
                                 new InternalPath.SelfContainedSegment(
                                         new InternalNode( 1 ),
-                                        new InternalRelationship( -1, String.valueOf( -1 ), 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "KNOWS" ),
+                                        new InternalRelationship( -1, 1, 2, "KNOWS" ),
                                         new InternalNode( 2 )
                                 ),
                         new InternalPath.SelfContainedSegment(
                                 new InternalNode( 2 ),
-                                new InternalRelationship( -2, String.valueOf( -2 ), 3, String.valueOf( 3 ), 2, String.valueOf( 2 ), "KNOWS" ),
+                                new InternalRelationship( -2, 3, 2, "KNOWS" ),
                                 new InternalNode( 3 )
                         ),
                         new InternalPath.SelfContainedSegment(
                                 new InternalNode( 3 ),
-                                new InternalRelationship( -3, String.valueOf( -3 ), 3, String.valueOf( 3 ), 4, String.valueOf( 4 ), "KNOWS" ),
+                                new InternalRelationship( -3, 3, 4, "KNOWS" ),
                                 new InternalNode( 4 )
                         )
                 )
@@ -127,12 +127,9 @@ class InternalPathTest
 
         // Then
         assertThat( segments, equalTo( Arrays.asList( (Relationship)
-                                                              new InternalRelationship( -1, String.valueOf( -1 ), 1, String.valueOf( 1 ), 2,
-                                                                                        String.valueOf( 2 ), "KNOWS" ),
-                                                      new InternalRelationship( -2, String.valueOf( -2 ), 3, String.valueOf( 3 ), 2, String.valueOf( 2 ),
-                                                                                "KNOWS" ),
-                                                      new InternalRelationship( -3, String.valueOf( -3 ), 3, String.valueOf( 3 ), 4, String.valueOf( 4 ),
-                                                                                "KNOWS" ) ) ) );
+                                                              new InternalRelationship( -1, 1, 2, "KNOWS" ),
+                                                      new InternalRelationship( -2, 3, 2, "KNOWS" ),
+                                                      new InternalRelationship( -3, 3, 4, "KNOWS" ) ) ) );
     }
 
     @Test
@@ -147,7 +144,7 @@ class InternalPathTest
         assertThrows( IllegalArgumentException.class,
                       () -> new InternalPath(
                               new InternalNode( 1 ),
-                              new InternalRelationship( 2, String.valueOf( 2 ), 3, String.valueOf( 3 ), 4, String.valueOf( 4 ), "KNOWS" ) ) );
+                              new InternalRelationship( 2, 3, 4, "KNOWS" ) ) );
     }
 
     @Test
@@ -163,7 +160,7 @@ class InternalPathTest
         assertThrows( IllegalArgumentException.class,
                 () -> new InternalPath(
                         new InternalNode( 1 ),
-                        new InternalRelationship( 2, String.valueOf( 2 ), 1, String.valueOf( 1 ), 3, String.valueOf( 3 ), "KNOWS" ),
+                        new InternalRelationship( 2, 1, 3, "KNOWS" ),
                         new InternalNode( 4 ) ) );
     }
 
@@ -173,7 +170,7 @@ class InternalPathTest
         assertThrows( IllegalArgumentException.class,
                 () -> new InternalPath(
                         new InternalNode( 1 ),
-                        new InternalRelationship( 2, String.valueOf( 2 ), 3, String.valueOf( 3 ), 4, String.valueOf( 4 ), "KNOWS" ),
+                        new InternalRelationship( 2, 3, 4, "KNOWS" ),
                         new InternalNode( 3 ) ) );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalRelationshipTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalRelationshipTest.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -29,7 +30,9 @@ import org.neo4j.driver.Value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.NULL;
 import static org.neo4j.driver.Values.value;
 
@@ -62,13 +65,49 @@ class InternalRelationshipTest
         assertThat( relationship.get( "k3" ), equalTo( NULL ) );
     }
 
+    @Test
+    void shouldThrowOnIdWhenNumericIdUnavailable()
+    {
+        // GIVEN
+        InternalRelationship relationship =
+                new InternalRelationship( -1, "value", 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "T", Collections.emptyMap(), false );
+
+        // WHEN & THEN
+        IllegalStateException e = assertThrows( IllegalStateException.class, relationship::id );
+        assertEquals( InternalEntity.INVALID_ID_ERROR, e.getMessage() );
+    }
+
+    @Test
+    void shouldThrowOnStartNodeIdWhenNumericIdUnavailable()
+    {
+        // GIVEN
+        InternalRelationship relationship =
+                new InternalRelationship( -1, "value", 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "T", Collections.emptyMap(), false );
+
+        // WHEN & THEN
+        IllegalStateException e = assertThrows( IllegalStateException.class, relationship::startNodeId );
+        assertEquals( InternalEntity.INVALID_ID_ERROR, e.getMessage() );
+    }
+
+    @Test
+    void shouldThrowOnEndNodeIdWhenNumericIdUnavailable()
+    {
+        // GIVEN
+        InternalRelationship relationship =
+                new InternalRelationship( -1, "value", 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "T", Collections.emptyMap(), false );
+
+        // WHEN & THEN
+        IllegalStateException e = assertThrows( IllegalStateException.class, relationship::endNodeId );
+        assertEquals( InternalEntity.INVALID_ID_ERROR, e.getMessage() );
+    }
+
     private InternalRelationship createRelationship()
     {
         Map<String,Value> props = new HashMap<>();
         props.put( "k1", value( 1 ) );
         props.put( "k2", value( 2 ) );
 
-        return new InternalRelationship( 1L, String.valueOf( 1L ), 0L, String.valueOf( 0L ), 1L, String.valueOf( 1L ), "T", props );
+        return new InternalRelationship( 1L, 0L, 1L, "T", props );
     }
 
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/SelfContainedNodeTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SelfContainedNodeTest.java
@@ -36,8 +36,7 @@ class SelfContainedNodeTest
 {
     private Node adamTheNode()
     {
-        return new InternalNode( 1, String.valueOf( 1 ), singletonList( "Person" ),
-                                 parameters( "name", Values.value( "Adam" ) ).asMap( ofValue() ) );
+        return new InternalNode( 1, singletonList( "Person" ), parameters( "name", Values.value( "Adam" ) ).asMap( ofValue() ) );
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/util/ValueFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/ValueFactory.java
@@ -35,32 +35,27 @@ public class ValueFactory
 {
     public static NodeValue emptyNodeValue()
     {
-        return new NodeValue( new InternalNode( 1234, String.valueOf( 1234 ), singletonList( "User" ), new HashMap<>() ) );
+        return new NodeValue( new InternalNode( 1234, singletonList( "User" ), new HashMap<>() ) );
     }
 
     public static NodeValue filledNodeValue()
     {
-        return new NodeValue( new InternalNode( 1234, String.valueOf( 1234 ), singletonList( "User" ), singletonMap( "name", value( "Dodo" ) ) ) );
+        return new NodeValue( new InternalNode( 1234, singletonList( "User" ), singletonMap( "name", value( "Dodo" ) ) ) );
     }
 
     public static RelationshipValue emptyRelationshipValue()
     {
-        return new RelationshipValue( new InternalRelationship( 1234, String.valueOf( 1234 ), 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "KNOWS" ) );
+        return new RelationshipValue( new InternalRelationship( 1234, 1, 2, "KNOWS" ) );
     }
 
     public static RelationshipValue filledRelationshipValue()
     {
-        return new RelationshipValue(
-                new InternalRelationship( 1234, String.valueOf( 1234 ), 1, String.valueOf( 1 ), 2, String.valueOf( 2 ), "KNOWS",
-                                          singletonMap( "name", value( "Dodo" ) ) ) );
+        return new RelationshipValue( new InternalRelationship( 1234, 1, 2, "KNOWS", singletonMap( "name", value( "Dodo" ) ) ) );
     }
 
     public static PathValue filledPathValue()
     {
-        return new PathValue(
-                new InternalPath( new InternalNode( 42L ),
-                                  new InternalRelationship( 43L, String.valueOf( 43L ), 42L, String.valueOf( 42L ), 44L, String.valueOf( 44L ), "T" ),
-                                  new InternalNode( 44L ) ) );
+        return new PathValue( new InternalPath( new InternalNode( 42L ), new InternalRelationship( 43L, 42L, 44L, "T" ), new InternalNode( 44L ) ) );
     }
 
     public static PathValue emptyPathValue()

--- a/driver/src/test/java/org/neo4j/driver/types/TypeSystemTest.java
+++ b/driver/src/test/java/org/neo4j/driver/types/TypeSystemTest.java
@@ -45,9 +45,9 @@ import static org.neo4j.driver.internal.types.InternalTypeSystem.TYPE_SYSTEM;
 
 class TypeSystemTest
 {
-    private final InternalNode node = new InternalNode( 42L );
+    private final InternalNode node = new InternalNode( 42L, String.valueOf( 42L ), Collections.emptyList(), Collections.emptyMap(), true );
     private final InternalRelationship relationship =
-            new InternalRelationship( 42L, String.valueOf( 42L ), 42L, String.valueOf( 42L ), 43L, String.valueOf( 43L ), "T" );
+            new InternalRelationship( 42L, String.valueOf( 42L ), 42L, String.valueOf( 42L ), 43L, String.valueOf( 43L ), "T", Collections.emptyMap(), true );
 
     private Value integerValue = value( 13 );
     private Value floatValue = value( 13.1 );

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/AbstractResultNext.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/AbstractResultNext.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages;
+
+import neo4j.org.testkit.backend.RxBufferedSubscriber;
+import neo4j.org.testkit.backend.TestkitState;
+import neo4j.org.testkit.backend.holder.RxResultHolder;
+import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
+import neo4j.org.testkit.backend.messages.responses.NullRecord;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletionStage;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.exceptions.NoSuchRecordException;
+
+public abstract class AbstractResultNext implements TestkitRequest
+{
+    @Override
+    public TestkitResponse process( TestkitState testkitState )
+    {
+        try
+        {
+            Result result = testkitState.getResultHolder( getResultId() ).getResult();
+            return createResponse( result.next() );
+        }
+        catch ( NoSuchRecordException ignored )
+        {
+            return NullRecord.builder().build();
+        }
+    }
+
+    @Override
+    public CompletionStage<TestkitResponse> processAsync( TestkitState testkitState )
+    {
+        return testkitState.getAsyncResultHolder( getResultId() )
+                           .thenCompose( resultCursorHolder -> resultCursorHolder.getResult().nextAsync() )
+                           .thenApply( this::createResponseNullSafe );
+    }
+
+    @Override
+    public Mono<TestkitResponse> processRx( TestkitState testkitState )
+    {
+        return testkitState.getRxResultHolder( getResultId() )
+                           .flatMap( resultHolder ->
+                                     {
+                                         RxBufferedSubscriber<Record> subscriber =
+                                                 resultHolder.getSubscriber()
+                                                             .orElseGet( () ->
+                                                                         {
+                                                                             RxBufferedSubscriber<Record> subscriberInstance =
+                                                                                     new RxBufferedSubscriber<>(
+                                                                                             getFetchSize( resultHolder ) );
+                                                                             resultHolder.setSubscriber( subscriberInstance );
+                                                                             resultHolder.getResult().records()
+                                                                                         .subscribe( subscriberInstance );
+                                                                             return subscriberInstance;
+                                                                         } );
+                                         return subscriber.next()
+                                                          .map( this::createResponse )
+                                                          .defaultIfEmpty( NullRecord.builder().build() );
+                                     } );
+    }
+
+    protected abstract neo4j.org.testkit.backend.messages.responses.TestkitResponse createResponse( Record record );
+
+    protected abstract String getResultId();
+
+    private neo4j.org.testkit.backend.messages.responses.TestkitResponse createResponseNullSafe( Record record )
+    {
+        return record != null ? createResponse( record ) : NullRecord.builder().build();
+    }
+
+    private long getFetchSize( RxResultHolder resultHolder )
+    {
+        long fetchSize = resultHolder.getSessionHolder().getConfig()
+                                     .fetchSize()
+                                     .orElse( resultHolder.getSessionHolder().getDriverHolder().getConfig().fetchSize() );
+        return fetchSize == -1 ? Long.MAX_VALUE : fetchSize;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CypherTypeField.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CypherTypeField.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.requests;
+
+import lombok.Getter;
+import lombok.Setter;
+import neo4j.org.testkit.backend.CustomDriverError;
+import neo4j.org.testkit.backend.messages.AbstractResultNext;
+import neo4j.org.testkit.backend.messages.responses.BackendError;
+import neo4j.org.testkit.backend.messages.responses.Field;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.types.Entity;
+import org.neo4j.driver.types.Path;
+
+@Setter
+@Getter
+public class CypherTypeField extends AbstractResultNext
+{
+    private CypherTypeFieldBody data;
+
+    @Override
+    protected neo4j.org.testkit.backend.messages.responses.TestkitResponse createResponse( Record record )
+    {
+        Value value = record.get( data.getRecordKey() );
+        String type = data.getType();
+        String field = data.getField();
+        String fieldValue = null;
+        TestkitResponse testkitResponse = null;
+
+        try
+        {
+            if ( "path".equals( type ) )
+            {
+                fieldValue = readPath( value.asPath() );
+            }
+            else if ( "node".equals( type ) )
+            {
+                fieldValue = readProperty( value.asNode(), field );
+            }
+            else if ( "relationship".equals( type ) )
+            {
+                fieldValue = readProperty( value.asRelationship(), field );
+            }
+            else
+            {
+                testkitResponse = BackendError.builder()
+                                              .data( BackendError.BackendErrorBody.builder().msg( String.format( "Unexpected type %s", type ) ).build() )
+                                              .build();
+            }
+        }
+        catch ( Throwable t )
+        {
+            throw new CustomDriverError( t );
+        }
+
+        if ( testkitResponse == null )
+        {
+            testkitResponse = neo4j.org.testkit.backend.messages.responses.Field.builder()
+                                                                                .data( Field.FieldBody.builder()
+                                                                                                      .value( fieldValue )
+                                                                                                      .build() )
+                                                                                .build();
+        }
+
+        return testkitResponse;
+    }
+
+    @Override
+    protected String getResultId()
+    {
+        return data.getResultId();
+    }
+
+    private String readPath( Path path ) throws Throwable
+    {
+        String[] parts = data.getField().split( "\\." );
+        String propertyName = parts[0];
+        int index = Integer.parseInt( parts[1] );
+        String methodName = parts[2];
+
+        Supplier<Iterable<? extends Entity>> iterableSupplier;
+        if ( "nodes".equals( propertyName ) )
+        {
+            iterableSupplier = path::nodes;
+        }
+        else if ( "relationships".equals( propertyName ) )
+        {
+            iterableSupplier = path::relationships;
+        }
+        else
+        {
+            throw new RuntimeException( "Unexpected" );
+        }
+
+        Entity entity = getEntity( iterableSupplier.get(), index );
+        return readProperty( entity, methodName );
+    }
+
+    private Entity getEntity( Iterable<? extends Entity> iterable, int index )
+    {
+        return StreamSupport.stream( iterable.spliterator(), false )
+                            .skip( index > 0 ? index - 1 : index )
+                            .findFirst()
+                            .orElseThrow( IndexOutOfBoundsException::new );
+    }
+
+    private String readProperty( Entity value, String property ) throws Throwable
+    {
+        try
+        {
+            return String.valueOf( value.getClass().getMethod( property ).invoke( value ) );
+        }
+        catch ( InvocationTargetException e )
+        {
+            throw e.getTargetException();
+        }
+    }
+
+    @Setter
+    @Getter
+    public static class CypherTypeFieldBody
+    {
+        private String resultId;
+        private String recordKey;
+        private String type;
+        private String field;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -65,7 +65,8 @@ public class GetFeatures implements TestkitRequest
             "Feature:API:ConnectionAcquisitionTimeout",
             "Feature:API:Driver.IsEncrypted",
             "Feature:API:SSLConfig",
-            "Detail:DefaultSecurityConfigValueEquality"
+            "Detail:DefaultSecurityConfigValueEquality",
+            "Detail:ThrowOnMissingId"
     ) );
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>( Arrays.asList(

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -41,7 +41,8 @@ import java.util.concurrent.CompletionStage;
         @JsonSubTypes.Type( TransactionRollback.class ), @JsonSubTypes.Type( GetFeatures.class ),
         @JsonSubTypes.Type( GetRoutingTable.class ), @JsonSubTypes.Type( TransactionClose.class ),
         @JsonSubTypes.Type( ResultList.class ), @JsonSubTypes.Type( GetConnectionPoolMetrics.class ),
-        @JsonSubTypes.Type( ResultPeek.class ), @JsonSubTypes.Type( CheckDriverIsEncrypted.class )
+        @JsonSubTypes.Type( ResultPeek.class ), @JsonSubTypes.Type( CheckDriverIsEncrypted.class ),
+        @JsonSubTypes.Type( CypherTypeField.class )
 } )
 public interface TestkitRequest
 {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Field.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Field.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.responses;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Field implements TestkitResponse
+{
+    private final FieldBody data;
+
+    @Override
+    public String testkitName()
+    {
+        return "Field";
+    }
+
+    @Getter
+    @Builder
+    public static class FieldBody
+    {
+        private final String value;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitNodeValueSerializer.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitNodeValueSerializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
 import org.neo4j.driver.internal.value.IntegerValue;
@@ -49,7 +50,7 @@ public class TestkitNodeValueSerializer extends StdSerializer<NodeValue>
         cypherObject( gen, "Node", () ->
         {
             Node node = nodeValue.asNode();
-            gen.writeObjectField( "id", new IntegerValue( node.id() ) );
+            gen.writeObjectField( "id", new IntegerValue( getId( node::id ) ) );
             gen.writeObjectField( "elementId", new StringValue( node.elementId() ) );
 
             StringValue[] labels = StreamSupport.stream( node.labels().spliterator(), false )
@@ -59,5 +60,17 @@ public class TestkitNodeValueSerializer extends StdSerializer<NodeValue>
             gen.writeObjectField( "labels", new ListValue( labels ) );
             gen.writeObjectField( "props", new MapValue( node.asMap( Function.identity() ) ) );
         } );
+    }
+
+    private long getId( Supplier<Long> supplier )
+    {
+        try
+        {
+            return supplier.get();
+        }
+        catch ( IllegalStateException e )
+        {
+            return -1;
+        }
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitRelationshipValueSerializer.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitRelationshipValueSerializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.neo4j.driver.internal.value.IntegerValue;
 import org.neo4j.driver.internal.value.MapValue;
@@ -46,14 +47,26 @@ public class TestkitRelationshipValueSerializer extends StdSerializer<Relationsh
         cypherObject( gen, "Relationship", () ->
         {
             Relationship relationship = relationshipValue.asRelationship();
-            gen.writeObjectField( "id", new IntegerValue( relationship.id() ) );
+            gen.writeObjectField( "id", new IntegerValue( getId( relationship::id ) ) );
             gen.writeObjectField( "elementId", new StringValue( relationship.elementId() ) );
-            gen.writeObjectField( "startNodeId", new IntegerValue( relationship.startNodeId() ) );
+            gen.writeObjectField( "startNodeId", new IntegerValue( getId( relationship::startNodeId ) ) );
             gen.writeObjectField( "startNodeElementId", new StringValue( relationship.startNodeElementId() ) );
-            gen.writeObjectField( "endNodeId", new IntegerValue( relationship.endNodeId() ) );
+            gen.writeObjectField( "endNodeId", new IntegerValue( getId( relationship::endNodeId ) ) );
             gen.writeObjectField( "endNodeElementId", new StringValue( relationship.endNodeElementId() ) );
             gen.writeObjectField( "type", new StringValue( relationship.type() ) );
             gen.writeObjectField( "props", new MapValue( relationship.asMap( Function.identity() ) ) );
         } );
+    }
+
+    private long getId( Supplier<Long> supplier )
+    {
+        try
+        {
+            return supplier.get();
+        }
+        catch ( IllegalStateException e )
+        {
+            return -1;
+        }
     }
 }


### PR DESCRIPTION
Depending on server configuration numeric id might not be available and accessing it will result in `IllegalStateException`.