### PR TITLE
Introduce TransactionTerminatedException

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/exceptions/TransactionTerminatedException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/TransactionTerminatedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.exceptions;
+
+import java.io.Serial;
+
+/**
+ * Indicates that the transaction has been terminated.
+ * @since 5.10
+ */
+public class TransactionTerminatedException extends ClientException {
+    @Serial
+    private static final long serialVersionUID = 7639191706067500206L;
+
+    /**
+     * Creates a new instance.
+     * @param message the message
+     */
+    public TransactionTerminatedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param code the code
+     * @param message the message
+     */
+    public TransactionTerminatedException(String code, String message) {
+        super(code, message);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalTransaction.java
@@ -66,6 +66,22 @@ public class InternalTransaction extends AbstractQueryRunner implements Transact
         return tx.isOpen();
     }
 
+    /**
+     * <b>THIS IS A PRIVATE API</b>
+     * <p>
+     * Terminates the transaction by sending the Bolt {@code RESET} message and waiting for its response as long as the
+     * transaction has not already been terminated, is not closed or closing.
+     *
+     * @since 5.10
+     * @throws org.neo4j.driver.exceptions.ClientException if the transaction is closed or is closing
+     * @see org.neo4j.driver.exceptions.TransactionTerminatedException
+     */
+    public void terminate() {
+        Futures.blockingGet(
+                tx.terminateAsync(),
+                () -> terminateConnectionOnThreadInterrupt("Thread interrupted while terminating the transaction"));
+    }
+
     private void terminateConnectionOnThreadInterrupt(String reason) {
         tx.connection().terminateAndRelease(reason);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.async.connection.ChannelAttributes;
 import org.neo4j.driver.internal.async.inbound.ConnectionReadTimeoutHandler;
@@ -146,9 +147,9 @@ public class NetworkConnection implements Connection {
     }
 
     @Override
-    public CompletionStage<Void> reset() {
+    public CompletionStage<Void> reset(Neo4jException error) {
         CompletableFuture<Void> result = new CompletableFuture<>();
-        ResetResponseHandler handler = new ResetResponseHandler(messageDispatcher, result);
+        ResetResponseHandler handler = new ResetResponseHandler(messageDispatcher, result, error);
         writeResetMessageIfNeeded(handler, true);
         return result;
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -43,6 +43,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.TransactionNestingException;
+import org.neo4j.driver.exceptions.TransactionTerminatedException;
 import org.neo4j.driver.internal.DatabaseBookmark;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.FailableCursor;
@@ -175,7 +176,8 @@ public class NetworkSession {
         return existingTransactionOrNull()
                 .thenAccept(tx -> {
                     if (tx != null) {
-                        tx.markTerminated(null);
+                        tx.markTerminated(new TransactionTerminatedException(
+                                "The transaction has been explicitly terminated by the driver"));
                     }
                 })
                 .thenCompose(ignore -> connectionStage)

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/DirectConnection.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async.connection;
 
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.DirectConnectionProvider;
@@ -84,8 +85,8 @@ public class DirectConnection implements Connection {
     }
 
     @Override
-    public CompletionStage<Void> reset() {
-        return delegate.reset();
+    public CompletionStage<Void> reset(Neo4jException error) {
+        return delegate.reset(error);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/connection/RoutingConnection.java
@@ -20,6 +20,7 @@ package org.neo4j.driver.internal.async.connection;
 
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.RoutingErrorHandler;
@@ -84,8 +85,8 @@ public class RoutingConnection implements Connection {
     }
 
     @Override
-    public CompletionStage<Void> reset() {
-        return delegate.reset();
+    public CompletionStage<Void> reset(Neo4jException error) {
+        return delegate.reset(error);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/handlers/ResetResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/handlers/ResetResponseHandler.java
@@ -19,22 +19,33 @@
 package org.neo4j.driver.internal.handlers;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.spi.ResponseHandler;
 
 public class ResetResponseHandler implements ResponseHandler {
     private final InboundMessageDispatcher messageDispatcher;
     private final CompletableFuture<Void> completionFuture;
+    private final Neo4jException error;
 
     public ResetResponseHandler(InboundMessageDispatcher messageDispatcher) {
         this(messageDispatcher, null);
     }
 
     public ResetResponseHandler(InboundMessageDispatcher messageDispatcher, CompletableFuture<Void> completionFuture) {
+        this(messageDispatcher, completionFuture, null);
+    }
+
+    public ResetResponseHandler(
+            InboundMessageDispatcher messageDispatcher,
+            CompletableFuture<Void> completionFuture,
+            Neo4jException error) {
         this.messageDispatcher = messageDispatcher;
         this.completionFuture = completionFuture;
+        this.error = error;
     }
 
     @Override
@@ -50,6 +61,10 @@ public class ResetResponseHandler implements ResponseHandler {
     @Override
     public final void onRecord(Value[] fields) {
         throw new UnsupportedOperationException();
+    }
+
+    public Optional<Neo4jException> error() {
+        return Optional.ofNullable(error);
     }
 
     private void resetCompleted(boolean success) {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalReactiveTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalReactiveTransaction.java
@@ -61,14 +61,16 @@ public class InternalReactiveTransaction extends AbstractReactiveTransaction
     }
 
     /**
-     * Marks transaction as terminated and sends {@code RESET} message over allocated connection.
+     * <b>THIS IS A PRIVATE API</b>
      * <p>
-     * <b>THIS METHOD IS NOT PART OF PUBLIC API. This method may be changed or removed at any moment in time.</b>
+     * Terminates the transaction by sending the Bolt {@code RESET} message and waiting for its response as long as the
+     * transaction has not already been terminated, is not closed or closing.
      *
-     * @return {@code RESET} response publisher
+     * @return completion publisher (the {@code RESET} completion publisher if the message was sent)
+     * @since 5.10
      */
-    public Publisher<Void> interrupt() {
-        return publisherToFlowPublisher(Mono.fromCompletionStage(tx.interruptAsync()));
+    public Publisher<Void> terminate() {
+        return publisherToFlowPublisher(Mono.fromCompletionStage(tx.terminateAsync()));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveTransaction.java
@@ -60,14 +60,16 @@ public class InternalReactiveTransaction extends AbstractReactiveTransaction
     }
 
     /**
-     * Marks transaction as terminated and sends {@code RESET} message over allocated connection.
+     * <b>THIS IS A PRIVATE API</b>
      * <p>
-     * <b>THIS METHOD IS NOT PART OF PUBLIC API. This method may be changed or removed at any moment in time.</b>
+     * Terminates the transaction by sending the Bolt {@code RESET} message and waiting for its response as long as the
+     * transaction has not already been terminated, is not closed or closing.
      *
-     * @return {@code RESET} response publisher
+     * @return completion publisher (the {@code RESET} completion publisher if the message was sent)
+     * @since 5.10
      */
-    public Publisher<Void> interrupt() {
-        return Mono.fromCompletionStage(tx.interruptAsync());
+    public Publisher<Void> terminate() {
+        return Mono.fromCompletionStage(tx.terminateAsync());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/spi/Connection.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
@@ -42,7 +43,11 @@ public interface Connection {
 
     void writeAndFlush(Message message1, ResponseHandler handler1, Message message2, ResponseHandler handler2);
 
-    CompletionStage<Void> reset();
+    default CompletionStage<Void> reset() {
+        return reset(null);
+    }
+
+    CompletionStage<Void> reset(Neo4jException error);
 
     CompletionStage<Void> release();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/ErrorUtil.java
@@ -32,6 +32,7 @@ import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.exceptions.SecurityException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.TokenExpiredException;
+import org.neo4j.driver.exceptions.TransactionTerminatedException;
 import org.neo4j.driver.exceptions.TransientException;
 
 public final class ErrorUtil {
@@ -72,6 +73,8 @@ public final class ErrorUtil {
                 } else {
                     if (code.equalsIgnoreCase("Neo.ClientError.Database.DatabaseNotFound")) {
                         return new FatalDiscoveryException(code, message);
+                    } else if (code.equalsIgnoreCase("Neo.ClientError.Transaction.Terminated")) {
+                        return new TransactionTerminatedException(code, message);
                     } else {
                         return new ClientException(code, message);
                     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/connection/DecoratedConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/connection/DecoratedConnectionTest.java
@@ -134,7 +134,7 @@ class DecoratedConnectionTest {
 
         connection.reset();
 
-        verify(mockConnection).reset();
+        verify(mockConnection).reset(null);
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveTransactionTest.java
@@ -35,33 +35,33 @@ public class InternalReactiveTransactionTest {
     @Test
     void shouldDelegateInterrupt() {
         // Given
-        UnmanagedTransaction utx = mock(UnmanagedTransaction.class);
-        given(utx.interruptAsync()).willReturn(completedFuture(null));
+        var utx = mock(UnmanagedTransaction.class);
+        given(utx.terminateAsync()).willReturn(completedFuture(null));
         tx = new InternalReactiveTransaction(utx);
 
         // When
-        StepVerifier.create(flowPublisherToFlux(tx.interrupt()))
+        StepVerifier.create(flowPublisherToFlux(tx.terminate()))
                 .expectComplete()
                 .verify();
 
         // Then
-        then(utx).should().interruptAsync();
+        then(utx).should().terminateAsync();
     }
 
     @Test
     void shouldDelegateInterruptAndReportError() {
         // Given
-        UnmanagedTransaction utx = mock(UnmanagedTransaction.class);
-        RuntimeException e = mock(RuntimeException.class);
-        given(utx.interruptAsync()).willReturn(failedFuture(e));
+        var utx = mock(UnmanagedTransaction.class);
+        var e = mock(RuntimeException.class);
+        given(utx.terminateAsync()).willReturn(failedFuture(e));
         tx = new InternalReactiveTransaction(utx);
 
         // When
-        StepVerifier.create(flowPublisherToFlux(tx.interrupt()))
+        StepVerifier.create(flowPublisherToFlux(tx.terminate()))
                 .expectErrorMatches(ar -> ar == e)
                 .verify();
 
         // Then
-        then(utx).should().interruptAsync();
+        then(utx).should().terminateAsync();
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/FailingConnectionDriverFactory.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.Config;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.internal.cluster.RoutingContext;
@@ -159,8 +160,8 @@ public class FailingConnectionDriverFactory extends DriverFactory {
         }
 
         @Override
-        public CompletionStage<Void> reset() {
-            return delegate.reset();
+        public CompletionStage<Void> reset(Neo4jException error) {
+            return delegate.reset(error);
         }
 
         @Override

--- a/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
@@ -73,6 +73,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.internal.BoltServerAddress;
 import org.neo4j.driver.internal.NoOpBookmarkManager;
@@ -467,6 +468,7 @@ public final class TestUtil {
             setupSuccessResponse(connection, BeginMessage.class);
             when(connection.release()).thenReturn(completedWithNull());
             when(connection.reset()).thenReturn(completedWithNull());
+            when(connection.reset(any(Neo4jException.class))).thenReturn(completedWithNull());
         } else {
             throw new IllegalArgumentException("Unsupported bolt protocol version: " + version);
         }


### PR DESCRIPTION
This update introduces a new `TransactionTerminatedException` that is a subclass of the `ClientException`. The server `Neo.ClientError.Transaction.Terminated` error code maps to this exception now, making it more fine-grained.

In addition, this update brings a PRIVATE API for transaction termination. It replaces the `InternalReactiveTransaction.interrupt()` and provides a similar functionality that is also available in the synchronous API. Please note that this is not a public API.