### PR TITLE
Turn off hostname verification for trustAllCertificates TrustStrategy

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -790,12 +790,14 @@ public final class Config implements Serializable {
 
         /**
          * Trust strategy for certificates that trust all certificates blindly. Suggested to only use this in tests.
+         * <p>
+         * This trust strategy comes with hostname verification turned off by default since driver version 5.0.
          *
          * @return an authentication config
          * @since 1.1
          */
         public static TrustStrategy trustAllCertificates() {
-            return new TrustStrategy(Strategy.TRUST_ALL_CERTIFICATES);
+            return new TrustStrategy(Strategy.TRUST_ALL_CERTIFICATES).withoutHostnameVerification();
         }
 
         /**

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -62,13 +62,7 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.test_partial_summary_contains_updates$", "Does not contain updates because value is zero");
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.test_supports_multi_db$", "Database is None");
-        String skipMessage =
-                "This test expects hostname verification to be turned off when all certificates are trusted";
-        COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*\\.TestTrustAllCertsConfig\\.test_trusted_ca_wrong_hostname$", skipMessage);
-        COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*\\.TestTrustAllCertsConfig\\.test_untrusted_ca_wrong_hostname$", skipMessage);
-        skipMessage = "Driver handles connection acquisition timeout differently";
+        var skipMessage = "Driver handles connection acquisition timeout differently";
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestConnectionAcquisitionTimeoutMs\\.test_should_encompass_the_handshake_time.*$", skipMessage);
         COMMON_SKIP_PATTERN_TO_REASON.put(


### PR DESCRIPTION
`Config.TrustStrategy.trustAllCertificates()` should return `TrustStrategy` with hostname verification turned off by default.

This update is part of behaviour unification among the official drivers.