### PR TITLE
Fix skipped test name

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -74,7 +74,7 @@ public class StartTest implements TestkitRequest {
         skipMessage = "This test needs updating to implement expected behaviour";
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.TestAuthenticationSchemes\\.test_custom_scheme_empty$", skipMessage);
         COMMON_SKIP_PATTERN_TO_REASON.put(
-                "^.*\\.TestAuthenticationSchemesV4x4\\.test_custom_scheme_empty$", skipMessage);
+                "^.*\\.TestAuthenticationSchemes[^.]+\\.test_custom_scheme_empty$", skipMessage);
         skipMessage = "Driver does not implement optimization for qid in explicit transaction";
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments$", skipMessage);

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -73,6 +73,8 @@ public class StartTest implements TestkitRequest {
                 skipMessage);
         skipMessage = "This test needs updating to implement expected behaviour";
         COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.TestAuthenticationSchemes\\.test_custom_scheme_empty$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.TestAuthenticationSchemesV4x4\\.test_custom_scheme_empty$", skipMessage);
         skipMessage = "Driver does not implement optimization for qid in explicit transaction";
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments$", skipMessage);


### PR DESCRIPTION
The test `stub.authorization.test_authorization.TestAuthenticationSchemes.test_custom_scheme_empty` was rename to `stub.authorization.test_authorization.TestAuthenticationSchemesV4x4.test_custom_scheme_empty` in the PR https://github.com/neo4j-drivers/testkit/pull/542. This change is causing the pipeline fails for java.