### PR TITLE
Remove support for setting driver's default BM for QueryTask

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -421,4 +421,10 @@
         <method>org.neo4j.driver.BookmarkManager queryBookmarkManager()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Driver</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.BookmarkManager queryTaskBookmarkManager()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -75,8 +75,6 @@ public final class Config implements Serializable {
 
     private static final Config EMPTY = builder().build();
 
-    private final BookmarkManager queryBookmarkManager;
-
     /**
      * User defined logging
      */
@@ -104,7 +102,6 @@ public final class Config implements Serializable {
     private final MetricsAdapter metricsAdapter;
 
     private Config(ConfigBuilder builder) {
-        this.queryBookmarkManager = builder.queryBookmarkManager;
         this.logging = builder.logging;
         this.logLeakedSessions = builder.logLeakedSessions;
 
@@ -124,21 +121,6 @@ public final class Config implements Serializable {
 
         this.eventLoopThreads = builder.eventLoopThreads;
         this.metricsAdapter = builder.metricsAdapter;
-    }
-
-    /**
-     * A {@link BookmarkManager} implementation for the driver to use on
-     * {@link Driver#queryTask(String)} method and its variants by default.
-     * <p>
-     * Please note that sessions will not use this automatically, but it is possible to enable it explicitly
-     * using {@link SessionConfig.Builder#withBookmarkManager(BookmarkManager)}.
-     *
-     * @return bookmark manager, must not be {@code null}
-     * @since 5.5
-     */
-    @Experimental
-    public BookmarkManager queryTaskBookmarkManager() {
-        return queryBookmarkManager;
     }
 
     /**
@@ -280,8 +262,6 @@ public final class Config implements Serializable {
      * Used to build new config instances
      */
     public static final class ConfigBuilder {
-        private BookmarkManager queryBookmarkManager =
-                BookmarkManagers.defaultManager(BookmarkManagerConfig.builder().build());
         private Logging logging = DEV_NULL_LOGGING;
         private boolean logLeakedSessions;
         private int maxConnectionPoolSize = PoolSettings.DEFAULT_MAX_CONNECTION_POOL_SIZE;
@@ -300,24 +280,6 @@ public final class Config implements Serializable {
         private int eventLoopThreads = 0;
 
         private ConfigBuilder() {}
-
-        /**
-         * Sets a {@link BookmarkManager} implementation for the driver to use on
-         * {@link Driver#queryTask(String)} method and its variants by default.
-         * <p>
-         * Please note that sessions will not use this automatically, but it is possible to enable it explicitly
-         * using {@link SessionConfig.Builder#withBookmarkManager(BookmarkManager)}.
-         *
-         * @param bookmarkManager bookmark manager, must not be {@code null}
-         * @return this builder
-         * @since 5.5
-         */
-        @Experimental
-        public ConfigBuilder withQueryTaskBookmarkManager(BookmarkManager bookmarkManager) {
-            Objects.requireNonNull(bookmarkManager, "bookmarkManager must not be null");
-            this.queryBookmarkManager = bookmarkManager;
-            return this;
-        }
 
         /**
          * Provide a logging implementation for the driver to use. Java logging framework {@link java.util.logging} with {@link Level#INFO} is used by default.

--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -75,13 +75,15 @@ public interface Driver extends AutoCloseable {
     QueryTask queryTask(String query);
 
     /**
-     * Returns an instance of {@link BookmarkManager} used by {@link QueryTask} instances by default.
+     * Returns a {@link BookmarkManager} that is used by default in {@link QueryTask} instances.
+     * <p>
+     * It is always an instance of {@link BookmarkManagers#defaultManager(BookmarkManagerConfig)}.
      *
-     * @return bookmark manager, must not be {@code null}
+     * @return the bookmark manager
      * @since 5.5
      */
     @Experimental
-    BookmarkManager queryBookmarkManager();
+    BookmarkManager queryTaskBookmarkManager();
 
     /**
      * Return a flag to indicate whether or not encryption is used for this driver.

--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -80,7 +80,7 @@ public interface Driver extends AutoCloseable {
      * It is always an instance of {@link BookmarkManagers#defaultManager(BookmarkManagerConfig)}.
      *
      * @return the bookmark manager
-     * @since 5.5
+     * @since 5.6
      */
     @Experimental
     BookmarkManager queryTaskBookmarkManager();

--- a/driver/src/main/java/org/neo4j/driver/QueryConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/QueryConfig.java
@@ -100,8 +100,7 @@ public final class QueryConfig implements Serializable {
     /**
      * Returns bookmark manager for the query.
      *
-     * @param defaultBookmarkManager default bookmark manager to use when none has been configured explicitly,
-     * {@link Config#queryTaskBookmarkManager()} as a default value by the driver
+     * @param defaultBookmarkManager default bookmark manager to use when none has been configured explicitly
      * @return bookmark manager
      */
     public Optional<BookmarkManager> bookmarkManager(BookmarkManager defaultBookmarkManager) {

--- a/driver/src/main/java/org/neo4j/driver/QueryTask.java
+++ b/driver/src/main/java/org/neo4j/driver/QueryTask.java
@@ -36,8 +36,7 @@ import org.neo4j.driver.util.Experimental;
  * methods like {@link Session#executeWrite(TransactionCallback)}, {@link Session#executeWriteWithoutResult(Consumer)}
  * and {@link Session#executeRead(TransactionCallback)} (there are also overloaded options available).
  * <p>
- * Causal consistency is managed via driver's {@link BookmarkManager} that is enabled by default and may
- * be replaced using {@link Config.ConfigBuilder#withQueryTaskBookmarkManager(BookmarkManager)}. It is also possible
+ * Causal consistency is managed via driver's {@link BookmarkManager} that is enabled by default. It is also possible
  * to use a different {@link BookmarkManager} or disable it via
  * {@link QueryConfig.Builder#withBookmarkManager(BookmarkManager)} on individual basis.
  * <p>

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.BookmarkManagerConfig;
+import org.neo4j.driver.BookmarkManagers;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Logger;
@@ -270,7 +272,11 @@ public class DriverFactory {
     protected InternalDriver createDriver(
             SecurityPlan securityPlan, SessionFactory sessionFactory, MetricsProvider metricsProvider, Config config) {
         return new InternalDriver(
-                config.queryTaskBookmarkManager(), securityPlan, sessionFactory, metricsProvider, config.logging());
+                BookmarkManagers.defaultManager(BookmarkManagerConfig.builder().build()),
+                securityPlan,
+                sessionFactory,
+                metricsProvider,
+                config.logging());
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -74,7 +74,7 @@ public class InternalDriver implements Driver {
     }
 
     @Override
-    public BookmarkManager queryBookmarkManager() {
+    public BookmarkManager queryTaskBookmarkManager() {
         return queryBookmarkManager;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalQueryTask.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalQueryTask.java
@@ -61,7 +61,7 @@ public class InternalQueryTask implements QueryTask {
         var sessionConfigBuilder = SessionConfig.builder();
         config.database().ifPresent(sessionConfigBuilder::withDatabase);
         config.impersonatedUser().ifPresent(sessionConfigBuilder::withImpersonatedUser);
-        config.bookmarkManager(driver.queryBookmarkManager()).ifPresent(sessionConfigBuilder::withBookmarkManager);
+        config.bookmarkManager(driver.queryTaskBookmarkManager()).ifPresent(sessionConfigBuilder::withBookmarkManager);
         var supplier = recordCollector.supplier();
         var accumulator = recordCollector.accumulator();
         var finisher = recordCollector.finisher();

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -52,38 +52,6 @@ import org.neo4j.driver.testutil.TestUtil;
 
 class ConfigTest {
     @Test
-    void shouldReturnDefaultBookmarkManager() {
-        // Given
-        var config = Config.defaultConfig();
-
-        // When
-        var manager = config.queryTaskBookmarkManager();
-
-        // Then
-        assertEquals(
-                BookmarkManagers.defaultManager(BookmarkManagerConfig.builder().build())
-                        .getClass(),
-                manager.getClass());
-    }
-
-    @Test
-    void shouldUpdateBookmarkManager() {
-        // Given
-        var manager = mock(BookmarkManager.class);
-
-        // When
-        var config = Config.builder().withQueryTaskBookmarkManager(manager).build();
-
-        // Then
-        assertEquals(manager, config.queryTaskBookmarkManager());
-    }
-
-    @Test
-    void shouldNotAllowNullBookmarkManager() {
-        assertThrows(NullPointerException.class, () -> Config.builder().withQueryTaskBookmarkManager(null));
-    }
-
-    @Test
     void shouldDefaultToKnownCerts() {
         // Given
         Config config = Config.defaultConfig();

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalQueryTaskTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalQueryTaskTest.java
@@ -118,7 +118,7 @@ class InternalQueryTaskTest {
         // GIVEN
         var driver = mock(Driver.class);
         var bookmarkManager = mock(BookmarkManager.class);
-        given(driver.queryBookmarkManager()).willReturn(bookmarkManager);
+        given(driver.queryTaskBookmarkManager()).willReturn(bookmarkManager);
         var session = mock(Session.class);
         given(driver.session(any(SessionConfig.class))).willReturn(session);
         var txContext = mock(TransactionContext.class);


### PR DESCRIPTION
At present, this is done to keep consistency with the other official drivers. It may be added back should it be needed.

In addition, `Driver.queryBookmarkManager()` has been renamed to `Driver.queryTaskBookmarkManager()`.
