### PR TITLE
Skip more unknown timezone tests

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -86,6 +86,9 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.test_unknown_then_known_zoned_date_time(_patched)?$",
                 "Unknown zone names make the driver close the connection.");
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.test_unknown_zoned_date_time(_patched)?$",
+                "Unknown zone names make the driver close the connection.");
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
 


### PR DESCRIPTION
These are currently passing by coincidence, as TestKit stub server
silently swallows the error, resulting from the Java driver early
connection close.