### PR TITLE
Deprecate RevocationStrategy and introduce RevocationCheckingStrategy

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -772,7 +772,7 @@ public class Config implements Serializable {
         private final Strategy strategy;
         private final List<File> certFiles;
         private boolean hostnameVerificationEnabled = true;
-        private RevocationStrategy revocationStrategy = RevocationStrategy.NO_CHECKS;
+        private RevocationCheckingStrategy revocationCheckingStrategy = RevocationCheckingStrategy.NO_CHECKS;
 
         private TrustStrategy(Strategy strategy) {
             this(strategy, Collections.emptyList());
@@ -883,7 +883,31 @@ public class Config implements Serializable {
          * The revocation strategy used for verifying certificates.
          * @return this {@link TrustStrategy}'s revocation strategy
          */
+        public RevocationCheckingStrategy revocationCheckingStrategy() {
+            return revocationCheckingStrategy;
+        }
+
+        /**
+         * The revocation strategy used for verifying certificates.
+         * @return this {@link TrustStrategy}'s revocation strategy
+         * @deprecated superseded by {@link TrustStrategy#revocationCheckingStrategy()}
+         */
+        @Deprecated
         public RevocationStrategy revocationStrategy() {
+            RevocationStrategy revocationStrategy;
+            switch (this.revocationCheckingStrategy) {
+                case VERIFY_IF_PRESENT:
+                    revocationStrategy = RevocationStrategy.VERIFY_IF_PRESENT;
+                    break;
+                case STRICT:
+                    revocationStrategy = RevocationStrategy.STRICT;
+                    break;
+                case NO_CHECKS:
+                    revocationStrategy = RevocationStrategy.NO_CHECKS;
+                    break;
+                default:
+                    throw new IllegalStateException("Failed to map RevocationCheckingStrategy to RevocationStrategy.");
+            }
             return revocationStrategy;
         }
 
@@ -893,7 +917,7 @@ public class Config implements Serializable {
          * @return the current trust strategy
          */
         public TrustStrategy withoutCertificateRevocationChecks() {
-            this.revocationStrategy = RevocationStrategy.NO_CHECKS;
+            this.revocationCheckingStrategy = RevocationCheckingStrategy.NO_CHECKS;
             return this;
         }
 
@@ -905,7 +929,7 @@ public class Config implements Serializable {
          * @return the current trust strategy
          */
         public TrustStrategy withVerifyIfPresentRevocationChecks() {
-            this.revocationStrategy = RevocationStrategy.VERIFY_IF_PRESENT;
+            this.revocationCheckingStrategy = RevocationCheckingStrategy.VERIFY_IF_PRESENT;
             return this;
         }
 
@@ -919,7 +943,7 @@ public class Config implements Serializable {
          * @return the current trust strategy
          */
         public TrustStrategy withStrictRevocationChecks() {
-            this.revocationStrategy = RevocationStrategy.STRICT;
+            this.revocationCheckingStrategy = RevocationCheckingStrategy.STRICT;
             return this;
         }
     }

--- a/driver/src/main/java/org/neo4j/driver/RevocationCheckingStrategy.java
+++ b/driver/src/main/java/org/neo4j/driver/RevocationCheckingStrategy.java
@@ -16,17 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal;
-
-import org.neo4j.driver.RevocationCheckingStrategy;
+package org.neo4j.driver;
 
 /**
  * Defines strategy for revocation checks.
- *
- * @deprecated superseded by {@link RevocationCheckingStrategy}
  */
-@Deprecated
-public enum RevocationStrategy {
+public enum RevocationCheckingStrategy {
     /** Don't do any OCSP revocation checks, regardless whether there are stapled revocation statuses or not. */
     NO_CHECKS,
     /** Verify OCSP revocation checks when the revocation status is stapled to the certificate, continue if not. */
@@ -34,7 +29,7 @@ public enum RevocationStrategy {
     /** Require stapled revocation status and verify OCSP revocation checks, fail if no revocation status is stapled to the certificate. */
     STRICT;
 
-    public static boolean requiresRevocationChecking(RevocationStrategy revocationStrategy) {
-        return revocationStrategy.equals(STRICT) || revocationStrategy.equals(VERIFY_IF_PRESENT);
+    public static boolean requiresRevocationChecking(RevocationCheckingStrategy revocationCheckingStrategy) {
+        return revocationCheckingStrategy.equals(STRICT) || revocationCheckingStrategy.equals(VERIFY_IF_PRESENT);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SecuritySettings.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import org.neo4j.driver.Config;
+import org.neo4j.driver.RevocationCheckingStrategy;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
@@ -56,6 +57,7 @@ public class SecuritySettings implements Serializable {
         return !(DEFAULT.encrypted() == this.encrypted() && DEFAULT.hasEqualTrustStrategy(this));
     }
 
+    @SuppressWarnings("deprecation")
     private boolean hasEqualTrustStrategy(SecuritySettings other) {
         Config.TrustStrategy t1 = this.trustStrategy;
         Config.TrustStrategy t2 = other.trustStrategy;
@@ -66,6 +68,7 @@ public class SecuritySettings implements Serializable {
         return t1.isHostnameVerificationEnabled() == t2.isHostnameVerificationEnabled()
                 && t1.strategy() == t2.strategy()
                 && t1.certFiles().equals(t2.certFiles())
+                && t1.revocationCheckingStrategy() == t2.revocationCheckingStrategy()
                 && t1.revocationStrategy() == t2.revocationStrategy();
     }
 
@@ -92,9 +95,9 @@ public class SecuritySettings implements Serializable {
 
     private SecurityPlan createSecurityPlanFromScheme(String scheme) throws GeneralSecurityException, IOException {
         if (isHighTrustScheme(scheme)) {
-            return SecurityPlanImpl.forSystemCASignedCertificates(true, RevocationStrategy.NO_CHECKS);
+            return SecurityPlanImpl.forSystemCASignedCertificates(true, RevocationCheckingStrategy.NO_CHECKS);
         } else {
-            return SecurityPlanImpl.forAllCertificates(false, RevocationStrategy.NO_CHECKS);
+            return SecurityPlanImpl.forAllCertificates(false, RevocationCheckingStrategy.NO_CHECKS);
         }
     }
 
@@ -106,16 +109,16 @@ public class SecuritySettings implements Serializable {
             throws GeneralSecurityException, IOException {
         if (encrypted) {
             boolean hostnameVerificationEnabled = trustStrategy.isHostnameVerificationEnabled();
-            RevocationStrategy revocationStrategy = trustStrategy.revocationStrategy();
+            RevocationCheckingStrategy revocationCheckingStrategy = trustStrategy.revocationCheckingStrategy();
             switch (trustStrategy.strategy()) {
                 case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
                     return SecurityPlanImpl.forCustomCASignedCertificates(
-                            trustStrategy.certFiles(), hostnameVerificationEnabled, revocationStrategy);
+                            trustStrategy.certFiles(), hostnameVerificationEnabled, revocationCheckingStrategy);
                 case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
                     return SecurityPlanImpl.forSystemCASignedCertificates(
-                            hostnameVerificationEnabled, revocationStrategy);
+                            hostnameVerificationEnabled, revocationCheckingStrategy);
                 case TRUST_ALL_CERTIFICATES:
-                    return SecurityPlanImpl.forAllCertificates(hostnameVerificationEnabled, revocationStrategy);
+                    return SecurityPlanImpl.forAllCertificates(hostnameVerificationEnabled, revocationCheckingStrategy);
                 default:
                     throw new ClientException("Unknown TLS authentication strategy: "
                             + trustStrategy.strategy().name());

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlan.java
@@ -19,7 +19,7 @@
 package org.neo4j.driver.internal.security;
 
 import javax.net.ssl.SSLContext;
-import org.neo4j.driver.internal.RevocationStrategy;
+import org.neo4j.driver.RevocationCheckingStrategy;
 
 /**
  * A SecurityPlan consists of encryption and trust details.
@@ -31,5 +31,5 @@ public interface SecurityPlan {
 
     boolean requiresHostnameVerification();
 
-    RevocationStrategy revocationStrategy();
+    RevocationCheckingStrategy revocationCheckingStrategy();
 }

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -26,9 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.driver.internal.RevocationStrategy.NO_CHECKS;
-import static org.neo4j.driver.internal.RevocationStrategy.STRICT;
-import static org.neo4j.driver.internal.RevocationStrategy.VERIFY_IF_PRESENT;
 import static org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil.DEFAULT_FETCH_SIZE;
 
 import java.io.File;
@@ -44,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.logging.DevNullLogging;
 import org.neo4j.driver.internal.logging.JULogging;
@@ -279,19 +277,24 @@ class ConfigTest {
         assertFalse(trustStrategy.isHostnameVerificationEnabled());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldEnableAndDisableCertificateRevocationChecksOnTestStrategy() {
         Config.TrustStrategy trustStrategy = Config.TrustStrategy.trustSystemCertificates();
-        assertEquals(NO_CHECKS, trustStrategy.revocationStrategy());
+        assertEquals(RevocationCheckingStrategy.NO_CHECKS, trustStrategy.revocationCheckingStrategy());
+        assertEquals(RevocationStrategy.NO_CHECKS, trustStrategy.revocationStrategy());
 
         assertSame(trustStrategy, trustStrategy.withoutCertificateRevocationChecks());
-        assertEquals(NO_CHECKS, trustStrategy.revocationStrategy());
+        assertEquals(RevocationCheckingStrategy.NO_CHECKS, trustStrategy.revocationCheckingStrategy());
+        assertEquals(RevocationStrategy.NO_CHECKS, trustStrategy.revocationStrategy());
 
         assertSame(trustStrategy, trustStrategy.withStrictRevocationChecks());
-        assertEquals(STRICT, trustStrategy.revocationStrategy());
+        assertEquals(RevocationCheckingStrategy.STRICT, trustStrategy.revocationCheckingStrategy());
+        assertEquals(RevocationStrategy.STRICT, trustStrategy.revocationStrategy());
 
         assertSame(trustStrategy, trustStrategy.withVerifyIfPresentRevocationChecks());
-        assertEquals(VERIFY_IF_PRESENT, trustStrategy.revocationStrategy());
+        assertEquals(RevocationCheckingStrategy.VERIFY_IF_PRESENT, trustStrategy.revocationCheckingStrategy());
+        assertEquals(RevocationStrategy.VERIFY_IF_PRESENT, trustStrategy.revocationStrategy());
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -49,12 +49,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.RevocationCheckingStrategy;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
-import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
 import org.neo4j.driver.internal.async.connection.ChannelConnectorImpl;
@@ -222,6 +222,6 @@ class ChannelConnectorImplIT {
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException {
-        return SecurityPlanImpl.forAllCertificates(false, RevocationStrategy.NO_CHECKS);
+        return SecurityPlanImpl.forAllCertificates(false, RevocationCheckingStrategy.NO_CHECKS);
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SecuritySettingsTest.java
@@ -22,9 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.neo4j.driver.internal.RevocationStrategy.NO_CHECKS;
-import static org.neo4j.driver.internal.RevocationStrategy.STRICT;
-import static org.neo4j.driver.internal.RevocationStrategy.VERIFY_IF_PRESENT;
+import static org.neo4j.driver.RevocationCheckingStrategy.NO_CHECKS;
+import static org.neo4j.driver.RevocationCheckingStrategy.STRICT;
+import static org.neo4j.driver.RevocationCheckingStrategy.VERIFY_IF_PRESENT;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,7 +77,7 @@ class SecuritySettingsTest {
 
         assertTrue(securityPlan.requiresEncryption());
         assertTrue(securityPlan.requiresHostnameVerification());
-        assertEquals(NO_CHECKS, securityPlan.revocationStrategy());
+        assertEquals(NO_CHECKS, securityPlan.revocationCheckingStrategy());
     }
 
     @ParameterizedTest
@@ -178,7 +178,7 @@ class SecuritySettingsTest {
 
         SecurityPlan securityPlan = securitySettings.createSecurityPlan(scheme);
 
-        assertEquals(STRICT, securityPlan.revocationStrategy());
+        assertEquals(STRICT, securityPlan.revocationCheckingStrategy());
     }
 
     @ParameterizedTest
@@ -192,7 +192,7 @@ class SecuritySettingsTest {
 
         SecurityPlan securityPlan = securitySettings.createSecurityPlan(scheme);
 
-        assertEquals(VERIFY_IF_PRESENT, securityPlan.revocationStrategy());
+        assertEquals(VERIFY_IF_PRESENT, securityPlan.revocationCheckingStrategy());
     }
 
     @ParameterizedTest
@@ -205,7 +205,7 @@ class SecuritySettingsTest {
 
         SecurityPlan securityPlan = securitySettings.createSecurityPlan(scheme);
 
-        assertEquals(NO_CHECKS, securityPlan.revocationStrategy());
+        assertEquals(NO_CHECKS, securityPlan.revocationCheckingStrategy());
     }
 
     @Nested

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/NettyChannelInitializerTest.java
@@ -43,8 +43,8 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.RevocationCheckingStrategy;
 import org.neo4j.driver.internal.BoltServerAddress;
-import org.neo4j.driver.internal.RevocationStrategy;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.security.SecurityPlanImpl;
 import org.neo4j.driver.internal.util.Clock;
@@ -134,7 +134,7 @@ class NettyChannelInitializerTest {
 
     private void testHostnameVerificationSetting(boolean enabled, String expectedValue) throws Exception {
         NettyChannelInitializer initializer =
-                newInitializer(SecurityPlanImpl.forAllCertificates(enabled, RevocationStrategy.NO_CHECKS));
+                newInitializer(SecurityPlanImpl.forAllCertificates(enabled, RevocationCheckingStrategy.NO_CHECKS));
 
         initializer.initChannel(channel);
 
@@ -158,6 +158,6 @@ class NettyChannelInitializerTest {
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException {
-        return SecurityPlanImpl.forAllCertificates(false, RevocationStrategy.NO_CHECKS);
+        return SecurityPlanImpl.forAllCertificates(false, RevocationCheckingStrategy.NO_CHECKS);
     }
 }


### PR DESCRIPTION
The `RevocationStrategy` is an internal type, it has been superseded by `RevocationCheckingStrategy`.