### PR TITLE
Update TestkitRequestProcessorHandler to adhere to req/res pattern

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/ResponseQueueHanlder.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/ResponseQueueHanlder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j.org.testkit.backend;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.function.Consumer;
+import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+
+public class ResponseQueueHanlder {
+    private final Consumer<TestkitResponse> responseWriter;
+    private final Queue<TestkitResponse> responseQueue = new ArrayDeque<>();
+    private boolean responseReady;
+
+    ResponseQueueHanlder(Consumer<TestkitResponse> responseWriter) {
+        this.responseWriter = responseWriter;
+    }
+
+    public synchronized void setResponseReadyAndDispatchFirst() {
+        responseReady = true;
+        dispatchFirst();
+    }
+
+    public synchronized void offerAndDispatchFirst(TestkitResponse response) {
+        responseQueue.offer(response);
+        if (responseReady) {
+            dispatchFirst();
+        }
+    }
+
+    private synchronized void dispatchFirst() {
+        var response = responseQueue.poll();
+        if (response != null) {
+            responseReady = false;
+            responseWriter.accept(response);
+        }
+    }
+}

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
@@ -49,10 +49,14 @@ public class Runner {
                     .childHandler(new ChannelInitializer<SocketChannel>() {
                         @Override
                         protected void initChannel(SocketChannel channel) {
+                            var responseQueueHanlder = new ResponseQueueHanlder(channel::writeAndFlush);
                             channel.pipeline().addLast(new TestkitMessageInboundHandler());
                             channel.pipeline().addLast(new TestkitMessageOutboundHandler());
-                            channel.pipeline().addLast(new TestkitRequestResponseMapperHandler(logging));
-                            channel.pipeline().addLast(new TestkitRequestProcessorHandler(backendMode, logging));
+                            channel.pipeline()
+                                    .addLast(new TestkitRequestResponseMapperHandler(logging, responseQueueHanlder));
+                            channel.pipeline()
+                                    .addLast(new TestkitRequestProcessorHandler(
+                                            backendMode, logging, responseQueueHanlder));
                         }
                     });
             var server = bootstrap.bind().sync();


### PR DESCRIPTION
This update aims to make sure the Teskit backend does not break the request / response pattern. For instance, by sending 2 responses together in case of internal callbacks.