### PR TITLE
Make the shaded artifact compile as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ All available versions of this driver can be found at
 
 Both `neo4j-java-driver` and `neo4j-java-driver-all` artifacts have `org.neo4j.driver` module name.
 
-Starting from version 5.0 the `neo4j-java-driver` includes an explicit module declaration ([module-info.java](driver/src/main/java/module-info.java)). The `neo4j-java-driver-all` stays unchanged and is shipped as an automatic module.
+Starting from version 5.0 the `neo4j-java-driver` includes an explicit module declaration ([module-info.java](driver/src/main/java/module-info.java)).
+
+The `neo4j-java-driver-all` includes an explicit module declaration ([module-info.java](bundle/src/main/jpms/module-info.java)) starting from version 5.7.
 
 ### Example
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -100,9 +100,6 @@
                   <includes>
                     <include>**\/*.java</include>
                   </includes>
-                  <excludes>
-                    <exclude>module-info.java</exclude>
-                  </excludes>
                 </resource>
               </resources>
             </configuration>
@@ -210,9 +207,35 @@
                     <exclude>META-INF/native-image/**</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>${groupId}:${artifactId}</artifact>
+                  <excludes>
+                    <exclude>module-info.java</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <shadeTestJar>true</shadeTestJar>
               <createSourcesJar>true</createSourcesJar>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-info-to-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <unzip src="${project.build.directory}/${artifactId}-${version}-sources.jar" dest="${project.build.directory}/sources-with-module"/>
+                <copy file="${project.basedir}/src/main/jpms/module-info.java" tofile="${project.build.directory}/sources-with-module/module-info.java" />
+                <zip basedir="${project.build.directory}/sources-with-module" destfile="${project.build.directory}/${artifactId}-${version}-sources.jar"/>
+              </target>
             </configuration>
           </execution>
         </executions>
@@ -230,26 +253,9 @@
             <configuration>
               <overwriteExistingFiles>true</overwriteExistingFiles>
               <module>
-                <moduleInfoSource><![CDATA[
-                  module org.neo4j.driver {
-                    exports org.neo4j.driver;
-                    exports org.neo4j.driver.async;
-                    exports org.neo4j.driver.reactive;
-                    exports org.neo4j.driver.reactivestreams;
-                    exports org.neo4j.driver.types;
-                    exports org.neo4j.driver.summary;
-                    exports org.neo4j.driver.net;
-                    exports org.neo4j.driver.util;
-                    exports org.neo4j.driver.exceptions;
-
-                    requires transitive java.logging;
-                    requires transitive org.reactivestreams;
-                    requires static micrometer.core;
-                    requires static org.graalvm.sdk;
-                    requires static org.slf4j;
-                    requires static java.management;
-                  }
-                ]]></moduleInfoSource>
+                <moduleInfoFile>
+                  ${basedir}/src/main/jpms/module-info.java
+                </moduleInfoFile>
               </module>
             </configuration>
           </execution>

--- a/bundle/src/main/jpms/module-info.java
+++ b/bundle/src/main/jpms/module-info.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The Neo4j Java Driver module.
+ */
+@SuppressWarnings({"requires-automatic", "requires-transitive-automatic"})
+module org.neo4j.driver {
+    exports org.neo4j.driver;
+    exports org.neo4j.driver.async;
+    exports org.neo4j.driver.reactive;
+    exports org.neo4j.driver.reactivestreams;
+    exports org.neo4j.driver.types;
+    exports org.neo4j.driver.summary;
+    exports org.neo4j.driver.net;
+    exports org.neo4j.driver.util;
+    exports org.neo4j.driver.exceptions;
+
+    requires transitive java.logging;
+    requires transitive org.reactivestreams;
+    requires static micrometer.core;
+    requires static org.graalvm.sdk;
+    requires static org.slf4j;
+    requires static java.management;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,11 @@
           <artifactId>moditect-maven-plugin</artifactId>
           <version>1.0.0.RC2</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
This update makes sure the shaded artifact is compiled as a module. This is needed for the features that depend on that, for instance the `sealed` types used across packages.

In addition, the shaded `module-info.java` is kept as a source file so that it could be checked by the licensing plugin and also be added into the sources jar.