### PR TITLE
Use moditect plugin to re-add `module-info` after it has been nuked by the shade plugin.

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -218,6 +218,43 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <module>
+                <moduleInfoSource><![CDATA[
+                  module org.neo4j.driver {
+                    exports org.neo4j.driver;
+                    exports org.neo4j.driver.async;
+                    exports org.neo4j.driver.reactive;
+                    exports org.neo4j.driver.reactivestreams;
+                    exports org.neo4j.driver.types;
+                    exports org.neo4j.driver.summary;
+                    exports org.neo4j.driver.net;
+                    exports org.neo4j.driver.util;
+                    exports org.neo4j.driver.exceptions;
+
+                    requires transitive java.logging;
+                    requires transitive org.reactivestreams;
+                    requires static micrometer.core;
+                    requires static org.graalvm.nativeimage.builder;
+                    requires static org.slf4j;
+                  }
+                ]]></moduleInfoSource>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -246,8 +246,9 @@
                     requires transitive java.logging;
                     requires transitive org.reactivestreams;
                     requires static micrometer.core;
-                    requires static org.graalvm.nativeimage.builder;
+                    requires static org.graalvm.sdk;
                     requires static org.slf4j;
+                    requires static java.management;
                   }
                 ]]></moduleInfoSource>
               </module>

--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>1.0.0.RC2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
The shade plugin will not only warn about shading breaking encapsulation, it will also remove existing modules inside the project that does the shading, without any option not doing this. We using the moditect plugin to re-add it after it has been nuked. The shaded dependencies have been omitted from the module declaration of course, as they included.
