### PR TITLE
Make BasicPullResponseHandler support emitting signals in and out lock

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/pulln/AutoPullResponseHandler.java
@@ -67,7 +67,7 @@ public class AutoPullResponseHandler extends BasicPullResponseHandler implements
             MetadataExtractor metadataExtractor,
             PullResponseCompletionListener completionListener,
             long fetchSize) {
-        super(query, runResponseHandler, connection, metadataExtractor, completionListener);
+        super(query, runResponseHandler, connection, metadataExtractor, completionListener, true);
         this.fetchSize = fetchSize;
 
         // For pull everything ensure conditions for disabling auto pull are never met


### PR DESCRIPTION
This update adds configuration param to `BasicPullResponseHandler` to emit signals to `recordConsumer` and `summaryConsumer` either in or out of lock.