### PR TITLE
Update sub millisecond transaction timeout handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -321,7 +321,7 @@ public class DriverFactory {
             Logging logging,
             DomainNameResolver domainNameResolver) {
         var clusterCompositionProvider =
-                new RoutingProcedureClusterCompositionProvider(clock, settings.routingContext());
+                new RoutingProcedureClusterCompositionProvider(clock, settings.routingContext(), logging);
         return new RediscoveryImpl(initialRouter, clusterCompositionProvider, resolver, logging, domainNameResolver);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -67,6 +67,7 @@ public class NetworkSession {
     private final NetworkSessionConnectionContext connectionContext;
     private final AccessMode mode;
     private final RetryLogic retryLogic;
+    private final Logging logging;
     protected final Logger log;
 
     private final long fetchSize;
@@ -97,6 +98,7 @@ public class NetworkSession {
         this.connectionProvider = connectionProvider;
         this.mode = mode;
         this.retryLogic = retryLogic;
+        this.logging = logging;
         this.log = new PrefixedLogger("[" + hashCode() + "]", logging.getLog(getClass()));
         var databaseNameFuture = databaseName
                 .databaseName()
@@ -150,7 +152,7 @@ public class NetworkSession {
                         ImpersonationUtil.ensureImpersonationSupport(connection, connection.impersonatedUser()))
                 .thenCompose(connection -> {
                     var tx = new UnmanagedTransaction(
-                            connection, this::handleNewBookmark, fetchSize, notificationConfig);
+                            connection, this::handleNewBookmark, fetchSize, notificationConfig, logging);
                     return tx.beginAsync(determineBookmarks(true), config, txType);
                 });
 
@@ -268,7 +270,8 @@ public class NetworkSession {
                                         this::handleNewBookmark,
                                         config,
                                         fetchSize,
-                                        notificationConfig);
+                                        notificationConfig,
+                                        logging);
                         return completedFuture(factory);
                     } catch (Throwable e) {
                         return Futures.failedFuture(e);

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Set;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.DatabaseName;
@@ -41,8 +42,8 @@ public class MultiDatabasesRoutingProcedureRunner extends SingleDatabaseRoutingP
     static final String MULTI_DB_GET_ROUTING_TABLE =
             String.format("CALL dbms.routing.getRoutingTable($%s, $%s)", ROUTING_CONTEXT, DATABASE_NAME);
 
-    public MultiDatabasesRoutingProcedureRunner(RoutingContext context) {
-        super(context);
+    public MultiDatabasesRoutingProcedureRunner(RoutingContext context, Logging logging) {
+        super(context, logging);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.exceptions.value.ValueException;
 import org.neo4j.driver.internal.DatabaseName;
@@ -40,11 +41,11 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
     private final RoutingProcedureRunner multiDatabaseRoutingProcedureRunner;
     private final RoutingProcedureRunner routeMessageRoutingProcedureRunner;
 
-    public RoutingProcedureClusterCompositionProvider(Clock clock, RoutingContext routingContext) {
+    public RoutingProcedureClusterCompositionProvider(Clock clock, RoutingContext routingContext, Logging logging) {
         this(
                 clock,
-                new SingleDatabaseRoutingProcedureRunner(routingContext),
-                new MultiDatabasesRoutingProcedureRunner(routingContext),
+                new SingleDatabaseRoutingProcedureRunner(routingContext, logging),
+                new MultiDatabasesRoutingProcedureRunner(routingContext, logging),
                 new RouteMessageRoutingProcedureRunner(routingContext));
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.TransactionConfig;
@@ -50,9 +51,11 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
     static final String GET_ROUTING_TABLE = "CALL dbms.cluster.routing.getRoutingTable($" + ROUTING_CONTEXT + ")";
 
     final RoutingContext context;
+    private Logging logging;
 
-    public SingleDatabaseRoutingProcedureRunner(RoutingContext context) {
+    public SingleDatabaseRoutingProcedureRunner(RoutingContext context, Logging logging) {
         this.context = context;
+        this.logging = logging;
     }
 
     @Override
@@ -93,7 +96,8 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
                         (ignored) -> {},
                         TransactionConfig.empty(),
                         UNLIMITED_FETCH_SIZE,
-                        null)
+                        null,
+                        logging)
                 .asyncResult()
                 .thenCompose(ResultCursor::listAsync);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
@@ -93,6 +94,7 @@ public interface BoltProtocol {
      * @param config             the transaction configuration. Never null, should be {@link TransactionConfig#empty()} when absent.
      * @param txType             the Kernel transaction type
      * @param notificationConfig the notification configuration
+     * @param logging            the driver logging
      * @return a completion stage completed when transaction is started or completed exceptionally when there was a failure.
      */
     CompletionStage<Void> beginTransaction(
@@ -100,7 +102,8 @@ public interface BoltProtocol {
             Set<Bookmark> bookmarks,
             TransactionConfig config,
             String txType,
-            NotificationConfig notificationConfig);
+            NotificationConfig notificationConfig,
+            Logging logging);
 
     /**
      * Commit the unmanaged transaction.
@@ -127,6 +130,7 @@ public interface BoltProtocol {
      * @param config             the transaction config for the implicitly started auto-commit transaction.
      * @param fetchSize          the record fetch size for PULL message.
      * @param notificationConfig the notification configuration
+     * @param logging            the driver logging
      * @return stage with cursor.
      */
     ResultCursorFactory runInAutoCommitTransaction(
@@ -136,7 +140,8 @@ public interface BoltProtocol {
             Consumer<DatabaseBookmark> bookmarkConsumer,
             TransactionConfig config,
             long fetchSize,
-            NotificationConfig notificationConfig);
+            NotificationConfig notificationConfig,
+            Logging logging);
 
     /**
      * Execute the given query in a running unmanaged transaction, i.e. {@link Transaction#run(Query)}.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
@@ -41,7 +42,8 @@ public class BeginMessage extends MessageWithMetadata {
             AccessMode mode,
             String impersonatedUser,
             String txType,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         this(
                 bookmarks,
                 config.timeout(),
@@ -50,7 +52,8 @@ public class BeginMessage extends MessageWithMetadata {
                 databaseName,
                 impersonatedUser,
                 txType,
-                notificationConfig);
+                notificationConfig,
+                logging);
     }
 
     public BeginMessage(
@@ -61,9 +64,18 @@ public class BeginMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             String impersonatedUser,
             String txType,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         super(buildMetadata(
-                txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, txType, notificationConfig));
+                txTimeout,
+                txMetadata,
+                databaseName,
+                mode,
+                bookmarks,
+                impersonatedUser,
+                txType,
+                notificationConfig,
+                logging));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
@@ -47,7 +48,8 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             AccessMode mode,
             Set<Bookmark> bookmarks,
             String impersonatedUser,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         return autoCommitTxRunMessage(
                 query,
                 config.timeout(),
@@ -56,7 +58,8 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
                 mode,
                 bookmarks,
                 impersonatedUser,
-                notificationConfig);
+                notificationConfig,
+                logging);
     }
 
     public static RunWithMetadataMessage autoCommitTxRunMessage(
@@ -67,9 +70,18 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             AccessMode mode,
             Set<Bookmark> bookmarks,
             String impersonatedUser,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         var metadata = buildMetadata(
-                txTimeout, txMetadata, databaseName, mode, bookmarks, impersonatedUser, null, notificationConfig);
+                txTimeout,
+                txMetadata,
+                databaseName,
+                mode,
+                bookmarks,
+                impersonatedUser,
+                null,
+                notificationConfig,
+                logging);
         return new RunWithMetadataMessage(query.text(), query.parameters().asMap(ofValue()), metadata);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/v3/BoltProtocolV3.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
@@ -135,7 +136,8 @@ public class BoltProtocolV3 implements BoltProtocol {
             Set<Bookmark> bookmarks,
             TransactionConfig config,
             String txType,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         var exception = verifyNotificationConfigSupported(notificationConfig);
         if (exception != null) {
             return CompletableFuture.failedStage(exception);
@@ -154,7 +156,8 @@ public class BoltProtocolV3 implements BoltProtocol {
                 connection.mode(),
                 connection.impersonatedUser(),
                 txType,
-                notificationConfig);
+                notificationConfig,
+                logging);
         connection.writeAndFlush(beginMessage, new BeginTxResponseHandler(beginTxFuture));
         return beginTxFuture;
     }
@@ -181,7 +184,8 @@ public class BoltProtocolV3 implements BoltProtocol {
             Consumer<DatabaseBookmark> bookmarkConsumer,
             TransactionConfig config,
             long fetchSize,
-            NotificationConfig notificationConfig) {
+            NotificationConfig notificationConfig,
+            Logging logging) {
         var exception = verifyNotificationConfigSupported(notificationConfig);
         if (exception != null) {
             throw exception;
@@ -194,7 +198,8 @@ public class BoltProtocolV3 implements BoltProtocol {
                 connection.mode(),
                 bookmarks,
                 connection.impersonatedUser(),
-                notificationConfig);
+                notificationConfig,
+                logging);
         return buildResultCursorFactory(connection, query, bookmarkConsumer, null, runMessage, fetchSize);
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.internal.spi.Connection;
@@ -115,7 +116,7 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         }
 
         TestRoutingProcedureRunner(RoutingContext context, CompletionStage<List<Record>> runProcedureResult) {
-            super(context);
+            super(context, Logging.none());
             this.runProcedureResult = runProcedureResult;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
@@ -126,7 +127,7 @@ class SingleDatabaseRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         }
 
         TestRoutingProcedureRunner(RoutingContext context, CompletionStage<List<Record>> runProcedureResult) {
-            super(context);
+            super(context, Logging.none());
             this.runProcedureResult = runProcedureResult;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.ValuePacker;
@@ -61,7 +62,15 @@ class BeginMessageEncoderTest {
 
         encoder.encode(
                 new BeginMessage(
-                        bookmarks, txTimeout, txMetadata, mode, defaultDatabase(), impersonatedUser, txType, null),
+                        bookmarks,
+                        txTimeout,
+                        txMetadata,
+                        mode,
+                        defaultDatabase(),
+                        impersonatedUser,
+                        txType,
+                        null,
+                        Logging.none()),
                 packer);
 
         var order = inOrder(packer);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -64,7 +65,8 @@ class RunWithMetadataMessageEncoderTest {
 
         var query = new Query("RETURN $answer", value(params));
         encoder.encode(
-                autoCommitTxRunMessage(query, txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null),
+                autoCommitTxRunMessage(
+                        query, txTimeout, txMetadata, defaultDatabase(), mode, bookmarks, null, null, Logging.none()),
                 packer);
 
         var order = inOrder(packer);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/request/TransactionMetadataBuilderTest.java
@@ -167,4 +167,32 @@ public class TransactionMetadataBuilderTest {
                 .info(
                         "The transaction timeout has been rounded up to next millisecond value since the config had a fractional millisecond value");
     }
+
+    @Test
+    void shouldNotLogWhenRoundingDoesNotHappen() {
+        // given
+        var logging = mock(Logging.class);
+        var logger = mock(Logger.class);
+        given(logging.getLog(TransactionMetadataBuilder.class)).willReturn(logger);
+        var timeout = 1000;
+
+        // when
+        var metadata = buildMetadata(
+                Duration.ofMillis(timeout),
+                null,
+                defaultDatabase(),
+                WRITE,
+                Collections.emptySet(),
+                null,
+                null,
+                null,
+                logging);
+
+        // then
+        var expectedMetadata = new HashMap<String, Value>();
+        expectedMetadata.put("tx_timeout", value(timeout));
+        assertEquals(expectedMetadata, metadata);
+        then(logging).shouldHaveNoInteractions();
+        then(logger).shouldHaveNoInteractions();
+    }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -46,6 +46,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -113,7 +114,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -122,7 +124,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 autoCommitTxRunMessage(
@@ -133,7 +136,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -142,7 +146,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
                 PULL_ALL,
                 DISCARD_ALL,
@@ -157,7 +162,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -166,7 +172,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -121,7 +122,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -130,7 +132,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -142,7 +145,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -151,7 +155,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -163,7 +168,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -172,7 +178,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -191,8 +191,8 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -203,7 +203,8 @@ public final class BoltProtocolV41Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -213,12 +214,20 @@ public final class BoltProtocolV41Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -227,12 +236,19 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -242,11 +258,12 @@ public final class BoltProtocolV41Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -352,7 +369,12 @@ public final class BoltProtocolV41Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -366,7 +388,8 @@ public final class BoltProtocolV41Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -381,7 +404,14 @@ public final class BoltProtocolV41Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -408,7 +438,14 @@ public final class BoltProtocolV41Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -464,7 +501,14 @@ public final class BoltProtocolV41Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -493,7 +537,8 @@ public final class BoltProtocolV41Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -503,7 +548,7 @@ public final class BoltProtocolV41Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -520,8 +565,8 @@ public final class BoltProtocolV41Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmarks, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -545,7 +590,7 @@ public final class BoltProtocolV41Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -120,7 +121,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -129,7 +131,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -141,7 +144,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -150,7 +154,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -162,7 +167,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -171,7 +177,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -191,8 +191,8 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -203,7 +203,8 @@ public final class BoltProtocolV42Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -213,12 +214,20 @@ public final class BoltProtocolV42Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -227,12 +236,19 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -242,11 +258,12 @@ public final class BoltProtocolV42Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -352,7 +369,12 @@ public final class BoltProtocolV42Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -366,7 +388,8 @@ public final class BoltProtocolV42Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -381,7 +404,14 @@ public final class BoltProtocolV42Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -407,7 +437,14 @@ public final class BoltProtocolV42Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -463,7 +500,14 @@ public final class BoltProtocolV42Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -494,7 +538,8 @@ public final class BoltProtocolV42Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -504,7 +549,7 @@ public final class BoltProtocolV42Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -521,8 +566,8 @@ public final class BoltProtocolV42Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmarks, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -546,7 +591,7 @@ public final class BoltProtocolV42Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.BoltAgentUtil;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -120,7 +121,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -129,7 +131,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -141,7 +144,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -150,7 +154,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -162,7 +167,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -171,7 +177,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/BoltProtocolV43Test.java
@@ -190,8 +190,8 @@ public final class BoltProtocolV43Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -202,7 +202,8 @@ public final class BoltProtocolV43Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -212,12 +213,20 @@ public final class BoltProtocolV43Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -226,12 +235,19 @@ public final class BoltProtocolV43Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -241,11 +257,12 @@ public final class BoltProtocolV43Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -351,7 +368,12 @@ public final class BoltProtocolV43Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -365,7 +387,8 @@ public final class BoltProtocolV43Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -380,7 +403,14 @@ public final class BoltProtocolV43Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -407,7 +437,14 @@ public final class BoltProtocolV43Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -465,7 +502,14 @@ public final class BoltProtocolV43Test {
             @SuppressWarnings("unchecked")
             Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            bookmarkConsumer,
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -496,7 +540,8 @@ public final class BoltProtocolV43Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -506,7 +551,7 @@ public final class BoltProtocolV43Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -523,8 +568,8 @@ public final class BoltProtocolV43Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmarks, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -548,7 +593,7 @@ public final class BoltProtocolV43Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -125,7 +126,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -134,7 +136,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -146,7 +149,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -155,7 +159,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -167,7 +172,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -176,7 +182,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
@@ -190,8 +190,8 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -202,7 +202,8 @@ public class BoltProtocolV44Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -212,12 +213,20 @@ public class BoltProtocolV44Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -226,12 +235,19 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -241,11 +257,12 @@ public class BoltProtocolV44Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -351,7 +368,12 @@ public class BoltProtocolV44Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -365,7 +387,8 @@ public class BoltProtocolV44Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -380,7 +403,14 @@ public class BoltProtocolV44Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -407,7 +437,14 @@ public class BoltProtocolV44Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -463,7 +500,14 @@ public class BoltProtocolV44Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -494,7 +538,8 @@ public class BoltProtocolV44Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -504,7 +549,7 @@ public class BoltProtocolV44Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -521,8 +566,8 @@ public class BoltProtocolV44Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmarks, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmarks, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -546,7 +591,7 @@ public class BoltProtocolV44Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -125,7 +126,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -134,7 +136,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -146,7 +149,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -155,7 +159,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -167,7 +172,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -176,7 +182,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/BoltProtocolV5Test.java
@@ -190,8 +190,8 @@ public class BoltProtocolV5Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -202,7 +202,8 @@ public class BoltProtocolV5Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -212,12 +213,20 @@ public class BoltProtocolV5Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -226,12 +235,19 @@ public class BoltProtocolV5Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -241,11 +257,12 @@ public class BoltProtocolV5Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -351,7 +368,12 @@ public class BoltProtocolV5Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -365,7 +387,8 @@ public class BoltProtocolV5Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -380,7 +403,14 @@ public class BoltProtocolV5Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -407,7 +437,14 @@ public class BoltProtocolV5Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -463,7 +500,14 @@ public class BoltProtocolV5Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -494,7 +538,8 @@ public class BoltProtocolV5Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -504,7 +549,7 @@ public class BoltProtocolV5Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -521,8 +566,8 @@ public class BoltProtocolV5Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -546,7 +591,7 @@ public class BoltProtocolV5Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v5/MessageWriterV5Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -125,7 +126,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -134,7 +136,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -146,7 +149,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -155,7 +159,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -167,7 +172,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -176,7 +182,8 @@ public class MessageWriterV5Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/BoltProtocolV51Test.java
@@ -162,8 +162,8 @@ public class BoltProtocolV51Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -174,7 +174,8 @@ public class BoltProtocolV51Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -184,12 +185,20 @@ public class BoltProtocolV51Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -198,12 +207,19 @@ public class BoltProtocolV51Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -213,11 +229,12 @@ public class BoltProtocolV51Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -323,7 +340,12 @@ public class BoltProtocolV51Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -337,7 +359,8 @@ public class BoltProtocolV51Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -352,7 +375,14 @@ public class BoltProtocolV51Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -379,7 +409,14 @@ public class BoltProtocolV51Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -435,7 +472,14 @@ public class BoltProtocolV51Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -466,7 +510,8 @@ public class BoltProtocolV51Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -476,7 +521,7 @@ public class BoltProtocolV51Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -493,8 +538,8 @@ public class BoltProtocolV51Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -518,7 +563,7 @@ public class BoltProtocolV51Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v51/MessageWriterV51Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -120,7 +121,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx123")),
                         ofSeconds(5),
@@ -129,7 +131,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         null,
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -141,7 +144,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -150,7 +154,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx1")),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -162,7 +167,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         READ,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -171,7 +177,8 @@ public class MessageWriterV51Test extends AbstractMessageWriterTestBase {
                         WRITE,
                         Collections.emptySet(),
                         null,
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v52/BoltProtocolV52Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v52/BoltProtocolV52Test.java
@@ -163,8 +163,8 @@ public class BoltProtocolV52Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -175,7 +175,8 @@ public class BoltProtocolV52Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -185,12 +186,20 @@ public class BoltProtocolV52Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -199,12 +208,19 @@ public class BoltProtocolV52Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -214,11 +230,12 @@ public class BoltProtocolV52Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -324,7 +341,12 @@ public class BoltProtocolV52Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -338,7 +360,8 @@ public class BoltProtocolV52Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -353,7 +376,14 @@ public class BoltProtocolV52Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -380,7 +410,14 @@ public class BoltProtocolV52Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -436,7 +473,14 @@ public class BoltProtocolV52Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -467,7 +511,8 @@ public class BoltProtocolV52Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -477,7 +522,7 @@ public class BoltProtocolV52Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -494,8 +539,8 @@ public class BoltProtocolV52Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -519,7 +564,7 @@ public class BoltProtocolV52Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v53/BoltProtocolV53Test.java
@@ -170,8 +170,8 @@ public class BoltProtocolV53Test {
     void shouldBeginTransactionWithoutBookmark() {
         var connection = connectionMock(protocol);
 
-        var stage =
-                protocol.beginTransaction(connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+        var stage = protocol.beginTransaction(
+                connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
@@ -182,7 +182,8 @@ public class BoltProtocolV53Test {
                                 WRITE,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -192,12 +193,20 @@ public class BoltProtocolV53Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx100"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null);
+        var stage =
+                protocol.beginTransaction(connection, bookmarks, TransactionConfig.empty(), null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                bookmarks, TransactionConfig.empty(), defaultDatabase(), WRITE, null, null, null)),
+                                bookmarks,
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -206,12 +215,19 @@ public class BoltProtocolV53Test {
     void shouldBeginTransactionWithConfig() {
         var connection = connectionMock(protocol);
 
-        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, Collections.emptySet(), txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                Collections.emptySet(), txConfig, defaultDatabase(), WRITE, null, null, null)),
+                                Collections.emptySet(),
+                                txConfig,
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                null,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -221,11 +237,12 @@ public class BoltProtocolV53Test {
         var connection = connectionMock(protocol);
         var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx4242"));
 
-        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null);
+        var stage = protocol.beginTransaction(connection, bookmarks, txConfig, null, null, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null)),
+                        eq(new BeginMessage(
+                                bookmarks, txConfig, defaultDatabase(), WRITE, null, null, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -331,7 +348,12 @@ public class BoltProtocolV53Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         var txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), Collections.emptySet(), TransactionConfig.empty(), null, null);
+                connectionMock("foo", protocol),
+                Collections.emptySet(),
+                TransactionConfig.empty(),
+                null,
+                null,
+                Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -345,7 +367,8 @@ public class BoltProtocolV53Test {
                 (ignored) -> {},
                 TransactionConfig.empty(),
                 UNLIMITED_FETCH_SIZE,
-                null));
+                null,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -360,7 +383,14 @@ public class BoltProtocolV53Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -387,7 +417,14 @@ public class BoltProtocolV53Test {
         Consumer<DatabaseBookmark> bookmarkConsumer = mock(Consumer.class);
 
         var cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarks, bookmarkConsumer, config, UNLIMITED_FETCH_SIZE, null)
+                        connection,
+                        QUERY,
+                        bookmarks,
+                        bookmarkConsumer,
+                        config,
+                        UNLIMITED_FETCH_SIZE,
+                        null,
+                        Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -443,7 +480,14 @@ public class BoltProtocolV53Test {
         CompletionStage<AsyncResultCursor> cursorStage;
         if (autoCommitTx) {
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, initialBookmarks, (ignored) -> {}, config, UNLIMITED_FETCH_SIZE, null)
+                            connection,
+                            QUERY,
+                            initialBookmarks,
+                            (ignored) -> {},
+                            config,
+                            UNLIMITED_FETCH_SIZE,
+                            null,
+                            Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -474,7 +518,8 @@ public class BoltProtocolV53Test {
                     (ignored) -> {},
                     TransactionConfig.empty(),
                     UNLIMITED_FETCH_SIZE,
-                    null);
+                    null,
+                    Logging.none());
             var resultStage = factory.asyncResult();
             var runHandler = verifySessionRunInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -484,7 +529,7 @@ public class BoltProtocolV53Test {
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
             var txStage = protocol.beginTransaction(
-                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null);
+                    connection, Collections.emptySet(), TransactionConfig.empty(), null, null, Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, Collections.emptySet(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -501,8 +546,8 @@ public class BoltProtocolV53Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        var runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null, null);
+        var runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -526,7 +571,7 @@ public class BoltProtocolV53Test {
             AccessMode mode,
             DatabaseName databaseName) {
         var beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null);
+        var beginMessage = new BeginMessage(bookmarks, config, databaseName, mode, null, null, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }


### PR DESCRIPTION
If transaction timeout value has a sub millisecond value, it gets rounded up to next millisecond value.