### PR TITLE
Introduce new session instantiation methods

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -400,13 +400,13 @@
     <difference>
         <className>org/neo4j/driver/Driver</className>
         <differenceType>7012</differenceType>
-        <method>org.neo4j.driver.BaseReactiveSession reactiveSession(java.lang.Class)</method>
+        <method>org.neo4j.driver.BaseSession session(java.lang.Class)</method>
     </difference>
 
     <difference>
         <className>org/neo4j/driver/Driver</className>
         <differenceType>7012</differenceType>
-        <method>org.neo4j.driver.BaseReactiveSession reactiveSession(java.lang.Class, org.neo4j.driver.SessionConfig)</method>
+        <method>org.neo4j.driver.BaseSession session(java.lang.Class, org.neo4j.driver.SessionConfig)</method>
     </difference>
 
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/BaseSession.java
+++ b/driver/src/main/java/org/neo4j/driver/BaseSession.java
@@ -19,6 +19,6 @@
 package org.neo4j.driver;
 
 /**
- * A base interface for reactive sessions, used by {@link Driver#reactiveSession(Class)} and {@link Driver#reactiveSession(Class, SessionConfig)}.
+ * A base interface for sessions, used by {@link Driver#session(Class)} and {@link Driver#session(Class, SessionConfig)}.
  */
-public interface BaseReactiveSession {}
+public interface BaseSession {}

