### PR TITLE
Update maven-bundle-plugin to 5.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>5.1.8</version>
           <executions>
             <execution>
               <id>bundle-manifest</id>


### PR DESCRIPTION
Fixes: #1340

With newer version `Import-Package` includes the following additional entires:
```
java.io,
java.lang,
java.lang.annotation,
java.lang.invoke,
java.lang.reflect,
java.lang.runtime,
java.net,
java.nio.charset,
java.security,
java.security.cert,
java.time,
java.time.format,
java.time.temporal,
java.util,
java.util.concurrent,
java.util.concurrent.atomic,
java.util.concurrent.locks,
java.util.function,
java.util.logging,
java.util.regex,
java.util.stream
```

In addition, the is a new `Build-Jdk-Spec: 17` entry and the `Created-By` includes the plugin version. The `Require-Capability` and `Tool` are also updated.