### PR TITLE
Add support for transaction type

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -123,10 +123,19 @@ public class NetworkSession {
     }
 
     public CompletionStage<UnmanagedTransaction> beginTransactionAsync(TransactionConfig config) {
-        return this.beginTransactionAsync(mode, config);
+        return beginTransactionAsync(mode, config, null);
+    }
+
+    public CompletionStage<UnmanagedTransaction> beginTransactionAsync(TransactionConfig config, String txType) {
+        return this.beginTransactionAsync(mode, config, txType);
     }
 
     public CompletionStage<UnmanagedTransaction> beginTransactionAsync(AccessMode mode, TransactionConfig config) {
+        return beginTransactionAsync(mode, config, null);
+    }
+
+    public CompletionStage<UnmanagedTransaction> beginTransactionAsync(
+            AccessMode mode, TransactionConfig config, String txType) {
         ensureSessionIsOpen();
 
         // create a chain that acquires connection and starts a transaction
@@ -136,7 +145,7 @@ public class NetworkSession {
                         ImpersonationUtil.ensureImpersonationSupport(connection, connection.impersonatedUser()))
                 .thenCompose(connection -> {
                     UnmanagedTransaction tx = new UnmanagedTransaction(connection, this::handleNewBookmark, fetchSize);
-                    return tx.beginAsync(determineBookmarks(false), config);
+                    return tx.beginAsync(determineBookmarks(false), config, txType);
                 });
 
         // update the reference to the only known transaction

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -110,20 +110,22 @@ public class UnmanagedTransaction {
         this.fetchSize = fetchSize;
     }
 
-    public CompletionStage<UnmanagedTransaction> beginAsync(Set<Bookmark> initialBookmarks, TransactionConfig config) {
-        return protocol.beginTransaction(connection, initialBookmarks, config).handle((ignore, beginError) -> {
-            if (beginError != null) {
-                if (beginError instanceof AuthorizationExpiredException) {
-                    connection.terminateAndRelease(AuthorizationExpiredException.DESCRIPTION);
-                } else if (beginError instanceof ConnectionReadTimeoutException) {
-                    connection.terminateAndRelease(beginError.getMessage());
-                } else {
-                    connection.release();
-                }
-                throw asCompletionException(beginError);
-            }
-            return this;
-        });
+    public CompletionStage<UnmanagedTransaction> beginAsync(
+            Set<Bookmark> initialBookmarks, TransactionConfig config, String txType) {
+        return protocol.beginTransaction(connection, initialBookmarks, config, txType)
+                .handle((ignore, beginError) -> {
+                    if (beginError != null) {
+                        if (beginError instanceof AuthorizationExpiredException) {
+                            connection.terminateAndRelease(AuthorizationExpiredException.DESCRIPTION);
+                        } else if (beginError instanceof ConnectionReadTimeoutException) {
+                            connection.terminateAndRelease(beginError.getMessage());
+                        } else {
+                            connection.release();
+                        }
+                        throw asCompletionException(beginError);
+                    }
+                    return this;
+                });
     }
 
     public CompletionStage<Void> closeAsync() {

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -79,9 +79,11 @@ public interface BoltProtocol {
      * @param connection the connection to use.
      * @param bookmarks  the bookmarks. Never null, should be empty when there are no bookmarks.
      * @param config     the transaction configuration. Never null, should be {@link TransactionConfig#empty()} when absent.
+     * @param txType the Kernel transaction type
      * @return a completion stage completed when transaction is started or completed exceptionally when there was a failure.
      */
-    CompletionStage<Void> beginTransaction(Connection connection, Set<Bookmark> bookmarks, TransactionConfig config);
+    CompletionStage<Void> beginTransaction(
+            Connection connection, Set<Bookmark> bookmarks, TransactionConfig config, String txType);
 
     /**
      * Commit the unmanaged transaction.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -38,8 +38,9 @@ public class BeginMessage extends MessageWithMetadata {
             TransactionConfig config,
             DatabaseName databaseName,
             AccessMode mode,
-            String impersonatedUser) {
-        this(bookmarks, config.timeout(), config.metadata(), mode, databaseName, impersonatedUser);
+            String impersonatedUser,
+            String txType) {
+        this(bookmarks, config.timeout(), config.metadata(), mode, databaseName, impersonatedUser, txType);
     }
 
     public BeginMessage(
@@ -48,8 +49,9 @@ public class BeginMessage extends MessageWithMetadata {
             Map<String, Value> txMetadata,
             AccessMode mode,
             DatabaseName databaseName,
-            String impersonatedUser) {
-        super(buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser));
+            String impersonatedUser,
+            String txType) {
+        super(buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, txType));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -59,7 +59,7 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             Set<Bookmark> bookmarks,
             String impersonatedUser) {
         Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser);
+                buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, null);
         return new RunWithMetadataMessage(query.text(), query.parameters().asMap(ofValue()), metadata);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
@@ -39,14 +39,16 @@ public class TransactionMetadataBuilder {
     private static final String MODE_KEY = "mode";
     private static final String MODE_READ_VALUE = "r";
     private static final String IMPERSONATED_USER_KEY = "imp_user";
+    private static final String TX_TYPE_KEY = "tx_type";
 
     public static Map<String, Value> buildMetadata(
             Duration txTimeout,
             Map<String, Value> txMetadata,
             AccessMode mode,
             Set<Bookmark> bookmarks,
-            String impersonatedUser) {
-        return buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, impersonatedUser);
+            String impersonatedUser,
+            String txType) {
+        return buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, impersonatedUser, txType);
     }
 
     public static Map<String, Value> buildMetadata(
@@ -55,20 +57,23 @@ public class TransactionMetadataBuilder {
             DatabaseName databaseName,
             AccessMode mode,
             Set<Bookmark> bookmarks,
-            String impersonatedUser) {
+            String impersonatedUser,
+            String txType) {
         boolean bookmarksPresent = !bookmarks.isEmpty();
         boolean txTimeoutPresent = txTimeout != null;
         boolean txMetadataPresent = txMetadata != null && !txMetadata.isEmpty();
         boolean accessModePresent = mode == AccessMode.READ;
         boolean databaseNamePresent = databaseName.databaseName().isPresent();
         boolean impersonatedUserPresent = impersonatedUser != null;
+        boolean txTypePresent = txType != null;
 
         if (!bookmarksPresent
                 && !txTimeoutPresent
                 && !txMetadataPresent
                 && !accessModePresent
                 && !databaseNamePresent
-                && !impersonatedUserPresent) {
+                && !impersonatedUserPresent
+                && !txTypePresent) {
             return emptyMap();
         }
 
@@ -88,6 +93,9 @@ public class TransactionMetadataBuilder {
         }
         if (impersonatedUserPresent) {
             result.put(IMPERSONATED_USER_KEY, value(impersonatedUser));
+        }
+        if (txTypePresent) {
+            result.put(TX_TYPE_KEY, value(txType));
         }
 
         databaseName.databaseName().ifPresent(name -> result.put(DATABASE_NAME_KEY, value(name)));

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -113,7 +113,7 @@ public class BoltProtocolV3 implements BoltProtocol {
 
     @Override
     public CompletionStage<Void> beginTransaction(
-            Connection connection, Set<Bookmark> bookmarks, TransactionConfig config) {
+            Connection connection, Set<Bookmark> bookmarks, TransactionConfig config, String txType) {
         try {
             verifyDatabaseNameBeforeTransaction(connection.databaseName());
         } catch (Exception error) {
@@ -122,7 +122,7 @@ public class BoltProtocolV3 implements BoltProtocol {
 
         CompletableFuture<Void> beginTxFuture = new CompletableFuture<>();
         BeginMessage beginMessage = new BeginMessage(
-                bookmarks, config, connection.databaseName(), connection.mode(), connection.impersonatedUser());
+                bookmarks, config, connection.databaseName(), connection.mode(), connection.impersonatedUser(), txType);
         connection.writeAndFlush(beginMessage, new BeginTxResponseHandler(beginTxFuture));
         return beginTxFuture;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveSession.java
@@ -50,10 +50,14 @@ abstract class AbstractReactiveSession<S> {
     abstract Publisher<Void> closeTransaction(S transaction, boolean commit);
 
     Publisher<S> doBeginTransaction(TransactionConfig config) {
+        return doBeginTransaction(config, null);
+    }
+
+    Publisher<S> doBeginTransaction(TransactionConfig config, String txType) {
         return createSingleItemPublisher(
                 () -> {
                     CompletableFuture<S> txFuture = new CompletableFuture<>();
-                    session.beginTransactionAsync(config).whenComplete((tx, completionError) -> {
+                    session.beginTransactionAsync(config, txType).whenComplete((tx, completionError) -> {
                         if (tx != null) {
                             txFuture.complete(createTransaction(tx));
                         } else {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalReactiveSession.java
@@ -57,7 +57,11 @@ public class InternalReactiveSession extends AbstractReactiveSession<ReactiveTra
 
     @Override
     public Publisher<ReactiveTransaction> beginTransaction(TransactionConfig config) {
-        return publisherToFlowPublisher(doBeginTransaction(config));
+        return beginTransaction(config, null);
+    }
+
+    public Publisher<ReactiveTransaction> beginTransaction(TransactionConfig config, String txType) {
+        return publisherToFlowPublisher(doBeginTransaction(config, txType));
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/InternalReactiveSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/InternalReactiveSessionIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration.reactive;
+
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
+import static reactor.adapter.JdkFlowAdapter.flowPublisherToFlux;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.TransactionConfig;
+import org.neo4j.driver.internal.reactive.InternalReactiveSession;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.reactive.ReactiveTransaction;
+import org.neo4j.driver.summary.ResultSummary;
+import org.neo4j.driver.testutil.DatabaseExtension;
+import org.neo4j.driver.testutil.ParallelizableIT;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@EnabledOnNeo4jWith(BOLT_V4)
+@ParallelizableIT
+class InternalReactiveSessionIT {
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    private InternalReactiveSession session;
+
+    @BeforeEach
+    void setUp() {
+        session = (InternalReactiveSession) neo4j.driver().reactiveSession();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"IMPLICIT", ""})
+    void shouldAcceptTxTypeWhenAvailable(String txType) {
+        // GIVEN
+        var txConfig = TransactionConfig.empty();
+        var txMono = Mono.fromDirect(flowPublisherToFlux(session.beginTransaction(txConfig, txType)));
+        Function<ReactiveTransaction, Mono<ResultSummary>> txUnit =
+                tx -> Mono.fromDirect(flowPublisherToFlux(tx.run("RETURN 1")))
+                        .flatMap(result -> Mono.fromDirect(flowPublisherToFlux(result.consume())));
+        Function<ReactiveTransaction, Mono<Void>> commit = tx -> Mono.fromDirect(flowPublisherToFlux(tx.commit()));
+
+        // WHEN
+        var summaryMono = Mono.usingWhen(txMono, txUnit, commit);
+
+        // THEN
+        StepVerifier.create(summaryMono).expectNextCount(1).expectComplete().verify();
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -177,7 +177,8 @@ class UnmanagedTransactionTest {
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         TransactionConfig txConfig = TransactionConfig.empty();
 
-        RuntimeException e = assertThrows(RuntimeException.class, () -> await(tx.beginAsync(bookmarks, txConfig)));
+        RuntimeException e =
+                assertThrows(RuntimeException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
 
         assertEquals(error, e);
         verify(connection).release();
@@ -191,7 +192,7 @@ class UnmanagedTransactionTest {
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         TransactionConfig txConfig = TransactionConfig.empty();
 
-        await(tx.beginAsync(bookmarks, txConfig));
+        await(tx.beginAsync(bookmarks, txConfig, null));
 
         verify(connection, never()).release();
     }
@@ -285,8 +286,8 @@ class UnmanagedTransactionTest {
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         TransactionConfig txConfig = TransactionConfig.empty();
 
-        AuthorizationExpiredException actualException =
-                assertThrows(AuthorizationExpiredException.class, () -> await(tx.beginAsync(bookmarks, txConfig)));
+        AuthorizationExpiredException actualException = assertThrows(
+                AuthorizationExpiredException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
 
         assertSame(exception, actualException);
         verify(connection).terminateAndRelease(AuthorizationExpiredException.DESCRIPTION);
@@ -301,8 +302,8 @@ class UnmanagedTransactionTest {
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         TransactionConfig txConfig = TransactionConfig.empty();
 
-        ConnectionReadTimeoutException actualException =
-                assertThrows(ConnectionReadTimeoutException.class, () -> await(tx.beginAsync(bookmarks, txConfig)));
+        ConnectionReadTimeoutException actualException = assertThrows(
+                ConnectionReadTimeoutException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
 
         assertSame(ConnectionReadTimeoutException.INSTANCE, actualException);
         verify(connection).terminateAndRelease(ConnectionReadTimeoutException.INSTANCE.getMessage());
@@ -461,7 +462,7 @@ class UnmanagedTransactionTest {
 
     private static UnmanagedTransaction beginTx(Connection connection, Set<Bookmark> initialBookmarks) {
         UnmanagedTransaction tx = new UnmanagedTransaction(connection, (ignored) -> {}, UNLIMITED_FETCH_SIZE);
-        return await(tx.beginAsync(initialBookmarks, TransactionConfig.empty()));
+        return await(tx.beginAsync(initialBookmarks, TransactionConfig.empty(), null));
     }
 
     private static Connection connectionWithBegin(Consumer<ResponseHandler> beginBehaviour) {

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
@@ -59,7 +59,8 @@ public class TransactionMetadataBuilderTest {
 
         Duration txTimeout = Duration.ofSeconds(7);
 
-        Map<String, Value> metadata = buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null);
+        Map<String, Value> metadata =
+                buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>();
         expectedMetadata.put(
@@ -87,7 +88,7 @@ public class TransactionMetadataBuilderTest {
         Duration txTimeout = Duration.ofSeconds(7);
 
         Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, database(databaseName), WRITE, bookmarks, null);
+                buildMetadata(txTimeout, txMetadata, database(databaseName), WRITE, bookmarks, null, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>();
         expectedMetadata.put(
@@ -101,7 +102,8 @@ public class TransactionMetadataBuilderTest {
 
     @Test
     void shouldNotHaveMetadataForDatabaseNameWhenIsNull() {
-        Map<String, Value> metadata = buildMetadata(null, null, defaultDatabase(), WRITE, Collections.emptySet(), null);
+        Map<String, Value> metadata =
+                buildMetadata(null, null, defaultDatabase(), WRITE, Collections.emptySet(), null, null);
         assertTrue(metadata.isEmpty());
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -184,12 +184,17 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -199,11 +204,12 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -212,11 +218,11 @@ public class BoltProtocolV3Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -226,11 +232,11 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -336,7 +342,7 @@ public class BoltProtocolV3Test {
     @Test
     void shouldNotSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         ClientException e = assertThrows(ClientException.class, () -> await(txStage));
         assertThat(e.getMessage(), startsWith("Database name parameter for selecting database is not supported"));
@@ -370,7 +376,7 @@ public class BoltProtocolV3Test {
                             UNLIMITED_FETCH_SIZE));
         } else {
             CompletionStage<Void> txStage = protocol.beginTransaction(
-                    connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                    connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
             e = assertThrows(ClientException.class, () -> await(txStage));
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -108,6 +108,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -115,6 +116,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         defaultDatabase(),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -179,12 +179,17 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -194,11 +199,12 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -207,11 +213,11 @@ public final class BoltProtocolV4Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -221,11 +227,11 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -331,7 +337,7 @@ public final class BoltProtocolV4Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -489,7 +495,7 @@ public final class BoltProtocolV4Test {
             await(resultStage);
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -531,7 +537,7 @@ public final class BoltProtocolV4Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -116,6 +116,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -123,6 +124,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -183,12 +183,17 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -198,11 +203,12 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -211,11 +217,11 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -225,11 +231,11 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -335,7 +341,7 @@ public final class BoltProtocolV41Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -484,7 +490,7 @@ public final class BoltProtocolV41Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -526,7 +532,7 @@ public final class BoltProtocolV41Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -115,6 +115,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -122,6 +123,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -183,12 +183,17 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -198,11 +203,12 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -211,11 +217,11 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -225,11 +231,11 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -335,7 +341,7 @@ public final class BoltProtocolV42Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -485,7 +491,7 @@ public final class BoltProtocolV42Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -527,7 +533,7 @@ public final class BoltProtocolV42Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -115,6 +115,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -122,6 +123,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
@@ -182,12 +182,17 @@ public final class BoltProtocolV43Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -197,11 +202,12 @@ public final class BoltProtocolV43Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -210,11 +216,11 @@ public final class BoltProtocolV43Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -224,11 +230,11 @@ public final class BoltProtocolV43Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -334,7 +340,7 @@ public final class BoltProtocolV43Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -487,7 +493,7 @@ public final class BoltProtocolV43Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -529,7 +535,7 @@ public final class BoltProtocolV43Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -120,6 +120,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -127,6 +128,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
@@ -182,12 +182,17 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -197,11 +202,12 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -210,11 +216,11 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -224,11 +230,11 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -334,7 +340,7 @@ public class BoltProtocolV44Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -485,7 +491,7 @@ public class BoltProtocolV44Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -527,7 +533,7 @@ public class BoltProtocolV44Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -120,6 +120,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -127,6 +128,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
@@ -182,12 +182,17 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                Collections.emptySet(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -197,11 +202,12 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -210,11 +216,11 @@ public class BoltProtocolV5Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -224,11 +230,11 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -334,7 +340,7 @@ public class BoltProtocolV5Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty());
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -485,7 +491,7 @@ public class BoltProtocolV5Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty());
+                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -527,7 +533,7 @@ public class BoltProtocolV5Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
@@ -120,6 +120,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -127,6 +128,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null),
                 COMMIT,
                 ROLLBACK,

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveSessionTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -138,7 +139,8 @@ public class InternalReactiveSessionTest {
         NetworkSession session = mock(NetworkSession.class);
         UnmanagedTransaction tx = mock(UnmanagedTransaction.class);
 
-        when(session.beginTransactionAsync(any(TransactionConfig.class))).thenReturn(completedFuture(tx));
+        when(session.beginTransactionAsync(any(TransactionConfig.class), isNull()))
+                .thenReturn(completedFuture(tx));
         InternalReactiveSession rxSession = new InternalReactiveSession(session);
 
         // When
@@ -146,7 +148,7 @@ public class InternalReactiveSessionTest {
         StepVerifier.create(Mono.from(rxTx)).expectNextCount(1).verifyComplete();
 
         // Then
-        verify(session).beginTransactionAsync(any(TransactionConfig.class));
+        verify(session).beginTransactionAsync(any(TransactionConfig.class), isNull());
     }
 
     @ParameterizedTest
@@ -157,7 +159,8 @@ public class InternalReactiveSessionTest {
         NetworkSession session = mock(NetworkSession.class);
 
         // Run failed with error
-        when(session.beginTransactionAsync(any(TransactionConfig.class))).thenReturn(Futures.failedFuture(error));
+        when(session.beginTransactionAsync(any(TransactionConfig.class), isNull()))
+                .thenReturn(Futures.failedFuture(error));
         when(session.releaseConnectionAsync()).thenReturn(Futures.completedWithNull());
 
         InternalReactiveSession rxSession = new InternalReactiveSession(session);
@@ -167,7 +170,7 @@ public class InternalReactiveSessionTest {
         CompletableFuture<ReactiveTransaction> txFuture = Mono.from(rxTx).toFuture();
 
         // Then
-        verify(session).beginTransactionAsync(any(TransactionConfig.class));
+        verify(session).beginTransactionAsync(any(TransactionConfig.class), isNull());
         RuntimeException t = assertThrows(CompletionException.class, () -> Futures.getNow(txFuture));
         MatcherAssert.assertThat(t.getCause(), equalTo(error));
         verify(session).releaseConnectionAsync();

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -147,7 +148,8 @@ class InternalRxSessionTest {
         NetworkSession session = mock(NetworkSession.class);
         UnmanagedTransaction tx = mock(UnmanagedTransaction.class);
 
-        when(session.beginTransactionAsync(any(TransactionConfig.class))).thenReturn(completedFuture(tx));
+        when(session.beginTransactionAsync(any(TransactionConfig.class), isNull()))
+                .thenReturn(completedFuture(tx));
         InternalRxSession rxSession = new InternalRxSession(session);
 
         // When
@@ -155,7 +157,7 @@ class InternalRxSessionTest {
         StepVerifier.create(Mono.from(rxTx)).expectNextCount(1).verifyComplete();
 
         // Then
-        verify(session).beginTransactionAsync(any(TransactionConfig.class));
+        verify(session).beginTransactionAsync(any(TransactionConfig.class), isNull());
     }
 
     @ParameterizedTest
@@ -166,7 +168,8 @@ class InternalRxSessionTest {
         NetworkSession session = mock(NetworkSession.class);
 
         // Run failed with error
-        when(session.beginTransactionAsync(any(TransactionConfig.class))).thenReturn(Futures.failedFuture(error));
+        when(session.beginTransactionAsync(any(TransactionConfig.class), isNull()))
+                .thenReturn(Futures.failedFuture(error));
         when(session.releaseConnectionAsync()).thenReturn(Futures.completedWithNull());
 
         InternalRxSession rxSession = new InternalRxSession(session);
@@ -176,7 +179,7 @@ class InternalRxSessionTest {
         CompletableFuture<RxTransaction> txFuture = Mono.from(rxTx).toFuture();
 
         // Then
-        verify(session).beginTransactionAsync(any(TransactionConfig.class));
+        verify(session).beginTransactionAsync(any(TransactionConfig.class), isNull());
         RuntimeException t = assertThrows(CompletionException.class, () -> Futures.getNow(txFuture));
         assertThat(t.getCause(), equalTo(error));
         verify(session).releaseConnectionAsync();


### PR DESCRIPTION
This is an internal feature only that allows specifying transaction type on reactive session begin method.