### PR TITLE
TestKit: add verifyConnectivity to feature list

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -56,6 +56,7 @@ public class GetFeatures implements TestkitRequest {
             "Optimization:EagerTransactionBegin",
             "Feature:API:ConnectionAcquisitionTimeout",
             "Feature:API:Driver.IsEncrypted",
+            "Feature:API:Driver.VerifyConnectivity",
             "Feature:API:SSLConfig",
             "Detail:DefaultSecurityConfigValueEquality",
             "Optimization:ImplicitDefaultArguments",


### PR DESCRIPTION
The driver already supports the API, so does the backend. The backend just never told TestKit about it ;)