### PR TITLE
Ensure transaction prevents new query runs when it is closing

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkConnection.java
@@ -43,11 +43,13 @@ import org.neo4j.driver.internal.handlers.ChannelReleasingResetResponseHandler;
 import org.neo4j.driver.internal.handlers.ResetResponseHandler;
 import org.neo4j.driver.internal.messaging.BoltProtocol;
 import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.messaging.request.CommitMessage;
 import org.neo4j.driver.internal.messaging.request.DiscardAllMessage;
 import org.neo4j.driver.internal.messaging.request.DiscardMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.PullMessage;
 import org.neo4j.driver.internal.messaging.request.ResetMessage;
+import org.neo4j.driver.internal.messaging.request.RollbackMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
 import org.neo4j.driver.internal.metrics.ListenerEvent;
 import org.neo4j.driver.internal.metrics.MetricsListener;
@@ -295,7 +297,9 @@ public class NetworkConnection implements Connection {
                 || message instanceof PullMessage
                 || message instanceof PullAllMessage
                 || message instanceof DiscardMessage
-                || message instanceof DiscardAllMessage;
+                || message instanceof DiscardAllMessage
+                || message instanceof CommitMessage
+                || message instanceof RollbackMessage;
     }
 
     private enum Status {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -247,6 +247,10 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
                                     + "it has either experienced an fatal error or was explicitly terminated",
                             causeOfTermination);
                 }
+            } else if (commitFuture != null) {
+                throw new ClientException("Cannot run more queries in this transaction, it is being committed");
+            } else if (rollbackFuture != null) {
+                throw new ClientException("Cannot run more queries in this transaction, it is being rolled back");
             }
         });
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkConnectionTest.java
@@ -68,10 +68,12 @@ import org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher;
 import org.neo4j.driver.internal.async.pool.ExtendedChannelPool;
 import org.neo4j.driver.internal.handlers.NoOpResponseHandler;
 import org.neo4j.driver.internal.messaging.Message;
+import org.neo4j.driver.internal.messaging.request.CommitMessage;
 import org.neo4j.driver.internal.messaging.request.DiscardAllMessage;
 import org.neo4j.driver.internal.messaging.request.DiscardMessage;
 import org.neo4j.driver.internal.messaging.request.PullAllMessage;
 import org.neo4j.driver.internal.messaging.request.PullMessage;
+import org.neo4j.driver.internal.messaging.request.RollbackMessage;
 import org.neo4j.driver.internal.messaging.request.RunWithMetadataMessage;
 import org.neo4j.driver.internal.metrics.DevNullMetricsListener;
 import org.neo4j.driver.internal.spi.ResponseHandler;
@@ -559,7 +561,11 @@ class NetworkConnectionTest {
                 new QueryMessage(false, mock(DiscardMessage.class)),
                 new QueryMessage(true, mock(DiscardMessage.class)),
                 new QueryMessage(false, mock(DiscardAllMessage.class)),
-                new QueryMessage(true, mock(DiscardAllMessage.class)));
+                new QueryMessage(true, mock(DiscardAllMessage.class)),
+                new QueryMessage(false, mock(CommitMessage.class)),
+                new QueryMessage(true, mock(CommitMessage.class)),
+                new QueryMessage(false, mock(RollbackMessage.class)),
+                new QueryMessage(true, mock(RollbackMessage.class)));
     }
 
     private record QueryMessage(boolean flush, Message message) {}


### PR DESCRIPTION
As a protection measure also prevent `COMMIT` and `ROLLBACK` Bolt messages from being dispatched if transaction is terminated.