### PR TITLE
Introduce SessionConnectionTimeout option

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -79,6 +79,7 @@ public class Config implements Serializable {
 
     private final boolean logLeakedSessions;
 
+    private final long sessionConnectionTimeoutMillis;
     private final long updateRoutingTableTimeoutMillis;
 
     private final int maxConnectionPoolSize;
@@ -104,6 +105,7 @@ public class Config implements Serializable {
         this.logging = builder.logging;
         this.logLeakedSessions = builder.logLeakedSessions;
 
+        this.sessionConnectionTimeoutMillis = builder.sessionConnectionTimeoutMillis;
         this.updateRoutingTableTimeoutMillis = builder.updateRoutingTableTimeoutMillis;
         this.idleTimeBeforeConnectionTest = builder.idleTimeBeforeConnectionTest;
         this.maxConnectionLifetimeMillis = builder.maxConnectionLifetimeMillis;
@@ -138,6 +140,15 @@ public class Config implements Serializable {
      */
     public boolean logLeakedSessions() {
         return logLeakedSessions;
+    }
+
+    /**
+     * Returns maximum amount of time the driver may wait for read or write connection to a server node in routing mode for running query.
+     *
+     * @return the maximum time in milliseconds
+     */
+    public long sessionConnectionTimeoutMillis() {
+        return sessionConnectionTimeoutMillis;
     }
 
     /**
@@ -269,6 +280,7 @@ public class Config implements Serializable {
     public static class ConfigBuilder {
         private Logging logging = DEV_NULL_LOGGING;
         private boolean logLeakedSessions;
+        private long sessionConnectionTimeoutMillis = TimeUnit.SECONDS.toMillis(120);
         private long updateRoutingTableTimeoutMillis = TimeUnit.SECONDS.toMillis(90);
         private int maxConnectionPoolSize = PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
@@ -320,6 +332,26 @@ public class Config implements Serializable {
          */
         public ConfigBuilder withLeakedSessionsLogging() {
             this.logLeakedSessions = true;
+            return this;
+        }
+
+        /**
+         * Sets maximum amount of time the driver may wait for read or write connection to a server node in routing mode for running query.
+         * <p>
+         * This option allows setting API response time expectation.
+         * <p>
+         * Default is 120 seconds.
+         *
+         * @param value the maximum time amount
+         * @param unit  the time unit
+         * @return this builder
+         */
+        public ConfigBuilder withSessionConnectionTimeout(long value, TimeUnit unit) {
+            var millis = unit.toMillis(value);
+            if (millis <= 0) {
+                throw new IllegalArgumentException("The provided value must be at least 1 millisecond.");
+            }
+            this.sessionConnectionTimeoutMillis = millis;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -281,6 +281,7 @@ public class DriverFactory {
                 address,
                 routingSettings,
                 connectionPool,
+                config.sessionConnectionTimeoutMillis(),
                 config.updateRoutingTableTimeoutMillis(),
                 eventExecutorGroup,
                 createClock(),

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -148,6 +148,29 @@ class ConfigTest {
     }
 
     @Test
+    void shouldHaveDefaultSessionConnectionTimeout() {
+        var defaultConfig = Config.defaultConfig();
+        assertEquals(TimeUnit.SECONDS.toMillis(120), defaultConfig.sessionConnectionTimeoutMillis());
+    }
+
+    @Test
+    void shouldSetSessionConnectionTimeout() {
+        var value = 1;
+        var config = Config.builder()
+                .withSessionConnectionTimeout(value, TimeUnit.HOURS)
+                .build();
+        assertEquals(TimeUnit.HOURS.toMillis(value), config.sessionConnectionTimeoutMillis());
+    }
+
+    @Test
+    void shouldRejectLessThen1MillisecondSessionConnectionTimeout() {
+        var builder = Config.builder();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> builder.withSessionConnectionTimeout(999_999, TimeUnit.NANOSECONDS));
+    }
+
+    @Test
     void shouldHaveDefaultUpdateRoutingTableTimeout() {
         var defaultConfig = Config.defaultConfig();
         assertEquals(TimeUnit.SECONDS.toMillis(90), defaultConfig.updateRoutingTableTimeoutMillis());
@@ -163,7 +186,7 @@ class ConfigTest {
     }
 
     @Test
-    void shouldRejectLessThen1Millisecond() {
+    void shouldRejectLessThen1MillisecondRoutingTableTimeout() {
         var builder = Config.builder();
         assertThrows(
                 IllegalArgumentException.class,

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancerTest.java
@@ -375,6 +375,7 @@ class LoadBalancerTest {
                 routingTables,
                 rediscovery,
                 new LeastConnectedLoadBalancingStrategy(connectionPool, DEV_NULL_LOGGING),
+                Long.MAX_VALUE,
                 GlobalEventExecutor.INSTANCE,
                 DEV_NULL_LOGGING);
         ConnectionContext context = mock(ConnectionContext.class);
@@ -454,6 +455,7 @@ class LoadBalancerTest {
                 routingTables,
                 rediscovery,
                 new LeastConnectedLoadBalancingStrategy(connectionPool, DEV_NULL_LOGGING),
+                Long.MAX_VALUE,
                 GlobalEventExecutor.INSTANCE,
                 DEV_NULL_LOGGING);
     }
@@ -472,6 +474,7 @@ class LoadBalancerTest {
                 routingTables,
                 rediscovery,
                 new LeastConnectedLoadBalancingStrategy(connectionPool, DEV_NULL_LOGGING),
+                Long.MAX_VALUE,
                 GlobalEventExecutor.INSTANCE,
                 DEV_NULL_LOGGING);
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/loadbalancing/RoutingTableAndConnectionPoolTest.java
@@ -333,6 +333,7 @@ class RoutingTableAndConnectionPoolTest {
                 routingTables,
                 rediscovery,
                 new LeastConnectedLoadBalancingStrategy(connectionPool, logging),
+                Long.MAX_VALUE,
                 GlobalEventExecutor.INSTANCE,
                 logging);
     }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -58,7 +58,8 @@ public class GetFeatures implements TestkitRequest {
             "Optimization:ImplicitDefaultArguments",
             "Feature:Bolt:Patch:UTC",
             "Feature:API:Type.Temporal",
-            "Feature:API:UpdateRoutingTableTimeout"));
+            "Feature:API:UpdateRoutingTableTimeout",
+            "Feature:API:SessionConnectionTimeout"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -101,6 +101,8 @@ public class NewDriver implements TestkitRequest {
             domainNameResolver = callbackDomainNameResolver(testkitState);
         }
         Optional.ofNullable(data.userAgent).ifPresent(configBuilder::withUserAgent);
+        Optional.ofNullable(data.sessionConnectionTimeoutMs)
+                .ifPresent(timeout -> configBuilder.withSessionConnectionTimeout(timeout, TimeUnit.MILLISECONDS));
         Optional.ofNullable(data.updateRoutingTableTimeoutMs)
                 .ifPresent(timeout -> configBuilder.withUpdateRoutingTableTimeout(timeout, TimeUnit.MILLISECONDS));
         Optional.ofNullable(data.connectionTimeoutMs)
@@ -280,6 +282,7 @@ public class NewDriver implements TestkitRequest {
         private String userAgent;
         private boolean resolverRegistered;
         private boolean domainNameResolverRegistered;
+        private Long sessionConnectionTimeoutMs;
         private Long updateRoutingTableTimeoutMs;
         private Long connectionTimeoutMs;
         private Integer fetchSize;


### PR DESCRIPTION
Sets maximum amount of time the driver may wait for read or write connection to a server node in routing mode for running query.

This option allows setting API response time expectation.