### PR TITLE
Throw ProtocolException when QueryType is unknown

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/BasicPullResponseHandler.java
@@ -24,6 +24,7 @@ import java.util.function.BiConsumer;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.handlers.PullResponseCompletionListener;
 import org.neo4j.driver.internal.handlers.RunResponseHandler;
@@ -112,9 +113,18 @@ public class BasicPullResponseHandler implements PullResponseHandler
     protected void completeWithSuccess( Map<String,Value> metadata )
     {
         completionListener.afterSuccess( metadata );
-        ResultSummary summary = extractResultSummary( metadata );
-
-        complete( summary, null );
+        ResultSummary summary;
+        Neo4jException exception = null;
+        try
+        {
+            summary = extractResultSummary( metadata );
+        }
+        catch ( Neo4jException e )
+        {
+            summary = extractResultSummary( emptyMap() );
+            exception = e;
+        }
+        complete( summary, exception );
     }
 
     protected void successHasMore()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -41,7 +41,6 @@ public class StartTest implements TestkitRequest
 
     static
     {
-        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_invalid_query_type$", "Does not report type exception" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_no_notifications$", "An empty list is returned when there are no notifications" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_no_notification_info$", "An empty list is returned when there are no notifications" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_notifications_without_position$", "Null value is provided when position is absent" );


### PR DESCRIPTION
This update ensures that `ProtocolException` is thrown when server provides an unknown `QueryType`.