### PR TITLE
Introduce `bolt_agent`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.driver;
 
-import static java.lang.String.format;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
+import static org.neo4j.driver.internal.util.DriverInfoUtil.driverVersion;
 
 import java.io.File;
 import java.io.Serial;
@@ -345,7 +345,7 @@ public final class Config implements Serializable {
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private long maxConnectionLifetimeMillis = PoolSettings.DEFAULT_MAX_CONNECTION_LIFETIME;
         private long connectionAcquisitionTimeoutMillis = PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
-        private String userAgent = format("neo4j-java/%s", driverVersion());
+        private String userAgent = driverVersion();
         private final SecuritySettings.SecuritySettingsBuilder securitySettingsBuilder =
                 new SecuritySettings.SecuritySettingsBuilder();
         private long routingTablePurgeDelayMillis = RoutingSettings.STALE_ROUTING_TABLE_PURGE_DELAY_MS;
@@ -746,23 +746,6 @@ public final class Config implements Serializable {
         public ConfigBuilder withNotificationConfig(NotificationConfig notificationConfig) {
             this.notificationConfig = Objects.requireNonNull(notificationConfig, "notificationConfig must not be null");
             return this;
-        }
-
-        /**
-         * Extracts the driver version from the driver jar MANIFEST.MF file.
-         */
-        private static String driverVersion() {
-            // "Session" is arbitrary - the only thing that matters is that the class we use here is in the
-            // 'org.neo4j.driver' package, because that is where the jar manifest specifies the version.
-            // This is done as part of the build, adding a MANIFEST.MF file to the generated jarfile.
-            Package pkg = Session.class.getPackage();
-            if (pkg != null && pkg.getImplementationVersion() != null) {
-                return pkg.getImplementationVersion();
-            }
-
-            // If there is no version, we're not running from a jar file, but from raw compiled class files.
-            // This should only happen during development, so call the version 'dev'.
-            return "dev";
         }
 
         /**

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.driver;
 
+import static java.lang.String.format;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.DriverInfoUtil.driverVersion;
 
@@ -345,7 +346,7 @@ public final class Config implements Serializable {
         private long idleTimeBeforeConnectionTest = PoolSettings.DEFAULT_IDLE_TIME_BEFORE_CONNECTION_TEST;
         private long maxConnectionLifetimeMillis = PoolSettings.DEFAULT_MAX_CONNECTION_LIFETIME;
         private long connectionAcquisitionTimeoutMillis = PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT;
-        private String userAgent = driverVersion();
+        private String userAgent = format("neo4j-java/%s", driverVersion());
         private final SecuritySettings.SecuritySettingsBuilder securitySettingsBuilder =
                 new SecuritySettings.SecuritySettingsBuilder();
         private long routingTablePurgeDelayMillis = RoutingSettings.STALE_ROUTING_TABLE_PURGE_DELAY_MS;

--- a/driver/src/main/java/org/neo4j/driver/internal/BoltAgent.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltAgent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+public record BoltAgent(String product, String platform, String language, String languageDetails) {}

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -61,6 +61,7 @@ import org.neo4j.driver.internal.security.SecurityPlans;
 import org.neo4j.driver.internal.security.StaticAuthTokenManager;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
+import org.neo4j.driver.internal.util.DriverInfoUtil;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.net.ServerAddressResolver;
 
@@ -141,7 +142,8 @@ public class DriverFactory {
         Clock clock = createClock();
         ConnectionSettings settings =
                 new ConnectionSettings(authTokenManager, config.userAgent(), config.connectionTimeoutMillis());
-        ChannelConnector connector = createConnector(settings, securityPlan, config, clock, routingContext);
+        var boltAgent = DriverInfoUtil.boltAgent();
+        ChannelConnector connector = createConnector(settings, securityPlan, config, clock, routingContext, boltAgent);
         PoolSettings poolSettings = new PoolSettings(
                 config.maxConnectionPoolSize(),
                 config.connectionAcquisitionTimeoutMillis(),
@@ -179,7 +181,8 @@ public class DriverFactory {
             SecurityPlan securityPlan,
             Config config,
             Clock clock,
-            RoutingContext routingContext) {
+            RoutingContext routingContext,
+            BoltAgent boltAgent) {
         return new ChannelConnectorImpl(
                 settings,
                 securityPlan,
@@ -187,7 +190,8 @@ public class DriverFactory {
                 clock,
                 routingContext,
                 getDomainNameResolver(),
-                config.notificationConfig());
+                config.notificationConfig(),
+                boltAgent);
     }
 
     private InternalDriver createDriver(

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtil.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
-import org.neo4j.driver.internal.messaging.v52.BoltProtocolV52;
+import org.neo4j.driver.internal.messaging.v53.BoltProtocolV53;
 
 public final class BoltProtocolUtil {
     public static final int BOLT_MAGIC_PREAMBLE = 0x6060B017;
@@ -41,7 +41,7 @@ public final class BoltProtocolUtil {
 
     private static final ByteBuf HANDSHAKE_BUF = unreleasableBuffer(copyInt(
                     BOLT_MAGIC_PREAMBLE,
-                    BoltProtocolV52.VERSION.toIntRange(BoltProtocolV5.VERSION),
+                    BoltProtocolV53.VERSION.toIntRange(BoltProtocolV5.VERSION),
                     BoltProtocolV44.VERSION.toIntRange(BoltProtocolV42.VERSION),
                     BoltProtocolV41.VERSION.toInt(),
                     BoltProtocolV3.VERSION.toInt()))

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/ChannelConnectorImpl.java
@@ -33,6 +33,7 @@ import java.time.Clock;
 import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
+import org.neo4j.driver.internal.BoltAgent;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DomainNameResolver;
@@ -42,6 +43,7 @@ import org.neo4j.driver.internal.security.SecurityPlan;
 
 public class ChannelConnectorImpl implements ChannelConnector {
     private final String userAgent;
+    private final BoltAgent boltAgent;
     private final AuthTokenManager authTokenManager;
     private final RoutingContext routingContext;
     private final SecurityPlan securityPlan;
@@ -60,7 +62,8 @@ public class ChannelConnectorImpl implements ChannelConnector {
             Clock clock,
             RoutingContext routingContext,
             DomainNameResolver domainNameResolver,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            BoltAgent boltAgent) {
         this(
                 connectionSettings,
                 securityPlan,
@@ -69,7 +72,8 @@ public class ChannelConnectorImpl implements ChannelConnector {
                 clock,
                 routingContext,
                 domainNameResolver,
-                notificationConfig);
+                notificationConfig,
+                boltAgent);
     }
 
     public ChannelConnectorImpl(
@@ -80,8 +84,10 @@ public class ChannelConnectorImpl implements ChannelConnector {
             Clock clock,
             RoutingContext routingContext,
             DomainNameResolver domainNameResolver,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            BoltAgent boltAgent) {
         this.userAgent = connectionSettings.userAgent();
+        this.boltAgent = requireNonNull(boltAgent);
         this.authTokenManager = connectionSettings.authTokenProvider();
         this.routingContext = routingContext;
         this.connectTimeoutMillis = connectionSettings.connectTimeoutMillis();
@@ -145,6 +151,6 @@ public class ChannelConnectorImpl implements ChannelConnector {
         // add listener that sends an INIT message. connection is now fully established. channel pipeline if fully
         // set to send/receive messages for a selected protocol version
         handshakeCompleted.addListener(new HandshakeCompletedListener(
-                userAgent, routingContext, connectionInitialized, notificationConfig, clock));
+                userAgent, boltAgent, routingContext, connectionInitialized, notificationConfig, clock));
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListener.java
@@ -26,12 +26,14 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
 import java.time.Clock;
 import org.neo4j.driver.NotificationConfig;
+import org.neo4j.driver.internal.BoltAgent;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 
 public class HandshakeCompletedListener implements ChannelFutureListener {
     private final String userAgent;
+    private final BoltAgent boltAgent;
     private final RoutingContext routingContext;
     private final ChannelPromise connectionInitializedPromise;
     private final NotificationConfig notificationConfig;
@@ -39,12 +41,14 @@ public class HandshakeCompletedListener implements ChannelFutureListener {
 
     public HandshakeCompletedListener(
             String userAgent,
+            BoltAgent boltAgent,
             RoutingContext routingContext,
             ChannelPromise connectionInitializedPromise,
             NotificationConfig notificationConfig,
             Clock clock) {
         requireNonNull(clock, "clock must not be null");
         this.userAgent = requireNonNull(userAgent);
+        this.boltAgent = requireNonNull(boltAgent);
         this.routingContext = routingContext;
         this.connectionInitializedPromise = requireNonNull(connectionInitializedPromise);
         this.notificationConfig = notificationConfig;
@@ -71,6 +75,7 @@ public class HandshakeCompletedListener implements ChannelFutureListener {
                                         authContext.setValidToken(authToken);
                                         protocol.initializeChannel(
                                                 userAgent,
+                                                boltAgent,
                                                 authToken,
                                                 routingContext,
                                                 connectionInitializedPromise,
@@ -81,7 +86,13 @@ public class HandshakeCompletedListener implements ChannelFutureListener {
                                 channel.eventLoop());
             } else {
                 protocol.initializeChannel(
-                        userAgent, null, routingContext, connectionInitializedPromise, notificationConfig, clock);
+                        userAgent,
+                        boltAgent,
+                        null,
+                        routingContext,
+                        connectionInitializedPromise,
+                        notificationConfig,
+                        clock);
             }
         } else {
             connectionInitializedPromise.setFailure(future.cause());

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.internal.BoltAgent;
 import org.neo4j.driver.internal.DatabaseBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -47,6 +48,7 @@ import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
 import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
 import org.neo4j.driver.internal.messaging.v52.BoltProtocolV52;
+import org.neo4j.driver.internal.messaging.v53.BoltProtocolV53;
 import org.neo4j.driver.internal.spi.Connection;
 
 public interface BoltProtocol {
@@ -61,14 +63,16 @@ public interface BoltProtocol {
      * Initialize channel after it is connected and handshake selected this protocol version.
      *
      * @param userAgent                 the user agent string.
+     * @param boltAgent                 the bolt agent
      * @param authToken                 the authentication token.
      * @param routingContext            the configured routing context
      * @param channelInitializedPromise the promise to be notified when initialization is completed.
-     * @param notificationConfig the notification configuration
-     * @param clock the clock to use
+     * @param notificationConfig        the notification configuration
+     * @param clock                     the clock to use
      */
     void initializeChannel(
             String userAgent,
+            BoltAgent boltAgent,
             AuthToken authToken,
             RoutingContext routingContext,
             ChannelPromise channelInitializedPromise,
@@ -189,6 +193,8 @@ public interface BoltProtocol {
             return BoltProtocolV51.INSTANCE;
         } else if (BoltProtocolV52.VERSION.equals(version)) {
             return BoltProtocolV52.INSTANCE;
+        } else if (BoltProtocolV53.VERSION.equals(version)) {
+            return BoltProtocolV53.INSTANCE;
         }
         throw new ClientException("Unknown protocol version: " + version);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -40,6 +40,7 @@ import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.UnsupportedFeatureException;
+import org.neo4j.driver.internal.BoltAgent;
 import org.neo4j.driver.internal.DatabaseBookmark;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
@@ -81,6 +82,7 @@ public class BoltProtocolV3 implements BoltProtocol {
     @Override
     public void initializeChannel(
             String userAgent,
+            BoltAgent boltAgent,
             AuthToken authToken,
             RoutingContext routingContext,
             ChannelPromise channelInitializedPromise,
@@ -97,6 +99,7 @@ public class BoltProtocolV3 implements BoltProtocol {
         if (routingContext.isServerRoutingEnabled()) {
             message = new HelloMessage(
                     userAgent,
+                    null,
                     ((InternalAuthToken) authToken).toMap(),
                     routingContext.toMap(),
                     includeDateTimeUtcPatchInHello(),
@@ -104,6 +107,7 @@ public class BoltProtocolV3 implements BoltProtocol {
         } else {
             message = new HelloMessage(
                     userAgent,
+                    null,
                     ((InternalAuthToken) authToken).toMap(),
                     null,
                     includeDateTimeUtcPatchInHello(),

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging.v51;
+package org.neo4j.driver.internal.messaging.v53;
 
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.messageDispatcher;
 import static org.neo4j.driver.internal.async.connection.ChannelAttributes.setHelloStage;
@@ -32,13 +32,12 @@ import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.handlers.HelloV51ResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.BoltProtocolVersion;
-import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.request.HelloMessage;
-import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
+import org.neo4j.driver.internal.messaging.v52.BoltProtocolV52;
 
-public class BoltProtocolV51 extends BoltProtocolV5 {
-    public static final BoltProtocolVersion VERSION = new BoltProtocolVersion(5, 1);
-    public static final BoltProtocol INSTANCE = new BoltProtocolV51();
+public class BoltProtocolV53 extends BoltProtocolV52 {
+    public static final BoltProtocolVersion VERSION = new BoltProtocolVersion(5, 3);
+    public static final BoltProtocol INSTANCE = new BoltProtocolV53();
 
     @Override
     public void initializeChannel(
@@ -59,9 +58,9 @@ public class BoltProtocolV51 extends BoltProtocolV5 {
 
         if (routingContext.isServerRoutingEnabled()) {
             message = new HelloMessage(
-                    userAgent, null, Collections.emptyMap(), routingContext.toMap(), false, notificationConfig);
+                    userAgent, boltAgent, Collections.emptyMap(), routingContext.toMap(), false, notificationConfig);
         } else {
-            message = new HelloMessage(userAgent, null, Collections.emptyMap(), null, false, notificationConfig);
+            message = new HelloMessage(userAgent, boltAgent, Collections.emptyMap(), null, false, notificationConfig);
         }
 
         var helloFuture = new CompletableFuture<Void>();
@@ -74,10 +73,5 @@ public class BoltProtocolV51 extends BoltProtocolV5 {
     @Override
     public BoltProtocolVersion version() {
         return VERSION;
-    }
-
-    @Override
-    public MessageFormat createMessageFormat() {
-        return new MessageFormatV51();
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/DriverInfoUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/DriverInfoUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import static java.lang.String.format;
+
+import java.util.Optional;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.internal.BoltAgent;
+
+public class DriverInfoUtil {
+    public static BoltAgent boltAgent() {
+        var productInfo = format("neo4j-java/%s", driverVersion());
+
+        var platformBuilder = new StringBuilder();
+        getProperty("os.name").ifPresent(value -> append(value, platformBuilder));
+        getProperty("os.version").ifPresent(value -> append(value, platformBuilder));
+        getProperty("os.arch").ifPresent(value -> append(value, platformBuilder));
+
+        var language = getProperty("java.version").map(version -> "Java/" + version);
+
+        var languageDetails = language.map(ignored -> {
+            var languageDetailsBuilder = new StringBuilder();
+            getProperty("java.vm.vendor").ifPresent(value -> append(value, languageDetailsBuilder));
+            getProperty("java.vm.name").ifPresent(value -> append(value, languageDetailsBuilder));
+            getProperty("java.vm.version").ifPresent(value -> append(value, languageDetailsBuilder));
+            return languageDetailsBuilder.isEmpty() ? null : languageDetailsBuilder;
+        });
+
+        return new BoltAgent(
+                productInfo,
+                platformBuilder.isEmpty() ? null : platformBuilder.toString(),
+                language.orElse(null),
+                languageDetails.isEmpty() ? null : languageDetails.toString());
+    }
+
+    /**
+     * Extracts the driver version from the driver jar MANIFEST.MF file.
+     */
+    public static String driverVersion() {
+        // "Session" is arbitrary - the only thing that matters is that the class we use here is in the
+        // 'org.neo4j.driver' package, because that is where the jar manifest specifies the version.
+        // This is done as part of the build, adding a MANIFEST.MF file to the generated jarfile.
+        Package pkg = Session.class.getPackage();
+        if (pkg != null && pkg.getImplementationVersion() != null) {
+            return pkg.getImplementationVersion();
+        }
+
+        // If there is no version, we're not running from a jar file, but from raw compiled class files.
+        // This should only happen during development, so call the version 'dev'.
+        return "dev";
+    }
+
+    private static Optional<String> getProperty(String key) {
+        try {
+            var value = System.getProperty(key);
+            if (value != null) {
+                value = value.trim();
+            }
+            return value != null && !value.isEmpty() ? Optional.of(value) : Optional.empty();
+        } catch (SecurityException exception) {
+            return Optional.empty();
+        }
+    }
+
+    private static void append(String value, StringBuilder builder) {
+        if (value != null && !value.isEmpty()) {
+            var separator = builder.isEmpty() ? "" : "; ";
+            builder.append(separator).append(value);
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -503,4 +503,11 @@ class ConfigTest {
             assertTrue(Serializable.class.isAssignableFrom(loggingClass));
         }
     }
+
+    @Test
+    void shouldHaveDefaultUserAgent() {
+        var config = Config.defaultConfig();
+
+        assertTrue(config.userAgent().matches("^neo4j-java/.+$"));
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ChannelConnectorImplIT.java
@@ -54,6 +54,7 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.RevocationCheckingStrategy;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
@@ -226,7 +227,8 @@ class ChannelConnectorImplIT {
                 new FakeClock(),
                 RoutingContext.EMPTY,
                 DefaultDomainNameResolver.getInstance(),
-                null);
+                null,
+                BoltAgentUtil.VALUE);
     }
 
     private static SecurityPlan trustAllCertificates() throws GeneralSecurityException {

--- a/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ConnectionHandlingIT.java
@@ -57,6 +57,7 @@ import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DriverFactory;
@@ -467,8 +468,8 @@ class ConnectionHandlingIT {
                     config.maxConnectionLifetimeMillis(),
                     config.idleTimeBeforeConnectionTest());
             Clock clock = createClock();
-            ChannelConnector connector =
-                    super.createConnector(connectionSettings, securityPlan, config, clock, routingContext);
+            ChannelConnector connector = super.createConnector(
+                    connectionSettings, securityPlan, config, clock, routingContext, BoltAgentUtil.VALUE);
             connectionPool = new MemorizingConnectionPool(
                     connector, bootstrap, poolSettings, config.logging(), clock, ownsEventLoopGroup);
             return connectionPool;

--- a/driver/src/test/java/org/neo4j/driver/internal/BoltAgentUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/BoltAgentUtil.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal;
+
+public interface BoltAgentUtil {
+    BoltAgent VALUE = new BoltAgent("agent", null, null, null);
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/BoltProtocolUtilTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.internal.messaging.v3.BoltProtocolV3;
 import org.neo4j.driver.internal.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
-import org.neo4j.driver.internal.messaging.v52.BoltProtocolV52;
+import org.neo4j.driver.internal.messaging.v53.BoltProtocolV53;
 
 class BoltProtocolUtilTest {
     @Test
@@ -41,7 +41,7 @@ class BoltProtocolUtilTest {
         assertByteBufContains(
                 handshakeBuf(),
                 BOLT_MAGIC_PREAMBLE,
-                (2 << 16) | BoltProtocolV52.VERSION.toInt(),
+                (3 << 16) | BoltProtocolV53.VERSION.toInt(),
                 (2 << 16) | BoltProtocolV44.VERSION.toInt(),
                 BoltProtocolV41.VERSION.toInt(),
                 BoltProtocolV3.VERSION.toInt());
@@ -49,7 +49,7 @@ class BoltProtocolUtilTest {
 
     @Test
     void shouldReturnHandshakeString() {
-        assertEquals("[0x6060b017, 131589, 132100, 260, 3]", handshakeString());
+        assertEquals("[0x6060b017, 197381, 132100, 260, 3]", handshakeString());
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/HandshakeCompletedListenerTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.async.pool.AuthContext;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -70,7 +71,12 @@ class HandshakeCompletedListenerTest {
     void shouldFailConnectionInitializedPromiseWhenHandshakeFails() {
         ChannelPromise channelInitializedPromise = channel.newPromise();
         HandshakeCompletedListener listener = new HandshakeCompletedListener(
-                "user-agent", RoutingContext.EMPTY, channelInitializedPromise, null, mock(Clock.class));
+                USER_AGENT,
+                BoltAgentUtil.VALUE,
+                RoutingContext.EMPTY,
+                channelInitializedPromise,
+                null,
+                mock(Clock.class));
 
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
         IOException cause = new IOException("Bad handshake");
@@ -92,7 +98,7 @@ class HandshakeCompletedListenerTest {
         setAuthContext(channel, authContext);
         testWritingOfInitializationMessage(
                 BoltProtocolV3.VERSION,
-                new HelloMessage(USER_AGENT, authToken().toMap(), Collections.emptyMap(), false, null),
+                new HelloMessage(USER_AGENT, null, authToken().toMap(), Collections.emptyMap(), false, null),
                 HelloResponseHandler.class);
         then(authContext).should().initiateAuth(authToken);
     }
@@ -102,7 +108,12 @@ class HandshakeCompletedListenerTest {
         // given
         var channelInitializedPromise = channel.newPromise();
         var listener = new HandshakeCompletedListener(
-                "agent", mock(RoutingContext.class), channelInitializedPromise, null, mock(Clock.class));
+                USER_AGENT,
+                BoltAgentUtil.VALUE,
+                mock(RoutingContext.class),
+                channelInitializedPromise,
+                null,
+                mock(Clock.class));
         var handshakeCompletedPromise = channel.newPromise();
         handshakeCompletedPromise.setSuccess();
         setProtocolVersion(channel, BoltProtocolV5.VERSION);
@@ -134,7 +145,12 @@ class HandshakeCompletedListenerTest {
 
         ChannelPromise channelInitializedPromise = channel.newPromise();
         HandshakeCompletedListener listener = new HandshakeCompletedListener(
-                USER_AGENT, RoutingContext.EMPTY, channelInitializedPromise, null, mock(Clock.class));
+                USER_AGENT,
+                BoltAgentUtil.VALUE,
+                RoutingContext.EMPTY,
+                channelInitializedPromise,
+                null,
+                mock(Clock.class));
 
         ChannelPromise handshakeCompletedPromise = channel.newPromise();
         handshakeCompletedPromise.setSuccess();

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/ConnectionPoolImplIT.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
@@ -59,7 +60,7 @@ class ConnectionPoolImplIT {
     private ConnectionPoolImpl pool;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         pool = newPool();
     }
 
@@ -143,7 +144,8 @@ class ConnectionPoolImplIT {
                 clock,
                 RoutingContext.EMPTY,
                 DefaultDomainNameResolver.getInstance(),
-                null);
+                null,
+                BoltAgentUtil.VALUE);
         PoolSettings poolSettings = newSettings();
         Bootstrap bootstrap = BootstrapFactory.newBootstrap(1);
         return new ConnectionPoolImpl(

--- a/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/pool/NettyChannelPoolIT.java
@@ -47,6 +47,7 @@ import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.AuthenticationException;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
@@ -198,7 +199,8 @@ class NettyChannelPoolIT {
                 new FakeClock(),
                 RoutingContext.EMPTY,
                 DefaultDomainNameResolver.getInstance(),
-                null);
+                null,
+                BoltAgentUtil.VALUE);
         var nettyChannelHealthChecker = mock(NettyChannelHealthChecker.class);
         when(nettyChannelHealthChecker.isHealthy(any())).thenAnswer(NettyChannelPoolIT::answer);
         return new NettyChannelPool(

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/HelloMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/HelloMessageEncoderTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.messaging.ValuePacker;
 import org.neo4j.driver.internal.messaging.request.HelloMessage;
 
@@ -42,13 +43,14 @@ class HelloMessageEncoderTest {
         authToken.put("username", value("bob"));
         authToken.put("password", value("secret"));
 
-        encoder.encode(new HelloMessage("MyDriver", authToken, null, false, null), packer);
+        encoder.encode(new HelloMessage("MyDriver", BoltAgentUtil.VALUE, authToken, null, false, null), packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(1, HelloMessage.SIGNATURE);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver"));
+        expectedMetadata.put("bolt_agent", value(Map.of("product", BoltAgentUtil.VALUE.product())));
         order.verify(packer).pack(expectedMetadata);
     }
 
@@ -61,13 +63,15 @@ class HelloMessageEncoderTest {
         Map<String, String> routingContext = new HashMap<>();
         routingContext.put("policy", "eu-fast");
 
-        encoder.encode(new HelloMessage("MyDriver", authToken, routingContext, false, null), packer);
+        encoder.encode(
+                new HelloMessage("MyDriver", BoltAgentUtil.VALUE, authToken, routingContext, false, null), packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(1, HelloMessage.SIGNATURE);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver"));
+        expectedMetadata.put("bolt_agent", value(Map.of("product", BoltAgentUtil.VALUE.product())));
         expectedMetadata.put("routing", value(routingContext));
         order.verify(packer).pack(expectedMetadata);
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/HelloMessageTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.BoltAgentUtil;
 
 class HelloMessageTest {
     @Test
@@ -39,10 +40,12 @@ class HelloMessageTest {
         authToken.put("user", value("Alice"));
         authToken.put("credentials", value("SecretPassword"));
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap(), false, null);
+        HelloMessage message =
+                new HelloMessage("MyDriver/1.0.2", BoltAgentUtil.VALUE, authToken, Collections.emptyMap(), false, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver/1.0.2"));
+        expectedMetadata.put("bolt_agent", value(Map.of("product", BoltAgentUtil.VALUE.product())));
         expectedMetadata.put("routing", value(Collections.emptyMap()));
         assertEquals(expectedMetadata, message.metadata());
     }
@@ -57,10 +60,12 @@ class HelloMessageTest {
         routingContext.put("region", "China");
         routingContext.put("speed", "Slow");
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, routingContext, false, null);
+        HelloMessage message =
+                new HelloMessage("MyDriver/1.0.2", BoltAgentUtil.VALUE, authToken, routingContext, false, null);
 
         Map<String, Value> expectedMetadata = new HashMap<>(authToken);
         expectedMetadata.put("user_agent", value("MyDriver/1.0.2"));
+        expectedMetadata.put("bolt_agent", value(Map.of("product", BoltAgentUtil.VALUE.product())));
         expectedMetadata.put("routing", value(routingContext));
         assertEquals(expectedMetadata, message.metadata());
     }
@@ -71,7 +76,8 @@ class HelloMessageTest {
         authToken.put(PRINCIPAL_KEY, value("Alice"));
         authToken.put(CREDENTIALS_KEY, value("SecretPassword"));
 
-        HelloMessage message = new HelloMessage("MyDriver/1.0.2", authToken, Collections.emptyMap(), false, null);
+        HelloMessage message =
+                new HelloMessage("MyDriver/1.0.2", BoltAgentUtil.VALUE, authToken, Collections.emptyMap(), false, null);
 
         assertThat(message.toString(), not(containsString("SecretPassword")));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3Test.java
@@ -144,7 +144,8 @@ public class BoltProtocolV3Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -177,7 +178,7 @@ public class BoltProtocolV3Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -47,6 +47,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.neo4j.driver.Query;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -98,6 +99,7 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -48,6 +48,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.neo4j.driver.Query;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -106,6 +107,7 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -143,7 +143,8 @@ public final class BoltProtocolV41Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -176,7 +177,7 @@ public final class BoltProtocolV41Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -48,6 +48,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.neo4j.driver.Query;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -105,6 +106,7 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -143,7 +143,8 @@ public final class BoltProtocolV42Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -176,7 +177,7 @@ public final class BoltProtocolV42Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -48,6 +48,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.neo4j.driver.Query;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -105,6 +106,7 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
@@ -142,7 +142,8 @@ public final class BoltProtocolV43Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -175,7 +176,7 @@ public final class BoltProtocolV43Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -110,6 +111,7 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
@@ -142,7 +142,8 @@ public class BoltProtocolV44Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -175,7 +176,7 @@ public class BoltProtocolV44Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -110,6 +111,7 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
@@ -142,7 +142,8 @@ public class BoltProtocolV5Test {
         when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
         ChannelAttributes.setAuthContext(channel, authContext);
 
-        protocol.initializeChannel("MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+        protocol.initializeChannel(
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
@@ -175,7 +176,7 @@ public class BoltProtocolV5Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/2.2.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -110,6 +111,7 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51Test.java
@@ -135,7 +135,7 @@ public class BoltProtocolV51Test {
         ChannelPromise promise = channel.newPromise();
 
         protocol.initializeChannel(
-                "MyDriver/0.0.1", dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
+                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
 
         assertThat(channel.outboundMessages(), hasSize(0));
         assertEquals(1, messageDispatcher.queuedHandlersCount());

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51Test.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
 import org.neo4j.driver.internal.messaging.MessageFormat;
@@ -105,6 +106,7 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                 // Bolt V3 messages
                 new HelloMessage(
                         "MyDriver/1.2.3",
+                        BoltAgentUtil.VALUE,
                         ((InternalAuthToken) basic("neo4j", "neo4j")).toMap(),
                         Collections.emptyMap(),
                         false,

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53Test.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.driver.internal.messaging.v4;
+package org.neo4j.driver.internal.messaging.v53;
 
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.emptyMap;
@@ -71,13 +71,13 @@ import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.DatabaseBookmark;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
-import org.neo4j.driver.internal.async.pool.AuthContext;
 import org.neo4j.driver.internal.cluster.RoutingContext;
 import org.neo4j.driver.internal.cursor.AsyncResultCursor;
 import org.neo4j.driver.internal.cursor.ResultCursorFactory;
@@ -91,16 +91,15 @@ import org.neo4j.driver.internal.messaging.MessageFormat;
 import org.neo4j.driver.internal.messaging.request.BeginMessage;
 import org.neo4j.driver.internal.messaging.request.CommitMessage;
 import org.neo4j.driver.internal.messaging.request.GoodbyeMessage;
-import org.neo4j.driver.internal.messaging.request.HelloMessage;
 import org.neo4j.driver.internal.messaging.request.PullMessage;
 import org.neo4j.driver.internal.messaging.request.RollbackMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
+import org.neo4j.driver.internal.messaging.v51.MessageFormatV51;
 import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 
-public final class BoltProtocolV4Test {
-
+public class BoltProtocolV53Test {
     protected static final String QUERY_TEXT = "RETURN $x";
     protected static final Map<String, Value> PARAMS = singletonMap("x", value(42));
     protected static final Query QUERY = new Query(QUERY_TEXT, value(PARAMS));
@@ -113,6 +112,10 @@ public final class BoltProtocolV4Test {
             .withTimeout(ofSeconds(12))
             .withMetadata(singletonMap("key", value(42)))
             .build();
+
+    protected BoltProtocol createProtocol() {
+        return BoltProtocolV53.INSTANCE;
+    }
 
     @BeforeEach
     void beforeEach() {
@@ -132,31 +135,29 @@ public final class BoltProtocolV4Test {
     @Test
     void shouldInitializeChannel() {
         ChannelPromise promise = channel.newPromise();
-        var clock = mock(Clock.class);
-        var time = 1L;
-        when(clock.millis()).thenReturn(time);
-        var authContext = mock(AuthContext.class);
-        when(authContext.getAuthToken()).thenReturn(dummyAuthToken());
-        ChannelAttributes.setAuthContext(channel, authContext);
 
         protocol.initializeChannel(
-                "MyDriver/0.0.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, clock);
+                "MyDriver/0.0.1",
+                BoltAgentUtil.VALUE,
+                dummyAuthToken(),
+                RoutingContext.EMPTY,
+                promise,
+                null,
+                mock(Clock.class));
 
-        assertThat(channel.outboundMessages(), hasSize(1));
-        assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
+        assertThat(channel.outboundMessages(), hasSize(0));
         assertEquals(1, messageDispatcher.queuedHandlersCount());
-        assertFalse(promise.isDone());
+        assertTrue(promise.isDone());
 
         Map<String, Value> metadata = new HashMap<>();
-        metadata.put("server", value("Neo4j/4.0.0"));
+        metadata.put("server", value("Neo4j/4.4.0"));
         metadata.put("connection_id", value("bolt-42"));
 
         messageDispatcher.handleSuccessMessage(metadata);
 
+        channel.flush();
         assertTrue(promise.isDone());
         assertTrue(promise.isSuccess());
-        verify(clock).millis();
-        verify(authContext).finishAuth(time);
     }
 
     @Test
@@ -166,24 +167,6 @@ public final class BoltProtocolV4Test {
         assertThat(channel.outboundMessages(), hasSize(1));
         assertThat(channel.outboundMessages().poll(), instanceOf(GoodbyeMessage.class));
         assertEquals(1, messageDispatcher.queuedHandlersCount());
-    }
-
-    @Test
-    void shouldFailToInitializeChannelWhenErrorIsReceived() {
-        ChannelPromise promise = channel.newPromise();
-
-        protocol.initializeChannel(
-                "MyDriver/2.2.1", null, dummyAuthToken(), RoutingContext.EMPTY, promise, null, mock(Clock.class));
-
-        assertThat(channel.outboundMessages(), hasSize(1));
-        assertThat(channel.outboundMessages().poll(), instanceOf(HelloMessage.class));
-        assertEquals(1, messageDispatcher.queuedHandlersCount());
-        assertFalse(promise.isDone());
-
-        messageDispatcher.handleFailureMessage("Neo.TransientError.General.DatabaseUnavailable", "Error!");
-
-        assertTrue(promise.isDone());
-        assertFalse(promise.isSuccess());
     }
 
     @Test
@@ -370,19 +353,11 @@ public final class BoltProtocolV4Test {
                 null));
     }
 
-    private BoltProtocol createProtocol() {
-        return BoltProtocolV4.INSTANCE;
-    }
-
     private Class<? extends MessageFormat> expectedMessageFormatType() {
-        return MessageFormatV4.class;
+        return MessageFormatV51.class;
     }
 
-    private static InternalAuthToken dummyAuthToken() {
-        return (InternalAuthToken) AuthTokens.basic("hello", "world");
-    }
-
-    protected void testFailedRunInAutoCommitTxWithWaitingForResponse(
+    private void testFailedRunInAutoCommitTxWithWaitingForResponse(
             Set<Bookmark> bookmarks, TransactionConfig config, AccessMode mode) throws Exception {
         // Given
         Connection connection = connectionMock(mode, protocol);
@@ -409,7 +384,7 @@ public final class BoltProtocolV4Test {
         assertSame(error, actual);
     }
 
-    protected void testSuccessfulRunInAutoCommitTxWithWaitingForResponse(
+    private void testSuccessfulRunInAutoCommitTxWithWaitingForResponse(
             Set<Bookmark> bookmarks, TransactionConfig config, AccessMode mode) throws Exception {
         // Given
         Connection connection = connectionMock(mode, protocol);
@@ -433,8 +408,7 @@ public final class BoltProtocolV4Test {
         assertNotNull(cursorFuture.get());
     }
 
-    protected void testRunInUnmanagedTransactionAndWaitForRunResponse(boolean success, AccessMode mode)
-            throws Exception {
+    private void testRunInUnmanagedTransactionAndWaitForRunResponse(boolean success, AccessMode mode) throws Exception {
         // Given
         Connection connection = connectionMock(mode, protocol);
 
@@ -465,7 +439,7 @@ public final class BoltProtocolV4Test {
         }
     }
 
-    protected void testRunAndWaitForRunResponse(boolean autoCommitTx, TransactionConfig config, AccessMode mode)
+    private void testRunAndWaitForRunResponse(boolean autoCommitTx, TransactionConfig config, AccessMode mode)
             throws Exception {
         // Given
         Connection connection = connectionMock(mode, protocol);
@@ -495,7 +469,7 @@ public final class BoltProtocolV4Test {
         assertNotNull(cursorFuture.get());
     }
 
-    protected void testDatabaseNameSupport(boolean autoCommitTx) {
+    private void testDatabaseNameSupport(boolean autoCommitTx) {
         Connection connection = connectionMock("foo", protocol);
         if (autoCommitTx) {
             ResultCursorFactory factory = protocol.runInAutoCommitTransaction(
@@ -511,6 +485,8 @@ public final class BoltProtocolV4Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
             runHandler.onSuccess(emptyMap());
             await(resultStage);
+            verifySessionRunInvoked(
+                    connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             CompletionStage<Void> txStage = protocol.beginTransaction(
                     connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
@@ -526,12 +502,12 @@ public final class BoltProtocolV4Test {
 
     private ResponseHandler verifySessionRunInvoked(
             Connection connection,
-            Set<Bookmark> bookmarks,
+            Set<Bookmark> bookmark,
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
         RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
+                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -558,5 +534,9 @@ public final class BoltProtocolV4Test {
         BeginMessage beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
+    }
+
+    private static InternalAuthToken dummyAuthToken() {
+        return (InternalAuthToken) AuthTokens.basic("hello", "world");
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverInfoUtilTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverInfoUtilTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DriverInfoUtilTest {
+    @Test
+    void shouldIncludeValidProduct() {
+        var boltAgent = DriverInfoUtil.boltAgent();
+
+        assertTrue(boltAgent.product().matches("^neo4j-java/.+$"));
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MessageRecordingDriverFactory.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Logging;
+import org.neo4j.driver.internal.BoltAgent;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.DriverFactory;
@@ -55,7 +57,8 @@ public class MessageRecordingDriverFactory extends DriverFactory {
             SecurityPlan securityPlan,
             Config config,
             Clock clock,
-            RoutingContext routingContext) {
+            RoutingContext routingContext,
+            BoltAgent boltAgent) {
         ChannelPipelineBuilder pipelineBuilder = new MessageRecordingChannelPipelineBuilder();
         return new ChannelConnectorImpl(
                 settings,
@@ -65,7 +68,8 @@ public class MessageRecordingDriverFactory extends DriverFactory {
                 clock,
                 routingContext,
                 DefaultDomainNameResolver.getInstance(),
-                null);
+                null,
+                BoltAgentUtil.VALUE);
     }
 
     private class MessageRecordingChannelPipelineBuilder extends ChannelPipelineBuilderImpl {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactory.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.Config;
+import org.neo4j.driver.internal.BoltAgent;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.async.connection.BootstrapFactory;
@@ -40,10 +42,6 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock {
     private final List<Channel> channels = new CopyOnWriteArrayList<>();
     private final int eventLoopThreads;
     private ConnectionPool pool;
-
-    public ChannelTrackingDriverFactory() {
-        this(0, Clock.systemUTC());
-    }
 
     public ChannelTrackingDriverFactory(Clock clock) {
         this(0, clock);
@@ -65,7 +63,8 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock {
             SecurityPlan securityPlan,
             Config config,
             Clock clock,
-            RoutingContext routingContext) {
+            RoutingContext routingContext,
+            BoltAgent boltAgent) {
         return createChannelTrackingConnector(
                 createRealConnector(settings, securityPlan, config, clock, routingContext));
     }
@@ -90,7 +89,7 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock {
             Config config,
             Clock clock,
             RoutingContext routingContext) {
-        return super.createConnector(settings, securityPlan, config, clock, routingContext);
+        return super.createConnector(settings, securityPlan, config, clock, routingContext, BoltAgentUtil.VALUE);
     }
 
     private ChannelTrackingConnector createChannelTrackingConnector(ChannelConnector connector) {
@@ -99,12 +98,6 @@ public class ChannelTrackingDriverFactory extends DriverFactoryWithClock {
 
     public List<Channel> channels() {
         return new ArrayList<>(channels);
-    }
-
-    public List<Channel> pollChannels() {
-        List<Channel> result = new ArrayList<>(channels);
-        channels.clear();
-        return result;
     }
 
     public int activeChannels(BoltServerAddress address) {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/io/ChannelTrackingDriverFactoryWithFailingMessageFormat.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.util.io;
 
 import java.time.Clock;
 import org.neo4j.driver.Config;
+import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.ConnectionSettings;
 import org.neo4j.driver.internal.DefaultDomainNameResolver;
 import org.neo4j.driver.internal.async.connection.ChannelConnector;
@@ -51,7 +52,8 @@ public class ChannelTrackingDriverFactoryWithFailingMessageFormat extends Channe
                 clock,
                 routingContext,
                 DefaultDomainNameResolver.getInstance(),
-                null);
+                null,
+                BoltAgentUtil.VALUE);
     }
 
     public FailingMessageFormat getFailingMessageFormat() {

--- a/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
@@ -95,6 +95,8 @@ import org.neo4j.driver.internal.messaging.v43.BoltProtocolV43;
 import org.neo4j.driver.internal.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.messaging.v5.BoltProtocolV5;
 import org.neo4j.driver.internal.messaging.v51.BoltProtocolV51;
+import org.neo4j.driver.internal.messaging.v52.BoltProtocolV52;
+import org.neo4j.driver.internal.messaging.v53.BoltProtocolV53;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionProvider;
@@ -457,7 +459,9 @@ public final class TestUtil {
                 || version.equals(BoltProtocolV43.VERSION)
                 || version.equals(BoltProtocolV44.VERSION)
                 || version.equals(BoltProtocolV5.VERSION)
-                || version.equals(BoltProtocolV51.VERSION)) {
+                || version.equals(BoltProtocolV51.VERSION)
+                || version.equals(BoltProtocolV52.VERSION)
+                || version.equals(BoltProtocolV53.VERSION)) {
             setupSuccessResponse(connection, CommitMessage.class);
             setupSuccessResponse(connection, RollbackMessage.class);
             setupSuccessResponse(connection, BeginMessage.class);

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -41,6 +41,7 @@ public class GetFeatures implements TestkitRequest {
             "Feature:Bolt:5.0",
             "Feature:Bolt:5.1",
             "Feature:Bolt:5.2",
+            "Feature:Bolt:5.3",
             "AuthorizationExpiredTreatment",
             "ConfHint:connection.recv_timeout_seconds",
             "Feature:Auth:Bearer",


### PR DESCRIPTION
This update introduces support for the new `HELLO` message `bolt_agent` field that is mandatory in the Bolt protocol version 5.3.

The `bolt_agent` value is non-configurable and follows a common format among the official drivers.

Java driver `bolt_agent` sample:
```json
{"product": "neo4j-java/5.7.0-bf6c5444e19cef8b6cb7aa7e0cecf80b7f8a19a9", "platform": "Linux; 5.15.49-linuxkit; aarch64", "language": "Java/17.0.6", "language_details": "Eclipse Adoptium; OpenJDK 64-Bit Server VM; 17.0.6+10"}
```

This update also brings support for the Bolt protocol version 5.3.