### PR TITLE
Delete Neo4jException.neo4jErrorCode and update documentation

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -328,4 +328,10 @@
         <method>java.util.Set lastBookmarks()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/exceptions/Neo4jException</className>
+        <differenceType>7002</differenceType>
+        <method>java.lang.String neo4jErrorCode()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
@@ -19,7 +19,7 @@
 package org.neo4j.driver.exceptions;
 
 /**
- * This is the base class for all exceptions caused as part of communication with the remote Neo4j server.
+ * This is the base class for Neo4j exceptions.
  *
  * @since 1.0
  */
@@ -43,17 +43,6 @@ public class Neo4jException extends RuntimeException {
     public Neo4jException(String code, String message, Throwable cause) {
         super(message, cause);
         this.code = code;
-    }
-
-    /**
-     * Access the standard Neo4j Status Code for this exception, you can use this to refer to the Neo4j manual for
-     * details on what caused the error.
-     *
-     * @return the Neo4j Status Code for this exception, or 'N/A' if none is available
-     */
-    @Deprecated
-    public String neo4jErrorCode() {
-        return code;
     }
 
     /**


### PR DESCRIPTION
This update deletes the deprecated `Neo4jException.neo4jErrorCode()` method and updates documentation.