### PR TITLE
Wrap checked exceptions when rethrowing async exception

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
@@ -23,7 +23,7 @@ package org.neo4j.driver.exceptions;
  *
  * @since 1.0
  */
-public abstract class Neo4jException extends RuntimeException {
+public class Neo4jException extends RuntimeException {
     private static final long serialVersionUID = -80579062276712566L;
 
     private final String code;

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.driver.internal.util;
 
-import io.netty.util.internal.PlatformDependent;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -115,7 +114,13 @@ public final class ErrorUtil {
                 .toArray(StackTraceElement[]::new);
         error.setStackTrace(currentStackTrace);
 
-        PlatformDependent.throwException(error);
+        RuntimeException exception;
+        if (error instanceof RuntimeException) {
+            exception = (RuntimeException) error;
+        } else {
+            exception = new Neo4jException("Driver execution failed", error);
+        }
+        throw exception;
     }
 
     private static boolean isProtocolViolationError(Neo4jException error) {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FuturesTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.async.connection.EventLoopGroupFactory;
 
 class FuturesTest {
@@ -177,8 +178,8 @@ class FuturesTest {
         CompletableFuture<String> future = new CompletableFuture<>();
         future.completeExceptionally(error);
 
-        Exception e = assertThrows(Exception.class, () -> Futures.blockingGet(future));
-        assertEquals(error, e);
+        Neo4jException e = assertThrows(Neo4jException.class, () -> Futures.blockingGet(future));
+        assertEquals(error, e.getCause());
     }
 
     @Test


### PR DESCRIPTION
Driver may throw checked exception without declaring it. This update fixes this behaviour.