### PR TITLE
Unmark TypeSystem as experimental

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Driver.java
+++ b/driver/src/main/java/org/neo4j/driver/Driver.java
@@ -296,8 +296,10 @@ public interface Driver extends AutoCloseable {
      * The types supported on a particular server a session is connected against might not contain all of the types defined here.
      *
      * @return type system used by this query runner for classifying values
+     * @deprecated superseded by {@link TypeSystem#getDefault()}
      */
     @Experimental
+    @Deprecated
     TypeSystem defaultTypeSystem();
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/Value.java
@@ -42,7 +42,6 @@ import org.neo4j.driver.types.Point;
 import org.neo4j.driver.types.Relationship;
 import org.neo4j.driver.types.Type;
 import org.neo4j.driver.types.TypeSystem;
-import org.neo4j.driver.util.Experimental;
 import org.neo4j.driver.util.Immutable;
 
 /**
@@ -140,7 +139,6 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
     Value get(int index);
 
     /** @return The type of this value as defined in the Neo4j type system */
-    @Experimental
     Type type();
 
     /**
@@ -149,7 +147,6 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      * @param type the given type
      * @return type.isTypeOf( this )
      */
-    @Experimental
     boolean hasType(Type type);
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -132,6 +132,7 @@ public class InternalDriver implements Driver {
         return completedWithNull();
     }
 
+    @Deprecated
     @Override
     public final TypeSystem defaultTypeSystem() {
         return InternalTypeSystem.TYPE_SYSTEM;

--- a/driver/src/main/java/org/neo4j/driver/types/Type.java
+++ b/driver/src/main/java/org/neo4j/driver/types/Type.java
@@ -19,7 +19,6 @@
 package org.neo4j.driver.types;
 
 import org.neo4j.driver.Value;
-import org.neo4j.driver.util.Experimental;
 import org.neo4j.driver.util.Immutable;
 
 /**
@@ -27,7 +26,6 @@ import org.neo4j.driver.util.Immutable;
  * @since 1.0
  */
 @Immutable
-@Experimental
 public interface Type {
     /**
      * @return the name of the Cypher type (as defined by Cypher)

--- a/driver/src/main/java/org/neo4j/driver/types/TypeSystem.java
+++ b/driver/src/main/java/org/neo4j/driver/types/TypeSystem.java
@@ -20,7 +20,6 @@ package org.neo4j.driver.types;
 
 import static org.neo4j.driver.internal.types.InternalTypeSystem.TYPE_SYSTEM;
 
-import org.neo4j.driver.util.Experimental;
 import org.neo4j.driver.util.Immutable;
 
 /**
@@ -28,7 +27,6 @@ import org.neo4j.driver.util.Immutable;
  * @since 1.0
  */
 @Immutable
-@Experimental
 public interface TypeSystem {
     /**
      * Returns an instance of type system.

--- a/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ParametersIT.java
@@ -33,6 +33,7 @@ import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.emptyRelationshipValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
+import static org.neo4j.driver.types.TypeSystem.getDefault;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -67,7 +68,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().BOOLEAN()), equalTo(true));
+            assertThat(value.hasType(getDefault().BOOLEAN()), equalTo(true));
             assertThat(value.asBoolean(), equalTo(true));
         }
     }
@@ -80,7 +81,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().INTEGER()), equalTo(true));
+            assertThat(value.hasType(getDefault().INTEGER()), equalTo(true));
             assertThat(value.asLong(), equalTo(1L));
         }
     }
@@ -93,7 +94,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().INTEGER()), equalTo(true));
+            assertThat(value.hasType(getDefault().INTEGER()), equalTo(true));
             assertThat(value.asLong(), equalTo(1L));
         }
     }
@@ -106,7 +107,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().INTEGER()), equalTo(true));
+            assertThat(value.hasType(getDefault().INTEGER()), equalTo(true));
             assertThat(value.asLong(), equalTo(1L));
         }
     }
@@ -119,7 +120,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().INTEGER()), equalTo(true));
+            assertThat(value.hasType(getDefault().INTEGER()), equalTo(true));
             assertThat(value.asLong(), equalTo(1L));
         }
     }
@@ -132,7 +133,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().FLOAT()), equalTo(true));
+            assertThat(value.hasType(getDefault().FLOAT()), equalTo(true));
             assertThat(value.asDouble(), equalTo(6.28));
         }
     }
@@ -164,10 +165,10 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().LIST()), equalTo(true));
+            assertThat(value.hasType(getDefault().LIST()), equalTo(true));
             assertThat(value.size(), equalTo(3));
             for (Value item : value.asList(ofValue())) {
-                assertThat(item.hasType(session.typeSystem().BOOLEAN()), equalTo(true));
+                assertThat(item.hasType(getDefault().BOOLEAN()), equalTo(true));
                 assertThat(item.asBoolean(), equalTo(true));
             }
         }
@@ -182,10 +183,10 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().LIST()), equalTo(true));
+            assertThat(value.hasType(getDefault().LIST()), equalTo(true));
             assertThat(value.size(), equalTo(3));
             for (Value item : value.asList(ofValue())) {
-                assertThat(item.hasType(session.typeSystem().INTEGER()), equalTo(true));
+                assertThat(item.hasType(getDefault().INTEGER()), equalTo(true));
                 assertThat(item.asLong(), equalTo(42L));
             }
         }
@@ -200,10 +201,10 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().LIST()), equalTo(true));
+            assertThat(value.hasType(getDefault().LIST()), equalTo(true));
             assertThat(value.size(), equalTo(3));
             for (Value item : value.asList(ofValue())) {
-                assertThat(item.hasType(session.typeSystem().FLOAT()), equalTo(true));
+                assertThat(item.hasType(getDefault().FLOAT()), equalTo(true));
                 assertThat(item.asDouble(), equalTo(6.28));
             }
         }
@@ -223,10 +224,10 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().LIST()), equalTo(true));
+            assertThat(value.hasType(getDefault().LIST()), equalTo(true));
             assertThat(value.size(), equalTo(3));
             for (Value item : value.asList(ofValue())) {
-                assertThat(item.hasType(session.typeSystem().STRING()), equalTo(true));
+                assertThat(item.hasType(getDefault().STRING()), equalTo(true));
                 assertThat(item.asString(), equalTo(str));
             }
         }
@@ -262,7 +263,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().BOOLEAN()), equalTo(true));
+            assertThat(value.hasType(getDefault().BOOLEAN()), equalTo(true));
             assertThat(value.asBoolean(), equalTo(true));
         }
     }
@@ -276,7 +277,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().INTEGER()), equalTo(true));
+            assertThat(value.hasType(getDefault().INTEGER()), equalTo(true));
             assertThat(value.asLong(), equalTo(42L));
         }
     }
@@ -290,7 +291,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().FLOAT()), equalTo(true));
+            assertThat(value.hasType(getDefault().FLOAT()), equalTo(true));
             assertThat(value.asDouble(), equalTo(6.28));
         }
     }
@@ -304,7 +305,7 @@ class ParametersIT {
         // Then
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().STRING()), equalTo(true));
+            assertThat(value.hasType(getDefault().STRING()), equalTo(true));
             assertThat(value.asString(), equalTo("Mjölnir"));
         }
     }
@@ -397,7 +398,7 @@ class ParametersIT {
 
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().BYTES()), equalTo(true));
+            assertThat(value.hasType(getDefault().BYTES()), equalTo(true));
             assertThat(value.asByteArray(), equalTo(array));
         }
     }
@@ -407,7 +408,7 @@ class ParametersIT {
 
         for (Record record : result.list()) {
             Value value = record.get("a.value");
-            assertThat(value.hasType(session.typeSystem().STRING()), equalTo(true));
+            assertThat(value.hasType(getDefault().STRING()), equalTo(true));
             assertThat(value.asString(), equalTo(string));
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/testutil/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/DatabaseExtension.java
@@ -50,7 +50,6 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.testutil.CertificateUtil.CertificateKeyPair;
-import org.neo4j.driver.types.TypeSystem;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Neo4jContainer;
@@ -147,10 +146,6 @@ public class DatabaseExtension implements ExecutionCondition, BeforeEachCallback
 
     public Driver driver() {
         return driver;
-    }
-
-    public TypeSystem typeSystem() {
-        return driver.defaultTypeSystem();
     }
 
     public void deleteAndStartNeo4j(Map<String, String> config) {


### PR DESCRIPTION
The `TypeSystem` has been available for a significant time. This update removes the experimental status from it.