### PR TITLE
Add support for cancellation on reactive session run

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/ResultCursorFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/ResultCursorFactoryImpl.java
@@ -74,6 +74,7 @@ public class ResultCursorFactoryImpl implements ResultCursorFactory {
     @Override
     public CompletionStage<RxResultCursor> rxResult() {
         connection.writeAndFlush(runMessage, runHandler);
-        return runFuture.handle((ignored, error) -> new RxResultCursorImpl(error, runHandler, pullHandler));
+        return runFuture.handle(
+                (ignored, error) -> new RxResultCursorImpl(error, runHandler, pullHandler, connection::release));
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursor.java
@@ -36,4 +36,13 @@ public interface RxResultCursor extends Subscription, FailableCursor {
     boolean isDone();
 
     Throwable getRunError();
+
+    /**
+     * Rolls back this instance by releasing connection with RESET.
+     * <p>
+     * This must never be called on a published instance.
+     * @return reset completion stage
+     * @since 5.11
+     */
+    CompletionStage<Void> rollback();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/InternalRxSession.java
@@ -96,7 +96,7 @@ public class InternalRxSession extends AbstractReactiveSession<RxTransaction> im
     public RxResult run(Query query, TransactionConfig config) {
         return new InternalRxResult(() -> {
             var resultCursorFuture = new CompletableFuture<RxResultCursor>();
-            session.runRx(query, config).whenComplete((cursor, completionError) -> {
+            session.runRx(query, config, resultCursorFuture).whenComplete((cursor, completionError) -> {
                 if (cursor != null) {
                     resultCursorFuture.complete(cursor);
                 } else {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactive/RxUtils.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactive/RxUtils.java
@@ -56,7 +56,7 @@ public class RxUtils {
      * @param <T>                         the type of the item to publish.
      * @return A publisher that succeeds exactly one item or fails with an error.
      */
-    public static <T> Publisher<T> createSingleItemPublisher(
+    public static <T> Mono<T> createSingleItemPublisher(
             Supplier<CompletionStage<T>> supplier,
             Supplier<Throwable> nullResultThrowableSupplier,
             Consumer<T> cancellationHandler) {

--- a/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/reactivestreams/InternalReactiveSession.java
@@ -20,22 +20,18 @@ package org.neo4j.driver.internal.reactivestreams;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.async.UnmanagedTransaction;
-import org.neo4j.driver.internal.cursor.RxResultCursor;
 import org.neo4j.driver.internal.reactive.AbstractReactiveSession;
-import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.reactivestreams.ReactiveResult;
 import org.neo4j.driver.reactivestreams.ReactiveSession;
 import org.neo4j.driver.reactivestreams.ReactiveTransaction;
 import org.neo4j.driver.reactivestreams.ReactiveTransactionCallback;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Mono;
 
 public class InternalReactiveSession extends AbstractReactiveSession<ReactiveTransaction>
         implements ReactiveSession, BaseReactiveQueryRunner {
@@ -83,30 +79,7 @@ public class InternalReactiveSession extends AbstractReactiveSession<ReactiveTra
 
     @Override
     public Publisher<ReactiveResult> run(Query query, TransactionConfig config) {
-        CompletionStage<RxResultCursor> cursorStage;
-        try {
-            cursorStage = session.runRx(query, config);
-        } catch (Throwable t) {
-            cursorStage = Futures.failedFuture(t);
-        }
-
-        return Mono.fromCompletionStage(cursorStage)
-                .onErrorResume(error -> Mono.fromCompletionStage(session.releaseConnectionAsync())
-                        .onErrorMap(releaseError -> Futures.combineErrors(error, releaseError))
-                        .then(Mono.error(error)))
-                .flatMap(cursor -> {
-                    Mono<RxResultCursor> publisher;
-                    var runError = cursor.getRunError();
-                    if (runError != null) {
-                        publisher = Mono.fromCompletionStage(session.releaseConnectionAsync())
-                                .onErrorMap(releaseError -> Futures.combineErrors(runError, releaseError))
-                                .then(Mono.error(runError));
-                    } else {
-                        publisher = Mono.just(cursor);
-                    }
-                    return publisher;
-                })
-                .map(InternalReactiveResult::new);
+        return run(query, config, InternalReactiveResult::new);
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
@@ -20,13 +20,25 @@ package org.neo4j.driver.integration.reactive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.ConnectionPoolMetrics;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.reactivestreams.ReactiveResult;
@@ -34,7 +46,10 @@ import org.neo4j.driver.reactivestreams.ReactiveSession;
 import org.neo4j.driver.testutil.DatabaseExtension;
 import org.neo4j.driver.testutil.ParallelizableIT;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @EnabledOnNeo4jWith(BOLT_V4)
 @ParallelizableIT
@@ -55,6 +70,90 @@ public class ReactiveStreamsSessionIT {
                 "org.neo4j.driver.reactivestreams.ReactiveResult is not a valid return value, it should be consumed before producing a return value",
                 error.getMessage());
         Flux.from(session.close()).blockFirst();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SuppressWarnings("BusyWait")
+    void shouldReleaseResultsOnSubscriptionCancellation(boolean request) throws InterruptedException {
+        var config = Config.builder().withDriverMetrics().build();
+        try (var driver = neo4j.customDriver(config)) {
+            // verify the database is available as runs may not report errors due to the subscription cancellation
+            driver.verifyConnectivity();
+            var threadsNumber = 100;
+            var executorService = Executors.newFixedThreadPool(threadsNumber);
+
+            var subscriptionFutures = IntStream.range(0, threadsNumber)
+                    .mapToObj(ignored -> CompletableFuture.supplyAsync(
+                            () -> {
+                                var subscriptionFuture = new CompletableFuture<Subscription>();
+                                driver.session(ReactiveSession.class)
+                                        .run("UNWIND range (0,10000) AS x RETURN x")
+                                        .subscribe(new BaseSubscriber<>() {
+                                            @Override
+                                            protected void hookOnSubscribe(Subscription subscription) {
+                                                // use subscription from another thread to avoid immediate cancellation
+                                                // within the subscribe method
+                                                subscriptionFuture.complete(subscription);
+                                            }
+                                        });
+                                return subscriptionFuture.thenApplyAsync(
+                                        subscription -> {
+                                            if (request) {
+                                                subscription.request(1);
+                                            }
+                                            subscription.cancel();
+                                            return subscription;
+                                        },
+                                        executorService);
+                            },
+                            executorService))
+                    .map(future -> future.thenCompose(itself -> itself))
+                    .toArray(CompletableFuture[]::new);
+
+            CompletableFuture.allOf(subscriptionFutures).join();
+
+            // Subscription cancellation does not guarantee neither onComplete nor onError signal.
+            var timeout = Instant.now().plus(5, ChronoUnit.MINUTES);
+            var totalInUseConnections = -1;
+            while (Instant.now().isBefore(timeout)) {
+                totalInUseConnections = driver.metrics().connectionPoolMetrics().stream()
+                        .map(ConnectionPoolMetrics::inUse)
+                        .mapToInt(Integer::intValue)
+                        .sum();
+                if (totalInUseConnections == 0) {
+                    return;
+                }
+                Thread.sleep(100);
+            }
+            fail(String.format("not all connections have been released, %d are still in use", totalInUseConnections));
+        }
+    }
+
+    @Test
+    void shouldRollbackResultOnSubscriptionCancellation() {
+        var config = Config.builder().withMaxConnectionPoolSize(1).build();
+        try (var driver = neo4j.customDriver(config)) {
+            var session = driver.session(ReactiveSession.class);
+            var nodeId = UUID.randomUUID().toString();
+            var cancellationFuture = new CompletableFuture<Void>();
+
+            session.run("CREATE ({id: $id})", Map.of("id", nodeId)).subscribe(new BaseSubscriber<>() {
+                @Override
+                protected void hookOnSubscribe(Subscription subscription) {
+                    subscription.cancel();
+                    cancellationFuture.complete(null);
+                }
+            });
+
+            cancellationFuture.join();
+
+            var nodesNum = Mono.fromDirect(session.run("MATCH (n {id: $id}) RETURN n", Map.of("id", nodeId)))
+                    .flatMapMany(ReactiveResult::records)
+                    .count()
+                    .block();
+            assertEquals(0, nodesNum);
+        }
     }
 
     static List<Function<ReactiveSession, Publisher<ReactiveResult>>>

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -53,6 +53,7 @@ import static org.neo4j.driver.testutil.TestUtil.verifyRunRx;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -99,7 +100,7 @@ class NetworkSessionTest {
     @Test
     void shouldFlushOnRunRx() {
         setupSuccessfulRunRx(connection);
-        await(session.runRx(new Query("RETURN 1"), TransactionConfig.empty()));
+        await(session.runRx(new Query("RETURN 1"), TransactionConfig.empty(), CompletableFuture.completedStage(null)));
 
         verifyRunRx(connection, "RETURN 1");
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
@@ -60,7 +60,7 @@ class RxResultCursorImplTest {
         var pullHandler = mock(PullResponseHandler.class);
 
         // When
-        new RxResultCursorImpl(error, runHandler, pullHandler);
+        new RxResultCursorImpl(error, runHandler, pullHandler, () -> CompletableFuture.completedStage(null));
 
         // Then
         verify(pullHandler).installSummaryConsumer(any(BiConsumer.class));
@@ -160,7 +160,8 @@ class RxResultCursorImplTest {
         // When
         var runHandler = newRunResponseHandler(error);
         PullResponseHandler pullHandler = new ListBasedPullHandler();
-        RxResultCursor cursor = new RxResultCursorImpl(error, runHandler, pullHandler);
+        RxResultCursor cursor =
+                new RxResultCursorImpl(error, runHandler, pullHandler, () -> CompletableFuture.completedStage(null));
         cursor.installRecordConsumer(recordConsumer);
 
         // Then

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalReactiveSessionTest.java
@@ -98,14 +98,16 @@ public class InternalReactiveSessionTest {
         RxResultCursor cursor = mock(RxResultCursorImpl.class);
 
         // Run succeeded with a cursor
-        when(session.runRx(any(Query.class), any(TransactionConfig.class))).thenReturn(completedFuture(cursor));
+        when(session.runRx(any(Query.class), any(TransactionConfig.class), any()))
+                .thenReturn(completedFuture(cursor));
         var rxSession = new InternalReactiveSession(session);
 
         // When
         var result = flowPublisherToFlux(runReturnOne.apply(rxSession));
+        result.subscribe();
 
         // Then
-        verify(session).runRx(any(Query.class), any(TransactionConfig.class));
+        verify(session).runRx(any(Query.class), any(TransactionConfig.class), any());
         StepVerifier.create(result).expectNextCount(1).verifyComplete();
     }
 
@@ -117,7 +119,8 @@ public class InternalReactiveSessionTest {
         var session = mock(NetworkSession.class);
 
         // Run failed with error
-        when(session.runRx(any(Query.class), any(TransactionConfig.class))).thenReturn(Futures.failedFuture(error));
+        when(session.runRx(any(Query.class), any(TransactionConfig.class), any()))
+                .thenReturn(Futures.failedFuture(error));
         when(session.releaseConnectionAsync()).thenReturn(Futures.completedWithNull());
 
         var rxSession = new InternalReactiveSession(session);
@@ -127,7 +130,7 @@ public class InternalReactiveSessionTest {
 
         // Then
         StepVerifier.create(result).expectErrorMatches(t -> error == t).verify();
-        verify(session).runRx(any(Query.class), any(TransactionConfig.class));
+        verify(session).runRx(any(Query.class), any(TransactionConfig.class), any());
         verify(session).releaseConnectionAsync();
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/reactive/InternalRxSessionTest.java
@@ -98,7 +98,8 @@ class InternalRxSessionTest {
         RxResultCursor cursor = mock(RxResultCursorImpl.class);
 
         // Run succeeded with a cursor
-        when(session.runRx(any(Query.class), any(TransactionConfig.class))).thenReturn(completedFuture(cursor));
+        when(session.runRx(any(Query.class), any(TransactionConfig.class), any()))
+                .thenReturn(completedFuture(cursor));
         var rxSession = new InternalRxSession(session);
 
         // When
@@ -107,7 +108,7 @@ class InternalRxSessionTest {
         var cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify(session).runRx(any(Query.class), any(TransactionConfig.class));
+        verify(session).runRx(any(Query.class), any(TransactionConfig.class), any());
         assertThat(Futures.getNow(cursorFuture), equalTo(cursor));
     }
 
@@ -119,7 +120,8 @@ class InternalRxSessionTest {
         var session = mock(NetworkSession.class);
 
         // Run failed with error
-        when(session.runRx(any(Query.class), any(TransactionConfig.class))).thenReturn(Futures.failedFuture(error));
+        when(session.runRx(any(Query.class), any(TransactionConfig.class), any()))
+                .thenReturn(Futures.failedFuture(error));
         when(session.releaseConnectionAsync()).thenReturn(Futures.completedWithNull());
 
         var rxSession = new InternalRxSession(session);
@@ -130,7 +132,7 @@ class InternalRxSessionTest {
         var cursorFuture = ((InternalRxResult) result).cursorFutureSupplier().get();
 
         // Then
-        verify(session).runRx(any(Query.class), any(TransactionConfig.class));
+        verify(session).runRx(any(Query.class), any(TransactionConfig.class), any());
         RuntimeException t = assertThrows(CompletionException.class, () -> Futures.getNow(cursorFuture));
         assertThat(t.getCause(), equalTo(error));
         verify(session).releaseConnectionAsync();

--- a/driver/src/test/java/org/neo4j/driver/testutil/DatabaseExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/DatabaseExtension.java
@@ -148,6 +148,10 @@ public class DatabaseExtension implements ExecutionCondition, BeforeEachCallback
         return driver;
     }
 
+    public Driver customDriver(Config config) {
+        return GraphDatabase.driver(boltUri, authToken, config);
+    }
+
     public void deleteAndStartNeo4j(Map<String, String> config) {
         Map<String, String> updatedConfig = new HashMap<>(defaultConfig);
         updatedConfig.putAll(config);


### PR DESCRIPTION
This update brings support for cancelling subscription on reactive session `run` methods, like:
- `org.neo4j.driver.reactive.ReactiveSession.run(..)`
- `org.neo4j.driver.reactivestreams.ReactiveSession.run(..)`

If subscription is cancelled before an instance of the `ReactiveResult` is published, the driver will rollback the initiated query by sending the Bolt `RESET` message and will release the network connection back to its connection pool. This will be done in the background.

Once the `ReactiveResult` is published, the cancellation with the rollback is no longer possible.

In addition, this update makes the driver wait until subscriber subscribes to the publisher before dispatching the query to the server. Previously, the driver would do that immediately upon calling the `run` method.