### PR TITLE
Stop shading dependencies in neo4j-java-driver package

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,4 +1,3 @@
 Aggregator project for building the single JAR with shaded dependencies.
 
-This module aggregates the slim version, unpacks it and repackages it.
-The sources are unpacked so that an individual JavaDoc artifact is produced, too.
+This module aggregates neo4j-java-driver, unpacks it and repackages it. The sources are unpacked so that an individual JavaDoc artifact is produced, too.

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -10,10 +10,10 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>neo4j-java-driver</artifactId>
+  <artifactId>neo4j-java-driver-all</artifactId>
 
   <packaging>jar</packaging>
-  <name>Neo4j Java Driver</name>
+  <name>Neo4j Java Driver (shaded package)</name>
   <description>Access to the Neo4j graph database through Java</description>
 
   <properties>
@@ -26,7 +26,7 @@
     <!-- The original driver that will be repackaged. -->
     <dependency>
       <groupId>org.neo4j.driver</groupId>
-      <artifactId>neo4j-java-driver-slim</artifactId>
+      <artifactId>neo4j-java-driver</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
@@ -68,7 +68,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources/slim</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/neo4j-java-driver</outputDirectory>
               <overwrite>true</overwrite>
               <resources>
                 <resource>
@@ -93,7 +93,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources/slim</source>
+                <source>${project.build.directory}/generated-sources/neo4j-java-driver</source>
               </sources>
             </configuration>
           </execution>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -9,10 +9,10 @@
     <version>5.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>neo4j-java-driver-slim</artifactId>
+  <artifactId>neo4j-java-driver</artifactId>
 
   <packaging>jar</packaging>
-  <name>Neo4j Java Driver (Slim package)</name>
+  <name>Neo4j Java Driver</name>
   <description>Access to the Neo4j graph database through Java</description>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -39,7 +39,7 @@
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.neo4j.driver</groupId>
-      <artifactId>neo4j-java-driver-slim</artifactId>
+      <artifactId>neo4j-java-driver</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>org.neo4j.driver</groupId>
-            <artifactId>neo4j-java-driver-slim</artifactId>
+            <artifactId>neo4j-java-driver</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
`neo4j-java-driver` package no longer includes shaded dependencies.

The new `neo4j-java-driver-all` package includes shaded Netty and Project Reactor dependencies.