### PR TITLE
Remove whitelisted Testkit server configs

### DIFF
--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -161,11 +161,6 @@
                                             <env>
                                                 <TESTKIT_CHECKOUT_PATH>${project.build.directory}/testkit-reactive-legacy</TESTKIT_CHECKOUT_PATH>
                                                 <TEST_BACKEND_SERVER>reactive-legacy</TEST_BACKEND_SERVER>
-                                                <!-- Excludes 3.5 -->
-                                                <TESTKIT_ARGS>--configs 4.0-enterprise-neo4j 4.1-enterprise-neo4j 4.2-community-bolt 4.2-community-neo4j
-                                                    4.2-enterprise-bolt 4.2-enterprise-neo4j 4.2-enterprise-cluster-neo4j 4.3-community-bolt 4.3-community-neo4j
-                                                    4.3-enterprise-bolt 4.3-enterprise-neo4j 4.3-enterprise-cluster-neo4j ${testkit.args}
-                                                </TESTKIT_ARGS>
                                             </env>
                                             <log>
                                                 <prefix xml:space="preserve">${testkit.reactive.legacy.name.pattern}> </prefix>
@@ -192,11 +187,6 @@
                                             <env>
                                                 <TESTKIT_CHECKOUT_PATH>${project.build.directory}/testkit-reactive</TESTKIT_CHECKOUT_PATH>
                                                 <TEST_BACKEND_SERVER>reactive</TEST_BACKEND_SERVER>
-                                                <!-- Excludes 3.5 -->
-                                                <TESTKIT_ARGS>--configs 4.0-enterprise-neo4j 4.1-enterprise-neo4j 4.2-community-bolt 4.2-community-neo4j
-                                                    4.2-enterprise-bolt 4.2-enterprise-neo4j 4.2-enterprise-cluster-neo4j 4.3-community-bolt 4.3-community-neo4j
-                                                    4.3-enterprise-bolt 4.3-enterprise-neo4j 4.3-enterprise-cluster-neo4j ${testkit.args}
-                                                </TESTKIT_ARGS>
                                             </env>
                                             <log>
                                                 <prefix xml:space="preserve">${testkit.reactive.name.pattern}> </prefix>


### PR DESCRIPTION
Testkit no longer uses 3.x servers and these configs are not necessary.