### PR TITLE
Emit run errors on `RxResult.keys()`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver.internal.cursor;
 
 import org.reactivestreams.Subscription;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -30,7 +31,7 @@ import org.neo4j.driver.summary.ResultSummary;
 
 public interface RxResultCursor extends Subscription, FailableCursor
 {
-    List<String> keys();
+    Mono<List<String>> keys();
 
     void installRecordConsumer( BiConsumer<Record,Throwable> recordConsumer );
 

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxResult.java
@@ -50,8 +50,9 @@ public class InternalRxResult implements RxResult
     @Override
     public Publisher<List<String>> keys()
     {
-        return Mono.defer( () -> Mono.fromCompletionStage( getCursorFuture() ).map( RxResultCursor::keys )
-                .onErrorMap( Futures::completionExceptionCause ) );
+        return Mono.defer( () -> Mono.fromCompletionStage( getCursorFuture() )
+                                     .flatMap( RxResultCursor::keys )
+                                     .onErrorMap( Futures::completionExceptionCause ) );
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxResultIT.java
@@ -36,7 +36,6 @@ import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.util.DatabaseExtension;
 import org.neo4j.driver.util.ParallelizableIT;
 
-import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -219,18 +218,24 @@ class RxResultIT
         Mono<ResultSummary> summaryMono = Mono.from( result.consume() );
 
         // Then
-        StepVerifier.create( keys ).expectNext( emptyList() ).verifyComplete();
+        StepVerifier.create( keys ).expectErrorSatisfies( error ->
+                                                          {
+                                                              assertThat( error, instanceOf( ClientException.class ) );
+                                                              assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                                                          } ).verify();
 
-        StepVerifier.create( records ).expectErrorSatisfies( error -> {
-            assertThat( error, instanceOf( ClientException.class ) );
-            assertThat( error.getMessage(), containsString( "Invalid input" ) );
-        } ).verify();
+        StepVerifier.create( records ).expectErrorSatisfies( error ->
+                                                             {
+                                                                 assertThat( error, instanceOf( ClientException.class ) );
+                                                                 assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                                                             } ).verify();
 
         StepVerifier.create( summaryMono )
-                .assertNext( summary -> {
-                    assertThat( summary.query().text(), equalTo( "INVALID" ) );
-                    assertNotNull( summary.server().address() );
-                } ).verifyComplete();
+                    .assertNext( summary ->
+                                 {
+                                     assertThat( summary.query().text(), equalTo( "INVALID" ) );
+                                     assertNotNull( summary.server().address() );
+                                 } ).verifyComplete();
     }
 
 
@@ -246,18 +251,25 @@ class RxResultIT
         Mono<ResultSummary> summaryMono = Mono.from( result.consume() );
 
         // Then
-        StepVerifier.create( keys ).expectNext( emptyList() ).verifyComplete();
+        StepVerifier.create( keys ).expectErrorSatisfies( error ->
+                                                          {
+                                                              assertThat( error, instanceOf( ClientException.class ) );
+                                                              assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                                                          } ).verify();
+        ;
 
-        StepVerifier.create( summaryMono ).expectErrorSatisfies( error -> {
-            assertThat( error, instanceOf( ClientException.class ) );
-            assertThat( error.getMessage(), containsString( "Invalid input" ) );
-        } ).verify();
+        StepVerifier.create( summaryMono ).expectErrorSatisfies( error ->
+                                                                 {
+                                                                     assertThat( error, instanceOf( ClientException.class ) );
+                                                                     assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                                                                 } ).verify();
 
         // The error stick with the summary forever
-        StepVerifier.create( summaryMono ).expectErrorSatisfies( error -> {
-            assertThat( error, instanceOf( ClientException.class ) );
-            assertThat( error.getMessage(), containsString( "Invalid input" ) );
-        } ).verify();
+        StepVerifier.create( summaryMono ).expectErrorSatisfies( error ->
+                                                                 {
+                                                                     assertThat( error, instanceOf( ClientException.class ) );
+                                                                     assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                                                                 } ).verify();
     }
 
     @Test
@@ -423,15 +435,29 @@ class RxResultIT
     }
 
     @Test
-    void keysShouldNotReportRunError()
+    void keysShouldReportRunError()
     {
         // Given
         RxSession session = neo4j.driver().rxSession();
         RxResult result = session.run( "Invalid" );
 
         // When
-        StepVerifier.create( Flux.from( result.keys() ) ).expectNext( EMPTY_LIST ).verifyComplete();
-        StepVerifier.create( Flux.from( result.keys() ) ).expectNext( EMPTY_LIST ).verifyComplete();
+        StepVerifier.create( Flux.from( result.keys() ) )
+                    .expectErrorSatisfies(
+                            error ->
+                            {
+                                assertThat( error, instanceOf( ClientException.class ) );
+                                assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                            } ).verify();
+        ;
+        StepVerifier.create( Flux.from( result.keys() ) )
+                    .expectErrorSatisfies(
+                            error ->
+                            {
+                                assertThat( error, instanceOf( ClientException.class ) );
+                                assertThat( error.getMessage(), containsString( "Invalid input" ) );
+                            } ).verify();
+        ;
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/RxTransactionIT.java
@@ -741,11 +741,21 @@ class RxTransactionIT
     }
 
     @Test
