### PR TITLE
Introduce updateRoutingTableTimeout option

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -79,6 +79,8 @@ public class Config implements Serializable {
 
     private final boolean logLeakedSessions;
 
+    private final long updateRoutingTableTimeoutMillis;
+
     private final int maxConnectionPoolSize;
 
     private final long idleTimeBeforeConnectionTest;
@@ -102,6 +104,7 @@ public class Config implements Serializable {
         this.logging = builder.logging;
         this.logLeakedSessions = builder.logLeakedSessions;
 
+        this.updateRoutingTableTimeoutMillis = builder.updateRoutingTableTimeoutMillis;
         this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
         this.maxConnectionLifetimeMillis = builder.maxConnectionLifetimeMillis;
         this.maxConnectionPoolSize = builder.maxConnectionPoolSize;
@@ -135,6 +138,15 @@ public class Config implements Serializable {
      */
     public boolean logLeakedSessions() {
         return logLeakedSessions;
+    }
+
+    /**
+     * Returns maximum amount of time the driver may wait for routing table acquisition.
+     *
+     * @return the maximum time in milliseconds
+     */
+    public long updateRoutingTableTimeoutMillis() {
+        return updateRoutingTableTimeoutMillis;
     }
 
     /**
@@ -257,6 +269,7 @@ public class Config implements Serializable {
     public static class ConfigBuilder {
         private Logging logging = DEV_NULL_LOGGING;
         private boolean logLeakedSessions;
+        private long updateRoutingTableTimeoutMillis = TimeUnit.SECONDS.toMillis(90);
         private int maxConnectionPoolSize = PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private long maxConnectionLifetimeMillis = PoolSettings.DEFAULT_MAX_CONNECTION_LIFETIME;
@@ -307,6 +320,26 @@ public class Config implements Serializable {
          */
         public ConfigBuilder withLeakedSessionsLogging() {
             this.logLeakedSessions = true;
+            return this;
+        }
+
+        /**
+         * Sets maximum amount of time the driver may wait for routing table acquisition.
+         * <p>
+         * This option allows setting API response time expectation. It does not limit the time the driver might need when getting routing table.
+         * <p>
+         * Default is 90 seconds.
+         *
+         * @param value the maximum time amount
+         * @param unit  the time unit
+         * @return this builder
+         */
+        public ConfigBuilder withUpdateRoutingTableTimeout(long value, TimeUnit unit) {
+            var millis = unit.toMillis(value);
+            if (millis <= 0) {
+                throw new IllegalArgumentException("The provided value must be at least 1 millisecond.");
+            }
+            this.updateRoutingTableTimeoutMillis = millis;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -281,6 +281,7 @@ public class DriverFactory {
                 address,
                 routingSettings,
                 connectionPool,
+                config.updateRoutingTableTimeoutMillis(),
                 eventExecutorGroup,
                 createClock(),
                 config.logging(),

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
@@ -76,6 +76,7 @@ public class LoadBalancer implements ConnectionProvider {
             BoltServerAddress initialRouter,
             RoutingSettings settings,
             ConnectionPool connectionPool,
+            long updateRoutingTableTimeoutMillis,
             EventExecutorGroup eventExecutorGroup,
             Clock clock,
             Logging logging,
@@ -88,6 +89,7 @@ public class LoadBalancer implements ConnectionProvider {
                         initialRouter, resolver, settings, clock, logging, requireNonNull(domainNameResolver)),
                 settings,
                 loadBalancingStrategy,
+                updateRoutingTableTimeoutMillis,
                 eventExecutorGroup,
                 clock,
                 logging);
@@ -98,12 +100,14 @@ public class LoadBalancer implements ConnectionProvider {
             Rediscovery rediscovery,
             RoutingSettings settings,
             LoadBalancingStrategy loadBalancingStrategy,
+            long updateRoutingTableTimeoutMillis,
             EventExecutorGroup eventExecutorGroup,
             Clock clock,
             Logging logging) {
         this(
                 connectionPool,
-                createRoutingTables(connectionPool, rediscovery, settings, clock, logging),
+                createRoutingTables(
+                        connectionPool, rediscovery, settings, updateRoutingTableTimeoutMillis, clock, logging),
                 rediscovery,
                 loadBalancingStrategy,
                 eventExecutorGroup,
@@ -275,10 +279,16 @@ public class LoadBalancer implements ConnectionProvider {
             ConnectionPool connectionPool,
             Rediscovery rediscovery,
             RoutingSettings settings,
+            long updateRoutingTableTimeoutMillis,
             Clock clock,
             Logging logging) {
         return new RoutingTableRegistryImpl(
-                connectionPool, rediscovery, clock, logging, settings.routingTablePurgeDelayMs());
+                connectionPool,
+                rediscovery,
+                updateRoutingTableTimeoutMillis,
+                clock,
+                logging,
+                settings.routingTablePurgeDelayMs());
     }
 
     private static Rediscovery createRediscovery(

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -148,6 +148,29 @@ class ConfigTest {
     }
 
     @Test
+    void shouldHaveDefaultUpdateRoutingTableTimeout() {
+        var defaultConfig = Config.defaultConfig();
+        assertEquals(TimeUnit.SECONDS.toMillis(90), defaultConfig.updateRoutingTableTimeoutMillis());
+    }
+
+    @Test
+    void shouldSetUpdateRoutingTableTimeout() {
+        var value = 1;
+        var config = Config.builder()
+                .withUpdateRoutingTableTimeout(value, TimeUnit.HOURS)
+                .build();
+        assertEquals(TimeUnit.HOURS.toMillis(value), config.updateRoutingTableTimeoutMillis());
+    }
+
+    @Test
+    void shouldRejectLessThen1Millisecond() {
+        var builder = Config.builder();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> builder.withUpdateRoutingTableTimeout(999_999, TimeUnit.NANOSECONDS));
+    }
+
+    @Test
     void shouldHaveDefaultConnectionTimeout() {
         Config defaultConfig = Config.defaultConfig();
         assertEquals(TimeUnit.SECONDS.toMillis(30), defaultConfig.connectionTimeoutMillis());

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
@@ -323,7 +323,7 @@ class RoutingTableAndConnectionPoolTest {
 
     private RoutingTableRegistryImpl newRoutingTables(ConnectionPool connectionPool, Rediscovery rediscovery) {
         return new RoutingTableRegistryImpl(
-                connectionPool, rediscovery, clock, logging, STALE_ROUTING_TABLE_PURGE_DELAY_MS);
+                connectionPool, rediscovery, Long.MAX_VALUE, clock, logging, STALE_ROUTING_TABLE_PURGE_DELAY_MS);
     }
 
     private LoadBalancer newLoadBalancer(ConnectionPool connectionPool, RoutingTableRegistry routingTables) {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -57,7 +57,8 @@ public class GetFeatures implements TestkitRequest {
             "Detail:DefaultSecurityConfigValueEquality",
             "Optimization:ImplicitDefaultArguments",
             "Feature:Bolt:Patch:UTC",
-            "Feature:API:Type.Temporal"));
+            "Feature:API:Type.Temporal",
+            "Feature:API:UpdateRoutingTableTimeout"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -101,6 +101,8 @@ public class NewDriver implements TestkitRequest {
             domainNameResolver = callbackDomainNameResolver(testkitState);
         }
         Optional.ofNullable(data.userAgent).ifPresent(configBuilder::withUserAgent);
+        Optional.ofNullable(data.updateRoutingTableTimeoutMs)
+                .ifPresent(timeout -> configBuilder.withUpdateRoutingTableTimeout(timeout, TimeUnit.MILLISECONDS));
         Optional.ofNullable(data.connectionTimeoutMs)
                 .ifPresent(timeout -> configBuilder.withConnectionTimeout(timeout, TimeUnit.MILLISECONDS));
         Optional.ofNullable(data.fetchSize).ifPresent(configBuilder::withFetchSize);
@@ -278,6 +280,7 @@ public class NewDriver implements TestkitRequest {
         private String userAgent;
         private boolean resolverRegistered;
         private boolean domainNameResolverRegistered;
+        private Long updateRoutingTableTimeoutMs;
         private Long connectionTimeoutMs;
         private Integer fetchSize;
         private Long maxTxRetryTimeMs;


### PR DESCRIPTION
Sets maximum amount of time the driver may wait for routing table acquisition.

This option allows setting API response time expectation. It does not limit the time the driver might need when getting routing table.