### PR TITLE
Update clirr configuration to check against previous version

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.5-SNAPSHOT</version>
+    <version>5.6-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -423,6 +423,12 @@
 
     <difference>
         <className>org/neo4j/driver/Driver</className>
+        <differenceType>7002</differenceType>
+        <method>org.neo4j.driver.BookmarkManager queryBookmarkManager()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Driver</className>
         <differenceType>7012</differenceType>
         <method>org.neo4j.driver.BookmarkManager queryTaskBookmarkManager()</method>
     </difference>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.5-SNAPSHOT</version>
+    <version>5.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver</artifactId>
@@ -164,17 +164,17 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
           <configuration>
-            <comparisonArtifacts>
-              <comparisonArtifact>
-                <groupId>org.neo4j.driver</groupId>
-                <artifactId>neo4j-java-driver</artifactId>
-                <version>4.0.0</version>
-              </comparisonArtifact>
-            </comparisonArtifacts>
             <classesDirectory>${api.classes.directory}</classesDirectory>
             <excludes>org/neo4j/driver/internal/**</excludes>
             <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.bcel</groupId>
+              <artifactId>bcel</artifactId>
+              <version>6.7.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.5-SNAPSHOT</version>
+    <version>5.6-SNAPSHOT</version>
   </parent>
 
   <groupId>org.neo4j.doc.driver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j.driver</groupId>
   <artifactId>neo4j-java-driver-parent</artifactId>
-  <version>5.5-SNAPSHOT</version>
+  <version>5.6-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Neo4j Java Driver Project</name>

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>5.5-SNAPSHOT</version>
+        <version>5.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>testkit-backend</artifactId>

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>5.5-SNAPSHOT</version>
+        <version>5.6-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
The `clirr-maven-plugin` configuration has been checking against `4.0.0` driver version for significant time. While it is useful in general, comparing against previous driver version (the default setting) has a benefit of making removals of public methods more visible in reviews.