--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -78,17 +78,80 @@ public interface Driver extends AutoCloseable {
      * @return a new {@link Session} object.
      */
     default Session session() {
-        return session(SessionConfig.defaultConfig());
+        return session(Session.class);
     }
 
     /**
-     * Create a new {@link Session} with a specified {@link SessionConfig session configuration}.
+     * Instantiate a new {@link Session} with a specified {@link SessionConfig session configuration}.
      * Use {@link SessionConfig#forDatabase(String)} to obtain a general purpose session configuration for the specified database.
      * @param sessionConfig specifies session configurations for this session.
      * @return a new {@link Session} object.
      * @see SessionConfig
      */
-    Session session(SessionConfig sessionConfig);
+    default Session session(SessionConfig sessionConfig) {
+        return session(Session.class, sessionConfig);
+    }
+
+    /**
+     * Instantiate a new session of supported type with default {@link SessionConfig session configuration}.
+     * <p>
+     * Supported types are:
+     * <ul>
+     *     <li>{@link org.neo4j.driver.Session} - synchronous session</li>
+     *     <li>{@link org.neo4j.driver.async.AsyncSession} - asynchronous session</li>
+     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
+     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams
+     * API</li>
+     *     <li>{@link org.neo4j.driver.reactive.RxSession} - deprecated reactive session using Reactive Streams
+     * API, superseded by {@link org.neo4j.driver.reactivestreams.ReactiveSession}</li>
+     * </ul>
+     * <p>
+     * Sample usage:
+     * <pre>
+     * {@code
+     * var session = driver.session(AsyncSession.class);
+     * }
+     * </pre>
+     *
+     * @param sessionClass session type class, must not be null
+     * @return session instance
+     * @param <T> session type
+     * @throws IllegalArgumentException for unsupported session types
+     * @since 5.2
+     */
+    default <T extends BaseSession> T session(Class<T> sessionClass) {
+        return session(sessionClass, SessionConfig.defaultConfig());
+    }
+
+    /**
+     * Create a new session of supported type with a specified {@link SessionConfig session configuration}.
+     * <p>
+     * Supported types are:
+     * <ul>
+     *     <li>{@link org.neo4j.driver.Session} - synchronous session</li>
+     *     <li>{@link org.neo4j.driver.async.AsyncSession} - asynchronous session</li>
+     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
+     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams
+     * API</li>
+     *     <li>{@link org.neo4j.driver.reactive.RxSession} - deprecated reactive session using Reactive Streams
+     * API, superseded by {@link org.neo4j.driver.reactivestreams.ReactiveSession}</li>
+     * </ul>
+     * <p>
+     * Sample usage:
+     * <pre>
+     * {@code
+     * var session = driver.session(AsyncSession.class);
+     * }
+     * </pre>
+     *
+     * @param sessionClass session type class, must not be null
+     * @param sessionConfig session config, must not be null
+     * @return session instance
+     * @param <T> session type
+     * @throws IllegalArgumentException for unsupported session types
+     * @since 5.2
+     */
+    <T extends BaseSession> T session(Class<T> sessionClass, SessionConfig sessionConfig);
 
     /**
      * Create a new general purpose {@link RxSession} with default {@link SessionConfig session configuration}. The {@link RxSession} provides a reactive way to
@@ -97,11 +160,11 @@ public interface Driver extends AutoCloseable {
      * Alias to {@link #rxSession(SessionConfig)}}.
      *
      * @return a new {@link RxSession} object.
-     * @deprecated superseded by {@link #reactiveSession()}.
+     * @deprecated superseded by {@link #session(Class)}
      */
     @Deprecated
     default RxSession rxSession() {
-        return rxSession(SessionConfig.defaultConfig());
+        return session(RxSession.class);
     }
 
     /**
@@ -110,10 +173,12 @@ public interface Driver extends AutoCloseable {
      *
      * @param sessionConfig used to customize the session.
      * @return a new {@link RxSession} object.
-     * @deprecated superseded by {@link #reactiveSession(SessionConfig)}.
+     * @deprecated superseded by {@link #session(Class, SessionConfig)}
      */
     @Deprecated
-    RxSession rxSession(SessionConfig sessionConfig);
+    default RxSession rxSession(SessionConfig sessionConfig) {
+        return session(RxSession.class, sessionConfig);
+    }
 
     /**
      * Create a new general purpose {@link ReactiveSession} with default {@link SessionConfig session configuration}. The {@link ReactiveSession} provides a
@@ -122,9 +187,11 @@ public interface Driver extends AutoCloseable {
      * Alias to {@link #rxSession(SessionConfig)}}.
      *
      * @return a new {@link ReactiveSession} object.
+     * @deprecated superseded by {@link #session(Class)}
      */
+    @Deprecated
     default ReactiveSession reactiveSession() {
-        return reactiveSession(SessionConfig.defaultConfig());
+        return session(ReactiveSession.class);
     }
 
     /**
@@ -134,42 +201,12 @@ public interface Driver extends AutoCloseable {
      *
      * @param sessionConfig used to customize the session.
      * @return a new {@link ReactiveSession} object.
+     * @deprecated superseded by {@link #session(Class, SessionConfig)}
      */
+    @Deprecated
     default ReactiveSession reactiveSession(SessionConfig sessionConfig) {
-        return reactiveSession(ReactiveSession.class, sessionConfig);
+        return session(ReactiveSession.class, sessionConfig);
     }
-
-    /**
-     * Create a new reactive session of supported type with default {@link SessionConfig session configuration}.
-     * <p>
-     * Supported types are:
-     * <ul>
-     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
-     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams API</li>
-     * </ul>
-     *
-     * @param sessionClass session type class
-     * @return session instance
-     * @param <T> session type
-     */
-    default <T extends BaseReactiveSession> T reactiveSession(Class<T> sessionClass) {
-        return reactiveSession(sessionClass, SessionConfig.defaultConfig());
-    }
-
-    /**
-     * Create a new reactive session of supported type with a specified {@link SessionConfig session configuration}.
-     * <p>
-     * Supported types are:
-     * <ul>
-     *     <li>{@link org.neo4j.driver.reactive.ReactiveSession} - reactive session using Flow API</li>
-     *     <li>{@link org.neo4j.driver.reactivestreams.ReactiveSession} - reactive session using Reactive Streams API</li>
-     * </ul>
-     *
-     * @param sessionClass session type class
-     * @return session instance
-     * @param <T> session type
-     */
-    <T extends BaseReactiveSession> T reactiveSession(Class<T> sessionClass, SessionConfig sessionConfig);
 
     /**
      * Create a new general purpose {@link AsyncSession} with default {@link SessionConfig session configuration}. The {@link AsyncSession} provides an
@@ -178,9 +215,11 @@ public interface Driver extends AutoCloseable {
      * Alias to {@link #asyncSession(SessionConfig)}}.
      *
      * @return a new {@link AsyncSession} object.
+     * @deprecated superseded by {@link #session(Class)}
      */
+    @Deprecated
     default AsyncSession asyncSession() {
-        return asyncSession(SessionConfig.defaultConfig());
+        return session(AsyncSession.class);
     }
 
     /**
@@ -190,8 +229,12 @@ public interface Driver extends AutoCloseable {
      *
      * @param sessionConfig used to customize the session.
      * @return a new {@link AsyncSession} object.
+     * @deprecated superseded by {@link #session(Class, SessionConfig)}
      */
-    AsyncSession asyncSession(SessionConfig sessionConfig);
+    @Deprecated
+    default AsyncSession asyncSession(SessionConfig sessionConfig) {
+        return session(AsyncSession.class, sessionConfig);
+    }
 
     /**
      * Close all the resources assigned to this driver, including open connections and IO threads.

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -53,7 +53,7 @@ import org.neo4j.driver.util.Resource;
  *
  * @since 1.0 (Removed async API to {@link AsyncSession} in 4.0)
  */
-public interface Session extends Resource, QueryRunner {
+public interface Session extends BaseSession, Resource, QueryRunner {
     /**
      * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em>. At
      * most one transaction may exist in a session at any point in time. To

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.BaseSession;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
@@ -70,7 +71,7 @@ import org.neo4j.driver.Values;
  *
  * @since 4.0
  */
-public interface AsyncSession extends AsyncQueryRunner {
+public interface AsyncSession extends BaseSession, AsyncQueryRunner {
     /**
      * Begin a new <em>unmanaged {@linkplain Transaction transaction}</em>. At
      * most one transaction may exist in a session at any point in time. To

--- a/driver/src/main/java/org/neo4j/driver/reactive/ReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/ReactiveSession.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow.Publisher;
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.BaseReactiveSession;
+import org.neo4j.driver.BaseSession;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
@@ -40,7 +40,7 @@ import org.neo4j.driver.Values;
  * @see Publisher
  * @since 5.0
  */
-public interface ReactiveSession extends BaseReactiveSession, ReactiveQueryRunner {
+public interface ReactiveSession extends BaseSession, ReactiveQueryRunner {
     /**
      * Begin a new <em>unmanaged {@linkplain ReactiveTransaction transaction}</em>. At most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent sessions.

--- a/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactive/RxSession.java
@@ -21,6 +21,7 @@ package org.neo4j.driver.reactive;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.BaseSession;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
@@ -38,7 +39,7 @@ import org.reactivestreams.Publisher;
  * @deprecated superseded by {@link org.neo4j.driver.reactive.ReactiveSession} and {@link org.neo4j.driver.reactivestreams.ReactiveSession}
  */
 @Deprecated
-public interface RxSession extends RxQueryRunner {
+public interface RxSession extends BaseSession, RxQueryRunner {
     /**
      * Begin a new <em>unmanaged {@linkplain RxTransaction transaction}</em>. At most one transaction may exist in a session at any point in time. To maintain
      * multiple concurrent transactions, use multiple concurrent sessions.

--- a/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/reactivestreams/ReactiveSession.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.BaseReactiveSession;
+import org.neo4j.driver.BaseSession;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
@@ -40,7 +40,7 @@ import org.reactivestreams.Publisher;
  * @see Publisher
  * @since 5.2
  */
-public interface ReactiveSession extends BaseReactiveSession, ReactiveQueryRunner {
+public interface ReactiveSession extends BaseSession, ReactiveQueryRunner {
     /**
      * Begin a new <em>unmanaged {@linkplain ReactiveTransaction transaction}</em>. At most one transaction may exist in a session at any point in time. To
      * maintain multiple concurrent transactions, use multiple concurrent sessions.

--- a/driver/src/test/java/org/neo4j/driver/integration/QueryRunnerCloseIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/QueryRunnerCloseIT.java
@@ -133,7 +133,7 @@ class QueryRunnerCloseIT {
     @Test
     void shouldErrorToAccessRecordsAfterConsumeAsync() {
         // Given
-        AsyncSession session = neo4j.driver().asyncSession();
+        AsyncSession session = neo4j.driver().session(AsyncSession.class);
         ResultCursor result = await(session.runAsync("UNWIND [1,2] AS a RETURN a"));
 
         // When
@@ -151,7 +151,7 @@ class QueryRunnerCloseIT {
     @Test
     void shouldErrorToAccessRecordsAfterCloseAsync() {
         // Given
-        AsyncSession session = neo4j.driver().asyncSession();
+        AsyncSession session = neo4j.driver().session(AsyncSession.class);
         ResultCursor result = await(session.runAsync("UNWIND [1,2] AS a RETURN a"));
 
         // When
@@ -169,7 +169,7 @@ class QueryRunnerCloseIT {
     @Test
     void shouldAllowConsumeAndKeysAfterConsumeAsync() {
         // Given
-        AsyncSession session = neo4j.driver().asyncSession();
+        AsyncSession session = neo4j.driver().session(AsyncSession.class);
         ResultCursor result = await(session.runAsync("UNWIND [1,2] AS a RETURN a"));
 
         List<String> keys = result.keys();
@@ -188,7 +188,7 @@ class QueryRunnerCloseIT {
     @Test
     void shouldAllowConsumeAndKeysAfterCloseAsync() {
         // Given
-        AsyncSession session = neo4j.driver().asyncSession();
+        AsyncSession session = neo4j.driver().session(AsyncSession.class);
         ResultCursor result = await(session.runAsync("UNWIND [1,2] AS a RETURN a"));
         List<String> keys = result.keys();
         ResultSummary summary = await(result.consumeAsync());

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionMixIT.java
@@ -71,7 +71,7 @@ class SessionMixIT {
     }
 
     private AsyncSession newAsyncSession() {
-        return neo4j.driver().asyncSession();
+        return neo4j.driver().session(AsyncSession.class);
     }
 
     private Session newSession() {

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncQueryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncQueryIT.java
@@ -42,7 +42,7 @@ public class AsyncQueryIT {
 
     @BeforeEach
     void setUp() {
-        session = neo4j.driver().asyncSession();
+        session = neo4j.driver().session(AsyncSession.class);
     }
 
     @AfterEach

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
@@ -94,7 +94,7 @@ class AsyncSessionIT {
 
     @BeforeEach
     void setUp() {
-        session = neo4j.driver().asyncSession();
+        session = neo4j.driver().session(AsyncSession.class);
     }
 
     @AfterEach
@@ -212,7 +212,7 @@ class AsyncSessionIT {
         awaitAll(records);
 
         await(session.closeAsync());
-        session = neo4j.driver().asyncSession();
+        session = neo4j.driver().session(AsyncSession.class);
 
         ResultCursor cursor = await(session.runAsync("MATCH (p:Person) RETURN count(p)"));
         Record record = await(cursor.nextAsync());
@@ -525,7 +525,9 @@ class AsyncSessionIT {
     void shouldRunAfterBeginTxFailureOnBookmark() {
         Bookmark illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
         session = neo4j.driver()
-                .asyncSession(builder().withBookmarks(illegalBookmark).build());
+                .session(
+                        AsyncSession.class,
+                        builder().withBookmarks(illegalBookmark).build());
 
         assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
 
@@ -538,7 +540,9 @@ class AsyncSessionIT {
     void shouldNotBeginTxAfterBeginTxFailureOnBookmark() {
         Bookmark illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
         session = neo4j.driver()
-                .asyncSession(builder().withBookmarks(illegalBookmark).build());
+                .session(
+                        AsyncSession.class,
+                        builder().withBookmarks(illegalBookmark).build());
         assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
         assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
     }
@@ -548,7 +552,9 @@ class AsyncSessionIT {
     void shouldNotRunAfterBeginTxFailureOnBookmark() {
         Bookmark illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
         session = neo4j.driver()
-                .asyncSession(builder().withBookmarks(illegalBookmark).build());
+                .session(
+                        AsyncSession.class,
+                        builder().withBookmarks(illegalBookmark).build());
         assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
         assertThrows(ClientException.class, () -> await(session.runAsync("RETURN 'Hello!'")));
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionServerRestartIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionServerRestartIT.java
@@ -45,7 +45,7 @@ class AsyncSessionServerRestartIT {
 
     @BeforeEach
     void setUp() {
-        session = neo4j.driver().asyncSession();
+        session = neo4j.driver().session(AsyncSession.class);
     }
 
     @AfterEach

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -79,7 +79,7 @@ class AsyncTransactionIT {
 
     @BeforeEach
     void setUp() {
-        session = neo4j.driver().asyncSession();
+        session = neo4j.driver().session(AsyncSession.class);
     }
 
     @AfterEach
@@ -276,7 +276,9 @@ class AsyncTransactionIT {
     @Test
     void shouldFailBoBeginTxWithInvalidBookmark() {
         AsyncSession session = neo4j.driver()
-                .asyncSession(builder().withBookmarks(parse("InvalidBookmark")).build());
+                .session(
+                        AsyncSession.class,
+                        builder().withBookmarks(parse("InvalidBookmark")).build());
 
         ClientException e = assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
         assertThat(e.getMessage(), containsString("InvalidBookmark"));

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/InternalReactiveSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/InternalReactiveSessionIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.internal.reactive.InternalReactiveSession;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.reactive.ReactiveSession;
 import org.neo4j.driver.reactive.ReactiveTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.testutil.DatabaseExtension;
@@ -47,7 +48,7 @@ class InternalReactiveSessionIT {
 
     @BeforeEach
     void setUp() {
-        session = (InternalReactiveSession) neo4j.driver().reactiveSession();
+        session = (InternalReactiveSession) neo4j.driver().session(ReactiveSession.class);
     }
 
     @ParameterizedTest

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractAsyncQuery.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractAsyncQuery.java
@@ -35,11 +35,14 @@ public abstract class AbstractAsyncQuery<C extends AbstractContext> implements A
 
     public AsyncSession newSession(AccessMode mode, C context) {
         if (useBookmark) {
-            return driver.asyncSession(builder()
-                    .withDefaultAccessMode(mode)
-                    .withBookmarks(context.getBookmark())
-                    .build());
+            return driver.session(
+                    AsyncSession.class,
+                    builder()
+                            .withDefaultAccessMode(mode)
+                            .withBookmarks(context.getBookmark())
+                            .build());
         }
-        return driver.asyncSession(builder().withDefaultAccessMode(mode).build());
+        return driver.session(
+                AsyncSession.class, builder().withDefaultAccessMode(mode).build());
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -506,7 +506,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
     private static Bookmark createNodesAsync(int batchCount, int batchSize, Driver driver) throws Throwable {
         long start = System.nanoTime();
 
-        AsyncSession session = driver.asyncSession();
+        AsyncSession session = driver.session(AsyncSession.class);
         CompletableFuture<Throwable> writeTransactions = completedFuture(null);
 
         for (int i = 0; i < batchCount; i++) {
@@ -532,8 +532,8 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
     private static void readNodesAsync(Driver driver, Bookmark bookmark, int expectedNodeCount) throws Throwable {
         long start = System.nanoTime();
 
-        AsyncSession session =
-                driver.asyncSession(builder().withBookmarks(bookmark).build());
+        AsyncSession session = driver.session(
+                AsyncSession.class, builder().withBookmarks(bookmark).build());
         AtomicInteger nodesSeen = new AtomicInteger();
 
         CompletionStage<Throwable> readQuery = session.readTransactionAsync(tx -> tx.runAsync("MATCH (n:Node) RETURN n")

--- a/driver/src/test/java/org/neo4j/driver/tck/reactive/ReactiveResultPublisherVerificationIT.java
+++ b/driver/src/test/java/org/neo4j/driver/tck/reactive/ReactiveResultPublisherVerificationIT.java
@@ -64,13 +64,13 @@ public class ReactiveResultPublisherVerificationIT extends PublisherVerification
 
     @Override
     public Publisher<ReactiveResult> createPublisher(long elements) {
-        ReactiveSession session = driver.reactiveSession();
+        ReactiveSession session = driver.session(ReactiveSession.class);
         return Mono.from(flowPublisherToFlux(session.run("RETURN 1")));
     }
 
     @Override
     public Publisher<ReactiveResult> createFailedPublisher() {
-        ReactiveSession session = driver.reactiveSession();
+        ReactiveSession session = driver.session(ReactiveSession.class);
         // Please note that this publisher fails on run stage.
         return Mono.from(flowPublisherToFlux(session.run("RETURN 5/0")));
     }

--- a/driver/src/test/java/org/neo4j/driver/tck/reactive/ReactiveResultRecordPublisherVerificationIT.java
+++ b/driver/src/test/java/org/neo4j/driver/tck/reactive/ReactiveResultRecordPublisherVerificationIT.java
@@ -70,14 +70,14 @@ public class ReactiveResultRecordPublisherVerificationIT extends PublisherVerifi
 
     @Override
     public Publisher<Record> createPublisher(long elements) {
-        ReactiveSession session = driver.reactiveSession();
+        ReactiveSession session = driver.session(ReactiveSession.class);
         return Mono.fromDirect(flowPublisherToFlux(session.run(QUERY, parameters("numberOfRecords", elements))))
                 .flatMapMany(r -> Flux.from(flowPublisherToFlux(r.records())));
     }
 
     @Override
     public Publisher<Record> createFailedPublisher() {
-        ReactiveSession session = driver.reactiveSession();
+        ReactiveSession session = driver.session(ReactiveSession.class);
         // Please note that this publisher fails on run stage.
         return Mono.fromDirect(flowPublisherToFlux(session.run("RETURN 5/0")))
                 .flatMapMany(r -> Flux.from(flowPublisherToFlux(r.records())));

--- a/driver/src/test/java/org/neo4j/driver/testutil/DriverExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/DriverExtension.java
@@ -45,7 +45,7 @@ public class DriverExtension extends DatabaseExtension implements BeforeEachCall
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         super.beforeEach(context);
-        asyncSession = driver().asyncSession();
+        asyncSession = driver().session(AsyncSession.class);
         session = driver().session();
     }
 

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncAutocommitTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncAutocommitTransactionExample.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.docs.driver;
 
+import org.neo4j.driver.async.AsyncSession;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +35,7 @@ public class AsyncAutocommitTransactionExample extends BaseApplication {
         var query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         var parameters = Map.<String, Object>of("id", 0);
 
-        var session = driver.asyncSession();
+        var session = driver.session(AsyncSession.class);
 
         return session.runAsync(query, parameters)
                 .thenCompose(cursor -> cursor.listAsync(record -> record.get(0).asString()))

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncResultConsumeExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncResultConsumeExample.java
@@ -19,6 +19,7 @@
 package org.neo4j.docs.driver;
 
 import org.neo4j.driver.Query;
+import org.neo4j.driver.async.AsyncSession;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -31,7 +32,7 @@ public class AsyncResultConsumeExample extends BaseApplication {
     // tag::async-result-consume[]
     public CompletionStage<List<String>> getPeople() {
         var query = new Query("MATCH (a:Person) RETURN a.name ORDER BY a.name");
-        var session = driver.asyncSession();
+        var session = driver.session(AsyncSession.class);
         return session.executeReadAsync(tx -> tx.runAsync(query)
                 .thenCompose(cursor -> cursor.listAsync(record -> record.get(0).asString())));
     }

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncRunMultipleTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncRunMultipleTransactionExample.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.docs.driver;
 
+import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransactionContext;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.summary.ResultSummary;
@@ -36,7 +37,7 @@ public class AsyncRunMultipleTransactionExample extends BaseApplication {
 
     // tag::async-multiple-tx[]
     public CompletionStage<Integer> addEmployees(final String companyName) {
-        var session = driver.asyncSession();
+        var session = driver.session(AsyncSession.class);
         return session.executeReadAsync(AsyncRunMultipleTransactionExample::matchPersonNodes)
                 .thenCompose(personNames -> session.executeWriteAsync(tx -> createNodes(tx, companyName, personNames)));
     }

--- a/examples/src/main/java/org/neo4j/docs/driver/AsyncTransactionFunctionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/AsyncTransactionFunctionExample.java
@@ -35,7 +35,7 @@ public class AsyncTransactionFunctionExample extends BaseApplication {
         String query = "MATCH (p:Product) WHERE p.id = $id RETURN p.title";
         Map<String, Object> parameters = Collections.singletonMap("id", 0);
 
-        AsyncSession session = driver.asyncSession();
+        AsyncSession session = driver.session(AsyncSession.class);
 
         return session.executeReadAsync(tx -> tx.runAsync(query, parameters)
                 .thenCompose(cursor -> cursor.forEachAsync(record ->

--- a/examples/src/main/java/org/neo4j/docs/driver/RxAutocommitTransactionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxAutocommitTransactionExample.java
@@ -19,6 +19,7 @@
 package org.neo4j.docs.driver;
 
 import org.neo4j.driver.Query;
+import org.neo4j.driver.reactive.ReactiveSession;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -35,7 +36,7 @@ public class RxAutocommitTransactionExample extends BaseApplication {
     public Flux<String> readProductTitles() {
         var query = new Query("MATCH (p:Product) WHERE p.id = $id RETURN p.title", Collections.singletonMap("id", 0));
         return Flux.usingWhen(
-                Mono.fromSupplier(driver::reactiveSession),
+                Mono.fromSupplier(() -> driver.session(ReactiveSession.class)),
                 session -> flowPublisherToFlux(session.run(query))
                         .flatMap(result -> flowPublisherToFlux(result.records()))
                         .map(record -> record.get(0).asString()),

--- a/examples/src/main/java/org/neo4j/docs/driver/RxResultConsumeExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxResultConsumeExample.java
@@ -19,6 +19,7 @@
 package org.neo4j.docs.driver;
 
 import org.neo4j.driver.Query;
+import org.neo4j.driver.reactive.ReactiveSession;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -34,7 +35,7 @@ public class RxResultConsumeExample extends BaseApplication {
     public Flux<String> getPeople() {
         var query = new Query("MATCH (a:Person) RETURN a.name ORDER BY a.name");
         return Flux.usingWhen(
-                Mono.fromSupplier(driver::reactiveSession),
+                Mono.fromSupplier(() -> driver.session(ReactiveSession.class)),
                 session -> flowPublisherToFlux(session.executeRead(tx -> {
                     var flux = flowPublisherToFlux(tx.run(query))
                             .flatMap(result -> flowPublisherToFlux(result.records()))

--- a/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
+++ b/examples/src/main/java/org/neo4j/docs/driver/RxTransactionFunctionExample.java
@@ -20,6 +20,7 @@ package org.neo4j.docs.driver;
 
 import org.neo4j.driver.Query;
 import org.neo4j.driver.reactive.ReactiveResult;
+import org.neo4j.driver.reactive.ReactiveSession;
 import org.neo4j.driver.summary.ResultSummary;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -40,7 +41,7 @@ public class RxTransactionFunctionExample extends BaseApplication {
         var query = new Query("MATCH (p:Product) WHERE p.id = $id RETURN p.title", Collections.singletonMap("id", 0));
 
         return Flux.usingWhen(
-                Mono.fromSupplier(driver::reactiveSession),
+                Mono.fromSupplier(() -> driver.session(ReactiveSession.class)),
                 session -> flowPublisherToFlux(session.executeRead(tx -> {
                     var resultRef = new AtomicReference<ReactiveResult>();
                     var flux = flowPublisherToFlux(tx.run(query))

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
@@ -38,7 +38,10 @@ import neo4j.org.testkit.backend.messages.responses.Session;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.internal.InternalBookmark;
+import org.neo4j.driver.reactive.ReactiveSession;
+import org.neo4j.driver.reactive.RxSession;
 import reactor.core.publisher.Mono;
 
 @Setter
@@ -113,26 +116,25 @@ public class NewSession implements TestkitRequest {
 
     private AsyncSessionHolder createAsyncSessionState(DriverHolder driverHolder, SessionConfig sessionConfig) {
         return new AsyncSessionHolder(
-                driverHolder, driverHolder.getDriver().asyncSession(sessionConfig), sessionConfig);
+                driverHolder, driverHolder.getDriver().session(AsyncSession.class, sessionConfig), sessionConfig);
     }
 
     @SuppressWarnings("deprecation")
     private RxSessionHolder createRxSessionState(DriverHolder driverHolder, SessionConfig sessionConfig) {
-        return new RxSessionHolder(driverHolder, driverHolder.getDriver().rxSession(sessionConfig), sessionConfig);
+        return new RxSessionHolder(
+                driverHolder, driverHolder.getDriver().session(RxSession.class, sessionConfig), sessionConfig);
     }
 
     private ReactiveSessionHolder createReactiveSessionState(DriverHolder driverHolder, SessionConfig sessionConfig) {
         return new ReactiveSessionHolder(
-                driverHolder, driverHolder.getDriver().reactiveSession(sessionConfig), sessionConfig);
+                driverHolder, driverHolder.getDriver().session(ReactiveSession.class, sessionConfig), sessionConfig);
     }
 
     private ReactiveSessionStreamsHolder createReactiveSessionStreamsState(
             DriverHolder driverHolder, SessionConfig sessionConfig) {
         return new ReactiveSessionStreamsHolder(
                 driverHolder,
-                driverHolder
-                        .getDriver()
-                        .reactiveSession(org.neo4j.driver.reactivestreams.ReactiveSession.class, sessionConfig),
+                driverHolder.getDriver().session(org.neo4j.driver.reactivestreams.ReactiveSession.class, sessionConfig),
                 sessionConfig);
     }
 


### PR DESCRIPTION
These new methods provide a consistent API for creating different types of session APIs.

Sample usage:
```
var synchronousSession = driver.session(Session.class);
var asynchronousSession = driver.session(AsyncSession.class);
var reactiveSession1 = driver.session(org.neo4j.driver.reactive.ReactiveSession.class);
var reactiveSession2 = driver.session(org.neo4j.driver.reactivestreams.ReactiveSession.class);
var reactiveSession3 = driver.session(org.neo4j.driver.reactive.RxSession.class);
```

The following methods have been deprecated:
- `asyncSession`
- `reactiveSession`