### PR TITLE
Seal AuthToken interface

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/AuthToken.java
+++ b/driver/src/main/java/org/neo4j/driver/AuthToken.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.driver;
 
+import org.neo4j.driver.internal.security.InternalAuthToken;
+
 /**
  * Token for holding authentication details, such as <em>user name</em> and <em>password</em>.
  * Such a token is required by a {@link Driver} to authenticate with a Neo4j
@@ -27,4 +29,4 @@ package org.neo4j.driver;
  * @see GraphDatabase#driver(String, AuthToken)
  * @since 1.0
  */
-public interface AuthToken {}
+public sealed interface AuthToken permits InternalAuthToken {}

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
@@ -31,15 +31,12 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Clock;
 import org.neo4j.driver.AuthToken;
-import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Logging;
-import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DomainNameResolver;
 import org.neo4j.driver.internal.async.inbound.ConnectTimeoutHandler;
 import org.neo4j.driver.internal.cluster.RoutingContext;
-import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.security.SecurityPlan;
 
 public class ChannelConnectorImpl implements ChannelConnector {
@@ -80,7 +77,7 @@ public class ChannelConnectorImpl implements ChannelConnector {
             RoutingContext routingContext,
             DomainNameResolver domainNameResolver) {
         this.userAgent = connectionSettings.userAgent();
-        this.authToken = requireValidAuthToken(connectionSettings.authToken());
+        this.authToken = connectionSettings.authToken();
         this.routingContext = routingContext;
         this.connectTimeoutMillis = connectionSettings.connectTimeoutMillis();
         this.securityPlan = requireNonNull(securityPlan);
@@ -142,14 +139,5 @@ public class ChannelConnectorImpl implements ChannelConnector {
         // set to send/receive messages for a selected protocol version
         handshakeCompleted.addListener(
                 new HandshakeCompletedListener(userAgent, authToken, routingContext, connectionInitialized));
-    }
-
-    private static AuthToken requireValidAuthToken(AuthToken token) {
-        if (token instanceof InternalAuthToken) {
-            return token;
-        } else {
-            throw new ClientException("Unknown authentication token, `" + token + "`. Please use one of the supported "
-                    + "tokens from `" + AuthTokens.class.getSimpleName() + "`.");
-        }
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/security/InternalAuthToken.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/InternalAuthToken.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.Value;
  * A simple common token for authentication schemes that easily convert to
  * an auth token map
  */
-public class InternalAuthToken implements AuthToken {
+public final class InternalAuthToken implements AuthToken {
     public static final String SCHEME_KEY = "scheme";
     public static final String PRINCIPAL_KEY = "principal";
     public static final String CREDENTIALS_KEY = "credentials";


### PR DESCRIPTION
Driver effectively does not expect external implementations of `AuthToken` interface. This update makes it more explicit.