### PR TITLE
Update LoadCSVIT.shouldLoadCSV to work with 5.0

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/LoadCSVIT.java
@@ -40,7 +40,9 @@ import static org.neo4j.driver.Values.parameters;
 class LoadCSVIT
 {
     @RegisterExtension
-    static final DatabaseExtension neo4j = new DatabaseExtension( Neo4jSettings.TEST_SETTINGS.without( Neo4jSettings.IMPORT_DIR ) );
+    static final DatabaseExtension neo4j = new DatabaseExtension( Neo4jSettings.TEST_SETTINGS
+                                                                          .without( Neo4jSettings.IMPORT_DIR )
+                                                                          .without( Neo4jSettings.SERVER_IMPORT_DIR ) );
 
     @Test
     void shouldLoadCSV() throws Throwable

--- a/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
+++ b/driver/src/test/java/org/neo4j/driver/util/Neo4jSettings.java
@@ -30,6 +30,8 @@ public class Neo4jSettings
 {
     public static final String DATA_DIR = "dbms.directories.data";
     public static final String IMPORT_DIR = "dbms.directories.import";
+    // 5.0
+    public static final String SERVER_IMPORT_DIR = "server.directories.import";
     public static final String LISTEN_ADDR = "dbms.default_listen_address";
     public static final String IPV6_ENABLED_ADDR = "::";
     public static final String BOLT_TLS_LEVEL = "dbms.connector.bolt.tls_level";


### PR DESCRIPTION
To make it work with 5.0, `server.directories.import` must be excluded from config.