### PR TITLE
Add ability of checking if result handle is open

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -104,4 +104,22 @@
         <method>java.lang.String startNodeElementId()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Result</className>
+        <differenceType>7012</differenceType>
+        <method>boolean isOpen()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/async/ResultCursor</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.concurrent.CompletionStage isOpenAsync()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/reactive/RxResult</className>
+        <differenceType>7012</differenceType>
+        <method>org.reactivestreams.Publisher isOpen()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Result.java
+++ b/driver/src/main/java/org/neo4j/driver/Result.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.Resource;
 
@@ -140,12 +141,24 @@ public interface Result extends Iterator<Record>
 
     /**
      * Return the result summary.
-     *
+     * <p>
      * If the records in the result is not fully consumed, then calling this method will exhausts the result.
-     *
+     * <p>
      * If you want to access unconsumed records after summary, you shall use {@link Result#list()} to buffer all records into memory before summary.
      *
      * @return a summary for the whole query result.
      */
     ResultSummary consume();
+
+    /**
+     * Determine if result is open.
+     * <p>
+     * Result is considered to be open if it has not been consumed ({@link #consume()}) and its creator object (e.g. session or transaction) has not been closed
+     * (including committed or rolled back).
+     * <p>
+     * Attempts to access data on closed result will produce {@link ResultConsumedException}.
+     *
+     * @return {@code true} if result is open and {@code false} otherwise.
+     */
+    boolean isOpen();
 }

--- a/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/async/ResultCursor.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Records;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
 
 /**
@@ -154,4 +155,16 @@ public interface ResultCursor
      * completed exceptionally if query execution or provided function fails.
      */
     <T> CompletionStage<List<T>> listAsync( Function<Record,T> mapFunction );
+
+    /**
+     * Determine if result is open.
+     * <p>
+     * Result is considered to be open if it has not been consumed ({@link #consumeAsync()}) and its creator object (e.g. session or transaction) has not been
+     * closed (including committed or rolled back).
+     * <p>
+     * Attempts to access data on closed result will produce {@link ResultConsumedException}.
+     *
+     * @return a {@link CompletionStage} completed with {@code true} if result is open and {@code false} otherwise.
+     */
+    CompletionStage<Boolean> isOpenAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalResult.java
@@ -100,7 +100,7 @@ public class InternalResult implements Result
     }
 
     @Override
-    public <T> List<T> list( Function<Record, T> mapFunction )
+    public <T> List<T> list( Function<Record,T> mapFunction )
     {
         return blockingGet( cursor.listAsync( mapFunction ) );
     }
@@ -109,6 +109,12 @@ public class InternalResult implements Result
     public ResultSummary consume()
     {
         return blockingGet( cursor.consumeAsync() );
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return blockingGet( cursor.isOpenAsync() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/AsyncResultCursorImpl.java
@@ -113,6 +113,12 @@ public class AsyncResultCursorImpl implements AsyncResultCursor
     }
 
     @Override
+    public CompletionStage<Boolean> isOpenAsync()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public CompletionStage<Throwable> discardAllFailureAsync()
     {
         // runError has priority over other errors and is expected to have been reported to user by now

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursor.java
@@ -91,6 +91,12 @@ public class DisposableAsyncResultCursor implements AsyncResultCursor
     }
 
     @Override
+    public CompletionStage<Boolean> isOpenAsync()
+    {
+        return CompletableFuture.completedFuture( !isDisposed() );
+    }
+
+    @Override
     public CompletionStage<Throwable> discardAllFailureAsync()
     {
         isDisposed = true;

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
@@ -154,6 +154,13 @@ public class InternalRxResult implements RxResult
         } ) );
     }
 
+    @Override
+    public Publisher<Boolean> isOpen()
+    {
+        return Mono.fromCompletionStage( getCursorFuture() )
+                   .map( cursor -> !cursor.isDone() );
+    }
+
     // For testing purpose
     Supplier<CompletionStage<RxResultCursor>> cursorFutureSupplier()
     {

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
@@ -18,13 +18,13 @@
  */
 package org.neo4j.driver.reactive;
 
-import org.neo4j.driver.Query;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.util.List;
 
+import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.summary.ResultSummary;
@@ -108,4 +108,16 @@ public interface RxResult
      * @return a cold publisher of result summary which only arrives after all records.
      */
     Publisher<ResultSummary> consume();
+
+    /**
+     * Determine if result is open.
+     * <p>
+     * Result is considered to be open if it has not been consumed ({@link #consume()}) and its creator object (e.g. session or transaction) has not been closed
+     * (including committed or rolled back).
+     * <p>
+     * Attempts to access data on closed result will produce {@link ResultConsumedException}.
+     *
+     * @return a publisher emitting {@code true} if result is open and {@code false} otherwise.
+     */
+    Publisher<Boolean> isOpen();
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/AsyncResultCursorImplTest.java
@@ -401,12 +401,22 @@ class AsyncResultCursorImplTest
         assertEquals( error, e );
     }
 
-    private static AsyncResultCursorImpl newCursor(PullAllResponseHandler pullAllHandler )
+    @Test
+    void shouldThrowOnIsOpenAsync()
+    {
+        // GIVEN
+        AsyncResultCursorImpl cursor = new AsyncResultCursorImpl( null, null, null );
+
+        // WHEN & THEN
+        assertThrows( UnsupportedOperationException.class, cursor::isOpenAsync );
+    }
+
+    private static AsyncResultCursorImpl newCursor( PullAllResponseHandler pullAllHandler )
     {
         return new AsyncResultCursorImpl( null, newRunResponseHandler(), pullAllHandler );
     }
 
-    private static AsyncResultCursorImpl newCursor(RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
+    private static AsyncResultCursorImpl newCursor( RunResponseHandler runHandler, PullAllResponseHandler pullAllHandler )
     {
         return new AsyncResultCursorImpl( null, runHandler, pullAllHandler );
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/DisposableAsyncResultCursorTest.java
@@ -125,4 +125,38 @@ class DisposableAsyncResultCursorTest
         then( delegate ).should().mapSuccessfulRunCompletionAsync();
         assertSame( error, actual );
     }
+
+    @Test
+    void shouldBeOpenOnCreation()
+    {
+        assertTrue( await( cursor.isOpenAsync() ) );
+    }
+
+    @Test
+    void shouldCloseOnConsume()
+    {
+        // Given
+        boolean initialState = await( cursor.isOpenAsync() );
+
+        // When
+        await( cursor.consumeAsync() );
+
+        // Then
+        assertTrue( initialState );
+        assertFalse( await( cursor.isOpenAsync() ) );
+    }
+
+    @Test
+    void shouldCloseOnDiscardAll()
+    {
+        // Given
+        boolean initialState = await( cursor.isOpenAsync() );
+
+        // When
+        await( cursor.discardAllFailureAsync() );
+
+        // Then
+        assertTrue( initialState );
+        assertFalse( await( cursor.isOpenAsync() ) );
+    }
 }


### PR DESCRIPTION
This update introduces a new method to result handles for checking if result is open:
- `Result.isOpen()`
- `ResultCursor.isOpenAsync()`
- `RxResult.isOpen()`

Result is considered to be open if it has not been consumed via the consume method and its creator object (e.g. session or transaction) has not been closed (including committed or rolled back).

Attempts to access data on closed result will produce {@link ResultConsumedException}.

Implementation is based on existing internal logic.
