### PR TITLE
Add support for sending datetime values in UTC

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
@@ -22,9 +22,13 @@ import static io.netty.util.AttributeKey.newInstance;
 
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.messaging.BoltPatchesListener;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
 
 public final class ChannelAttributes {
@@ -39,6 +43,8 @@ public final class ChannelAttributes {
     private static final AttributeKey<String> TERMINATION_REASON = newInstance("terminationReason");
     private static final AttributeKey<AuthorizationStateListener> AUTHORIZATION_STATE_LISTENER =
             newInstance("authorizationStateListener");
+    private static final AttributeKey<Set<BoltPatchesListener>> BOLT_PATCHES_LISTENERS =
+            newInstance("boltPatchesListeners");
 
     // configuration hints provided by the server
     private static final AttributeKey<Long> CONNECTION_READ_TIMEOUT = newInstance("connectionReadTimeout");
@@ -132,6 +138,20 @@ public final class ChannelAttributes {
 
     public static void setConnectionReadTimeout(Channel channel, Long connectionReadTimeout) {
         setOnce(channel, CONNECTION_READ_TIMEOUT, connectionReadTimeout);
+    }
+
+    public static void addBoltPatchesListener(Channel channel, BoltPatchesListener listener) {
+        Set<BoltPatchesListener> boltPatchesListeners = get(channel, BOLT_PATCHES_LISTENERS);
+        if (boltPatchesListeners == null) {
+            boltPatchesListeners = new HashSet<>();
+            setOnce(channel, BOLT_PATCHES_LISTENERS, boltPatchesListeners);
+        }
+        boltPatchesListeners.add(listener);
+    }
+
+    public static Set<BoltPatchesListener> boltPatchesListeners(Channel channel) {
+        Set<BoltPatchesListener> boltPatchesListeners = get(channel, BOLT_PATCHES_LISTENERS);
+        return boltPatchesListeners != null ? boltPatchesListeners : Collections.emptySet();
     }
 
     private static <T> T get(Channel channel, AttributeKey<T> key) {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltPatchesListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltPatchesListener.java
@@ -16,21 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging.v4;
+package org.neo4j.driver.internal.messaging;
 
-import org.neo4j.driver.internal.messaging.MessageFormat;
-import org.neo4j.driver.internal.messaging.common.CommonMessageReader;
-import org.neo4j.driver.internal.packstream.PackInput;
-import org.neo4j.driver.internal.packstream.PackOutput;
+import java.util.Set;
 
-public class MessageFormatV4 implements MessageFormat {
-    @Override
-    public Writer newWriter(PackOutput output) {
-        return new MessageWriterV4(output);
-    }
+public interface BoltPatchesListener {
+    String DATE_TIME_UTC_PATCH = "utc";
 
-    @Override
-    public Reader newReader(PackInput input) {
-        return new CommonMessageReader(input, false);
-    }
+    void handle(Set<String> patches);
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/MessageFormat.java
@@ -34,4 +34,11 @@ public interface MessageFormat {
     Writer newWriter(PackOutput output);
 
     Reader newReader(PackInput input);
+
+    /**
+     * Enables datetime in UTC if supported by the given message format. This is only for use with formats that support multiple modes.
+     * <p>
+     * This only takes effect on subsequent writer and reader creation via {@link #newWriter(PackOutput)} and {@link #newReader(PackInput)}.
+     */
+    default void enableDateTimeUtc() {}
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonMessageReader.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonMessageReader.java
@@ -33,8 +33,8 @@ import org.neo4j.driver.internal.packstream.PackInput;
 public class CommonMessageReader implements MessageFormat.Reader {
     private final ValueUnpacker unpacker;
 
-    public CommonMessageReader(PackInput input) {
-        this(new CommonValueUnpacker(input));
+    public CommonMessageReader(PackInput input, boolean dateTimeUtcEnabled) {
+        this(new CommonValueUnpacker(input, dateTimeUtcEnabled));
     }
 
     protected CommonMessageReader(ValueUnpacker unpacker) {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
@@ -72,7 +72,9 @@ public class CommonValueUnpacker implements ValueUnpacker {
     public static final int LOCAL_DATE_TIME_STRUCT_SIZE = 2;
 
     public static final byte DATE_TIME_WITH_ZONE_OFFSET = 'F';
+    public static final byte DATE_TIME_WITH_ZONE_OFFSET_UTC = 'I';
     public static final byte DATE_TIME_WITH_ZONE_ID = 'f';
+    public static final byte DATE_TIME_WITH_ZONE_ID_UTC = 'i';
     public static final int DATE_TIME_STRUCT_SIZE = 3;
 
     public static final byte DURATION = 'E';
@@ -92,9 +94,11 @@ public class CommonValueUnpacker implements ValueUnpacker {
     private static final int NODE_FIELDS = 3;
     private static final int RELATIONSHIP_FIELDS = 5;
 
+    private final boolean dateTimeUtcEnabled;
     protected final PackStream.Unpacker unpacker;
 
-    public CommonValueUnpacker(PackInput input) {
+    public CommonValueUnpacker(PackInput input, boolean dateTimeUtcEnabled) {
+        this.dateTimeUtcEnabled = dateTimeUtcEnabled;
         this.unpacker = new PackStream.Unpacker(input);
     }
 
@@ -182,11 +186,25 @@ public class CommonValueUnpacker implements ValueUnpacker {
                 ensureCorrectStructSize(TypeConstructor.LOCAL_DATE_TIME, LOCAL_DATE_TIME_STRUCT_SIZE, size);
                 return unpackLocalDateTime();
             case DATE_TIME_WITH_ZONE_OFFSET:
-                ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
-                return unpackDateTimeWithZoneOffset();
+                if (!dateTimeUtcEnabled) {
+                    ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
+                    return unpackDateTimeWithZoneOffset();
+                }
+            case DATE_TIME_WITH_ZONE_OFFSET_UTC:
+                if (dateTimeUtcEnabled) {
+                    ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
+                    return unpackDateTimeUtcWithZoneOffset();
+                }
             case DATE_TIME_WITH_ZONE_ID:
-                ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
-                return unpackDateTimeWithZoneId();
+                if (!dateTimeUtcEnabled) {
+                    ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
+                    return unpackDateTimeWithZoneId();
+                }
+            case DATE_TIME_WITH_ZONE_ID_UTC:
+                if (dateTimeUtcEnabled) {
+                    ensureCorrectStructSize(TypeConstructor.DATE_TIME, DATE_TIME_STRUCT_SIZE, size);
+                    return unpackDateTimeUtcWithZoneId();
+                }
             case DURATION:
                 ensureCorrectStructSize(TypeConstructor.DURATION, DURATION_TIME_STRUCT_SIZE, size);
                 return unpackDuration();
@@ -355,11 +373,27 @@ public class CommonValueUnpacker implements ValueUnpacker {
         return value(newZonedDateTime(epochSecondLocal, nano, ZoneOffset.ofTotalSeconds(offsetSeconds)));
     }
 
+    private Value unpackDateTimeUtcWithZoneOffset() throws IOException {
+        long epochSecondLocal = unpacker.unpackLong();
+        int nano = Math.toIntExact(unpacker.unpackLong());
+        int offsetSeconds = Math.toIntExact(unpacker.unpackLong());
+        ZoneOffset offset = ZoneOffset.ofTotalSeconds(offsetSeconds);
+        return value(newZonedDateTimeUsingUtcBaseline(epochSecondLocal, nano, offset));
+    }
+
     private Value unpackDateTimeWithZoneId() throws IOException {
         long epochSecondLocal = unpacker.unpackLong();
         int nano = Math.toIntExact(unpacker.unpackLong());
         String zoneIdString = unpacker.unpackString();
         return value(newZonedDateTime(epochSecondLocal, nano, ZoneId.of(zoneIdString)));
+    }
+
+    private Value unpackDateTimeUtcWithZoneId() throws IOException {
+        long epochSecondLocal = unpacker.unpackLong();
+        int nano = Math.toIntExact(unpacker.unpackLong());
+        String zoneIdString = unpacker.unpackString();
+        ZoneId zoneId = ZoneId.of(zoneIdString);
+        return value(newZonedDateTimeUsingUtcBaseline(epochSecondLocal, nano, zoneId));
     }
 
     private Value unpackDuration() throws IOException {
@@ -388,6 +422,12 @@ public class CommonValueUnpacker implements ValueUnpacker {
     private static ZonedDateTime newZonedDateTime(long epochSecondLocal, long nano, ZoneId zoneId) {
         Instant instant = Instant.ofEpochSecond(epochSecondLocal, nano);
         LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, UTC);
+        return ZonedDateTime.of(localDateTime, zoneId);
+    }
+
+    private ZonedDateTime newZonedDateTimeUsingUtcBaseline(long epochSecondLocal, int nano, ZoneId zoneId) {
+        Instant instant = Instant.ofEpochSecond(epochSecondLocal, nano);
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, zoneId);
         return ZonedDateTime.of(localDateTime, zoneId);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.internal.messaging.request;
 import static org.neo4j.driver.Values.value;
 import static org.neo4j.driver.internal.security.InternalAuthToken.CREDENTIALS_KEY;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -31,9 +32,16 @@ public class HelloMessage extends MessageWithMetadata {
 
     private static final String USER_AGENT_METADATA_KEY = "user_agent";
     private static final String ROUTING_CONTEXT_METADATA_KEY = "routing";
+    private static final String PATCH_BOLT_METADATA_KEY = "patch_bolt";
 
-    public HelloMessage(String userAgent, Map<String, Value> authToken, Map<String, String> routingContext) {
-        super(buildMetadata(userAgent, authToken, routingContext));
+    private static final String DATE_TIME_UTC_PATCH_VALUE = "utc";
+
+    public HelloMessage(
+            String userAgent,
+            Map<String, Value> authToken,
+            Map<String, String> routingContext,
+            boolean includeDateTimeUtc) {
+        super(buildMetadata(userAgent, authToken, routingContext, includeDateTimeUtc));
     }
 
     @Override
@@ -66,11 +74,17 @@ public class HelloMessage extends MessageWithMetadata {
     }
 
     private static Map<String, Value> buildMetadata(
-            String userAgent, Map<String, Value> authToken, Map<String, String> routingContext) {
+            String userAgent,
+            Map<String, Value> authToken,
+            Map<String, String> routingContext,
+            boolean includeDateTimeUtc) {
         Map<String, Value> result = new HashMap<>(authToken);
         result.put(USER_AGENT_METADATA_KEY, value(userAgent));
         if (routingContext != null) {
             result.put(ROUTING_CONTEXT_METADATA_KEY, value(routingContext));
+        }
+        if (includeDateTimeUtc) {
+            result.put(PATCH_BOLT_METADATA_KEY, value(Collections.singleton(DATE_TIME_UTC_PATCH_VALUE)));
         }
         return result;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -83,9 +83,14 @@ public class BoltProtocolV3 implements BoltProtocol {
         HelloMessage message;
 
         if (routingContext.isServerRoutingEnabled()) {
-            message = new HelloMessage(userAgent, ((InternalAuthToken) authToken).toMap(), routingContext.toMap());
+            message = new HelloMessage(
+                    userAgent,
+                    ((InternalAuthToken) authToken).toMap(),
+                    routingContext.toMap(),
+                    includeDateTimeUtcPatchInHello());
         } else {
-            message = new HelloMessage(userAgent, ((InternalAuthToken) authToken).toMap(), null);
+            message = new HelloMessage(
+                    userAgent, ((InternalAuthToken) authToken).toMap(), null, includeDateTimeUtcPatchInHello());
         }
 
         HelloResponseHandler handler = new HelloResponseHandler(channelInitializedPromise);
@@ -182,5 +187,9 @@ public class BoltProtocolV3 implements BoltProtocol {
     @Override
     public BoltProtocolVersion version() {
         return VERSION;
+    }
+
+    protected boolean includeDateTimeUtcPatchInHello() {
+        return false;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/MessageFormatV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/MessageFormatV3.java
@@ -31,6 +31,6 @@ public class MessageFormatV3 implements MessageFormat {
 
     @Override
     public Reader newReader(PackInput input) {
-        return new CommonMessageReader(input);
+        return new CommonMessageReader(input, false);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3.java
@@ -45,7 +45,7 @@ import org.neo4j.driver.internal.util.Iterables;
 
 public class MessageWriterV3 extends AbstractMessageWriter {
     public MessageWriterV3(PackOutput output) {
-        super(new CommonValuePacker(output), buildEncoders());
+        super(new CommonValuePacker(output, false), buildEncoders());
     }
 
     private static Map<Byte, MessageEncoder> buildEncoders() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4.java
@@ -45,7 +45,7 @@ import org.neo4j.driver.internal.util.Iterables;
 
 public class MessageWriterV4 extends AbstractMessageWriter {
     public MessageWriterV4(PackOutput output) {
-        super(new CommonValuePacker(output), buildEncoders());
+        super(new CommonValuePacker(output, false), buildEncoders());
     }
 
     private static Map<Byte, MessageEncoder> buildEncoders() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43.java
@@ -41,4 +41,9 @@ public class BoltProtocolV43 extends BoltProtocolV42 {
     public BoltProtocolVersion version() {
         return VERSION;
     }
+
+    @Override
+    protected boolean includeDateTimeUtcPatchInHello() {
+        return true;
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/MessageFormatV43.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/MessageFormatV43.java
@@ -27,13 +27,20 @@ import org.neo4j.driver.internal.packstream.PackOutput;
  * Bolt message format v4.3
  */
 public class MessageFormatV43 implements MessageFormat {
+    private boolean dateTimeUtcEnabled;
+
     @Override
     public Writer newWriter(PackOutput output) {
-        return new MessageWriterV43(output);
+        return new MessageWriterV43(output, dateTimeUtcEnabled);
     }
 
     @Override
     public Reader newReader(PackInput input) {
-        return new CommonMessageReader(input);
+        return new CommonMessageReader(input, dateTimeUtcEnabled);
+    }
+
+    @Override
+    public void enableDateTimeUtc() {
+        dateTimeUtcEnabled = true;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43.java
@@ -52,8 +52,8 @@ import org.neo4j.driver.internal.util.Iterables;
  * new messages such as ROUTE
  */
 public class MessageWriterV43 extends AbstractMessageWriter {
-    public MessageWriterV43(PackOutput output) {
-        super(new CommonValuePacker(output), buildEncoders());
+    public MessageWriterV43(PackOutput output, boolean dateTimeUtcEnabled) {
+        super(new CommonValuePacker(output, dateTimeUtcEnabled), buildEncoders());
     }
 
     private static Map<Byte, MessageEncoder> buildEncoders() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v44/MessageFormatV44.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v44/MessageFormatV44.java
@@ -27,13 +27,20 @@ import org.neo4j.driver.internal.packstream.PackOutput;
  * Bolt message format v4.4
  */
 public class MessageFormatV44 implements MessageFormat {
+    private boolean dateTimeUtcEnabled;
+
     @Override
     public MessageFormat.Writer newWriter(PackOutput output) {
-        return new MessageWriterV44(output);
+        return new MessageWriterV44(output, dateTimeUtcEnabled);
     }
 
     @Override
     public MessageFormat.Reader newReader(PackInput input) {
-        return new CommonMessageReader(input);
+        return new CommonMessageReader(input, dateTimeUtcEnabled);
+    }
+
+    @Override
+    public void enableDateTimeUtc() {
+        dateTimeUtcEnabled = true;
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44.java
@@ -49,8 +49,8 @@ import org.neo4j.driver.internal.util.Iterables;
  * Bolt message writer v4.4
  */
 public class MessageWriterV44 extends AbstractMessageWriter {
-    public MessageWriterV44(PackOutput output) {
-        super(new CommonValuePacker(output), buildEncoders());
+    public MessageWriterV44(PackOutput output, boolean dateTimeUtcEnabled) {
+        super(new CommonValuePacker(output, dateTimeUtcEnabled), buildEncoders());
     }
 
     private static Map<Byte, MessageEncoder> buildEncoders() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5.java
@@ -36,4 +36,9 @@ public class BoltProtocolV5 extends BoltProtocolV44 {
     public BoltProtocolVersion version() {
         return VERSION;
     }
+
+    @Override
+    protected boolean includeDateTimeUtcPatchInHello() {
+        return false;
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5.java
@@ -47,7 +47,7 @@ import org.neo4j.driver.internal.util.Iterables;
 
 public class MessageWriterV5 extends AbstractMessageWriter {
     public MessageWriterV5(PackOutput output) {
-        super(new CommonValuePacker(output), buildEncoders());
+        super(new CommonValuePacker(output, true), buildEncoders());
     }
 
     private static Map<Byte, MessageEncoder> buildEncoders() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/ValueUnpackerV5.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v5/ValueUnpackerV5.java
@@ -42,7 +42,7 @@ public class ValueUnpackerV5 extends CommonValueUnpacker {
     private static final int RELATIONSHIP_FIELDS = 8;
 
     public ValueUnpackerV5(PackInput input) {
-        super(input);
+        super(input, true);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
@@ -22,8 +22,10 @@ import static org.neo4j.driver.internal.summary.InternalDatabaseInfo.DEFAULT_DAT
 import static org.neo4j.driver.internal.types.InternalTypeSystem.TYPE_SYSTEM;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
@@ -203,5 +205,14 @@ public class MetadataExtractor {
             return resultConsumedAfterValue.asLong();
         }
         return -1;
+    }
+
+    public static Set<String> extractBoltPatches(Map<String, Value> metadata) {
+        Value boltPatch = metadata.get("patch_bolt");
+        if (boltPatch != null && !boltPatch.isNull()) {
+            return new HashSet<>(boltPatch.asList(Value::asString));
+        } else {
+            return Collections.emptySet();
+        }
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
@@ -75,7 +75,7 @@ class HandshakeCompletedListenerTest {
     void shouldWriteInitializationMessageInBoltV3WhenHandshakeCompleted() {
         testWritingOfInitializationMessage(
                 BoltProtocolV3.VERSION,
-                new HelloMessage(USER_AGENT, authToken().toMap(), Collections.emptyMap()),
+                new HelloMessage(USER_AGENT, authToken().toMap(), Collections.emptyMap(), false),
                 HelloResponseHandler.class);
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/HelloMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/HelloMessageEncoderTest.java
@@ -42,7 +42,7 @@ class HelloMessageEncoderTest {
         authToken.put("username", value("bob"));
         authToken.put("password", value("secret"));
 
-        encoder.encode(new HelloMessage("MyDriver", authToken, null), packer);
+        encoder.encode(new HelloMessage("MyDriver", authToken, null, false), packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(1, HelloMessage.SIGNATURE);
@@ -61,7 +61,7 @@ class HelloMessageEncoderTest {
         Map<String, String> routingContext = new HashMap<>();
         routingContext.put("policy", "eu-fast");
 
-        encoder.encode(new HelloMessage("MyDriver", authToken, routingContext), packer);
+        encoder.encode(new HelloMessage("MyDriver", authToken, routingContext, false), packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(1, HelloMessage.SIGNATURE);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
@@ -39,7 +39,7 @@ class HelloMessageTest {
         authToken.put("user", value("Alice"));
         authToken.put("credentials", value("SecretPassword"));
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap());
+        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap(), false);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver/1.0.2"));
@@ -57,7 +57,7 @@ class HelloMessageTest {
         routingContext.put("region", "China");
         routingContext.put("speed", "Slow");
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, routingContext);
+        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, routingContext, false);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver/1.0.2"));
@@ -71,7 +71,7 @@ class HelloMessageTest {
         authToken.put(PRINCIPAL_KEY, value("Alice"));
         authToken.put(CREDENTIALS_KEY, value("SecretPassword"));
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap());
+        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap(), false);
 
         assertThat(message.toString(), not(containsString("SecretPassword")));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -99,7 +99,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -107,7 +107,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -106,7 +106,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -106,7 +106,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -111,7 +111,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -111,7 +111,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageReaderV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageReaderV5Test.java
@@ -113,4 +113,9 @@ public class MessageReaderV5Test extends AbstractMessageReaderTestBase {
     protected boolean isElementIdEnabled() {
         return true;
     }
+
+    @Override
+    protected boolean isDateTimeUtcEnabled() {
+        return true;
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
@@ -111,7 +111,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                 new HelloMessage(
                         "MyDriver/1.2.3",
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
-                        Collections.emptyMap()),
+                        Collections.emptyMap(),
+                        false),
                 GOODBYE,
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),

--- a/driver/src/test/java/org/neo4j/driver/internal/util/messaging/AbstractMessageReaderTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/messaging/AbstractMessageReaderTestBase.java
@@ -97,6 +97,9 @@ public abstract class AbstractMessageReaderTestBase {
         ByteBuf buffer = Unpooled.buffer();
 
         MessageFormat messageFormat = new KnowledgeableMessageFormat(isElementIdEnabled());
+        if (isDateTimeUtcEnabled()) {
+            messageFormat.enableDateTimeUtc();
+        }
         MessageFormat.Writer writer = messageFormat.newWriter(new ByteBufOutput(buffer));
         writer.write(message);
 
@@ -106,6 +109,10 @@ public abstract class AbstractMessageReaderTestBase {
     }
 
     protected boolean isElementIdEnabled() {
+        return false;
+    }
+
+    protected boolean isDateTimeUtcEnabled() {
         return false;
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/messaging/KnowledgeableMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/messaging/KnowledgeableMessageFormat.java
@@ -50,6 +50,7 @@ import org.neo4j.driver.types.Relationship;
  */
 public class KnowledgeableMessageFormat extends MessageFormatV3 {
     private final boolean elementIdEnabled;
+    private boolean dateTimeUtcEnabled;
 
     public KnowledgeableMessageFormat(boolean elementIdEnabled) {
         this.elementIdEnabled = elementIdEnabled;
@@ -57,12 +58,17 @@ public class KnowledgeableMessageFormat extends MessageFormatV3 {
 
     @Override
     public Writer newWriter(PackOutput output) {
-        return new KnowledgeableMessageWriter(output, elementIdEnabled);
+        return new KnowledgeableMessageWriter(output, elementIdEnabled, dateTimeUtcEnabled);
+    }
+
+    @Override
+    public void enableDateTimeUtc() {
+        dateTimeUtcEnabled = true;
     }
 
     private static class KnowledgeableMessageWriter extends AbstractMessageWriter {
-        KnowledgeableMessageWriter(PackOutput output, boolean enableElementId) {
-            super(new KnowledgeableValuePacker(output, enableElementId), buildEncoders());
+        KnowledgeableMessageWriter(PackOutput output, boolean enableElementId, boolean dateTimeUtcEnabled) {
+            super(new KnowledgeableValuePacker(output, enableElementId, dateTimeUtcEnabled), buildEncoders());
         }
 
         static Map<Byte, MessageEncoder> buildEncoders() {
@@ -83,8 +89,8 @@ public class KnowledgeableMessageFormat extends MessageFormatV3 {
     private static class KnowledgeableValuePacker extends CommonValuePacker {
         private final boolean elementIdEnabled;
 
-        KnowledgeableValuePacker(PackOutput output, boolean elementIdEnabled) {
-            super(output);
+        KnowledgeableValuePacker(PackOutput output, boolean elementIdEnabled, boolean dateTimeUtcEnabled) {
+            super(output, dateTimeUtcEnabled);
             this.elementIdEnabled = elementIdEnabled;
         }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/TestkitModule.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/TestkitModule.java
@@ -19,7 +19,9 @@
 package neo4j.org.testkit.backend.messages;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.ZonedDateTime;
 import java.util.List;
+import neo4j.org.testkit.backend.messages.requests.deserializer.TestkitCypherDateTimeDeserializer;
 import neo4j.org.testkit.backend.messages.requests.deserializer.TestkitListDeserializer;
 import neo4j.org.testkit.backend.messages.responses.serializer.TestkitListValueSerializer;
 import neo4j.org.testkit.backend.messages.responses.serializer.TestkitMapValueSerializer;
@@ -39,6 +41,7 @@ import org.neo4j.driver.internal.value.RelationshipValue;
 public class TestkitModule extends SimpleModule {
     public TestkitModule() {
         this.addDeserializer(List.class, new TestkitListDeserializer());
+        this.addDeserializer(ZonedDateTime.class, new TestkitCypherDateTimeDeserializer());
 
         this.addSerializer(Value.class, new TestkitValueSerializer());
         this.addSerializer(NodeValue.class, new TestkitNodeValueSerializer());

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -57,7 +57,8 @@ public class GetFeatures implements TestkitRequest {
             "Detail:DefaultSecurityConfigValueEquality",
             "Detail:ThrowOnMissingId",
             "Optimization:ImplicitDefaultArguments",
-            "Feature:Bolt:Patch:UTC"));
+            "Feature:Bolt:Patch:UTC",
+            "Feature:API:Type.Temporal"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -56,7 +56,8 @@ public class GetFeatures implements TestkitRequest {
             "Feature:API:SSLConfig",
             "Detail:DefaultSecurityConfigValueEquality",
             "Detail:ThrowOnMissingId",
-            "Optimization:ImplicitDefaultArguments"));
+            "Optimization:ImplicitDefaultArguments",
+            "Feature:Bolt:Patch:UTC"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -85,7 +85,7 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.test_trusted_ca_correct_hostname$", skipMessage);
         skipMessage = "Additional type support is needed";
         COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
+                "^neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -83,6 +83,9 @@ public class StartTest implements TestkitRequest {
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments_multi_query_nested$", skipMessage);
         skipMessage = "This test became flaky and needs investigation";
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.test_trusted_ca_correct_hostname$", skipMessage);
+        skipMessage = "Additional type support is needed";
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -85,7 +85,7 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.test_trusted_ca_correct_hostname$", skipMessage);
         skipMessage = "Additional type support is needed";
         COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*\\neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
+                "^.*\\.neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -85,7 +85,7 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.test_trusted_ca_correct_hostname$", skipMessage);
         skipMessage = "Additional type support is needed";
         COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*\\.neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
+                "^.*neo4j\\.datatypes\\.test_temporal_types\\.TestDataTypes\\..*$", skipMessage);
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
 
@@ -174,6 +174,7 @@ public class StartTest implements TestkitRequest {
     }
 
     private TestkitResponse createResponse(Map<String, String> skipPatternToReason) {
+        System.out.println(data.getTestName());
         return skipPatternToReason.entrySet().stream()
                 .filter(entry -> data.getTestName().matches(entry.getKey()))
                 .findFirst()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/deserializer/TestkitCypherDateTimeDeserializer.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/deserializer/TestkitCypherDateTimeDeserializer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.messages.requests.deserializer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class TestkitCypherDateTimeDeserializer extends StdDeserializer<ZonedDateTime> {
+    public TestkitCypherDateTimeDeserializer() {
+        super(ZonedDateTime.class);
+    }
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+
+        CypherDateTime dateTime = new CypherDateTime();
+
+        JsonToken token = p.currentToken();
+        while (token == JsonToken.FIELD_NAME
+                || token == JsonToken.VALUE_NUMBER_INT
+                || token == JsonToken.VALUE_STRING) {
+            if (token == JsonToken.VALUE_NUMBER_INT) {
+                String field = p.getCurrentName();
+                int value = p.getValueAsInt();
+                setField(dateTime, field, value);
+            } else if (token == JsonToken.VALUE_STRING) {
+                String field = p.getCurrentName();
+                String value = p.getValueAsString();
+                setField(dateTime, field, value);
+            }
+            token = p.nextToken();
+        }
+
+        ZoneId zoneId = dateTime.timezone_id != null
+                ? ZoneId.of(dateTime.timezone_id)
+                : ZoneOffset.ofTotalSeconds(dateTime.utc_offset_s);
+        return ZonedDateTime.of(
+                dateTime.year,
+                dateTime.month,
+                dateTime.day,
+                dateTime.hour,
+                dateTime.minute,
+                dateTime.second,
+                dateTime.nanosecond,
+                zoneId);
+    }
+
+    private void setField(CypherDateTime dateTime, String fieldName, Object value) {
+        try {
+            Field field = CypherDateTime.class.getDeclaredField(fieldName);
+            field.set(dateTime, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // ignored
+        }
+    }
+
+    private static class CypherDateTime {
+        Integer year;
+        Integer month;
+        Integer day;
+        Integer hour;
+        Integer minute;
+        Integer second;
+        Integer nanosecond;
+        Integer utc_offset_s;
+        String timezone_id;
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/GenUtils.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/GenUtils.java
@@ -20,6 +20,7 @@ package neo4j.org.testkit.backend.messages.responses.serializer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -68,6 +69,8 @@ public final class GenUtils {
                 return List.class;
             case "CypherMap":
                 return Map.class;
+            case "CypherDateTime":
+                return ZonedDateTime.class;
             case "CypherNull":
                 return null;
             default:


### PR DESCRIPTION
This update brings 2 new Bolt structures for transmitting datetime in UTC, specifically tag bytes 49 and 69.

Bolt 5 will only support these structures and will no longer accept tag bytes 46 and 66. Bolt 4.4 and 4.3 will negotiate with server and use the new structures if possible. Previous protocol versions behaviour remains unchanged.