### PR TITLE
Introduce notification filtering

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -409,4 +409,28 @@
         <method>org.neo4j.driver.BaseSession session(java.lang.Class, org.neo4j.driver.SessionConfig)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.Optional severityLevel()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.Optional rawSeverityLevel()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.Optional category()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.Optional rawCategory()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -19,6 +19,7 @@
 package org.neo4j.driver;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 import java.io.File;
@@ -29,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import org.neo4j.driver.internal.SecuritySettings;
@@ -38,6 +38,8 @@ import org.neo4j.driver.internal.cluster.RoutingSettings;
 import org.neo4j.driver.internal.handlers.pulln.FetchSizeUtil;
 import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.net.ServerAddressResolver;
+import org.neo4j.driver.summary.NotificationFilterConfig;
+import org.neo4j.driver.summary.NotificationFilterConfigs;
 import org.neo4j.driver.util.Experimental;
 import org.neo4j.driver.util.Immutable;
 
@@ -75,7 +77,9 @@ public final class Config implements Serializable {
 
     private static final Config EMPTY = builder().build();
 
-    /** User defined logging */
+    /**
+     * User defined logging
+     */
     private final Logging logging;
 
     private final boolean logLeakedSessions;
@@ -98,6 +102,7 @@ public final class Config implements Serializable {
     private final int eventLoopThreads;
     private final String userAgent;
     private final MetricsAdapter metricsAdapter;
+    private final NotificationFilterConfig notificationFilterConfig;
 
     private Config(ConfigBuilder builder) {
         this.logging = builder.logging;
@@ -119,10 +124,12 @@ public final class Config implements Serializable {
 
         this.eventLoopThreads = builder.eventLoopThreads;
         this.metricsAdapter = builder.metricsAdapter;
+        this.notificationFilterConfig = builder.notificationFilterConfig;
     }
 
     /**
      * Logging provider
+     *
      * @return the Logging provider to use
      */
     public Logging logging() {
@@ -253,6 +260,17 @@ public final class Config implements Serializable {
     }
 
     /**
+     * Returns notification filter configuration.
+     * <p>
+     * An instance of {@link NotificationFilterConfigs#serverDefaults()} is used by default.
+     *
+     * @return notification filter configuration
+     */
+    public NotificationFilterConfig notificationFilterConfig() {
+        return notificationFilterConfig;
+    }
+
+    /**
      * Used to build new config instances
      */
     public static final class ConfigBuilder {
@@ -272,6 +290,7 @@ public final class Config implements Serializable {
         private MetricsAdapter metricsAdapter = MetricsAdapter.DEV_NULL;
         private long fetchSize = FetchSizeUtil.DEFAULT_FETCH_SIZE;
         private int eventLoopThreads = 0;
+        private NotificationFilterConfig notificationFilterConfig = NotificationFilterConfigs.serverDefaults();
 
         private ConfigBuilder() {}
 
@@ -331,7 +350,7 @@ public final class Config implements Serializable {
          * validity and negative values mean connections will never be tested.
          *
          * @param value the minimum idle time
-         * @param unit the unit in which the duration is given
+         * @param unit  the unit in which the duration is given
          * @return this builder
          */
         public ConfigBuilder withConnectionLivenessCheckTimeout(long value, TimeUnit unit) {
@@ -356,7 +375,7 @@ public final class Config implements Serializable {
          * checked.
          *
          * @param value the maximum connection lifetime
-         * @param unit the unit in which the duration is given
+         * @param unit  the unit in which the duration is given
          * @return this builder
          */
         public ConfigBuilder withMaxConnectionLifetime(long value, TimeUnit unit) {
@@ -402,7 +421,7 @@ public final class Config implements Serializable {
          * of {@code 0} is allowed and results in no timeout and immediate failure when connection is unavailable.
          *
          * @param value the acquisition timeout
-         * @param unit the unit in which the duration is given
+         * @param unit  the unit in which the duration is given
          * @return this builder
          * @see #withMaxConnectionPoolSize(int)
          */
@@ -418,6 +437,7 @@ public final class Config implements Serializable {
 
         /**
          * Set to use encrypted traffic.
+         *
          * @return this builder
          */
         public ConfigBuilder withEncryption() {
@@ -427,6 +447,7 @@ public final class Config implements Serializable {
 
         /**
          * Set to use unencrypted traffic.
+         *
          * @return this builder
          */
         public ConfigBuilder withoutEncryption() {
@@ -461,13 +482,12 @@ public final class Config implements Serializable {
          * The routing table of a database get refreshed if the database is used frequently.
          * If the database is not used for a long time,
          * the driver use the timeout specified here to purge the stale routing table.
-         *
+         * <p>
          * After a routing table is removed, next time when using the database of the purged routing table,
          * the driver will fall back to use seed URI for a new routing table.
-         * @param delay
-         *         the amount of time to wait before purging routing tables
-         * @param unit
-         *         the unit in which the duration is given
+         *
+         * @param delay the amount of time to wait before purging routing tables
+         * @param unit  the unit in which the duration is given
          * @return this builder
          */
         public ConfigBuilder withRoutingTablePurgeDelay(long delay, TimeUnit unit) {
@@ -483,15 +503,16 @@ public final class Config implements Serializable {
         /**
          * Specify how many records to fetch in each batch.
          * This config is only valid when the driver is used with servers that support Bolt V4 (Server version 4.0 and later).
-         *
+         * <p>
          * Bolt V4 enables pulling records in batches to allow client to take control of data population and apply back pressure to server.
          * This config specifies the default fetch size for all query runs using {@link Session} and {@link org.neo4j.driver.async.AsyncSession}.
          * By default, the value is set to {@code 1000}.
          * Use {@code -1} to disables back pressure and config client to pull all records at once after each run.
-         *
+         * <p>
          * This config only applies to run result obtained via {@link Session} and {@link org.neo4j.driver.async.AsyncSession}.
          * As with {@link org.neo4j.driver.reactive.RxSession}, the batch size is provided via
          * {@link org.reactivestreams.Subscription#request(long)} instead.
+         *
          * @param size the default record fetch size when pulling records in batches using Bolt V4.
          * @return this builder
          */
@@ -512,10 +533,10 @@ public final class Config implements Serializable {
          * The default value of this parameter is {@code 30 SECONDS}.
          *
          * @param value the timeout duration
-         * @param unit the unit in which duration is given
+         * @param unit  the unit in which duration is given
          * @return this builder
          * @throws IllegalArgumentException when given value is negative or does not fit in {@code int} when
-         * converted to milliseconds.
+         *                                  converted to milliseconds.
          */
         public ConfigBuilder withConnectionTimeout(long value, TimeUnit unit) {
             long connectionTimeoutMillis = unit.toMillis(value);
@@ -543,7 +564,7 @@ public final class Config implements Serializable {
          * Default value is 30 seconds.
          *
          * @param value the timeout duration
-         * @param unit the unit in which duration is given
+         * @param unit  the unit in which duration is given
          * @return this builder
          * @throws IllegalArgumentException when given value is negative
          */
@@ -571,7 +592,7 @@ public final class Config implements Serializable {
          * @throws NullPointerException when the given resolver is {@code null}.
          */
         public ConfigBuilder withResolver(ServerAddressResolver resolver) {
-            this.resolver = Objects.requireNonNull(resolver, "resolver");
+            this.resolver = requireNonNull(resolver, "resolver");
             return this;
         }
 
@@ -586,6 +607,7 @@ public final class Config implements Serializable {
 
         /**
          * Disable driver metrics. When disabled, driver metrics cannot be accessed via {@link Driver#metrics()}.
+         *
          * @return this builder.
          */
         public ConfigBuilder withoutDriverMetrics() {
@@ -612,13 +634,14 @@ public final class Config implements Serializable {
          */
         @Experimental
         public ConfigBuilder withMetricsAdapter(MetricsAdapter metricsAdapter) {
-            this.metricsAdapter = Objects.requireNonNull(metricsAdapter, "metricsAdapter");
+            this.metricsAdapter = requireNonNull(metricsAdapter, "metricsAdapter");
             return this;
         }
 
         /**
          * Configure the event loop thread count. This specifies how many threads the driver can use to handle network I/O events
          * and user's events in driver's I/O threads. By default, 2 * NumberOfProcessors amount of threads will be used instead.
+         *
          * @param size the thread count.
          * @return this builder.
          * @throws IllegalArgumentException if the value of the size is set to a number that is less than 1.
@@ -634,6 +657,7 @@ public final class Config implements Serializable {
 
         /**
          * Configure the user_agent field sent to the server to identify the connected client.
+         *
          * @param userAgent the string to configure user_agent.
          * @return this builder.
          */
@@ -642,6 +666,23 @@ public final class Config implements Serializable {
                 throw new IllegalArgumentException("The user_agent string must not be empty");
             }
             this.userAgent = userAgent;
+            return this;
+        }
+
+        /**
+         * Set notification filter configuration.
+         * <p>
+         * An instance of {@link NotificationFilterConfigs#serverDefaults()} is used by default.
+         * <p>
+         * Please note that configuration requires a minimum Bolt protocol version 5.1 that is available on Neo4j server version 5.3.
+         * On prior versions the configuration will be ignored.
+         *
+         * @param notificationFilterConfig notification filter configuration, must not be {@code null}
+         * @return this builder
+         */
+        public ConfigBuilder withNotificationFilterConfig(NotificationFilterConfig notificationFilterConfig) {
+            this.notificationFilterConfig =
+                    requireNonNull(notificationFilterConfig, "notificationFilterConfig must not be null");
             return this;
         }
 
@@ -698,7 +739,7 @@ public final class Config implements Serializable {
         }
 
         private TrustStrategy(Strategy strategy, List<File> certFiles) {
-            Objects.requireNonNull(certFiles, "certFiles can't be null");
+            requireNonNull(certFiles, "certFiles can't be null");
             this.strategy = strategy;
             this.certFiles = Collections.unmodifiableList(new ArrayList<>(certFiles));
         }
@@ -772,7 +813,7 @@ public final class Config implements Serializable {
          * @return an authentication config
          */
         public static TrustStrategy trustCustomCertificateSignedBy(File... certFiles) {
-            Objects.requireNonNull(certFiles, "certFiles can't be null");
+            requireNonNull(certFiles, "certFiles can't be null");
             if (certFiles.length == 0) {
                 throw new IllegalArgumentException("certFiles can't be empty");
             }
@@ -802,6 +843,7 @@ public final class Config implements Serializable {
 
         /**
          * The revocation strategy used for verifying certificates.
+         *
          * @return this {@link TrustStrategy}'s revocation strategy
          */
         public RevocationCheckingStrategy revocationCheckingStrategy() {
@@ -811,6 +853,7 @@ public final class Config implements Serializable {
         /**
          * Configures the {@link TrustStrategy} to not carry out OCSP revocation checks on certificates. This is the
          * option that is configured by default.
+         *
          * @return the current trust strategy
          */
         public TrustStrategy withoutCertificateRevocationChecks() {
@@ -823,6 +866,7 @@ public final class Config implements Serializable {
          * stapled to the certificate. If no stapled response is found, then certificate verification continues
          * (and does not fail verification). This setting also requires the server to be configured to enable
          * OCSP stapling.
+         *
          * @return the current trust strategy
          */
         public TrustStrategy withVerifyIfPresentRevocationChecks() {
@@ -834,9 +878,10 @@ public final class Config implements Serializable {
          * Configures the {@link TrustStrategy} to carry out strict OCSP revocation checks for revocation status that
          * are stapled to the certificate. If no stapled response is found, then the driver will fail certificate verification
          * and not connect to the server. This setting also requires the server to be configured to enable OCSP stapling.
-         *
+         * <p>
          * Note: enabling this setting will prevent the driver connecting to the server when the server is unable to reach
          * the certificate's configured OCSP responder URL.
+         *
          * @return the current trust strategy
          */
         public TrustStrategy withStrictRevocationChecks() {

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -55,6 +55,7 @@ import org.neo4j.driver.internal.retry.RetrySettings;
 import org.neo4j.driver.internal.security.SecurityPlan;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
+import org.neo4j.driver.internal.summary.InternalNotificationFilterConfig;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.net.ServerAddressResolver;
@@ -173,7 +174,13 @@ public class DriverFactory {
             Clock clock,
             RoutingContext routingContext) {
         return new ChannelConnectorImpl(
-                settings, securityPlan, config.logging(), clock, routingContext, getDomainNameResolver());
+                settings,
+                securityPlan,
+                config.logging(),
+                clock,
+                routingContext,
+                getDomainNameResolver(),
+                ((InternalNotificationFilterConfig) config.notificationFilterConfig()).filters());
     }
 
     private InternalDriver createDriver(

--- a/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
 import org.neo4j.driver.internal.util.Futures;
+import org.neo4j.driver.summary.NotificationFilterConfig;
 
 public class LeakLoggingNetworkSession extends NetworkSession {
     private final String stackTrace;
@@ -42,7 +43,8 @@ public class LeakLoggingNetworkSession extends NetworkSession {
             String impersonatedUser,
             long fetchSize,
             Logging logging,
-            BookmarkManager bookmarkManager) {
+            BookmarkManager bookmarkManager,
+            NotificationFilterConfig notificationFilterConfig) {
         super(
                 connectionProvider,
                 retryLogic,
@@ -52,7 +54,8 @@ public class LeakLoggingNetworkSession extends NetworkSession {
                 impersonatedUser,
                 fetchSize,
                 logging,
-                bookmarkManager);
+                bookmarkManager,
+                notificationFilterConfig);
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -48,6 +48,7 @@ import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.summary.NotificationFilterConfig;
 
 public class UnmanagedTransaction {
     private enum State {
@@ -111,8 +112,11 @@ public class UnmanagedTransaction {
     }
 
     public CompletionStage<UnmanagedTransaction> beginAsync(
-            Set<Bookmark> initialBookmarks, TransactionConfig config, String txType) {
-        return protocol.beginTransaction(connection, initialBookmarks, config, txType)
+            Set<Bookmark> initialBookmarks,
+            TransactionConfig config,
+            String txType,
+            NotificationFilterConfig notificationFilterConfig) {
+        return protocol.beginTransaction(connection, initialBookmarks, config, txType, notificationFilterConfig)
                 .handle((ignore, beginError) -> {
                     if (beginError != null) {
                         if (beginError instanceof AuthorizationExpiredException) {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 
 public final class BoltProtocolUtil {
     public static final int BOLT_MAGIC_PREAMBLE = 0x6060B017;
@@ -40,7 +41,7 @@ public final class BoltProtocolUtil {
 
     private static final ByteBuf HANDSHAKE_BUF = unreleasableBuffer(copyInt(
                     BOLT_MAGIC_PREAMBLE,
-                    BoltProtocolV5.VERSION.toInt(),
+                    BoltProtocolV51.VERSION.toIntRange(BoltProtocolV5.VERSION),
                     BoltProtocolV44.VERSION.toIntRange(BoltProtocolV42.VERSION),
                     BoltProtocolV41.VERSION.toInt(),
                     BoltProtocolV3.VERSION.toInt()))

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelAttributes.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.messaging.BoltPatchesListener;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
+import org.neo4j.driver.summary.NotificationFilter;
 
 public final class ChannelAttributes {
     private static final AttributeKey<String> CONNECTION_ID = newInstance("connectionId");
@@ -48,6 +49,8 @@ public final class ChannelAttributes {
 
     // configuration hints provided by the server
     private static final AttributeKey<Long> CONNECTION_READ_TIMEOUT = newInstance("connectionReadTimeout");
+    private static final AttributeKey<Set<NotificationFilter>> NOTIFICATION_FILTERS =
+            newInstance("notificationFilters");
 
     private ChannelAttributes() {}
 
@@ -152,6 +155,14 @@ public final class ChannelAttributes {
     public static Set<BoltPatchesListener> boltPatchesListeners(Channel channel) {
         Set<BoltPatchesListener> boltPatchesListeners = get(channel, BOLT_PATCHES_LISTENERS);
         return boltPatchesListeners != null ? boltPatchesListeners : Collections.emptySet();
+    }
+
+    public static Set<NotificationFilter> notificationFilters(Channel channel) {
+        return get(channel, NOTIFICATION_FILTERS);
+    }
+
+    public static void setNotificationFilters(Channel channel, Set<NotificationFilter> notificationFilters) {
+        setOnce(channel, NOTIFICATION_FILTERS, notificationFilters);
     }
 
     private static <T> T get(Channel channel, AttributeKey<T> key) {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingTableHandlerImpl.java
@@ -74,7 +74,7 @@ public class RoutingTableHandlerImpl implements RoutingTableHandler {
     @Override
     public synchronized CompletionStage<RoutingTable> ensureRoutingTable(ConnectionContext context) {
         if (refreshRoutingTableFuture != null) {
-            // refresh is already happening concurrently, just use it's result
+            // refresh is already happening concurrently, just use its result
             return refreshRoutingTableFuture;
         } else if (routingTable.isStaleFor(context.mode())) {
             // existing routing table is not fresh and should be updated

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
@@ -92,7 +92,8 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
                         bookmarks,
                         (ignored) -> {},
                         TransactionConfig.empty(),
-                        UNLIMITED_FETCH_SIZE)
+                        UNLIMITED_FETCH_SIZE,
+                        null)
                 .asyncResult()
                 .thenCompose(ResultCursor::listAsync);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -43,7 +43,9 @@ import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.summary.NotificationFilterConfig;
 
 public interface BoltProtocol {
     /**
@@ -80,10 +82,15 @@ public interface BoltProtocol {
      * @param bookmarks  the bookmarks. Never null, should be empty when there are no bookmarks.
      * @param config     the transaction configuration. Never null, should be {@link TransactionConfig#empty()} when absent.
      * @param txType the Kernel transaction type
+     * @param notificationFilterConfig the notification filters config
      * @return a completion stage completed when transaction is started or completed exceptionally when there was a failure.
      */
     CompletionStage<Void> beginTransaction(
-            Connection connection, Set<Bookmark> bookmarks, TransactionConfig config, String txType);
+            Connection connection,
+            Set<Bookmark> bookmarks,
+            TransactionConfig config,
+            String txType,
+            NotificationFilterConfig notificationFilterConfig);
 
     /**
      * Commit the unmanaged transaction.
@@ -109,6 +116,7 @@ public interface BoltProtocol {
      * @param bookmarkConsumer the database bookmark consumer.
      * @param config          the transaction config for the implicitly started auto-commit transaction.
      * @param fetchSize       the record fetch size for PULL message.
+     * @param notificationFilterConfig the notification filters config
      * @return stage with cursor.
      */
     ResultCursorFactory runInAutoCommitTransaction(
@@ -117,7 +125,8 @@ public interface BoltProtocol {
             Set<Bookmark> bookmarks,
             Consumer<DatabaseBookmark> bookmarkConsumer,
             TransactionConfig config,
-            long fetchSize);
+            long fetchSize,
+            NotificationFilterConfig notificationFilterConfig);
 
     /**
      * Execute the given query in a running unmanaged transaction, i.e. {@link Transaction#run(Query)}.
@@ -170,6 +179,8 @@ public interface BoltProtocol {
             return BoltProtocolV44.INSTANCE;
         } else if (BoltProtocolV5.VERSION.equals(version)) {
             return BoltProtocolV5.INSTANCE;
+        } else if (BoltProtocolV51.VERSION.equals(version)) {
+            return BoltProtocolV51.INSTANCE;
         }
         throw new ClientException("Unknown protocol version: " + version);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/HelloMessageV51Encoder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/HelloMessageV51Encoder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.encode;
+
+import static org.neo4j.driver.internal.util.Preconditions.checkArgument;
+
+import java.io.IOException;
+import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.messaging.MessageEncoder;
+import org.neo4j.driver.internal.messaging.ValuePacker;
+import org.neo4j.driver.internal.messaging.request.HelloMessage;
+import org.neo4j.driver.internal.messaging.request.HelloMessageV51;
+
+public class HelloMessageV51Encoder implements MessageEncoder {
+    @Override
+    public void encode(Message message, ValuePacker packer) throws IOException {
+        checkArgument(message, HelloMessage.class);
+        var helloMessage = (HelloMessageV51) message;
+        packer.packStructHeader(2, helloMessage.signature());
+        packer.pack(helloMessage.authMap());
+        packer.pack(helloMessage.metadata());
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/NotificationFilterEncodingUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/encode/NotificationFilterEncodingUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.encode;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.summary.NotificationFilter;
+
+public class NotificationFilterEncodingUtil {
+    private static final String ENCODED_FILTER_PATTERN = "%s.%s";
+
+    public static Value encode(Set<NotificationFilter> filters, boolean encodeNullExplicitly) {
+        Value value;
+        if (filters == null) {
+            value = encodeNullExplicitly ? Values.NULL : null;
+        } else if (filters.isEmpty()) {
+            value = Values.value(Collections.emptySet());
+        } else {
+            value = Values.value(filters.stream()
+                    .map(NotificationFilterEncodingUtil::encodeNotificationFilter)
+                    .collect(Collectors.toSet()));
+        }
+        return value;
+    }
+
+    private static String encodeNotificationFilter(NotificationFilter filter) {
+        return String.format(
+                ENCODED_FILTER_PATTERN,
+                encodeString(filter.severity().name()),
+                encodeString(filter.category().name()));
+    }
+
+    private static String encodeString(String value) {
+        return value.equals("ALL") ? "*" : value;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -39,8 +39,17 @@ public class BeginMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             AccessMode mode,
             String impersonatedUser,
-            String txType) {
-        this(bookmarks, config.timeout(), config.metadata(), mode, databaseName, impersonatedUser, txType);
+            String txType,
+            Value notifications) {
+        this(
+                bookmarks,
+                config.timeout(),
+                config.metadata(),
+                mode,
+                databaseName,
+                impersonatedUser,
+                txType,
+                notifications);
     }
 
     public BeginMessage(
@@ -50,8 +59,10 @@ public class BeginMessage extends MessageWithMetadata {
             AccessMode mode,
             DatabaseName databaseName,
             String impersonatedUser,
-            String txType) {
-        super(buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, txType));
+            String txType,
+            Value notifications) {
+        super(buildMetadata(
+                txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, txType, notifications));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessage.java
@@ -30,8 +30,8 @@ import org.neo4j.driver.Value;
 public class HelloMessage extends MessageWithMetadata {
     public static final byte SIGNATURE = 0x01;
 
-    private static final String USER_AGENT_METADATA_KEY = "user_agent";
-    private static final String ROUTING_CONTEXT_METADATA_KEY = "routing";
+    public static final String USER_AGENT_METADATA_KEY = "user_agent";
+    public static final String ROUTING_CONTEXT_METADATA_KEY = "routing";
     private static final String PATCH_BOLT_METADATA_KEY = "patch_bolt";
 
     private static final String DATE_TIME_UTC_PATCH_VALUE = "utc";
@@ -42,6 +42,10 @@ public class HelloMessage extends MessageWithMetadata {
             Map<String, String> routingContext,
             boolean includeDateTimeUtc) {
         super(buildMetadata(userAgent, authToken, routingContext, includeDateTimeUtc));
+    }
+
+    protected HelloMessage(Map<String, Value> metadata) {
+        super(metadata);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessageV51.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/HelloMessageV51.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.request;
+
+import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.security.InternalAuthToken.CREDENTIALS_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.neo4j.driver.Value;
+
+public class HelloMessageV51 extends HelloMessage {
+    private static final String NOTIFICATIONS_KEY = "notifications";
+
+    private final Map<String, Value> authMap;
+
+    public HelloMessageV51(
+            String userAgent,
+            Map<String, Value> authToken,
+            Map<String, String> routingContext,
+            Value notificationFilters) {
+        super(buildMetadata(userAgent, routingContext, notificationFilters));
+        this.authMap = authToken;
+    }
+
+    public Map<String, Value> authMap() {
+        return authMap;
+    }
+
+    private static Map<String, Value> buildMetadata(
+            String userAgent, Map<String, String> routingContext, Value notificationFilters) {
+        var extras = new HashMap<String, Value>();
+        extras.put(USER_AGENT_METADATA_KEY, value(userAgent));
+        if (routingContext != null) {
+            extras.put(ROUTING_CONTEXT_METADATA_KEY, value(routingContext));
+        }
+        if (notificationFilters != null) {
+            extras.put(NOTIFICATIONS_KEY, notificationFilters);
+        }
+        return extras;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        HelloMessageV51 that = (HelloMessageV51) o;
+        return authMap.equals(that.authMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), authMap);
+    }
+
+    @Override
+    public String toString() {
+        Map<String, Map<String, Value>> dataMap = new HashMap<>();
+        Map<String, Value> updatedAuthMap = new HashMap<>(authMap);
+        updatedAuthMap.replace(CREDENTIALS_KEY, value("******"));
+        dataMap.put("authMap", updatedAuthMap);
+        dataMap.put("metadata", metadata());
+        return "HELLO " + dataMap;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -45,9 +45,17 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             AccessMode mode,
             Set<Bookmark> bookmarks,
-            String impersonatedUser) {
+            String impersonatedUser,
+            Value notifications) {
         return autoCommitTxRunMessage(
-                query, config.timeout(), config.metadata(), databaseName, mode, bookmarks, impersonatedUser);
+                query,
+                config.timeout(),
+                config.metadata(),
+                databaseName,
+                mode,
+                bookmarks,
+                impersonatedUser,
+                notifications);
     }
 
     public static RunWithMetadataMessage autoCommitTxRunMessage(
@@ -57,9 +65,10 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             AccessMode mode,
             Set<Bookmark> bookmarks,
-            String impersonatedUser) {
-        Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, null);
+            String impersonatedUser,
+            Value notifications) {
+        Map<String, Value> metadata = buildMetadata(
+                txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, null, notifications);
         return new RunWithMetadataMessage(query.text(), query.parameters().asMap(ofValue()), metadata);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
@@ -40,6 +40,7 @@ public class TransactionMetadataBuilder {
     private static final String MODE_READ_VALUE = "r";
     private static final String IMPERSONATED_USER_KEY = "imp_user";
     private static final String TX_TYPE_KEY = "tx_type";
+    private static final String NOTIFICATIONS_KEY = "notifications";
 
     public static Map<String, Value> buildMetadata(
             Duration txTimeout,
@@ -47,8 +48,10 @@ public class TransactionMetadataBuilder {
             AccessMode mode,
             Set<Bookmark> bookmarks,
             String impersonatedUser,
-            String txType) {
-        return buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, impersonatedUser, txType);
+            String txType,
+            Value notifications) {
+        return buildMetadata(
+                txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, impersonatedUser, txType, notifications);
     }
 
     public static Map<String, Value> buildMetadata(
@@ -58,7 +61,8 @@ public class TransactionMetadataBuilder {
             AccessMode mode,
             Set<Bookmark> bookmarks,
             String impersonatedUser,
-            String txType) {
+            String txType,
+            Value notifications) {
         boolean bookmarksPresent = !bookmarks.isEmpty();
         boolean txTimeoutPresent = txTimeout != null;
         boolean txMetadataPresent = txMetadata != null && !txMetadata.isEmpty();
@@ -96,6 +100,9 @@ public class TransactionMetadataBuilder {
         }
         if (txTypePresent) {
             result.put(TX_TYPE_KEY, value(txType));
+        }
+        if (notifications != null) {
+            result.put(NOTIFICATIONS_KEY, notifications);
         }
 
         databaseName.databaseName().ifPresent(name -> result.put(DATABASE_NAME_KEY, value(name)));

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.v51;
+
+import static org.neo4j.driver.internal.async.connection.ChannelAttributes.notificationFilters;
+
+import io.netty.channel.Channel;
+import java.util.Map;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.messaging.BoltProtocol;
+import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
+import org.neo4j.driver.internal.messaging.MessageFormat;
+import org.neo4j.driver.internal.messaging.encode.NotificationFilterEncodingUtil;
+import org.neo4j.driver.internal.messaging.request.HelloMessage;
+import org.neo4j.driver.internal.messaging.request.HelloMessageV51;
+import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.summary.InternalNotificationFilterConfig;
+import org.neo4j.driver.summary.NotificationFilterConfig;
+
+public class BoltProtocolV51 extends BoltProtocolV5 {
+    public static final BoltProtocolVersion VERSION = new BoltProtocolVersion(5, 1);
+    public static final BoltProtocol INSTANCE = new BoltProtocolV51();
+
+    @Override
+    public MessageFormat createMessageFormat() {
+        return new MessageFormatV51();
+    }
+
+    @Override
+    public BoltProtocolVersion version() {
+        return VERSION;
+    }
+
+    protected HelloMessage createHelloMessage(
+            String userAgent,
+            Map<String, Value> authToken,
+            Map<String, String> routingContext,
+            boolean includeDateTimeUtc,
+            Channel channel) {
+        var notificationFilters = NotificationFilterEncodingUtil.encode(notificationFilters(channel), false);
+        return new HelloMessageV51(userAgent, authToken, routingContext, notificationFilters);
+    }
+
+    @Override
+    protected Value toNotificationFiltersValue(NotificationFilterConfig notificationFilterConfig) {
+        return notificationFilterConfig == null
+                ? null
+                : NotificationFilterEncodingUtil.encode(
+                        ((InternalNotificationFilterConfig) notificationFilterConfig).filters(), true);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/MessageFormatV51.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/MessageFormatV51.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.v51;
+
+import org.neo4j.driver.internal.messaging.MessageFormat;
+import org.neo4j.driver.internal.messaging.v5.MessageReaderV5;
+import org.neo4j.driver.internal.packstream.PackInput;
+import org.neo4j.driver.internal.packstream.PackOutput;
+
+public class MessageFormatV51 implements MessageFormat {
+    @Override
+    public Writer newWriter(PackOutput output) {
+        return new MessageWriterV51(output);
+    }
+
+    @Override
+    public Reader newReader(PackInput input) {
+        return new MessageReaderV5(input);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.v51;
+
+import java.util.Map;
+import org.neo4j.driver.internal.messaging.AbstractMessageWriter;
+import org.neo4j.driver.internal.messaging.MessageEncoder;
+import org.neo4j.driver.internal.messaging.common.CommonValuePacker;
+import org.neo4j.driver.internal.messaging.encode.BeginMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.CommitMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.DiscardMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.GoodbyeMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.HelloMessageV51Encoder;
+import org.neo4j.driver.internal.messaging.encode.PullMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.ResetMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.RollbackMessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.RouteV44MessageEncoder;
+import org.neo4j.driver.internal.messaging.encode.RunWithMetadataMessageEncoder;
+import org.neo4j.driver.internal.messaging.request.BeginMessage;
+import org.neo4j.driver.internal.messaging.request.CommitMessage;
+import org.neo4j.driver.internal.messaging.request.DiscardMessage;
+import org.neo4j.driver.internal.messaging.request.GoodbyeMessage;
+import org.neo4j.driver.internal.messaging.request.HelloMessageV51;
+import org.neo4j.driver.internal.messaging.request.PullMessage;
+import org.neo4j.driver.internal.messaging.request.ResetMessage;
+import org.neo4j.driver.internal.messaging.request.RollbackMessage;
+import org.neo4j.driver.internal.messaging.request.RouteMessage;
+import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
+import org.neo4j.driver.internal.packstream.PackOutput;
+import org.neo4j.driver.internal.util.Iterables;
+
+public class MessageWriterV51 extends AbstractMessageWriter {
+    public MessageWriterV51(PackOutput output) {
+        super(new CommonValuePacker(output, true), buildEncoders());
+    }
+
+    private static Map<Byte, MessageEncoder> buildEncoders() {
+        Map<Byte, MessageEncoder> result = Iterables.newHashMapWithSize(9);
+        result.put(HelloMessageV51.SIGNATURE, new HelloMessageV51Encoder());
+        result.put(GoodbyeMessage.SIGNATURE, new GoodbyeMessageEncoder());
+        result.put(RunWithMetadataMessage.SIGNATURE, new RunWithMetadataMessageEncoder());
+        result.put(RouteMessage.SIGNATURE, new RouteV44MessageEncoder());
+
+        result.put(DiscardMessage.SIGNATURE, new DiscardMessageEncoder());
+        result.put(PullMessage.SIGNATURE, new PullMessageEncoder());
+
+        result.put(BeginMessage.SIGNATURE, new BeginMessageEncoder());
+        result.put(CommitMessage.SIGNATURE, new CommitMessageEncoder());
+        result.put(RollbackMessage.SIGNATURE, new RollbackMessageEncoder());
+
+        result.put(ResetMessage.SIGNATURE, new ResetMessageEncoder());
+        return result;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotificationFilter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotificationFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.summary;
+
+import org.neo4j.driver.summary.Category;
+import org.neo4j.driver.summary.NotificationFilter;
+import org.neo4j.driver.summary.Severity;
+
+public record InternalNotificationFilter(Severity severity, Category category) implements NotificationFilter {}

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotificationFilterConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotificationFilterConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.summary;
+
+import java.util.Set;
+import org.neo4j.driver.summary.NotificationFilter;
+import org.neo4j.driver.summary.NotificationFilterConfig;
+
+public record InternalNotificationFilterConfig(Set<NotificationFilter> filters) implements NotificationFilterConfig {}

--- a/driver/src/main/java/org/neo4j/driver/summary/Category.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Category.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+public enum Category {
+    ALL,
+    HINT,
+    UNRECOGNIZED,
+    UNSUPPORTED,
+    PERFORMANCE,
+    DEPRECATION,
+    GENERIC,
+    UNKNOWN;
+
+    public static Category of(String value) {
+        for (var category : values()) {
+            if (category.name().equals(value)) {
+                return category;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/summary/Notification.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Notification.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.summary;
 
+import java.util.Optional;
 import org.neo4j.driver.util.Immutable;
 
 /**
@@ -58,7 +59,37 @@ public interface Notification {
     /**
      * The severity level of the notification.
      *
+     * @deprecated superseded by {@link Notification#severityLevel()}
      * @return the severity level of the notification
      */
+    @Deprecated
     String severity();
+
+    /**
+     * The severity level of the notification.
+     *
+     * @return the severity level of the notification
+     */
+    Optional<Severity> severityLevel();
+
+    /**
+     * The severity level of the notification.
+     *
+     * @return the severity level of the notification
+     */
+    Optional<String> rawSeverityLevel();
+
+    /**
+     * The category of the notification.
+     *
+     * @return the category of the notification
+     */
+    Optional<Category> category();
+
+    /**
+     * The category of the notification.
+     *
+     * @return the category of the notification
+     */
+    Optional<String> rawCategory();
 }

--- a/driver/src/main/java/org/neo4j/driver/summary/NotificationFilter.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/NotificationFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+import java.util.Set;
+
+/**
+ * A filter for {@link Notification} objects served by Neo4j server.
+ * <p>
+ * Neo4j server is responsible for delivering on configured selection. Filtering is not done by driver itself.
+ * <p>
+ * Use {@link NotificationFilterConfigs#selection(Set)} to create an instance of {@link NotificationFilterConfig}
+ * with desired {@link NotificationFilter} selection.
+ */
+public interface NotificationFilter {
+    /**
+     * Returns {@link Severity} this filter accepts.
+     *
+     * @return notification severity
+     */
+    Severity severity();
+
+    /**
+     * Returns {@link Category} this filter accepts.
+     *
+     * @return notification category
+     */
+    Category category();
+}

--- a/driver/src/main/java/org/neo4j/driver/summary/NotificationFilterConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/NotificationFilterConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+import java.io.Serializable;
+
+/**
+ * A configuration object defining what kind of notifications the driver expects server to provide when available.
+ * <p>
+ * Please note that configuration requires a minimum Bolt protocol version 5.1 that is available on Neo4j server version 5.3.
+ * On prior versions the configuration will be ignored.
+ * <p>
+ * Use {@link NotificationFilterConfigs} to create instances.
+ * @see org.neo4j.driver.Config.ConfigBuilder#withNotificationFilterConfig(NotificationFilterConfig)
+ * @see org.neo4j.driver.SessionConfig.Builder#withNotificationFilterConfig(NotificationFilterConfig)
+ */
+public interface NotificationFilterConfig extends Serializable {}

--- a/driver/src/main/java/org/neo4j/driver/summary/NotificationFilterConfigs.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/NotificationFilterConfigs.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import org.neo4j.driver.internal.summary.InternalNotificationFilterConfig;
+
+/**
+ * Returns specific instances of {@link NotificationFilterConfig}.
+ */
+public final class NotificationFilterConfigs {
+    private static final NotificationFilterConfig NONE = new InternalNotificationFilterConfig(Collections.emptySet());
+    private static final NotificationFilterConfig SERVER_DEFAULTS = new InternalNotificationFilterConfig(null);
+
+    private NotificationFilterConfigs() {}
+
+    /**
+     * Returns configuration that disables notifications.
+     *
+     * @return notification filter configuration
+     */
+    public static NotificationFilterConfig none() {
+        return NONE;
+    }
+
+    /**
+     * Returns configuration that uses notifications produced by server by default.
+     * @return notification filter configuration
+     */
+    public static NotificationFilterConfig serverDefaults() {
+        return SERVER_DEFAULTS;
+    }
+
+    /**
+     * Returns configuration that defines a selection of {@link org.neo4j.driver.summary.NotificationFilter} instances.
+     * @param filters filters to use
+     * @return notification filter configuration
+     */
+    public static NotificationFilterConfig selection(Set<NotificationFilter> filters) {
+        Objects.requireNonNull(filters, "filters must not be null");
+        if (filters.isEmpty()) {
+            throw new IllegalArgumentException("filters must not be empty");
+        }
+        return new InternalNotificationFilterConfig(filters);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/summary/NotificationFilters.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/NotificationFilters.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+import org.neo4j.driver.internal.summary.InternalNotificationFilter;
+
+/**
+ * Creates instances of {@link org.neo4j.driver.summary.NotificationFilter}.
+ */
+public final class NotificationFilters {
+    private NotificationFilters() {}
+
+    /**
+     * Creates an instance of {@link NotificationFilter}.
+     *
+     * @param severity severity to accept
+     * @param category category to accept
+     * @return notification filter
+     */
+    public static NotificationFilter of(Severity severity, Category category) {
+        return new InternalNotificationFilter(severity, category);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/summary/Severity.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Severity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+public enum Severity {
+    ALL,
+    WARNING,
+    INFORMATION,
+    UNKNOWN;
+
+    public static Severity of(String value) {
+        for (var severity : values()) {
+            if (severity.name().equals(value)) {
+                return severity;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ParametersTest.java
@@ -111,7 +111,8 @@ class ParametersTest {
                 null,
                 UNLIMITED_FETCH_SIZE,
                 DEV_NULL_LOGGING,
-                mock(BookmarkManager.class));
+                mock(BookmarkManager.class),
+                null);
         return new InternalSession(session);
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -41,6 +41,7 @@ import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -218,7 +219,8 @@ class ChannelConnectorImplIT {
                 DEV_NULL_LOGGING,
                 new FakeClock(),
                 RoutingContext.EMPTY,
-                DefaultDomainNameResolver.getInstance());
+                DefaultDomainNameResolver.getInstance(),
+                Collections.emptySet());
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException {

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -235,6 +235,7 @@ class SummaryIT {
         assertEquals(1, profile.records());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldContainNotifications() {
         // When

--- a/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
@@ -101,7 +101,8 @@ class LeakLoggingNetworkSessionTest {
                 null,
                 FetchSizeUtil.UNLIMITED_FETCH_SIZE,
                 logging,
-                mock(BookmarkManager.class));
+                mock(BookmarkManager.class),
+                null);
     }
 
     private static ConnectionProvider connectionProviderMock(boolean openConnection) {

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -178,7 +178,7 @@ class UnmanagedTransactionTest {
         TransactionConfig txConfig = TransactionConfig.empty();
 
         RuntimeException e =
-                assertThrows(RuntimeException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
+                assertThrows(RuntimeException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null, null)));
 
         assertEquals(error, e);
         verify(connection).release();
@@ -192,7 +192,7 @@ class UnmanagedTransactionTest {
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         TransactionConfig txConfig = TransactionConfig.empty();
 
-        await(tx.beginAsync(bookmarks, txConfig, null));
+        await(tx.beginAsync(bookmarks, txConfig, null, null));
 
         verify(connection, never()).release();
     }
@@ -287,7 +287,7 @@ class UnmanagedTransactionTest {
         TransactionConfig txConfig = TransactionConfig.empty();
 
         AuthorizationExpiredException actualException = assertThrows(
-                AuthorizationExpiredException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
+                AuthorizationExpiredException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null, null)));
 
         assertSame(exception, actualException);
         verify(connection).terminateAndRelease(AuthorizationExpiredException.DESCRIPTION);
@@ -303,7 +303,7 @@ class UnmanagedTransactionTest {
         TransactionConfig txConfig = TransactionConfig.empty();
 
         ConnectionReadTimeoutException actualException = assertThrows(
-                ConnectionReadTimeoutException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null)));
+                ConnectionReadTimeoutException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null, null)));
 
         assertSame(ConnectionReadTimeoutException.INSTANCE, actualException);
         verify(connection).terminateAndRelease(ConnectionReadTimeoutException.INSTANCE.getMessage());
@@ -462,7 +462,7 @@ class UnmanagedTransactionTest {
 
     private static UnmanagedTransaction beginTx(Connection connection, Set<Bookmark> initialBookmarks) {
         UnmanagedTransaction tx = new UnmanagedTransaction(connection, (ignored) -> {}, UNLIMITED_FETCH_SIZE);
-        return await(tx.beginAsync(initialBookmarks, TransactionConfig.empty(), null));
+        return await(tx.beginAsync(initialBookmarks, TransactionConfig.empty(), null, null));
     }
 
     private static Connection connectionWithBegin(Consumer<ResponseHandler> beginBehaviour) {

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
 import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
-import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 
 class BoltProtocolUtilTest {
     @Test
@@ -41,7 +41,7 @@ class BoltProtocolUtilTest {
         assertByteBufContains(
                 handshakeBuf(),
                 BOLT_MAGIC_PREAMBLE,
-                BoltProtocolV5.VERSION.toInt(),
+                (1 << 16) | BoltProtocolV51.VERSION.toInt(),
                 (2 << 16) | BoltProtocolV44.VERSION.toInt(),
                 BoltProtocolV41.VERSION.toInt(),
                 BoltProtocolV3.VERSION.toInt());
@@ -49,7 +49,7 @@ class BoltProtocolUtilTest {
 
     @Test
     void shouldReturnHandshakeString() {
-        assertEquals("[0x6060b017, 5, 132100, 260, 3]", handshakeString());
+        assertEquals("[0x6060b017, 65797, 132100, 260, 3]", handshakeString());
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -141,7 +141,8 @@ class ConnectionPoolImplIT {
                 DEV_NULL_LOGGING,
                 clock,
                 RoutingContext.EMPTY,
-                DefaultDomainNameResolver.getInstance());
+                DefaultDomainNameResolver.getInstance(),
+                Collections.emptySet());
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap(1);
         return new ConnectionPoolImpl(

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
@@ -33,6 +33,7 @@ import static org.neo4j.driver.testutil.TestUtil.await;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.pool.ChannelHealthChecker;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -174,7 +175,8 @@ class NettyChannelPoolIT {
                 DEV_NULL_LOGGING,
                 new FakeClock(),
                 RoutingContext.EMPTY,
-                DefaultDomainNameResolver.getInstance());
+                DefaultDomainNameResolver.getInstance(),
+                Collections.emptySet());
         return new NettyChannelPool(
                 neo4j.address(), connector, bootstrap, poolHandler, ChannelHealthChecker.ACTIVE, 1_000, maxConnections);
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
@@ -62,7 +62,8 @@ class BeginMessageEncoderTest {
         Duration txTimeout = Duration.ofSeconds(1);
 
         encoder.encode(
-                new BeginMessage(bookmarks, txTimeout, txMetadata, mode, defaultDatabase(), impersonatedUser, txType),
+                new BeginMessage(
+                        bookmarks, txTimeout, txMetadata, mode, defaultDatabase(), impersonatedUser, txType, null),
                 packer);
 
         InOrder order = inOrder(packer);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
@@ -66,7 +66,8 @@ class RunWithMetadataMessageEncoderTest {
 
         Query query = new Query("RETURN $answer", value(params));
         encoder.encode(
-                autoCommitTxRunMessage(query, txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null), packer);
+                autoCommitTxRunMessage(query, txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null),
+                packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(3, RunWithMetadataMessage.SIGNATURE);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
@@ -60,7 +60,7 @@ public class TransactionMetadataBuilderTest {
         Duration txTimeout = Duration.ofSeconds(7);
 
         Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null);
+                buildMetadata(txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>();
         expectedMetadata.put(
@@ -88,7 +88,7 @@ public class TransactionMetadataBuilderTest {
         Duration txTimeout = Duration.ofSeconds(7);
 
         Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, database(databaseName), WRITE, bookmarks, null, null);
+                buildMetadata(txTimeout, txMetadata, database(databaseName), WRITE, bookmarks, null, null, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>();
         expectedMetadata.put(
@@ -103,7 +103,7 @@ public class TransactionMetadataBuilderTest {
     @Test
     void shouldNotHaveMetadataForDatabaseNameWhenIsNull() {
         Map<String, Value> metadata =
-                buildMetadata(null, null, defaultDatabase(), WRITE, Collections.emptySet(), null, null);
+                buildMetadata(null, null, defaultDatabase(), WRITE, Collections.emptySet(), null, null, null);
         assertTrue(metadata.isEmpty());
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -184,7 +184,7 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
@@ -193,6 +193,7 @@ public class BoltProtocolV3Test {
                                 TransactionConfig.empty(),
                                 defaultDatabase(),
                                 WRITE,
+                                null,
                                 null,
                                 null)),
                         any(BeginTxResponseHandler.class));
@@ -204,12 +205,13 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -218,11 +220,13 @@ public class BoltProtocolV3Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(
+                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -232,11 +236,11 @@ public class BoltProtocolV3Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -342,7 +346,7 @@ public class BoltProtocolV3Test {
     @Test
     void shouldNotSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         ClientException e = assertThrows(ClientException.class, () -> await(txStage));
         assertThat(e.getMessage(), startsWith("Database name parameter for selecting database is not supported"));
@@ -358,7 +362,8 @@ public class BoltProtocolV3Test {
                         Collections.emptySet(),
                         (ignored) -> {},
                         TransactionConfig.empty(),
-                        UNLIMITED_FETCH_SIZE));
+                        UNLIMITED_FETCH_SIZE,
+                        null));
         assertThat(e.getMessage(), startsWith("Database name parameter for selecting database is not supported"));
     }
 
@@ -373,10 +378,11 @@ public class BoltProtocolV3Test {
                             Collections.emptySet(),
                             (ignored) -> {},
                             TransactionConfig.empty(),
-                            UNLIMITED_FETCH_SIZE));
+                            UNLIMITED_FETCH_SIZE,
+                            null));
         } else {
             CompletionStage<Void> txStage = protocol.beginTransaction(
-                    connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                    connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
             e = assertThrows(ClientException.class, () -> await(txStage));
         }
 
@@ -424,7 +430,7 @@ public class BoltProtocolV3Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -452,7 +458,7 @@ public class BoltProtocolV3Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
         assertFalse(cursorFuture.isDone());
@@ -475,7 +481,7 @@ public class BoltProtocolV3Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
         assertFalse(cursorFuture.isDone());
@@ -507,7 +513,7 @@ public class BoltProtocolV3Test {
         RunWithMetadataMessage expectedMessage;
         if (session) {
             expectedMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
-                    QUERY, config, defaultDatabase(), mode, bookmarks, null);
+                    QUERY, config, defaultDatabase(), mode, bookmarks, null, null);
         } else {
             expectedMessage = RunWithMetadataMessage.unmanagedTxRunMessage(QUERY);
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -109,6 +109,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -116,6 +117,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         defaultDatabase(),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -127,6 +129,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -135,6 +138,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
                 PULL_ALL,
@@ -149,6 +153,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -157,6 +162,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -117,6 +117,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -124,6 +125,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -136,6 +138,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -144,6 +147,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -155,6 +159,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -163,6 +168,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -183,7 +183,7 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
@@ -192,6 +192,7 @@ public final class BoltProtocolV41Test {
                                 TransactionConfig.empty(),
                                 defaultDatabase(),
                                 WRITE,
+                                null,
                                 null,
                                 null)),
                         any(BeginTxResponseHandler.class));
@@ -203,12 +204,13 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -217,11 +219,13 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(
+                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -231,11 +235,11 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -341,7 +345,7 @@ public final class BoltProtocolV41Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -354,7 +358,8 @@ public final class BoltProtocolV41Test {
                 Collections.emptySet(),
                 (ignored) -> {},
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                null));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -369,7 +374,7 @@ public final class BoltProtocolV41Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -396,7 +401,7 @@ public final class BoltProtocolV41Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -452,7 +457,7 @@ public final class BoltProtocolV41Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -480,7 +485,8 @@ public final class BoltProtocolV41Test {
                     Collections.emptySet(),
                     (ignored) -> {},
                     TransactionConfig.empty(),
-                    UNLIMITED_FETCH_SIZE);
+                    UNLIMITED_FETCH_SIZE,
+                    null);
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -489,8 +495,8 @@ public final class BoltProtocolV41Test {
             verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -508,7 +514,7 @@ public final class BoltProtocolV41Test {
             AccessMode mode,
             DatabaseName databaseName) {
         RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null);
+                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -532,7 +538,7 @@ public final class BoltProtocolV41Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -116,6 +116,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -123,6 +124,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -135,6 +137,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -143,6 +146,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -154,6 +158,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -162,6 +167,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -183,7 +183,7 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
@@ -192,6 +192,7 @@ public final class BoltProtocolV42Test {
                                 TransactionConfig.empty(),
                                 defaultDatabase(),
                                 WRITE,
+                                null,
                                 null,
                                 null)),
                         any(BeginTxResponseHandler.class));
@@ -203,12 +204,13 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -217,11 +219,13 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(
+                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -231,11 +235,11 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -341,7 +345,7 @@ public final class BoltProtocolV42Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -354,7 +358,8 @@ public final class BoltProtocolV42Test {
                 Collections.emptySet(),
                 (ignored) -> {},
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                null));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -369,7 +374,7 @@ public final class BoltProtocolV42Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -395,7 +400,7 @@ public final class BoltProtocolV42Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -451,7 +456,7 @@ public final class BoltProtocolV42Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -481,7 +486,8 @@ public final class BoltProtocolV42Test {
                     Collections.emptySet(),
                     (ignored) -> {},
                     TransactionConfig.empty(),
-                    UNLIMITED_FETCH_SIZE);
+                    UNLIMITED_FETCH_SIZE,
+                    null);
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -490,8 +496,8 @@ public final class BoltProtocolV42Test {
             verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -509,7 +515,7 @@ public final class BoltProtocolV42Test {
             AccessMode mode,
             DatabaseName databaseName) {
         RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null);
+                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -533,7 +539,7 @@ public final class BoltProtocolV42Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -116,6 +116,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -123,6 +124,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -135,6 +137,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -143,6 +146,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -154,6 +158,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -162,6 +167,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -121,6 +121,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -128,6 +129,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -140,6 +142,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -148,6 +151,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -159,6 +163,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -167,6 +172,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
@@ -182,7 +182,7 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
@@ -191,6 +191,7 @@ public class BoltProtocolV44Test {
                                 TransactionConfig.empty(),
                                 defaultDatabase(),
                                 WRITE,
+                                null,
                                 null,
                                 null)),
                         any(BeginTxResponseHandler.class));
@@ -202,12 +203,13 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -216,11 +218,13 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(
+                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -230,11 +234,11 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -340,7 +344,7 @@ public class BoltProtocolV44Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -353,7 +357,8 @@ public class BoltProtocolV44Test {
                 Collections.emptySet(),
                 (ignored) -> {},
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                null));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -368,7 +373,7 @@ public class BoltProtocolV44Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -395,7 +400,7 @@ public class BoltProtocolV44Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -451,7 +456,7 @@ public class BoltProtocolV44Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -481,7 +486,8 @@ public class BoltProtocolV44Test {
                     Collections.emptySet(),
                     (ignored) -> {},
                     TransactionConfig.empty(),
-                    UNLIMITED_FETCH_SIZE);
+                    UNLIMITED_FETCH_SIZE,
+                    null);
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -490,8 +496,8 @@ public class BoltProtocolV44Test {
             verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -509,7 +515,7 @@ public class BoltProtocolV44Test {
             AccessMode mode,
             DatabaseName databaseName) {
         RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null);
+                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -533,7 +539,7 @@ public class BoltProtocolV44Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -121,6 +121,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -128,6 +129,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -140,6 +142,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -148,6 +151,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -159,6 +163,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -167,6 +172,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
@@ -182,7 +182,7 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
 
         CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
@@ -191,6 +191,7 @@ public class BoltProtocolV5Test {
                                 TransactionConfig.empty(),
                                 defaultDatabase(),
                                 WRITE,
+                                null,
                                 null,
                                 null)),
                         any(BeginTxResponseHandler.class));
@@ -202,12 +203,13 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null)),
+                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -216,11 +218,13 @@ public class BoltProtocolV5Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(
+                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -230,11 +234,11 @@ public class BoltProtocolV5Test {
         Connection connection = connectionMock(protocol);
         Set<Bookmark> bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null)),
+                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -340,7 +344,7 @@ public class BoltProtocolV5Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null);
+                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -353,7 +357,8 @@ public class BoltProtocolV5Test {
                 Collections.emptySet(),
                 (ignored) -> {},
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                null));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -368,7 +373,7 @@ public class BoltProtocolV5Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -395,7 +400,7 @@ public class BoltProtocolV5Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -451,7 +456,7 @@ public class BoltProtocolV5Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -481,7 +486,8 @@ public class BoltProtocolV5Test {
                     Collections.emptySet(),
                     (ignored) -> {},
                     TransactionConfig.empty(),
-                    UNLIMITED_FETCH_SIZE);
+                    UNLIMITED_FETCH_SIZE,
+                    null);
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -490,8 +496,8 @@ public class BoltProtocolV5Test {
             verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null);
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -509,7 +515,7 @@ public class BoltProtocolV5Test {
             AccessMode mode,
             DatabaseName databaseName) {
         RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null);
+                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -533,7 +539,7 @@ public class BoltProtocolV5Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null);
+        BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
@@ -121,6 +121,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         READ,
                         defaultDatabase(),
                         null,
+                        null,
                         null),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
@@ -128,6 +129,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
+                        null,
                         null,
                         null),
                 COMMIT,
@@ -140,6 +142,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
@@ -148,6 +151,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
@@ -159,6 +163,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         Collections.emptySet(),
+                        null,
                         null),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
@@ -167,6 +172,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         Collections.emptySet(),
+                        null,
                         null),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 

--- a/driver/src/test/java/org/neo4j/driver/internal/summary/InternalNotificationTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/summary/InternalNotificationTest.java
@@ -33,6 +33,7 @@ import org.neo4j.driver.summary.InputPosition;
 import org.neo4j.driver.summary.Notification;
 
 class InternalNotificationTest {
+    @SuppressWarnings("deprecation")
     @Test
     void shouldHandleNotificationWithPosition() {
         // GIVEN

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -63,7 +64,8 @@ public class MessageRecordingDriverFactory extends DriverFactory {
                 config.logging(),
                 clock,
                 routingContext,
-                DefaultDomainNameResolver.getInstance());
+                DefaultDomainNameResolver.getInstance(),
+                Collections.emptySet());
     }
 
     private class MessageRecordingChannelPipelineBuilder extends ChannelPipelineBuilderImpl {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
@@ -260,6 +260,7 @@ class MetadataExtractorTest {
         assertNull(summary.profile());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldBuildResultSummaryWithNotifications() {
         Value notification1 = parameters(

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver.internal.util.io;
 
+import java.util.Collections;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
@@ -50,7 +51,8 @@ public class ChannelTrackingDriverFactoryWithFailingMessageFormat extends Channe
                 config.logging(),
                 clock,
                 routingContext,
-                DefaultDomainNameResolver.getInstance());
+                DefaultDomainNameResolver.getInstance(),
+                Collections.emptySet());
     }
 
     public FailingMessageFormat getFailingMessageFormat() {

--- a/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
@@ -94,6 +94,7 @@ import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -267,7 +268,8 @@ public final class TestUtil {
                 null,
                 UNLIMITED_FETCH_SIZE,
                 DEV_NULL_LOGGING,
-                new NoOpBookmarkManager());
+                new NoOpBookmarkManager(),
+                null);
     }
 
     public static void verifyRunRx(Connection connection, String query) {
@@ -453,7 +455,8 @@ public final class TestUtil {
                 || version.equals(BoltProtocolV42.VERSION)
                 || version.equals(BoltProtocolV43.VERSION)
                 || version.equals(BoltProtocolV44.VERSION)
-                || version.equals(BoltProtocolV5.VERSION)) {
+                || version.equals(BoltProtocolV5.VERSION)
+                || version.equals(BoltProtocolV51.VERSION)) {
             setupSuccessResponse(connection, CommitMessage.class);
             setupSuccessResponse(connection, RollbackMessage.class);
             setupSuccessResponse(connection, BeginMessage.class);

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -39,6 +39,7 @@ public class GetFeatures implements TestkitRequest {
             "Feature:Bolt:4.3",
             "Feature:Bolt:4.4",
             "Feature:Bolt:5.0",
+            "Feature:Bolt:5.1",
             "AuthorizationExpiredTreatment",
             "ConfHint:connection.recv_timeout_seconds",
             "Feature:Auth:Bearer",
@@ -58,7 +59,9 @@ public class GetFeatures implements TestkitRequest {
             "Optimization:ImplicitDefaultArguments",
             "Feature:Bolt:Patch:UTC",
             "Feature:API:Type.Temporal",
-            "Feature:API:BookmarkManager"));
+            "Feature:API:BookmarkManager",
+            "Feature:API:Driver:NotificationFilters",
+            "Feature:API:Session:NotificationFilters"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
@@ -102,6 +102,10 @@ public class NewSession implements TestkitRequest {
                 .map(testkitState::getBookmarkManager)
                 .ifPresent(builder::withBookmarkManager);
 
+        Optional.ofNullable(data.notificationFilters)
+                .map(NewDriver::toNotificationFilter)
+                .ifPresent(builder::withNotificationFilterConfig);
+
         T sessionStateHolder = sessionStateProducer.apply(driverHolder, builder.build());
         String newId = addSessionHolder.apply(sessionStateHolder);
 
@@ -148,5 +152,6 @@ public class NewSession implements TestkitRequest {
         private String impersonatedUser;
         private int fetchSize;
         private String bookmarkManagerId;
+        private List<String> notificationFilters;
     }
 }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/ResultConsume.java
@@ -36,10 +36,12 @@ import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.summary.Category;
 import org.neo4j.driver.summary.InputPosition;
 import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ProfiledPlan;
 import org.neo4j.driver.summary.QueryType;
+import org.neo4j.driver.summary.Severity;
 import org.neo4j.driver.summary.SummaryCounters;
 import reactor.core.publisher.Mono;
 
@@ -122,6 +124,7 @@ public class ResultConsume implements TestkitRequest {
                 .text(summaryQuery.text())
                 .parameters(summaryQuery.parameters().asMap(Function.identity(), null))
                 .build();
+        @SuppressWarnings("deprecation")
         List<Summary.Notification> notifications = summary.notifications().stream()
                 .map(s -> Summary.Notification.builder()
                         .code(s.code())
@@ -129,6 +132,10 @@ public class ResultConsume implements TestkitRequest {
                         .description(s.description())
                         .position(toInputPosition(s.position()))
                         .severity(s.severity())
+                        .severityLevel(s.severityLevel().map(Severity::name).orElse(null))
+                        .rawSeverityLevel(s.rawSeverityLevel().orElse(null))
+                        .category(s.category().map(Category::name).orElse(null))
+                        .rawCategory(s.rawCategory().orElse(null))
                         .build())
                 .collect(Collectors.toList());
         Summary.SummaryBody data = Summary.SummaryBody.builder()

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -72,7 +72,8 @@ public class StartTest implements TestkitRequest {
                 "^.*\\.TestConnectionAcquisitionTimeoutMs\\.test_should_fail_when_acquisition_timeout_is_reached_first.*$",
                 skipMessage);
         skipMessage = "This test needs updating to implement expected behaviour";
-        COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.TestAuthenticationSchemes\\.test_custom_scheme_empty$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.TestAuthenticationSchemes[\\w]+\\.test_custom_scheme_empty$", skipMessage);
         skipMessage = "Driver does not implement optimization for qid in explicit transaction";
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments$", skipMessage);

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
@@ -18,6 +18,7 @@
  */
 package neo4j.org.testkit.backend.messages.responses;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
@@ -111,6 +112,7 @@ public class Summary implements TestkitResponse {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Notification {
         private String code;
 
@@ -119,8 +121,14 @@ public class Summary implements TestkitResponse {
         private String description;
 
         private InputPosition position;
-
         private String severity;
+
+        private String severityLevel;
+
+        private String rawSeverityLevel;
+        private String category;
+
+        private String rawCategory;
     }
 
     @Getter


### PR DESCRIPTION
This update brings notification filtering that allows driver users to set preferences on what notifications should be transmitted by server and made available on driver side. This is achieved by configuring a set of notification filters on driver and/or session configuration. The filter configuration is a mixture of notification severity and category.

The driver does not do filtering itself and transmits the preferences to server instead, which is preferable from bandwidth perspective.

Is it also possible to keep the original behaviour by keeping the server default setting or disable notifications entirely.