### PR TITLE
Migrate java-driver-rx-tck

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.support</groupId>
+      <artifactId>testng-engine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.rauschig</groupId>
       <artifactId>jarchivelib</artifactId>
     </dependency>
@@ -91,6 +95,10 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>neo4j</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams-tck</artifactId>
     </dependency>
   </dependencies>
 

--- a/driver/src/test/java/org/neo4j/driver/tck/reactive/RxResultRecordPublisherVerificationIT.java
+++ b/driver/src/test/java/org/neo4j/driver/tck/reactive/RxResultRecordPublisherVerificationIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.tck.reactive;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+
+import java.time.Duration;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxSession;
+
+import static org.neo4j.driver.Values.parameters;
+
+@Testcontainers( disabledWithoutDocker = true )
+public class RxResultRecordPublisherVerificationIT extends PublisherVerification<Record>
+{
+    private static final Neo4jContainer<?> NEO4J_CONTAINER = new Neo4jContainer<>( "neo4j:4.4" )
+            .withAdminPassword( null );
+
+    private final static long MAX_NUMBER_OF_RECORDS = 30000;
+
+    private static final Duration TIMEOUT = Duration.ofSeconds( 10 );
+    private static final Duration TIMEOUT_FOR_NO_SIGNALS = Duration.ofSeconds( 1 );
+    private static final Duration PUBLISHER_REFERENCE_CLEANUP_TIMEOUT_MILLIS = Duration.ofSeconds( 1 );
+
+    private final static String QUERY = "UNWIND RANGE(1, $numberOfRecords) AS n RETURN 'String Number' + n";
+
+    private Driver driver;
+
+    public RxResultRecordPublisherVerificationIT()
+    {
+        super( new TestEnvironment( TIMEOUT.toMillis(), TIMEOUT_FOR_NO_SIGNALS.toMillis() ),
+               PUBLISHER_REFERENCE_CLEANUP_TIMEOUT_MILLIS.toMillis() );
+    }
+
+    @BeforeClass
+    public void beforeClass()
+    {
+        if ( !isDockerAvailable() )
+        {
+            throw new SkipException( "Docker is unavailable" );
+        }
+        NEO4J_CONTAINER.start();
+        driver = GraphDatabase.driver( NEO4J_CONTAINER.getBoltUrl() );
+    }
+
+    public void afterClass()
+    {
+        NEO4J_CONTAINER.stop();
+    }
+
+    @Override
+    public long maxElementsFromPublisher()
+    {
+        return MAX_NUMBER_OF_RECORDS;
+    }
+
+    @Override
+    public Publisher<Record> createPublisher( long elements )
+    {
+        RxSession session = driver.rxSession();
+        RxResult result = session.run( QUERY, parameters( "numberOfRecords", elements ) );
+        return result.records();
+    }
+
+    @Override
+    public Publisher<Record> createFailedPublisher()
+    {
+        RxSession session = driver.rxSession();
+        RxResult result = session.run( "INVALID" );
+        return result.records();
+    }
+
+    boolean isDockerAvailable()
+    {
+        try
+        {
+            DockerClientFactory.instance().client();
+            return true;
+        }
+        catch ( Throwable ex )
+        {
+            return false;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parallelizable.it.forkCount>1C</parallelizable.it.forkCount>
     <!-- All tests tagged are to be executed in parallel -->
     <parallelizable.it.tags>parallelizableIT</parallelizable.it.tags>
-    <surefire.and.failsafe.version>2.22.1</surefire.and.failsafe.version>
+    <surefire.and.failsafe.version>3.0.0-M6</surefire.and.failsafe.version>
     <!-- Skip deployment by default for everything in this project. -->
     <maven.deploy.skip>true</maven.deploy.skip>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <hamcrest-junit.version>2.0.0.0</hamcrest-junit.version>
     <mockito-core.version>4.4.0</mockito-core.version>
     <junit.version>5.8.2</junit.version>
+    <testng-engine.version>1.0.2</testng-engine.version>
     <jarchivelib.version>1.2.0</jarchivelib.version>
     <bouncycastle-jdk15on.version>1.70</bouncycastle-jdk15on.version>
     <logback-classic.version>1.2.11</logback-classic.version>
@@ -148,6 +149,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.support</groupId>
+        <artifactId>testng-engine</artifactId>
+        <version>${testng-engine.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.rauschig</groupId>
         <artifactId>jarchivelib</artifactId>
         <version>${jarchivelib.version}</version>
@@ -169,6 +176,12 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback-classic.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams-tck</artifactId>
+        <version>${reactive-streams.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This update migrates verification tests from `java-driver-rx-tck` to this project.