+    void shouldPropagateRunFailureOnKeys()
+    {
+        RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
+        RxResult result = tx.run( "RETURN 42 / 0" );
+
+        ClientException e = assertThrows( ClientException.class, () -> await( result.keys() ) );
+        assertThat( e.getMessage(), containsString( "/ by zero" ) );
+        assertCanRollback( tx );
+    }
+
+    @Test
     void shouldPropagateRunFailureOnRecord()
     {
         RxTransaction tx = await( Mono.from( session.beginTransaction() ) );
         RxResult result = tx.run( "RETURN 42 / 0" );
-        await( result.keys() ); // always returns keys
 
         ClientException e = assertThrows( ClientException.class, () -> await( result.records() ) );
         assertThat( e.getMessage(), containsString( "/ by zero" ) );

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
@@ -83,7 +83,7 @@ class RxResultCursorImplTest
 
         // When
         RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
-        List<String> actual = cursor.keys();
+        List<String> actual = cursor.keys().block();
 
         // Then
         assertEquals( expected, actual );
@@ -103,14 +103,14 @@ class RxResultCursorImplTest
         RxResultCursor cursor = new RxResultCursorImpl( runHandler, pullHandler );
 
         // Then
-        List<String> actual = cursor.keys();
+        List<String> actual = cursor.keys().block();
         assertEquals( expected, actual );
 
         // Many times
-        actual = cursor.keys();
+        actual = cursor.keys().block();
         assertEquals( expected, actual );
 
-        actual = cursor.keys();
+        actual = cursor.keys().block();
         assertEquals( expected, actual );
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxResultTest.java
@@ -98,7 +98,7 @@ class InternalRxResultTest
         RxResult rxResult = newRxResult( cursor );
 
         List<String> keys = Arrays.asList( "one", "two", "three" );
-        when( cursor.keys() ).thenReturn( keys );
+        when( cursor.keys() ).thenReturn( Mono.just( keys ) );
 
         // When & Then
         StepVerifier.create( Flux.from( rxResult.keys() ) )
@@ -127,7 +127,7 @@ class InternalRxResultTest
         RxResult rxResult = newRxResult( cursor );
 
         List<String> keys = Arrays.asList( "one", "two", "three" );
-        when( cursor.keys() ).thenReturn( keys );
+        when( cursor.keys() ).thenReturn( Mono.just( keys ) );
 
         // When & Then
         StepVerifier.create( Flux.from( rxResult.keys() ).limitRate( 1 ).take( 1 ) )

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -70,28 +70,6 @@ public class StartTest implements TestkitRequest
 
         REACTIVE_SKIP_PATTERN_TO_REASON.putAll( COMMON_SKIP_PATTERN_TO_REASON );
         // Current limitations (require further investigation or bug fixing)
-        skipMessage = "Does not report RUN FAILURE";
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.Routing[^.]+\\.test_should_write_successfully_on_leader_switch_using_tx_function$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_after_hello$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_session_on_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDisconnects\\.test_disconnect_on_tx_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_raises_error_on_session_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_raises_error_on_tx(_func)?_run", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_failed_tx_run_allows(_skipping)?_rollback", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthorizationV\\dx\\d\\.test_should_fail_with_auth_expired_on_run_using_tx_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestAuthorizationV\\dx\\d\\.test_should_fail_with_token_expired_on_run_using_tx_run$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDirectConnectionRecvTimeout\\.test_timeout$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDirectConnectionRecvTimeout\\.test_timeout_unmanaged_tx$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDirectConnectionRecvTimeout\\.test_timeout_unmanaged_tx_should_fail_subsequent_usage_after_timeout$",
-                                             skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestDirectConnectionRecvTimeout\\.test_timeout_managed_tx_retry$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout_unmanaged_tx$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout_unmanaged_tx_should_fail_subsequent_usage_after_timeout$",
-                                             skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestRoutingConnectionRecvTimeout\\.test_timeout_managed_tx_retry$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_broken_transaction_should_not_break_session$", skipMessage );
-        REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestTxRun\\.test_does_not_update_last_bookmark_on_failure$", skipMessage );
         skipMessage = "Does not support multiple concurrent result streams on session level";
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_iteration_nested$", skipMessage );
         REACTIVE_SKIP_PATTERN_TO_REASON.put( "^.*\\.TestSessionRun\\.test_partial_iteration$", skipMessage );


### PR DESCRIPTION
This update ensures that `RUN` errors are reported on `RxResult.keys()` instead of publishing an empty list.