### PR TITLE
Introduce new Reactive Streams session

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -397,4 +397,16 @@
         <method>org.neo4j.driver.types.TypeSystem getDefault()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Driver</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.BaseReactiveSession reactiveSession(java.lang.Class)</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Driver</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.BaseReactiveSession reactiveSession(java.lang.Class, org.neo4j.driver.SessionConfig)</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/module-info.java
+++ b/driver/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module org.neo4j.driver {
     exports org.neo4j.driver;
     exports org.neo4j.driver.async;
     exports org.neo4j.driver.reactive;
+    exports org.neo4j.driver.reactivestreams;
     exports org.neo4j.driver.types;
     exports org.neo4j.driver.summary;
     exports org.neo4j.driver.net;

--- a/driver/src/main/java/org/neo4j/driver/BaseReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/BaseReactiveSession.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver;
+
+/**
+ * A base interface for reactive sessions, used by {@link Driver#reactiveSession(Class)} and {@link Driver#reactiveSession(Class, SessionConfig)}.
+ */
+public interface BaseReactiveSession {}

--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -77,7 +77,9 @@ public interface Driver extends AutoCloseable {
      *
      * @return a new {@link Session} object.
      */
-    Session session();
+    default Session session() {
+        return session(SessionConfig.defaultConfig());
+    }
 
     /**
      * Create a new {@link Session} with a specified {@link SessionConfig session configuration}.
@@ -133,7 +135,41 @@ public interface Driver extends AutoCloseable {
      * @param sessionConfig used to customize the session.
      * @return a new {@link ReactiveSession} object.
      */
-    ReactiveSession reactiveSession(SessionConfig sessionConfig);
+    default ReactiveSession reactiveSession(SessionConfig sessionConfig) {
+        return reactiveSession(ReactiveSession.class, sessionConfig);
+    }
+
+    /**
+     * Create a new reactive session of supported type with default {@link SessionConfig session configuration}.
+     * <p>
+     * Supported types are:
+     * <ul>
+     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
+     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams API</li>
+     * </ul>
+     *
+     * @param sessionClass session type class
+     * @return session instance
+     * @param <T> session type
+     */
+    default <T extends BaseReactiveSession> T reactiveSession(Class<T> sessionClass) {
+        return reactiveSession(sessionClass, SessionConfig.defaultConfig());
+    }
+
+    /**
+     * Create a new reactive session of supported type with a specified {@link SessionConfig session configuration}.
+     * <p>
+     * Supported types are:
+     * <ul>
+     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
+     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams API</li>
+     * </ul>
+     *
+     * @param sessionClass session type class
+     * @return session instance
+     * @param <T> session type
+     */
+    <T extends BaseReactiveSession> T reactiveSession(Class<T> sessionClass, SessionConfig sessionConfig);
 
     /**
      * Create a new general purpose {@link AsyncSession} with default {@link SessionConfig session configuration}. The {@link AsyncSession} provides an
@@ -143,7 +179,9 @@ public interface Driver extends AutoCloseable {
      *
      * @return a new {@link AsyncSession} object.
      */
-    AsyncSession asyncSession();
+    default AsyncSession asyncSession() {
+        return asyncSession(SessionConfig.defaultConfig());
+    }
 
     /**
      * Create a new {@link AsyncSession} with a specified {@link SessionConfig session configuration}.

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveSession.java
@@ -34,7 +34,7 @@ import org.neo4j.driver.internal.util.Futures;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
-abstract class AbstractReactiveSession<S> {
+public abstract class AbstractReactiveSession<S> {
     protected final NetworkSession session;
 
     public AbstractReactiveSession(NetworkSession session) {
@@ -45,15 +45,15 @@ abstract class AbstractReactiveSession<S> {
         this.session = session;
     }
 
-    abstract S createTransaction(UnmanagedTransaction unmanagedTransaction);
+    protected abstract S createTransaction(UnmanagedTransaction unmanagedTransaction);
 
-    abstract Publisher<Void> closeTransaction(S transaction, boolean commit);
+    protected abstract Publisher<Void> closeTransaction(S transaction, boolean commit);
 
     Publisher<S> doBeginTransaction(TransactionConfig config) {
         return doBeginTransaction(config, null);
     }
 
-    Publisher<S> doBeginTransaction(TransactionConfig config, String txType) {
+    protected Publisher<S> doBeginTransaction(TransactionConfig config, String txType) {
         return createSingleItemPublisher(
                 () -> {
                     CompletableFuture<S> txFuture = new CompletableFuture<>();
@@ -87,7 +87,7 @@ abstract class AbstractReactiveSession<S> {
                         "Unexpected condition, begin transaction call has completed successfully with transaction being null"));
     }
 
-    <T> Publisher<T> runTransaction(
+    protected <T> Publisher<T> runTransaction(
             AccessMode mode, Function<S, ? extends Publisher<T>> work, TransactionConfig config) {
         Flux<T> repeatableWork = Flux.usingWhen(
                 beginTransaction(mode, config),
@@ -119,7 +119,7 @@ abstract class AbstractReactiveSession<S> {
         return session.lastBookmarks();
     }
 
-    <T> Publisher<T> doClose() {
+    protected <T> Publisher<T> doClose() {
         return createEmptyPublisher(session::closeAsync);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/AbstractReactiveTransaction.java
@@ -24,30 +24,30 @@ import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
-abstract class AbstractReactiveTransaction {
+public abstract class AbstractReactiveTransaction {
     protected final UnmanagedTransaction tx;
 
     protected AbstractReactiveTransaction(UnmanagedTransaction tx) {
         this.tx = tx;
     }
 
-    <T> Publisher<T> doCommit() {
+    protected <T> Publisher<T> doCommit() {
         return createEmptyPublisher(tx::commitAsync);
     }
 
-    <T> Publisher<T> doRollback() {
+    protected <T> Publisher<T> doRollback() {
         return createEmptyPublisher(tx::rollbackAsync);
     }
 
-    Publisher<Void> doClose() {
+    protected Publisher<Void> doClose() {
         return close(false);
     }
 
-    Publisher<Boolean> doIsOpen() {
+    protected Publisher<Boolean> doIsOpen() {
         return Mono.just(tx.isOpen());
     }
 
-    Publisher<Void> close(boolean commit) {
+    public Publisher<Void> close(boolean commit) {
         return createEmptyPublisher(() -> tx.closeAsync(commit));
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
@@ -43,12 +43,12 @@ public class InternalRxSession extends AbstractReactiveSession<RxTransaction> im
     }
 
     @Override
-    RxTransaction createTransaction(UnmanagedTransaction unmanagedTransaction) {
+    protected RxTransaction createTransaction(UnmanagedTransaction unmanagedTransaction) {
         return new InternalRxTransaction(unmanagedTransaction);
     }
 
     @Override
-    Publisher<Void> closeTransaction(RxTransaction transaction, boolean commit) {
+    protected Publisher<Void> closeTransaction(RxTransaction transaction, boolean commit) {
         return ((InternalRxTransaction) transaction).close(commit);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/BaseReactiveQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/BaseReactiveQueryRunner.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.reactivestreams;
+
+import java.util.Map;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.util.Extract;
+import org.neo4j.driver.internal.value.MapValue;
+import org.neo4j.driver.reactivestreams.ReactiveQueryRunner;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+interface BaseReactiveQueryRunner extends ReactiveQueryRunner {
+    @Override
+    default Publisher<ReactiveResult> run(String queryStr, Value parameters) {
+        try {
+            Query query = new Query(queryStr, parameters);
+            return run(query);
+        } catch (Throwable t) {
+            return Mono.error(t);
+        }
+    }
+
+    @Override
+    default Publisher<ReactiveResult> run(String query, Map<String, Object> parameters) {
+        return run(query, parameters(parameters));
+    }
+
+    @Override
+    default Publisher<ReactiveResult> run(String query, Record parameters) {
+        return run(query, parameters(parameters));
+    }
+
+    @Override
+    default Publisher<ReactiveResult> run(String queryStr) {
+        try {
+            Query query = new Query(queryStr);
+            return run(query);
+        } catch (Throwable t) {
+            return Mono.error(t);
+        }
+    }
+
+    static Value parameters(Record record) {
+        return record == null ? Values.EmptyMap : parameters(record.asMap());
+    }
+
+    static Value parameters(Map<String, Object> map) {
+        if (map == null || map.isEmpty()) {
+            return Values.EmptyMap;
+        }
+        return new MapValue(Extract.mapOfValues(map));
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/DelegatingReactiveTransactionContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/DelegatingReactiveTransactionContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.reactivestreams;
+
+import java.util.Map;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.neo4j.driver.reactivestreams.ReactiveTransaction;
+import org.neo4j.driver.reactivestreams.ReactiveTransactionContext;
+import org.reactivestreams.Publisher;
+
+public final class DelegatingReactiveTransactionContext implements ReactiveTransactionContext {
+    private final ReactiveTransaction delegate;
+
+    public DelegatingReactiveTransactionContext(ReactiveTransaction delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Value parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Map<String, Object> parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Record parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query) {
+        return delegate.run(query);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(Query query) {
+        return delegate.run(query);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveResult.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveResult.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.reactivestreams;
+
+import static org.neo4j.driver.internal.util.ErrorUtil.newResultConsumedError;
+import static reactor.core.publisher.FluxSink.OverflowStrategy.IGNORE;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
+import org.neo4j.driver.internal.util.Futures;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.neo4j.driver.summary.ResultSummary;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+public class InternalReactiveResult implements ReactiveResult {
+    private final RxResultCursor cursor;
+
+    public InternalReactiveResult(RxResultCursor cursor) {
+        this.cursor = cursor;
+    }
+
+    @Override
+    public List<String> keys() {
+        return cursor.keys();
+    }
+
+    @Override
+    public Publisher<Record> records() {
+        return Flux.create(
+                sink -> {
+                    if (cursor.isDone()) {
+                        sink.error(newResultConsumedError());
+                    } else {
+                        cursor.installRecordConsumer(createRecordConsumer(sink));
+                        sink.onCancel(cursor::cancel);
+                        sink.onRequest(cursor::request);
+                    }
+                },
+                IGNORE);
+    }
+
+    @Override
+    public Publisher<ResultSummary> consume() {
+        return Mono.create(sink -> cursor.summaryAsync().whenComplete((summary, summaryCompletionError) -> {
+            Throwable error = Futures.completionExceptionCause(summaryCompletionError);
+            if (summary != null) {
+                sink.success(summary);
+            } else {
+                sink.error(error);
+            }
+        }));
+    }
+
+    @Override
+    public Publisher<Boolean> isOpen() {
+        return Mono.just(!cursor.isDone());
+    }
+
+    /**
+     * Defines how a subscriber shall consume records. A record consumer holds a reference to a subscriber. A publisher and/or a subscription who holds a
+     * reference to this consumer shall release the reference to this object after subscription is done or cancelled so that the subscriber can be garbage
+     * collected.
+     *
+     * @param sink the subscriber
+     * @return a record consumer.
+     */
+    private BiConsumer<Record, Throwable> createRecordConsumer(FluxSink<Record> sink) {
+        return (r, e) -> {
+            if (r != null) {
+                sink.next(r);
+            } else if (e != null) {
+                sink.error(e);
+            } else {
+                sink.complete();
+            }
+        };
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveTransaction.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.reactivestreams;
+
+import java.util.concurrent.CompletionStage;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.internal.async.UnmanagedTransaction;
+import org.neo4j.driver.internal.cursor.RxResultCursor;
+import org.neo4j.driver.internal.reactive.AbstractReactiveTransaction;
+import org.neo4j.driver.internal.util.Futures;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.neo4j.driver.reactivestreams.ReactiveTransaction;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+public class InternalReactiveTransaction extends AbstractReactiveTransaction
+        implements ReactiveTransaction, BaseReactiveQueryRunner {
+    protected InternalReactiveTransaction(UnmanagedTransaction tx) {
+        super(tx);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(Query query) {
+        CompletionStage<RxResultCursor> cursorStage;
+        try {
+            cursorStage = tx.runRx(query);
+        } catch (Throwable t) {
+            cursorStage = Futures.failedFuture(t);
+        }
+
+        return Mono.fromCompletionStage(cursorStage)
+                .flatMap(cursor -> {
+                    Mono<RxResultCursor> publisher;
+                    Throwable runError = cursor.getRunError();
+                    if (runError != null) {
+                        publisher = Mono.error(runError);
+                        tx.markTerminated(runError);
+                    } else {
+                        publisher = Mono.just(cursor);
+                    }
+                    return publisher;
+                })
+                .map(InternalReactiveResult::new);
+    }
+
+    /**
+     * Marks transaction as terminated and sends {@code RESET} message over allocated connection.
+     * <p>
+     * <b>THIS METHOD IS NOT PART OF PUBLIC API. This method may be changed or removed at any moment in time.</b>
+     *
+     * @return {@code RESET} response publisher
+     */
+    public Publisher<Void> interrupt() {
+        return Mono.fromCompletionStage(tx.interruptAsync());
+    }
+
+    @Override
+    public <T> Publisher<T> commit() {
+        return doCommit();
+    }
+
+    @Override
+    public <T> Publisher<T> rollback() {
+        return doRollback();
+    }
+
+    @Override
+    public Publisher<Void> close() {
+        return doClose();
+    }
+
+    @Override
+    public Publisher<Boolean> isOpen() {
+        return doIsOpen();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxQueryRunner.java
@@ -31,7 +31,7 @@ import org.neo4j.driver.internal.value.MapValue;
  * @see RxSession
  * @see RxTransaction
  * @since 4.0
- * @deprecated superseded by {@link ReactiveQueryRunner}
+ * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveQueryRunner} and {@link org.neo4j.driver.reactivestreams.ReactiveQueryRunner}
  */
 @Deprecated
 public interface RxQueryRunner {

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxResult.java
@@ -38,7 +38,7 @@ import org.reactivestreams.Subscription;
  * @see Subscriber
  * @see Subscription
  * @since 4.0
- * @deprecated superseded by {@link ReactiveResult}
+ * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveResult} and {@link org.neo4j.driver.reactivestreams.ReactiveResult}
  */
 @Deprecated
 public interface RxResult {

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
@@ -35,7 +35,7 @@ import org.reactivestreams.Publisher;
  * @see RxTransaction
  * @see Publisher
  * @since 4.0
- * @deprecated superseded by {@link ReactiveSession}
+ * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveSession} and {@link org.neo4j.driver.reactivestreams.ReactiveSession}
  */
 @Deprecated
 public interface RxSession extends RxQueryRunner {

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxTransactionWork.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxTransactionWork.java
@@ -24,7 +24,7 @@ package org.neo4j.driver.reactive;
  *
  * @param <T> the return type of this work
  * @since 4.0
- * @deprecated superseded by {@link ReactiveTransactionCallback}
+ * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveTransactionCallback} and {@link org.neo4j.driver.reactivestreams.ReactiveTransactionCallback}
  */
 @Deprecated
 public interface RxTransactionWork<T> {

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveQueryRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveQueryRunner.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.reactivestreams;
+
+import java.util.Map;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.reactivestreams.Publisher;
+
+/**
+ * Common interface for components that can execute Neo4j queries using Reactive API.
+ *
+ * @see ReactiveSession
+ * @see ReactiveTransaction
+ * @since 5.2
+ */
+public interface ReactiveQueryRunner {
+    /**
+     * Register running of a query and return a publisher of {@link ReactiveResult}.
+     * <p>
+     * Invoking this method will result in a Bolt RUN message exchange with server and the returned publisher will either emit an instance of {@link
+     * ReactiveResult} on success or an error otherwise.
+     * <p>
+     * This method takes a set of parameters that will be injected into the query by Neo4j. Using parameters is highly encouraged, it helps avoid dangerous
+     * cypher injection attacks and improves database performance as Neo4j can re-use query plans more often.
+     * <p>
+     * This particular method takes a {@link Value} as its input. This is useful if you want to take a map-like value that you've gotten from a prior result and
+     * send it back as parameters.
+     * <p>
+     * If you are creating parameters programmatically, {@link #run(String, Map)} might be more helpful, it converts your map to a {@link Value} for you.
+     *
+     * @param query      text of a Neo4j query
+     * @param parameters input parameters, should be a map Value, see {@link Values#parameters(Object...)}.
+     * @return a publisher of reactive result.
+     */
+    Publisher<ReactiveResult> run(String query, Value parameters);
+
+    /**
+     * Register running of a query and return a publisher of {@link ReactiveResult}.
+     * <p>
+     * Invoking this method will result in a Bolt RUN message exchange with server and the returned publisher will either emit an instance of {@link
+     * ReactiveResult} on success or an error otherwise.
+     * <p>
+     * This method takes a set of parameters that will be injected into the query by Neo4j. Using parameters is highly encouraged, it helps avoid dangerous
+     * cypher injection attacks and improves database performance as Neo4j can re-use query plans more often.
+     * <p>
+     * This version of run takes a {@link Map} of parameters. The values in the map must be values that can be converted to Neo4j types. See {@link
+     * Values#parameters(Object...)} for a list of allowed types.
+     *
+     * @param query      text of a Neo4j query
+     * @param parameters input data for the query
+     * @return a publisher of reactive result.
+     */
+    Publisher<ReactiveResult> run(String query, Map<String, Object> parameters);
+
+    /**
+     * Register running of a query and return a publisher of {@link ReactiveResult}.
+     * <p>
+     * Invoking this method will result in a Bolt RUN message exchange with server and the returned publisher will either emit an instance of {@link
+     * ReactiveResult} on success or an error otherwise.
+     * <p>
+     * This method takes a set of parameters that will be injected into the query by Neo4j. Using parameters is highly encouraged, it helps avoid dangerous
+     * cypher injection attacks and improves database performance as Neo4j can re-use query plans more often.
+     * <p>
+     * This version of run takes a {@link Record} of parameters, which can be useful if you want to use the output of one query as input for another.
+     *
+     * @param query      text of a Neo4j query
+     * @param parameters input data for the query
+     * @return a publisher of reactive result.
+     */
+    Publisher<ReactiveResult> run(String query, Record parameters);
+
+    /**
+     * Register running of a query and return a publisher of {@link ReactiveResult}.
+     * <p>
+     * Invoking this method will result in a Bolt RUN message exchange with server and the returned publisher will either emit an instance of {@link
+     * ReactiveResult} on success or an error otherwise.
+     *
+     * @param query text of a Neo4j query
+     * @return a publisher of reactive result.
+     */
+    Publisher<ReactiveResult> run(String query);
+
+    /**
+     * Register running of a query and return a publisher of {@link ReactiveResult}.
+     * <p>
+     * Invoking this method will result in a Bolt RUN message exchange with server and the returned publisher will either emit an instance of {@link
+     * ReactiveResult} on success or an error otherwise.
+     *
+     * @param query a Neo4j query
+     * @return a publisher of reactive result.
+     */
+    Publisher<ReactiveResult> run(Query query);
+}

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveResult.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveResult.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.reactivestreams;
+
+import java.util.List;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.exceptions.ResultConsumedException;
+import org.neo4j.driver.summary.ResultSummary;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * A reactive result provides a reactive way to execute query on the server and receives records back. This reactive result consists of a result key publisher,
+ * a record publisher and a result summary publisher. The reactive result is created via {@link ReactiveSession#run(Query)} and {@link
+ * ReactiveTransaction#run(Query)} for example. On the creation of the result, the query submitted to create this result will not be executed until one of the
+ * publishers in this class is subscribed. The records or the summary stream has to be consumed and finished (completed or errored) to ensure the resources used
+ * by this result to be freed correctly.
+ *
+ * @see Publisher
+ * @see Subscriber
+ * @see Subscription
+ * @since 5.2
+ */
+public interface ReactiveResult {
+    /**
+     * Returns a list of keys.
+     *
+     * @return a list of keys.
+     */
+    List<String> keys();
+
+    /**
+     * Returns a cold unicast publisher of records.
+     * <p>
+     * When the record publisher is {@linkplain Publisher#subscribe(Subscriber) subscribed}, the query is executed and the result is streamed back as a record
+     * stream followed by a result summary. This record publisher publishes all records in the result and signals the completion. However before completion or
+     * error reporting if any, a cleanup of result resources such as network connection will be carried out automatically.
+     * <p>
+     * Therefore the {@link Subscriber} of this record publisher shall wait for the termination signal (complete or error) to ensure that the resources used by
+     * this result are released correctly. Then the session is ready to be used to run more queries.
+     * <p>
+     * Cancelling of the record streaming will immediately terminate the propagation of new records. But it will not cancel query execution on the server. When
+     * the execution is finished, the {@link Subscriber} will be notified with a termination signal (complete or error).
+     * <p>
+     * The record publishing event by default runs in an Network IO thread, as a result no blocking operation is allowed in this thread. Otherwise network IO
+     * might be blocked by application logic.
+     * <p>
+     * This publisher can only be subscribed by one {@link Subscriber} once.
+     * <p>
+     * If this publisher is subscribed after {@link #keys()}, then the publish of records is carried out after the arrival of keys. If this publisher is
+     * subscribed after {@link #consume()}, then a {@link ResultConsumedException} will be thrown.
+     *
+     * @return a cold unicast publisher of records.
+     */
+    Publisher<Record> records();
+
+    /**
+     * Returns a cold publisher of result summary which arrives after all records.
+     * <p>
+     * {@linkplain Publisher#subscribe(Subscriber) Subscribing} the summary publisher results in the execution of the query followed by the result summary being
+     * returned. The summary publisher cancels record publishing if not yet subscribed and directly streams back the summary on query execution completion. As a
+     * result, the invocation of {@link #records()} after this method, would receive an {@link ResultConsumedException}.
+     * <p>
+     * If subscribed after {@link #keys()}, then the result summary will be published after the query execution without streaming any record to client. If
+     * subscribed after {@link #records()}, then the result summary will be published after the query execution and the streaming of records.
+     * <p>
+     * Usually, this method shall be chained after {@link #records()} to ensure that all records are processed before summary.
+     * <p>
+     * This method can be subscribed multiple times. When the {@linkplain ResultSummary summary} arrives, it will be buffered locally for all subsequent calls.
+     *
+     * @return a cold publisher of result summary which only arrives after all records.
+     */
+    Publisher<ResultSummary> consume();
+
+    /**
+     * Determine if result is open.
+     * <p>
+     * Result is considered to be open if it has not been consumed ({@link #consume()}) and its creator object (e.g. session or transaction) has not been closed
+     * (including committed or rolled back).
+     * <p>
+     * Attempts to access data on closed result will produce {@link ResultConsumedException}.
+     *
+     * @return a publisher emitting {@code true} if result is open and {@code false} otherwise.
+     */
+    Publisher<Boolean> isOpen();
+}

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveSession.java
@@ -16,12 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.reactive;
+package org.neo4j.driver.reactivestreams;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Flow.Publisher;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.BaseReactiveSession;
 import org.neo4j.driver.Bookmark;
@@ -30,6 +29,7 @@ import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Values;
+import org.reactivestreams.Publisher;
 
 /**
  * A reactive session is the same as {@link Session} except it provides a reactive API.
@@ -38,7 +38,7 @@ import org.neo4j.driver.Values;
  * @see ReactiveResult
  * @see ReactiveTransaction
  * @see Publisher
- * @since 5.0
+ * @since 5.2
  */
 public interface ReactiveSession extends BaseReactiveSession, ReactiveQueryRunner {
     /**

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransaction.java
@@ -16,25 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.reactive;
+package org.neo4j.driver.reactivestreams;
 
 import org.neo4j.driver.Transaction;
 import org.reactivestreams.Publisher;
 
 /**
  * Same as {@link Transaction} except this reactive transaction exposes a reactive API.
+ *
  * @see Transaction
- * @see RxSession
+ * @see ReactiveSession
  * @see Publisher
- * @since 4.0
- * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveTransaction} and {@link org.neo4j.driver.reactivestreams.ReactiveTransaction}
+ * @since 5.2
  */
-@Deprecated
-public interface RxTransaction extends RxQueryRunner {
+public interface ReactiveTransaction extends ReactiveQueryRunner {
     /**
-     * Commits the transaction.
-     * It completes without publishing anything if transaction is committed successfully.
-     * Otherwise, errors when there is any error to commit.
+     * Commits the transaction. It completes without publishing anything if transaction is committed successfully. Otherwise, errors when there is any error to
+     * commit.
+     *
      * @param <T> makes it easier to be chained after other publishers.
      * @return an empty publisher.
      */

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransactionCallback.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransactionCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.reactivestreams;
+
+/**
+ * Callback that executes operations against a given {@link ReactiveTransactionContext}.
+ *
+ * @param <T> the return type of this work.
+ * @since 5.2
+ */
+public interface ReactiveTransactionCallback<T> {
+    /**
+     * Executes all given operations against the same transaction context.
+     *
+     * @param context the transaction context to use.
+     * @return result object or {@code null} if none.
+     */
+    T execute(ReactiveTransactionContext context);
+}

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransactionContext.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveTransactionContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.reactivestreams;
+
+/**
+ * A context for running queries within transaction.
+ *
+ * @since 5.2
+ */
+public interface ReactiveTransactionContext extends ReactiveQueryRunner {}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/ReactiveTransactionContextStreamsAdapter.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/ReactiveTransactionContextStreamsAdapter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend;
+
+import java.util.Map;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.neo4j.driver.reactivestreams.ReactiveTransaction;
+import org.neo4j.driver.reactivestreams.ReactiveTransactionContext;
+import org.reactivestreams.Publisher;
+
+public class ReactiveTransactionContextStreamsAdapter implements ReactiveTransaction {
+    private final ReactiveTransactionContext delegate;
+
+    public ReactiveTransactionContextStreamsAdapter(ReactiveTransactionContext delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Value parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Map<String, Object> parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query, Record parameters) {
+        return delegate.run(query, parameters);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(String query) {
+        return delegate.run(query);
+    }
+
+    @Override
+    public Publisher<ReactiveResult> run(Query query) {
+        return delegate.run(query);
+    }
+
+    @Override
+    public <T> Publisher<T> commit() {
+        throw new UnsupportedOperationException("commit is not allowed on transaction context");
+    }
+
+    @Override
+    public <T> Publisher<T> rollback() {
+        throw new UnsupportedOperationException("rollback is not allowed on transaction context");
+    }
+
+    @Override
+    public Publisher<Void> close() {
+        throw new UnsupportedOperationException("close is not allowed on transaction context");
+    }
+
+    @Override
+    public Publisher<Boolean> isOpen() {
+        throw new UnsupportedOperationException("isOpen is not allowed on transaction context");
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
@@ -40,6 +40,8 @@ public class Runner {
             backendMode = TestkitRequestProcessorHandler.BackendMode.REACTIVE_LEGACY;
         } else if ("reactive".equals(modeArg)) {
             backendMode = TestkitRequestProcessorHandler.BackendMode.REACTIVE;
+        } else if ("reactive-streams".equals(modeArg)) {
+            backendMode = TestkitRequestProcessorHandler.BackendMode.REACTIVE;
         } else {
             backendMode = TestkitRequestProcessorHandler.BackendMode.SYNC;
         }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
@@ -29,8 +29,11 @@ import neo4j.org.testkit.backend.holder.AsyncSessionHolder;
 import neo4j.org.testkit.backend.holder.AsyncTransactionHolder;
 import neo4j.org.testkit.backend.holder.DriverHolder;
 import neo4j.org.testkit.backend.holder.ReactiveResultHolder;
+import neo4j.org.testkit.backend.holder.ReactiveResultStreamsHolder;
 import neo4j.org.testkit.backend.holder.ReactiveSessionHolder;
+import neo4j.org.testkit.backend.holder.ReactiveSessionStreamsHolder;
 import neo4j.org.testkit.backend.holder.ReactiveTransactionHolder;
+import neo4j.org.testkit.backend.holder.ReactiveTransactionStreamsHolder;
 import neo4j.org.testkit.backend.holder.ResultCursorHolder;
 import neo4j.org.testkit.backend.holder.ResultHolder;
 import neo4j.org.testkit.backend.holder.RxResultHolder;
@@ -60,14 +63,18 @@ public class TestkitState {
     private final Map<String, AsyncSessionHolder> sessionIdToAsyncSessionHolder = new HashMap<>();
     private final Map<String, RxSessionHolder> sessionIdToRxSessionHolder = new HashMap<>();
     private final Map<String, ReactiveSessionHolder> sessionIdToReactiveSessionHolder = new HashMap<>();
+    private final Map<String, ReactiveSessionStreamsHolder> sessionIdToReactiveSessionStreamsHolder = new HashMap<>();
     private final Map<String, ResultHolder> resultIdToResultHolder = new HashMap<>();
     private final Map<String, ResultCursorHolder> resultIdToResultCursorHolder = new HashMap<>();
     private final Map<String, RxResultHolder> resultIdToRxResultHolder = new HashMap<>();
     private final Map<String, ReactiveResultHolder> resultIdToReactiveResultHolder = new HashMap<>();
+    private final Map<String, ReactiveResultStreamsHolder> resultIdToReactiveResultStreamsHolder = new HashMap<>();
     private final Map<String, TransactionHolder> transactionIdToTransactionHolder = new HashMap<>();
     private final Map<String, AsyncTransactionHolder> transactionIdToAsyncTransactionHolder = new HashMap<>();
     private final Map<String, RxTransactionHolder> transactionIdToRxTransactionHolder = new HashMap<>();
     private final Map<String, ReactiveTransactionHolder> transactionIdToReactiveTransactionHolder = new HashMap<>();
+    private final Map<String, ReactiveTransactionStreamsHolder> transactionIdToReactiveTransactionStreamsHolder =
+            new HashMap<>();
     private final Map<String, BookmarkManager> bookmarkManagerIdToBookmarkManager = new HashMap<>();
 
     @Getter
@@ -129,6 +136,14 @@ public class TestkitState {
         return getRx(id, sessionIdToReactiveSessionHolder, SESSION_NOT_FOUND_MESSAGE);
     }
 
+    public String addReactiveSessionStreamsHolder(ReactiveSessionStreamsHolder sessionHolder) {
+        return add(sessionHolder, sessionIdToReactiveSessionStreamsHolder);
+    }
+
+    public Mono<ReactiveSessionStreamsHolder> getReactiveSessionStreamsHolder(String id) {
+        return getRx(id, sessionIdToReactiveSessionStreamsHolder, SESSION_NOT_FOUND_MESSAGE);
+    }
+
     public String addTransactionHolder(TransactionHolder transactionHolder) {
         return add(transactionHolder, transactionIdToTransactionHolder);
     }
@@ -161,6 +176,14 @@ public class TestkitState {
         return getRx(id, transactionIdToReactiveTransactionHolder, TRANSACTION_NOT_FOUND_MESSAGE);
     }
 
+    public String addReactiveTransactionStreamsHolder(ReactiveTransactionStreamsHolder transactionHolder) {
+        return add(transactionHolder, transactionIdToReactiveTransactionStreamsHolder);
+    }
+
+    public Mono<ReactiveTransactionStreamsHolder> getReactiveTransactionStreamsHolder(String id) {
+        return getRx(id, transactionIdToReactiveTransactionStreamsHolder, TRANSACTION_NOT_FOUND_MESSAGE);
+    }
+
     public String addResultHolder(ResultHolder resultHolder) {
         return add(resultHolder, resultIdToResultHolder);
     }
@@ -191,6 +214,14 @@ public class TestkitState {
 
     public Mono<ReactiveResultHolder> getReactiveResultHolder(String id) {
         return getRx(id, resultIdToReactiveResultHolder, RESULT_NOT_FOUND_MESSAGE);
+    }
+
+    public String addReactiveResultStreamsHolder(ReactiveResultStreamsHolder resultHolder) {
+        return add(resultHolder, resultIdToReactiveResultStreamsHolder);
+    }
+
+    public Mono<ReactiveResultStreamsHolder> getReactiveResultStreamsHolder(String id) {
+        return getRx(id, resultIdToReactiveResultStreamsHolder, RESULT_NOT_FOUND_MESSAGE);
     }
 
     public void addBookmarkManager(String id, BookmarkManager bookmarkManager) {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveResultStreamsHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveResultStreamsHolder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Getter;
+import lombok.Setter;
+import neo4j.org.testkit.backend.RxBufferedSubscriber;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+
+public class ReactiveResultStreamsHolder
+        extends AbstractResultHolder<ReactiveSessionStreamsHolder, ReactiveTransactionStreamsHolder, ReactiveResult> {
+    @Setter
+    private RxBufferedSubscriber<Record> subscriber;
+
+    @Getter
+    private final AtomicLong requestedRecordsCounter = new AtomicLong();
+
+    public ReactiveResultStreamsHolder(ReactiveSessionStreamsHolder sessionHolder, ReactiveResult result) {
+        super(sessionHolder, result);
+    }
+
+    public ReactiveResultStreamsHolder(ReactiveTransactionStreamsHolder transactionHolder, ReactiveResult result) {
+        super(transactionHolder, result);
+    }
+
+    public Optional<RxBufferedSubscriber<Record>> getSubscriber() {
+        return Optional.ofNullable(subscriber);
+    }
+
+    @Override
+    protected ReactiveSessionStreamsHolder getSessionHolder(ReactiveTransactionStreamsHolder transactionHolder) {
+        return transactionHolder.getSessionHolder();
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveSessionStreamsHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveSessionStreamsHolder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.reactivestreams.ReactiveSession;
+
+public class ReactiveSessionStreamsHolder extends AbstractSessionHolder<ReactiveSession> {
+    public ReactiveSessionStreamsHolder(DriverHolder driverHolder, ReactiveSession session, SessionConfig config) {
+        super(driverHolder, session, config);
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveTransactionStreamsHolder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/holder/ReactiveTransactionStreamsHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend.holder;
+
+import org.neo4j.driver.reactivestreams.ReactiveTransaction;
+
+public class ReactiveTransactionStreamsHolder
+        extends AbstractTransactionHolder<ReactiveSessionStreamsHolder, ReactiveTransaction> {
+    public ReactiveTransactionStreamsHolder(
+            ReactiveSessionStreamsHolder sessionHolder, ReactiveTransaction transaction) {
+        super(sessionHolder, transaction);
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/BookmarkManagerClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/BookmarkManagerClose.java
@@ -52,6 +52,11 @@ public class BookmarkManagerClose implements TestkitRequest {
         return Mono.just(removeBookmarkManagerAndCreateResponse(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return Mono.just(removeBookmarkManagerAndCreateResponse(testkitState));
+    }
+
     private BookmarkManager removeBookmarkManagerAndCreateResponse(TestkitState testkitState) {
         var id = data.getId();
         testkitState.removeBookmarkManager(id);

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckDriverIsEncrypted.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckDriverIsEncrypted.java
@@ -53,6 +53,11 @@ public class CheckDriverIsEncrypted implements TestkitRequest {
         return Mono.just(createResponse(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private DriverIsEncrypted createResponse(TestkitState testkitState) {
         DriverHolder driverHolder = testkitState.getDriverHolder(data.getDriverId());
         return DriverIsEncrypted.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/CheckMultiDBSupport.java
@@ -57,6 +57,11 @@ public class CheckMultiDBSupport implements TestkitRequest {
         return Mono.fromCompletionStage(processAsync(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private MultiDBSupport createResponse(boolean available) {
         return MultiDBSupport.builder()
                 .data(MultiDBSupport.MultiDBSupportBody.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/DriverClose.java
@@ -56,6 +56,11 @@ public class DriverClose implements TestkitRequest {
         return Mono.fromCompletionStage(processAsync(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private Driver createResponse() {
         return Driver.builder()
                 .data(Driver.DriverBody.builder().id(data.getDriverId()).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetConnectionPoolMetrics.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetConnectionPoolMetrics.java
@@ -58,6 +58,11 @@ public class GetConnectionPoolMetrics implements TestkitRequest {
         return Mono.just(getConnectionPoolMetrics(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private ConnectionPoolMetrics getConnectionPoolMetrics(TestkitState testkitState) {
         DriverHolder driverHolder = testkitState.getDriverHolder(data.getDriverId());
         Metrics metrics = driverHolder.getDriver().metrics();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -100,6 +100,11 @@ public class GetFeatures implements TestkitRequest {
         return Mono.just(createResponse(COMMON_FEATURES));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return Mono.just(createResponse(COMMON_FEATURES));
+    }
+
     private FeatureList createResponse(Set<String> features) {
         return FeatureList.builder()
                 .data(FeatureList.FeatureListBody.builder().features(features).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetRoutingTable.java
@@ -89,6 +89,11 @@ public class GetRoutingTable implements TestkitRequest {
         return Mono.just(process(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     @Setter
     @Getter
     public static class GetRoutingTableBody {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewBookmarkManager.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewBookmarkManager.java
@@ -60,6 +60,11 @@ public class NewBookmarkManager implements TestkitRequest {
         return Mono.just(createBookmarkManagerAndResponse(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return Mono.just(createBookmarkManagerAndResponse(testkitState));
+    }
+
     private BookmarkManager createBookmarkManagerAndResponse(TestkitState testkitState) {
         var id = testkitState.newId();
         var initialBookmarks =

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -147,6 +147,11 @@ public class NewDriver implements TestkitRequest {
         return Mono.fromCompletionStage(processAsync(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private ServerAddressResolver callbackResolver(TestkitState testkitState) {
         return address -> {
             String callbackId = testkitState.newId();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
@@ -31,6 +31,7 @@ import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.holder.AsyncSessionHolder;
 import neo4j.org.testkit.backend.holder.DriverHolder;
 import neo4j.org.testkit.backend.holder.ReactiveSessionHolder;
+import neo4j.org.testkit.backend.holder.ReactiveSessionStreamsHolder;
 import neo4j.org.testkit.backend.holder.RxSessionHolder;
 import neo4j.org.testkit.backend.holder.SessionHolder;
 import neo4j.org.testkit.backend.messages.responses.Session;
@@ -66,6 +67,12 @@ public class NewSession implements TestkitRequest {
     public Mono<TestkitResponse> processReactive(TestkitState testkitState) {
         return Mono.just(createSessionStateAndResponse(
                 testkitState, this::createReactiveSessionState, testkitState::addReactiveSessionHolder));
+    }
+
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return Mono.just(createSessionStateAndResponse(
+                testkitState, this::createReactiveSessionStreamsState, testkitState::addReactiveSessionStreamsHolder));
     }
 
     protected <T> TestkitResponse createSessionStateAndResponse(
@@ -117,6 +124,16 @@ public class NewSession implements TestkitRequest {
     private ReactiveSessionHolder createReactiveSessionState(DriverHolder driverHolder, SessionConfig sessionConfig) {
         return new ReactiveSessionHolder(
                 driverHolder, driverHolder.getDriver().reactiveSession(sessionConfig), sessionConfig);
+    }
+
+    private ReactiveSessionStreamsHolder createReactiveSessionStreamsState(
+            DriverHolder driverHolder, SessionConfig sessionConfig) {
+        return new ReactiveSessionStreamsHolder(
+                driverHolder,
+                driverHolder
+                        .getDriver()
+                        .reactiveSession(org.neo4j.driver.reactivestreams.ReactiveSession.class, sessionConfig),
+                sessionConfig);
     }
 
     @Setter

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
@@ -85,6 +85,15 @@ public class ResultConsume implements TestkitRequest {
                 .map(this::createResponse);
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveResultStreamsHolder(data.getResultId())
+                .flatMap(
+                        resultHolder -> Mono.fromDirect(resultHolder.getResult().consume()))
+                .map(this::createResponse);
+    }
+
     private Summary createResponse(org.neo4j.driver.summary.ResultSummary summary) {
         Summary.ServerInfo serverInfo = Summary.ServerInfo.builder()
                 .address(summary.server().address())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultList.java
@@ -59,6 +59,11 @@ public class ResultList implements TestkitRequest {
         throw new UnsupportedOperationException("Operation not supported");
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
+
     private RecordList createResponse(List<org.neo4j.driver.Record> records) {
         List<Record.RecordBody> mappedRecords = records.stream()
                 .map(record -> Record.RecordBody.builder().values(record).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultPeek.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultPeek.java
@@ -63,6 +63,11 @@ public class ResultPeek implements TestkitRequest {
         throw new UnsupportedOperationException("Operation not supported");
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
+
     private TestkitResponse createResponse(Record record) {
         return neo4j.org.testkit.backend.messages.responses.Record.builder()
                 .data(neo4j.org.testkit.backend.messages.responses.Record.RecordBody.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultSingle.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultSingle.java
@@ -58,6 +58,11 @@ public class ResultSingle implements TestkitRequest {
         throw new UnsupportedOperationException("Single method is not supported by reactive API");
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        throw new UnsupportedOperationException("Single method is not supported by reactive API");
+    }
+
     private neo4j.org.testkit.backend.messages.responses.TestkitResponse createResponse(Record record) {
         return neo4j.org.testkit.backend.messages.responses.Record.builder()
                 .data(neo4j.org.testkit.backend.messages.responses.Record.RecordBody.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryableNegative.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryableNegative.java
@@ -87,6 +87,20 @@ public class RetryableNegative implements TestkitRequest {
         });
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState.getReactiveSessionStreamsHolder(data.getSessionId()).mapNotNull(sessionHolder -> {
+            Throwable throwable;
+            if (!"".equals(data.getErrorId())) {
+                throwable = testkitState.getErrors().get(data.getErrorId());
+            } else {
+                throwable = new FrontendError();
+            }
+            sessionHolder.getTxWorkFuture().completeExceptionally(throwable);
+            return null;
+        });
+    }
+
     @Setter
     @Getter
     public static class RetryableNegativeBody {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryablePositive.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/RetryablePositive.java
@@ -65,6 +65,14 @@ public class RetryablePositive implements TestkitRequest {
         });
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState.getReactiveSessionStreamsHolder(data.getSessionId()).mapNotNull(sessionHolder -> {
+            sessionHolder.getTxWorkFuture().complete(null);
+            return null;
+        });
+    }
+
     @Setter
     @Getter
     public static class RetryablePositiveBody {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionClose.java
@@ -65,6 +65,15 @@ public class SessionClose implements TestkitRequest {
                 .then(Mono.just(createResponse()));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveSessionStreamsHolder(data.getSessionId())
+                .flatMap(sessionHolder ->
+                        Mono.fromDirect(sessionHolder.getSession().close()))
+                .then(Mono.just(createResponse()));
+    }
+
     private Session createResponse() {
         return Session.builder()
                 .data(Session.SessionBody.builder().id(data.getSessionId()).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionLastBookmarks.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionLastBookmarks.java
@@ -67,6 +67,14 @@ public class SessionLastBookmarks implements TestkitRequest {
                 .map(this::createResponse);
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveSessionStreamsHolder(data.getSessionId())
+                .map(sessionHolder -> sessionHolder.getSession().lastBookmarks())
+                .map(this::createResponse);
+    }
+
     private Bookmarks createResponse(Set<Bookmark> bookmarks) {
         return Bookmarks.builder()
                 .data(Bookmarks.BookmarksBody.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SessionWriteTransaction.java
@@ -28,9 +28,11 @@ import java.util.concurrent.ExecutionException;
 import lombok.Getter;
 import lombok.Setter;
 import neo4j.org.testkit.backend.ReactiveTransactionContextAdapter;
+import neo4j.org.testkit.backend.ReactiveTransactionContextStreamsAdapter;
 import neo4j.org.testkit.backend.TestkitState;
 import neo4j.org.testkit.backend.holder.AsyncTransactionHolder;
 import neo4j.org.testkit.backend.holder.ReactiveTransactionHolder;
+import neo4j.org.testkit.backend.holder.ReactiveTransactionStreamsHolder;
 import neo4j.org.testkit.backend.holder.RxTransactionHolder;
 import neo4j.org.testkit.backend.holder.SessionHolder;
 import neo4j.org.testkit.backend.holder.TransactionHolder;
@@ -117,6 +119,26 @@ public class SessionWriteTransaction implements TestkitRequest {
 
                     return Mono.fromDirect(
                             flowPublisherToFlux(sessionHolder.getSession().executeWrite(workWrapper)));
+                })
+                .then(Mono.just(retryableDone()));
+    }
+
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveSessionStreamsHolder(data.getSessionId())
+                .flatMap(sessionHolder -> {
+                    org.neo4j.driver.reactivestreams.ReactiveTransactionCallback<Publisher<Void>> workWrapper = tx -> {
+                        String txId =
+                                testkitState.addReactiveTransactionStreamsHolder(new ReactiveTransactionStreamsHolder(
+                                        sessionHolder, new ReactiveTransactionContextStreamsAdapter(tx)));
+                        testkitState.getResponseWriter().accept(retryableTry(txId));
+                        CompletableFuture<Void> tryResult = new CompletableFuture<>();
+                        sessionHolder.setTxWorkFuture(tryResult);
+                        return Mono.fromCompletionStage(tryResult);
+                    };
+
+                    return Mono.fromDirect(sessionHolder.getSession().executeWrite(workWrapper));
                 })
                 .then(Mono.just(retryableDone()));
     }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartSubTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartSubTest.java
@@ -175,6 +175,12 @@ public class StartSubTest implements TestkitRequest {
         return Mono.just(testkitResponse);
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        TestkitResponse testkitResponse = createResponse(REACTIVE_LEGACY_SKIP_PATTERN_TO_CHECK);
+        return Mono.just(testkitResponse);
+    }
+
     private TestkitResponse createResponse(Map<String, SkipDeciderInterface> skipPatternToCheck) {
         return skipPatternToCheck.entrySet().stream()
                 .filter(entry -> data.getTestName().matches(entry.getKey()))

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -179,6 +179,15 @@ public class StartTest implements TestkitRequest {
         return Mono.just(testkitResponse);
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        TestkitResponse testkitResponse = createSkipResponse(REACTIVE_SKIP_PATTERN_TO_REASON)
+                .orElseGet(() -> StartSubTest.decidePerSubTestReactive(data.getTestName())
+                        ? RunSubTests.builder().build()
+                        : RunTest.builder().build());
+        return Mono.just(testkitResponse);
+    }
+
     private Optional<TestkitResponse> createSkipResponse(Map<String, String> skipPatternToReason) {
         return skipPatternToReason.entrySet().stream()
                 .filter(entry -> data.getTestName().matches(entry.getKey()))

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitCallbackResult.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitCallbackResult.java
@@ -54,4 +54,10 @@ public interface TestkitCallbackResult extends TestkitRequest {
         testkitState.getCallbackIdToFuture().get(getCallbackId()).complete(this);
         return Mono.empty();
     }
+
+    @Override
+    default Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        testkitState.getCallbackIdToFuture().get(getCallbackId()).complete(this);
+        return Mono.empty();
+    }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TestkitRequest.java
@@ -71,4 +71,6 @@ public interface TestkitRequest {
     Mono<TestkitResponse> processRx(TestkitState testkitState);
 
     Mono<TestkitResponse> processReactive(TestkitState testkitState);
+
+    Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState);
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionClose.java
@@ -69,6 +69,15 @@ public class TransactionClose implements TestkitRequest {
                 .then(Mono.just(createResponse(data.getTxId())));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveTransactionStreamsHolder(data.getTxId())
+                .map(AbstractTransactionHolder::getTransaction)
+                .flatMap(tx -> Mono.fromDirect(tx.close()))
+                .then(Mono.just(createResponse(data.getTxId())));
+    }
+
     private Transaction createResponse(String txId) {
         return Transaction.builder()
                 .data(Transaction.TransactionBody.builder().id(txId).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionCommit.java
@@ -64,6 +64,14 @@ public class TransactionCommit implements TestkitRequest {
                 .then(Mono.just(createResponse(data.getTxId())));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveTransactionStreamsHolder(data.getTxId())
+                .flatMap(tx -> Mono.fromDirect(tx.getTransaction().commit()))
+                .then(Mono.just(createResponse(data.getTxId())));
+    }
+
     private Transaction createResponse(String txId) {
         return Transaction.builder()
                 .data(Transaction.TransactionBody.builder().id(txId).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/TransactionRollback.java
@@ -64,6 +64,14 @@ public class TransactionRollback implements TestkitRequest {
                 .then(Mono.just(createResponse(data.getTxId())));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return testkitState
+                .getReactiveTransactionStreamsHolder(data.getTxId())
+                .flatMap(tx -> Mono.fromDirect(tx.getTransaction().rollback()))
+                .then(Mono.just(createResponse(data.getTxId())));
+    }
+
     private Transaction createResponse(String txId) {
         return Transaction.builder()
                 .data(Transaction.TransactionBody.builder().id(txId).build())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/VerifyConnectivity.java
@@ -58,6 +58,11 @@ public class VerifyConnectivity implements TestkitRequest {
         return Mono.fromCompletionStage(processAsync(testkitState));
     }
 
+    @Override
+    public Mono<TestkitResponse> processReactiveStreams(TestkitState testkitState) {
+        return processReactive(testkitState);
+    }
+
     private Driver createResponse(String id) {
         return Driver.builder().data(Driver.DriverBody.builder().id(id).build()).build();
     }

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -26,6 +26,7 @@
         <testkit.async.name.pattern>%a-a</testkit.async.name.pattern>
         <testkit.reactive.legacy.name.pattern>%a-rl</testkit.reactive.legacy.name.pattern>
         <testkit.reactive.name.pattern>%a-r</testkit.reactive.name.pattern>
+        <testkit.reactive.streams.name.pattern>%a-rs</testkit.reactive.streams.name.pattern>
         <!-- Debug logging for backend messages. Empty string - off, Non-empty string - on. -->
         <testkit.debug.reqres></testkit.debug.reqres>
 
@@ -198,6 +199,37 @@
                                             </env>
                                             <log>
                                                 <prefix xml:space="preserve">${testkit.reactive.name.pattern}> </prefix>
+                                            </log>
+                                        </run>
+                                    </image>
+                                </images>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- Use reactive backend to test reactive driver. -->
+                            <id>run-testkit-reactive-streams</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <!-- Testkit is expected to exit automatically. -->
+                                <goal>start</goal>
+                            </goals>
+                            <configuration>
+                                <images>
+                                    <image>
+                                        <alias>tklnchr</alias>
+                                        <run>
+                                            <containerNamePattern>${testkit.reactive.streams.name.pattern}</containerNamePattern>
+                                            <env>
+                                                <TESTKIT_CHECKOUT_PATH>${project.build.directory}/testkit-reactive</TESTKIT_CHECKOUT_PATH>
+                                                <TEST_BACKEND_SERVER>reactive-streams</TEST_BACKEND_SERVER>
+                                                <!-- Excludes 3.5 -->
+                                                <TESTKIT_ARGS>--configs 4.0-enterprise-neo4j 4.1-enterprise-neo4j 4.2-community-bolt 4.2-community-neo4j
+                                                    4.2-enterprise-bolt 4.2-enterprise-neo4j 4.2-enterprise-cluster-neo4j 4.3-community-bolt 4.3-community-neo4j
+                                                    4.3-enterprise-bolt 4.3-enterprise-neo4j 4.3-enterprise-cluster-neo4j ${testkit.args}
+                                                </TESTKIT_ARGS>
+                                            </env>
+                                            <log>
+                                                <prefix xml:space="preserve">${testkit.reactive.streams.name.pattern}> </prefix>
                                             </log>
                                         </run>
                                     </image>


### PR DESCRIPTION
This update introduces support for reactive session with Reactive Streams types. While it is similar to the deprecated `RxSession`, it includes the improvements introduced with the `ReactiveSession` that uses Flow API types.

Sample session creation:
```
var session = driver.reactiveSession(org.neo4j.driver.reactivestreams.ReactiveSession.class);
```