### PR TITLE
Throw exception upon returning Result in managed transaction API

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
@@ -32,6 +32,7 @@ import org.neo4j.driver.TransactionCallback;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.TransactionWork;
 import org.neo4j.driver.async.ResultCursor;
+import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.spi.Connection;
@@ -158,6 +159,11 @@ public class InternalSession extends AbstractQueryRunner implements Session {
             try (Transaction tx = beginTransaction(mode, config)) {
 
                 T result = work.execute(tx);
+                if (result instanceof Result) {
+                    throw new ClientException(String.format(
+                            "%s is not a valid return value, it should be consumed before producing a return value",
+                            Result.class.getName()));
+                }
                 if (tx.isOpen()) {
                     // commit tx if a user has not explicitly committed or rolled back the transaction
                     tx.commit();

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -248,7 +248,7 @@ class SessionBoltV3IT {
         Session session = driver.session();
         Bookmark initialBookmark = session.lastBookmark();
 
-        session.writeTransaction(tx -> tx.run("CREATE ()"));
+        session.writeTransaction(tx -> tx.run("CREATE ()").consume());
         Bookmark bookmark1 = session.lastBookmark();
         assertNotNull(bookmark1);
         assertNotEquals(initialBookmark, bookmark1);
@@ -259,7 +259,7 @@ class SessionBoltV3IT {
         assertNotEquals(initialBookmark, bookmark2);
         assertNotEquals(bookmark1, bookmark2);
 
-        session.writeTransaction(tx -> tx.run("CREATE ()"));
+        session.writeTransaction(tx -> tx.run("CREATE ()").consume());
         Bookmark bookmark3 = session.lastBookmark();
         assertNotNull(bookmark3);
         assertNotEquals(initialBookmark, bookmark3);

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveSessionIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
+
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.reactive.ReactiveResult;
+import org.neo4j.driver.reactive.ReactiveSession;
+import org.neo4j.driver.testutil.DatabaseExtension;
+import org.neo4j.driver.testutil.ParallelizableIT;
+import org.reactivestreams.Publisher;
+import reactor.adapter.JdkFlowAdapter;
+import reactor.core.publisher.Flux;
+
+@EnabledOnNeo4jWith(BOLT_V4)
+@ParallelizableIT
+class ReactiveSessionIT {
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    @ParameterizedTest
+    @MethodSource("managedTransactionsReturningReactiveResultPublisher")
+    void shouldErrorWhenReactiveResultIsReturned(Function<ReactiveSession, Publisher<ReactiveResult>> fn) {
+        // GIVEN
+        var session = neo4j.driver().session(ReactiveSession.class);
+
+        // WHEN & THEN
+        var error = assertThrows(
+                ClientException.class, () -> Flux.from(fn.apply(session)).blockFirst());
+        assertEquals(
+                "org.neo4j.driver.reactive.ReactiveResult is not a valid return value, it should be consumed before producing a return value",
+                error.getMessage());
+        JdkFlowAdapter.flowPublisherToFlux(session.close()).blockFirst();
+    }
+
+    static List<Function<ReactiveSession, Publisher<ReactiveResult>>>
+            managedTransactionsReturningReactiveResultPublisher() {
+        return List.of(
+                session -> JdkFlowAdapter.flowPublisherToFlux(session.executeWrite(tx -> tx.run("RETURN 1"))),
+                session -> JdkFlowAdapter.flowPublisherToFlux(session.executeRead(tx -> tx.run("RETURN 1"))));
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.integration.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
+
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
+import org.neo4j.driver.reactivestreams.ReactiveResult;
+import org.neo4j.driver.reactivestreams.ReactiveSession;
+import org.neo4j.driver.testutil.DatabaseExtension;
+import org.neo4j.driver.testutil.ParallelizableIT;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+@EnabledOnNeo4jWith(BOLT_V4)
+@ParallelizableIT
+public class ReactiveStreamsSessionIT {
+    @RegisterExtension
+    static final DatabaseExtension neo4j = new DatabaseExtension();
+
+    @ParameterizedTest
+    @MethodSource("managedTransactionsReturningReactiveResultPublisher")
+    void shouldErrorWhenReactiveResultIsReturned(Function<ReactiveSession, Publisher<ReactiveResult>> fn) {
+        // GIVEN
+        var session = neo4j.driver().session(ReactiveSession.class);
+
+        // WHEN & THEN
+        var error = assertThrows(
+                ClientException.class, () -> Flux.from(fn.apply(session)).blockFirst());
+        assertEquals(
+                "org.neo4j.driver.reactivestreams.ReactiveResult is not a valid return value, it should be consumed before producing a return value",
+                error.getMessage());
+        Flux.from(session.close()).blockFirst();
+    }
+
+    static List<Function<ReactiveSession, Publisher<ReactiveResult>>>
+            managedTransactionsReturningReactiveResultPublisher() {
+        return List.of(
+                session -> session.executeWrite(tx -> tx.run("RETURN 1")),
+                session -> session.executeRead(tx -> tx.run("RETURN 1")));
+    }
+}


### PR DESCRIPTION
Returning `Result` (or `ResultCursor`, `ReactiveResult`, etc.) directly in the managed transaction API is an invalid use of the API and it should be avoided.

https://neo4j.com/docs/java-manual/current/session-api/#java-driver-simple-result-consume
> Any query results obtained within a transaction function should be consumed within that function, as connection-bound resources cannot be managed correctly when out of scope. To that end, transaction functions can return values but these should be derived values rather than raw results.