### PR TITLE
Dispatch empty query to server

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Query.java
+++ b/driver/src/main/java/org/neo4j/driver/Query.java
@@ -25,10 +25,10 @@ import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.Immutable;
 
 import static java.lang.String.format;
-import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
-import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
 import static org.neo4j.driver.Values.ofValue;
 import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.util.Iterables.newHashMapWithSize;
+import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
 
 /**
  * The components of a Cypher query, containing the query text and parameter map.
@@ -201,7 +201,6 @@ public class Query
     private static String validateQueryText(String query )
     {
         checkArgument( query != null, "Cypher query text should not be null" );
-        checkArgument( !query.isEmpty(), "Cypher query text should not be an empty string" );
         return query;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/QueryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/QueryTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
 
@@ -121,8 +122,12 @@ class QueryTest
     }
 
     @Test
-    void shouldProhibitEmptyQuery()
+    void shouldAcceptEmptyQuery()
     {
-        assertThrows( IllegalArgumentException.class, () -> new Query( "" ) );
+        // when
+        Query query = new Query( "" );
+
+        // then
+        assertNotNull( query );
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/QueryIT.java
@@ -18,13 +18,9 @@
  */
 package org.neo4j.driver.integration;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.function.Executable;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -34,13 +30,13 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.util.ParallelizableIT;
 import org.neo4j.driver.util.SessionExtension;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.util.TestUtil.assertNoCircularReferences;
@@ -186,7 +182,7 @@ class QueryIT
     void shouldFailForIllegalQueries()
     {
         assertThrows( IllegalArgumentException.class, () -> session.run( (String) null ) );
-        assertThrows( IllegalArgumentException.class, () -> session.run( "" ) );
+        assertThrows( ClientException.class, () -> session.run( "" ) );
     }
 
     @Test


### PR DESCRIPTION
This update ensures that empty query gets dispatched to server and expects it to handle it accordingly.

Please note that empty query string will no longer produce `IllegalArgumentException`. Instead, its handling will be defined by server that might produce `ClientException`.