### PR TITLE
Add support for `Optimization:ImplicitDefaultArguments` feature

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -66,7 +66,8 @@ public class GetFeatures implements TestkitRequest
             "Feature:API:Driver.IsEncrypted",
             "Feature:API:SSLConfig",
             "Detail:DefaultSecurityConfigValueEquality",
-            "Detail:ThrowOnMissingId"
+            "Detail:ThrowOnMissingId",
+            "Optimization:ImplicitDefaultArguments"
     ) );
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>( Arrays.asList(

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -61,6 +61,12 @@ public class StartTest implements TestkitRequest
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestConnectionAcquisitionTimeoutMs\\.test_should_encompass_the_handshake_time.*$", skipMessage );
         COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestConnectionAcquisitionTimeoutMs\\.test_should_fail_when_acquisition_timeout_is_reached_first.*$",
                                            skipMessage );
+        skipMessage = "This test needs updating to implement expected behaviour";
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthenticationSchemes\\.test_custom_scheme_empty$", skipMessage );
+        skipMessage = "Driver does not implement optimization for qid in explicit transaction";
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments$", skipMessage );
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments_multi_query$", skipMessage );
+        COMMON_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments_multi_query_nested$", skipMessage );
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll( COMMON_SKIP_PATTERN_TO_REASON );
 


### PR DESCRIPTION
This update excludes support for `qid` optimisation.