### PR TITLE
Expose transaction open status in AsyncTransaction and RxTransaction

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -268,4 +268,16 @@
         <method>org.reactivestreams.Publisher executeWriteWithoutResult(java.util.function.Consumer, org.neo4j.driver.TransactionConfig)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/async/AsyncTransaction</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.concurrent.CompletionStage isOpenAsync()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/reactive/RxTransaction</className>
+        <differenceType>7012</differenceType>
+        <method>org.reactivestreams.Publisher isOpen()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncTransaction.java
@@ -98,4 +98,11 @@ public interface AsyncTransaction extends AsyncQueryRunner
      * @return new {@link CompletionStage} that gets completed with {@code null} when close is successful, otherwise it gets completed exceptionally.
      */
     CompletionStage<Void> closeAsync();
+
+    /**
+     * Determine if transaction is open.
+     *
+     * @return a {@link CompletionStage} completed with {@code true} if transaction is open and {@code false} otherwise.
+     */
+    CompletionStage<Boolean> isOpenAsync();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncTransaction.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.async;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.neo4j.driver.Query;
@@ -48,6 +49,12 @@ public class InternalAsyncTransaction extends AsyncAbstractQueryRunner implement
     public CompletionStage<Void> closeAsync()
     {
         return tx.closeAsync();
+    }
+
+    @Override
+    public CompletionStage<Boolean> isOpenAsync()
+    {
+        return CompletableFuture.completedFuture( isOpen() );
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxTransaction.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.reactive;
 
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -79,6 +80,12 @@ public class InternalRxTransaction extends AbstractRxQueryRunner implements RxTr
     public Publisher<Void> close()
     {
         return close( false );
+    }
+
+    @Override
+    public Publisher<Boolean> isOpen()
+    {
+        return Mono.just( tx.isOpen() );
     }
 
     Publisher<Void> close( boolean commit )

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxTransaction.java
@@ -56,4 +56,11 @@ public interface RxTransaction extends RxQueryRunner
      * @return new {@link Publisher} that gets completed when close is successful, otherwise an error is signalled.
      */
     Publisher<Void> close();
+
+    /**
+     * Determine if transaction is open.
+     *
+     * @return a publisher emitting {@code true} if transaction is open and {@code false} otherwise.
+     */
+    Publisher<Boolean> isOpen();
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxTransactionTest.java
@@ -47,6 +47,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -162,5 +164,19 @@ class InternalRxTransactionTest
         StepVerifier.create( publisher ).verifyComplete();
 
         verify( tx ).closeAsync( false );
+    }
+
+    @Test
+    void shouldDelegateIsOpenAsync()
+    {
+        // GIVEN
+        UnmanagedTransaction utx = mock( UnmanagedTransaction.class );
+        boolean expected = false;
+        given( utx.isOpen() ).willReturn( expected );
+        RxTransaction tx = new InternalRxTransaction( utx );
+
+        // WHEN & THEN
+        StepVerifier.create( tx.isOpen() ).expectNext( expected ).expectComplete().verify();
+        then( utx ).should().isOpen();
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -52,8 +52,6 @@ public class StartTest implements TestkitRequest
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_partial_summary_contains_system_updates$", "Does not contain updates because value is zero" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_partial_summary_contains_updates$", "Does not contain updates because value is zero" );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_supports_multi_db$", "Database is None" );
-        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.test_managed_tx_raises_tx_managed_exec$",
-                                           "Driver (still) allows explicit managing of managed transaction" );
         String skipMessage = "This test expects hostname verification to be turned off when all certificates are trusted";
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTrustAllCertsConfig\\.test_trusted_ca_wrong_hostname$", skipMessage );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTrustAllCertsConfig\\.test_untrusted_ca_wrong_hostname$", skipMessage );


### PR DESCRIPTION
This update adds the following methods:
- `AsyncTransaction.isOpenAsync`
- `RxTransaction.isOpen`

They can be used to verify if transaction is open.