### PR TITLE
Add new java platform logger

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -409,4 +409,10 @@
         <method>org.neo4j.driver.BaseSession session(java.lang.Class, org.neo4j.driver.SessionConfig)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Logging</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.Logging javaPlatformLogging()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/module-info.java
+++ b/driver/src/main/java/module-info.java
@@ -35,7 +35,7 @@ module org.neo4j.driver {
     requires io.netty.buffer;
     requires io.netty.codec;
     requires io.netty.resolver;
-    requires static java.logging;
+    requires static transitive java.logging;
     requires transitive org.reactivestreams;
     requires static micrometer.core;
     requires static org.graalvm.nativeimage.builder;

--- a/driver/src/main/java/module-info.java
+++ b/driver/src/main/java/module-info.java
@@ -35,7 +35,7 @@ module org.neo4j.driver {
     requires io.netty.buffer;
     requires io.netty.codec;
     requires io.netty.resolver;
-    requires transitive java.logging;
+    requires static java.logging;
     requires transitive org.reactivestreams;
     requires static micrometer.core;
     requires static org.graalvm.nativeimage.builder;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JavaPlatformLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JavaPlatformLogger.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.neo4j.driver.Logger;
+
+import java.lang.System.Logger.Level;
+import java.util.Objects;
+
+public class JavaPlatformLogger implements Logger {
+    private final java.lang.System.Logger delegate;
+
+    public JavaPlatformLogger(System.Logger delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public void error(String message, Throwable cause) {
+        if (delegate.isLoggable(Level.ERROR)) {
+            delegate.log(Level.ERROR, message, cause);
+        }
+    }
+
+    @Override
+    public void info(String format, Object... params) {
+        if (delegate.isLoggable(Level.INFO)) {
+            delegate.log(Level.INFO, String.format(format, params));
+        }
+    }
+
+    @Override
+    public void warn(String format, Object... params) {
+        if (delegate.isLoggable(Level.WARNING)) {
+            delegate.log(Level.WARNING, String.format(format, params));
+        }
+    }
+
+    @Override
+    public void warn(String message, Throwable cause) {
+        if (delegate.isLoggable(Level.WARNING)) {
+            delegate.log(Level.WARNING, message, cause);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object... params) {
+        if (isDebugEnabled()) {
+            delegate.log(Level.DEBUG, String.format(format, params));
+        }
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        if (isDebugEnabled()) {
+            delegate.log(Level.DEBUG, message, throwable);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object... params) {
+        if (isTraceEnabled()) {
+            delegate.log(Level.TRACE, String.format(format, params));
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return delegate.isLoggable(Level.TRACE);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return delegate.isLoggable(Level.DEBUG);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JavaPlatformLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JavaPlatformLogging.java
@@ -18,39 +18,25 @@
  */
 package org.neo4j.driver.internal.logging;
 
-import java.io.Serializable;
-import java.util.logging.Level;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
 
+import java.io.Serializable;
+
 /**
- * Internal implementation of the JUL.
- * <b>This class should not be used directly.</b> Please use {@link Logging#javaUtilLogging(Level)} factory method instead.
+ * Internal implementation of the java platform logging module.
+ * <b>This class should not be used directly.</b> Please use {@link Logging#javaPlatformLogging()} factory method instead.
  *
- * @see Logging#javaUtilLogging(Level)
+ * @see Logging#javaPlatformLogging()
  */
-public class JULogging implements Logging, Serializable {
+public class JavaPlatformLogging implements Logging, Serializable {
     private static final long serialVersionUID = -1145576859241657833L;
 
-    private final Level loggingLevel;
-
-    public JULogging(Level loggingLevel) {
-        this.loggingLevel = loggingLevel;
+    public JavaPlatformLogging() {
     }
 
     @Override
     public Logger getLog(String name) {
-        return new JULogger(name, loggingLevel);
-    }
-
-    public static IllegalStateException checkAvailability() {
-        try {
-            Class.forName("java.util.logging.Logger");
-            return null;
-        } catch (Throwable error) {
-            return new IllegalStateException(
-                    "java.util.logging is not available. Please add the java.logging module.",
-                    error);
-        }
+        return new JavaPlatformLogger(System.getLogger(name));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -47,6 +47,7 @@ import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.logging.DevNullLogging;
 import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.internal.logging.Slf4jLogging;
+import org.neo4j.driver.internal.logging.JavaPlatformLogging;
 import org.neo4j.driver.net.ServerAddressResolver;
 import org.neo4j.driver.testutil.TestUtil;
 
@@ -486,7 +487,7 @@ class ConfigTest {
         }
 
         @ParameterizedTest
-        @ValueSource(classes = {DevNullLogging.class, JULogging.class, ConsoleLogging.class, Slf4jLogging.class})
+        @ValueSource(classes = {DevNullLogging.class, JULogging.class, ConsoleLogging.class, Slf4jLogging.class, JavaPlatformLogging.class})
         void officialLoggingProvidersShouldBeSerializable(Class<? extends Logging> loggingClass) {
             assertTrue(Serializable.class.isAssignableFrom(loggingClass));
         }

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/JULoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/JULoggingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Logger;
+
+import java.util.logging.Level;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JULoggingTest {
+    @Test
+    void shouldCreateLoggers() {
+        JULogging logging = new JULogging(Level.ALL);
+
+        Logger logger = logging.getLog("My Log");
+
+        assertThat(logger, instanceOf(JULogger.class));
+    }
+
+    @Test
+    void shouldCheckIfAvailable() {
+        assertNull(JULogging.checkAvailability());
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/JavaPlatformLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/JavaPlatformLoggerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+class JavaPlatformLoggerTest {
+    private final Logger logger = Mockito.mock(Logger.class);
+    private final JavaPlatformLogger javaPlatformLogger = new JavaPlatformLogger(logger);
+
+    @Test
+    void shouldLogErrorWithMessageAndThrowable() {
+        Mockito.when(logger.isLoggable(Level.ERROR)).thenReturn(true);
+        String message = "Hello";
+        IllegalArgumentException error = new IllegalArgumentException("World");
+
+        javaPlatformLogger.error(message, error);
+
+        Mockito.verify(logger).log(Level.ERROR, message, error);
+    }
+
+    @Test
+    void shouldLogInfoWithMessageAndParams() {
+        Mockito.when(logger.isLoggable(Level.INFO)).thenReturn(true);
+        String message = "One %s, two %s, three %s";
+        Object[] params = {"111", "222", "333"};
+
+        javaPlatformLogger.info(message, params);
+
+        Mockito.verify(logger).log(Level.INFO, "One 111, two 222, three 333");
+    }
+
+    @Test
+    void shouldLogWarnWithMessageAndParams() {
+        Mockito.when(logger.isLoggable(Level.WARNING)).thenReturn(true);
+        String message = "C for %s, d for %s";
+        Object[] params = {"cat", "dog"};
+
+        javaPlatformLogger.warn(message, params);
+
+        Mockito.verify(logger).log(Level.WARNING, "C for cat, d for dog");
+    }
+
+    @Test
+    void shouldLogWarnWithMessageAndThrowable() {
+        Mockito.when(logger.isLoggable(Level.WARNING)).thenReturn(true);
+        String message = "Hello";
+        RuntimeException error = new RuntimeException("World");
+
+        javaPlatformLogger.warn(message, error);
+
+        Mockito.verify(logger).log(Level.WARNING, message, error);
+    }
+
+    @Test
+    void shouldLogDebugWithMessageAndParams() {
+        Mockito.when(logger.isLoggable(Level.DEBUG)).thenReturn(true);
+        String message = "Hello%s%s!";
+        Object[] params = {" ", "World"};
+
+        javaPlatformLogger.debug(message, params);
+
+        Mockito.verify(logger).log(Level.DEBUG, "Hello World!");
+    }
+
+    @Test
+    void shouldLogTraceWithMessageAndParams() {
+        Mockito.when(logger.isLoggable(Level.TRACE)).thenReturn(true);
+        String message = "I'll be %s!";
+        Object[] params = {"back"};
+
+        javaPlatformLogger.trace(message, params);
+
+        Mockito.verify(logger).log(Level.TRACE, "I'll be back!");
+    }
+
+    @Test
+    void shouldCheckIfDebugIsEnabled() {
+        Mockito.when(logger.isLoggable(Level.DEBUG)).thenReturn(false);
+        assertFalse(javaPlatformLogger.isDebugEnabled());
+
+        Mockito.when(logger.isLoggable(Level.DEBUG)).thenReturn(true);
+        assertTrue(javaPlatformLogger.isDebugEnabled());
+    }
+
+    @Test
+    void shouldCheckIfTraceIsEnabled() {
+        Mockito.when(logger.isLoggable(Level.TRACE)).thenReturn(false);
+        assertFalse(javaPlatformLogger.isTraceEnabled());
+
+        Mockito.when(logger.isLoggable(Level.TRACE)).thenReturn(true);
+        assertTrue(javaPlatformLogger.isTraceEnabled());
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/JavaPlatformLoggingTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/JavaPlatformLoggingTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Logger;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+class JavaPlatformLoggingTest {
+    @Test
+    void shouldCreateLoggers() {
+        JavaPlatformLogging logging = new JavaPlatformLogging();
+
+        Logger logger = logging.getLog("My Log");
+
+        assertThat(logger, instanceOf(JavaPlatformLogger.class));
+    }
+
+}


### PR DESCRIPTION
With the [java platform logger](https://openjdk.org/jeps/264), we can make the slf4j and jul loggers optional. Users can use implementations of the java platform logging api such as the ones provided by slf4j https://www.slf4j.org/apidocs/org/slf4j/jdk/platform/logging/package-summary.html and log4j https://logging.apache.org/log4j/2.x/log4j-jpl/project-info.html