### PR TITLE
Include NotificationConfig on BEGIN message for bolt scheme

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.7-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver</artifactId>

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilder.java
@@ -68,6 +68,7 @@ public class TransactionMetadataBuilder {
         boolean databaseNamePresent = databaseName.databaseName().isPresent();
         boolean impersonatedUserPresent = impersonatedUser != null;
         boolean txTypePresent = txType != null;
+        boolean notificationConfigPresent = notificationConfig != null;
 
         if (!bookmarksPresent
                 && !txTimeoutPresent
@@ -75,7 +76,8 @@ public class TransactionMetadataBuilder {
                 && !accessModePresent
                 && !databaseNamePresent
                 && !impersonatedUserPresent
-                && !txTypePresent) {
+                && !txTypePresent
+                && !notificationConfigPresent) {
             return emptyMap();
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
@@ -42,6 +42,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.NotificationCategory;
+import org.neo4j.driver.NotificationConfig;
+import org.neo4j.driver.NotificationSeverity;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
 
@@ -105,5 +108,25 @@ public class TransactionMetadataBuilderTest {
         Map<String, Value> metadata =
                 buildMetadata(null, null, defaultDatabase(), WRITE, Collections.emptySet(), null, null, null);
         assertTrue(metadata.isEmpty());
+    }
+
+    @Test
+    void shouldIncludeNotificationConfig() {
+        var metadata = buildMetadata(
+                null,
+                null,
+                defaultDatabase(),
+                WRITE,
+                Collections.emptySet(),
+                null,
+                null,
+                NotificationConfig.defaultConfig()
+                        .enableMinimumSeverity(NotificationSeverity.WARNING)
+                        .disableCategories(Set.of(NotificationCategory.UNSUPPORTED)));
+
+        var expectedMetadata = new HashMap<String, Value>();
+        expectedMetadata.put("notifications_minimum_severity", value("WARNING"));
+        expectedMetadata.put("notifications_disabled_categories", value(Set.of("UNSUPPORTED")));
+        assertEquals(expectedMetadata, metadata);
     }
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.7-SNAPSHOT</version>
   </parent>
 
   <groupId>org.neo4j.doc.driver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j.driver</groupId>
   <artifactId>neo4j-java-driver-parent</artifactId>
-  <version>5.8-SNAPSHOT</version>
+  <version>5.7-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Neo4j Java Driver Project</name>

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>5.8-SNAPSHOT</version>
+        <version>5.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>testkit-backend</artifactId>

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>5.8-SNAPSHOT</version>
+        <version>5.7-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
`NotificationConfig` might be ignored on new sessions with `bolt` scheme. This update fixes it.