### PR TITLE
Make Bookmark Manager API GA

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver</artifactId>

--- a/driver/src/main/java/org/neo4j/driver/BookmarkManager.java
+++ b/driver/src/main/java/org/neo4j/driver/BookmarkManager.java
@@ -20,7 +20,6 @@ package org.neo4j.driver;
 
 import java.io.Serializable;
 import java.util.Set;
-import org.neo4j.driver.util.Preview;
 
 /**
  * Keeps track of bookmarks and is used by the driver to ensure causal consistency between sessions and query executions.
@@ -31,7 +30,6 @@ import org.neo4j.driver.util.Preview;
  *
  * @see org.neo4j.driver.SessionConfig.Builder#withBookmarkManager(BookmarkManager)
  */
-@Preview(name = "Bookmark Manager")
 public interface BookmarkManager extends Serializable {
     /**
      * Updates bookmarks by deleting the given previous bookmarks and adding the new bookmarks.

--- a/driver/src/main/java/org/neo4j/driver/BookmarkManagers.java
+++ b/driver/src/main/java/org/neo4j/driver/BookmarkManagers.java
@@ -19,12 +19,10 @@
 package org.neo4j.driver;
 
 import org.neo4j.driver.internal.Neo4jBookmarkManager;
-import org.neo4j.driver.util.Preview;
 
 /**
  * Setups new instances of {@link BookmarkManager}.
  */
-@Preview(name = "Bookmark Manager")
 public final class BookmarkManagers {
     private BookmarkManagers() {}
     /**

--- a/driver/src/main/java/org/neo4j/driver/SessionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/SessionConfig.java
@@ -30,7 +30,6 @@ import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.UnsupportedFeatureException;
 import org.neo4j.driver.reactive.ReactiveSession;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.util.Preview;
 import org.reactivestreams.Subscription;
 
 /**
@@ -162,7 +161,6 @@ public final class SessionConfig implements Serializable {
      *
      * @return bookmark implementation
      */
-    @Preview(name = "Bookmark Manager")
     public Optional<BookmarkManager> bookmarkManager() {
         return Optional.ofNullable(bookmarkManager);
     }
@@ -377,7 +375,6 @@ public final class SessionConfig implements Serializable {
          * @param bookmarkManager bookmark manager implementation. Providing {@code null} effectively disables bookmark manager.
          * @return this builder.
          */
-        @Preview(name = "Bookmark Manager")
         public Builder withBookmarkManager(BookmarkManager bookmarkManager) {
             this.bookmarkManager = bookmarkManager;
             return this;

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <groupId>org.neo4j.doc.driver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j.driver</groupId>
   <artifactId>neo4j-java-driver-parent</artifactId>
-  <version>5.7-SNAPSHOT</version>
+  <version>5.8-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Neo4j Java Driver Project</name>

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>5.7-SNAPSHOT</version>
+        <version>5.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>testkit-backend</artifactId>

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>5.7-SNAPSHOT</version>
+        <version>5.8-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
This update removes the Preview status from the Bookmark Manager API, making it GA.