### PR TITLE
Update sub millisecond transaction timeout handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunner.java
@@ -24,6 +24,7 @@ import static org.neo4j.driver.internal.DatabaseNameUtil.systemDatabase;
 import java.util.HashMap;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
@@ -42,8 +43,8 @@ public class MultiDatabasesRoutingProcedureRunner extends SingleDatabaseRoutingP
     static final String MULTI_DB_GET_ROUTING_TABLE =
             String.format("CALL dbms.routing.getRoutingTable($%s, $%s)", ROUTING_CONTEXT, DATABASE_NAME);
 
-    public MultiDatabasesRoutingProcedureRunner(RoutingContext context) {
-        super(context);
+    public MultiDatabasesRoutingProcedureRunner(RoutingContext context, Logging logging) {
+        super(context, logging);
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.ProtocolException;
@@ -42,11 +43,11 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
     private final RoutingProcedureRunner multiDatabaseRoutingProcedureRunner;
     private final RoutingProcedureRunner routeMessageRoutingProcedureRunner;
 
-    public RoutingProcedureClusterCompositionProvider(Clock clock, RoutingContext routingContext) {
+    public RoutingProcedureClusterCompositionProvider(Clock clock, RoutingContext routingContext, Logging logging) {
         this(
                 clock,
-                new SingleDatabaseRoutingProcedureRunner(routingContext),
-                new MultiDatabasesRoutingProcedureRunner(routingContext),
+                new SingleDatabaseRoutingProcedureRunner(routingContext, logging),
+                new MultiDatabasesRoutingProcedureRunner(routingContext, logging),
                 new RouteMessageRoutingProcedureRunner(routingContext));
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.TransactionConfig;
@@ -49,9 +50,11 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
     static final String GET_ROUTING_TABLE = "CALL dbms.cluster.routing.getRoutingTable($" + ROUTING_CONTEXT + ")";
 
     final RoutingContext context;
+    private Logging logging;
 
-    public SingleDatabaseRoutingProcedureRunner(RoutingContext context) {
+    public SingleDatabaseRoutingProcedureRunner(RoutingContext context, Logging logging) {
         this.context = context;
+        this.logging = logging;
     }
 
     @Override
@@ -87,7 +90,7 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
         return connection
                 .protocol()
                 .runInAutoCommitTransaction(
-                        connection, procedure, bookmarkHolder, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE)
+                        connection, procedure, bookmarkHolder, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE, logging)
                 .asyncResult()
                 .thenCompose(ResultCursor::listAsync);
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/loadbalancing/LoadBalancer.java
@@ -297,7 +297,7 @@ public class LoadBalancer implements ConnectionProvider {
             Logging logging,
             DomainNameResolver domainNameResolver) {
         ClusterCompositionProvider clusterCompositionProvider =
-                new RoutingProcedureClusterCompositionProvider(clock, settings.routingContext());
+                new RoutingProcedureClusterCompositionProvider(clock, settings.routingContext(), logging);
         return new RediscoveryImpl(
                 initialRouter,
                 settings,

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/BoltProtocol.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelPromise;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
@@ -77,9 +78,11 @@ public interface BoltProtocol {
      * @param connection the connection to use.
      * @param bookmark the bookmarks. Never null, should be {@link InternalBookmark#empty()} when absent.
      * @param config the transaction configuration. Never null, should be {@link TransactionConfig#empty()} when absent.
+     * @param logging            the driver logging
      * @return a completion stage completed when transaction is started or completed exceptionally when there was a failure.
      */
-    CompletionStage<Void> beginTransaction(Connection connection, Bookmark bookmark, TransactionConfig config);
+    CompletionStage<Void> beginTransaction(
+            Connection connection, Bookmark bookmark, TransactionConfig config, Logging logging);
 
     /**
      * Commit the unmanaged transaction.
@@ -105,6 +108,7 @@ public interface BoltProtocol {
      * @param bookmarkHolder the bookmarksHolder that keeps track of the current bookmark and can be updated with a new bookmark.
      * @param config         the transaction config for the implicitly started auto-commit transaction.
      * @param fetchSize      the record fetch size for PULL message.
+     * @param logging            the driver logging
      * @return stage with cursor.
      */
     ResultCursorFactory runInAutoCommitTransaction(
@@ -112,7 +116,8 @@ public interface BoltProtocol {
             Query query,
             BookmarkHolder bookmarkHolder,
             TransactionConfig config,
-            long fetchSize);
+            long fetchSize,
+            Logging logging);
 
     /**
      * Execute the given query in a running unmanaged transaction, i.e. {@link Transaction#run(Query)}.

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/BeginMessage.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.DatabaseName;
@@ -37,8 +38,9 @@ public class BeginMessage extends MessageWithMetadata {
             TransactionConfig config,
             DatabaseName databaseName,
             AccessMode mode,
-            String impersonatedUser) {
-        this(bookmark, config.timeout(), config.metadata(), mode, databaseName, impersonatedUser);
+            String impersonatedUser,
+            Logging logging) {
+        this(bookmark, config.timeout(), config.metadata(), mode, databaseName, impersonatedUser, logging);
     }
 
     public BeginMessage(
@@ -47,8 +49,9 @@ public class BeginMessage extends MessageWithMetadata {
             Map<String, Value> txMetadata,
             AccessMode mode,
             DatabaseName databaseName,
-            String impersonatedUser) {
-        super(buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmark, impersonatedUser));
+            String impersonatedUser,
+            Logging logging) {
+        super(buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmark, impersonatedUser, logging));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/request/RunWithMetadataMessage.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
@@ -44,9 +45,10 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             AccessMode mode,
             Bookmark bookmark,
-            String impersonatedUser) {
+            String impersonatedUser,
+            Logging logging) {
         return autoCommitTxRunMessage(
-                query, config.timeout(), config.metadata(), databaseName, mode, bookmark, impersonatedUser);
+                query, config.timeout(), config.metadata(), databaseName, mode, bookmark, impersonatedUser, logging);
     }
 
     public static RunWithMetadataMessage autoCommitTxRunMessage(
@@ -56,9 +58,10 @@ public class RunWithMetadataMessage extends MessageWithMetadata {
             DatabaseName databaseName,
             AccessMode mode,
             Bookmark bookmark,
-            String impersonatedUser) {
+            String impersonatedUser,
+            Logging logging) {
         Map<String, Value> metadata =
-                buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmark, impersonatedUser);
+                buildMetadata(txTimeout, txMetadata, databaseName, mode, bookmark, impersonatedUser, logging);
         return new RunWithMetadataMessage(query.text(), query.parameters().asMap(ofValue()), metadata);
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
@@ -117,7 +118,7 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         }
 
         TestRoutingProcedureRunner(RoutingContext context, CompletionStage<List<Record>> runProcedureResult) {
-            super(context);
+            super(context, Logging.none());
             this.runProcedureResult = runProcedureResult;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
@@ -125,7 +126,7 @@ class SingleDatabaseRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         }
 
         TestRoutingProcedureRunner(RoutingContext context, CompletionStage<List<Record>> runProcedureResult) {
-            super(context);
+            super(context, Logging.none());
             this.runProcedureResult = runProcedureResult;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/BeginMessageEncoderTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.ValuePacker;
@@ -59,7 +60,9 @@ class BeginMessageEncoderTest {
         Duration txTimeout = Duration.ofSeconds(1);
 
         encoder.encode(
-                new BeginMessage(bookmark, txTimeout, txMetadata, mode, defaultDatabase(), impersonatedUser), packer);
+                new BeginMessage(
+                        bookmark, txTimeout, txMetadata, mode, defaultDatabase(), impersonatedUser, Logging.none()),
+                packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(1, BeginMessage.SIGNATURE);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/encode/RunWithMetadataMessageEncoderTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InOrder;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Bookmark;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalBookmark;
@@ -63,7 +64,9 @@ class RunWithMetadataMessageEncoderTest {
 
         Query query = new Query("RETURN $answer", value(params));
         encoder.encode(
-                autoCommitTxRunMessage(query, txTimeout, txMetadata, defaultDatabase(), mode, bookmark, null), packer);
+                autoCommitTxRunMessage(
+                        query, txTimeout, txMetadata, defaultDatabase(), mode, bookmark, null, Logging.none()),
+                packer);
 
         InOrder order = inOrder(packer);
         order.verify(packer).packStructHeader(3, RunWithMetadataMessage.SIGNATURE);

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v3/MessageWriterV3Test.java
@@ -46,6 +46,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
@@ -108,14 +109,16 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 autoCommitTxRunMessage(
@@ -125,7 +128,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -133,7 +137,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
                 PULL_ALL,
                 DISCARD_ALL,
@@ -147,7 +152,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -155,7 +161,8 @@ class MessageWriterV3Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/BoltProtocolV4Test.java
@@ -175,13 +175,18 @@ public final class BoltProtocolV4Test {
     void shouldBeginTransactionWithoutBookmark() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(
+                connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                InternalBookmark.empty(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -191,11 +196,13 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx100");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, TransactionConfig.empty());
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmark, TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -204,11 +211,13 @@ public final class BoltProtocolV4Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -218,11 +227,11 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx4242");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -329,7 +338,7 @@ public final class BoltProtocolV4Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty());
+                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -341,7 +350,8 @@ public final class BoltProtocolV4Test {
                 new Query("RETURN 1"),
                 BookmarkHolder.NO_OP,
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                Logging.none()));
     }
 
     private BoltProtocol createProtocol() {
@@ -363,7 +373,7 @@ public final class BoltProtocolV4Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -389,7 +399,7 @@ public final class BoltProtocolV4Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -447,7 +457,7 @@ public final class BoltProtocolV4Test {
         if (autoCommitTx) {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(initialBookmark);
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -472,15 +482,20 @@ public final class BoltProtocolV4Test {
         Connection connection = connectionMock("foo", protocol);
         if (autoCommitTx) {
             ResultCursorFactory factory = protocol.runInAutoCommitTransaction(
-                    connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE);
+                    connection,
+                    QUERY,
+                    BookmarkHolder.NO_OP,
+                    TransactionConfig.empty(),
+                    UNLIMITED_FETCH_SIZE,
+                    Logging.none());
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
             runHandler.onSuccess(emptyMap());
             await(resultStage);
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -497,8 +512,8 @@ public final class BoltProtocolV4Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null);
+        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -522,7 +537,7 @@ public final class BoltProtocolV4Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v4/MessageWriterV4Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
@@ -116,14 +117,16 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -134,7 +137,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -142,7 +146,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -153,7 +158,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -161,7 +167,8 @@ class MessageWriterV4Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/BoltProtocolV41Test.java
@@ -179,13 +179,18 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithoutBookmark() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(
+                connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                InternalBookmark.empty(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -195,11 +200,13 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx100");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, TransactionConfig.empty());
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmark, TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -208,11 +215,13 @@ public final class BoltProtocolV41Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -222,11 +231,11 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx4242");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -333,7 +342,7 @@ public final class BoltProtocolV41Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty());
+                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -345,7 +354,8 @@ public final class BoltProtocolV41Test {
                 new Query("RETURN 1"),
                 BookmarkHolder.NO_OP,
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -359,7 +369,7 @@ public final class BoltProtocolV41Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -385,7 +395,7 @@ public final class BoltProtocolV41Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -442,7 +452,7 @@ public final class BoltProtocolV41Test {
         if (autoCommitTx) {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(initialBookmark);
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -465,7 +475,12 @@ public final class BoltProtocolV41Test {
         Connection connection = connectionMock("foo", protocol);
         if (autoCommitTx) {
             ResultCursorFactory factory = protocol.runInAutoCommitTransaction(
-                    connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE);
+                    connection,
+                    QUERY,
+                    BookmarkHolder.NO_OP,
+                    TransactionConfig.empty(),
+                    UNLIMITED_FETCH_SIZE,
+                    Logging.none());
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -474,8 +489,8 @@ public final class BoltProtocolV41Test {
             verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -492,8 +507,8 @@ public final class BoltProtocolV41Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null);
+        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -517,7 +532,7 @@ public final class BoltProtocolV41Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v41/MessageWriterV41Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
@@ -115,14 +116,16 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -133,7 +136,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -141,7 +145,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -152,7 +157,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -160,7 +166,8 @@ class MessageWriterV41Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/BoltProtocolV42Test.java
@@ -179,13 +179,18 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithoutBookmark() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(
+                connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                InternalBookmark.empty(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -195,11 +200,13 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx100");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, TransactionConfig.empty());
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmark, TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -208,11 +215,13 @@ public final class BoltProtocolV42Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -222,11 +231,11 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx4242");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -333,7 +342,7 @@ public final class BoltProtocolV42Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty());
+                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -345,7 +354,8 @@ public final class BoltProtocolV42Test {
                 new Query("RETURN 1"),
                 BookmarkHolder.NO_OP,
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -359,7 +369,7 @@ public final class BoltProtocolV42Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -384,7 +394,7 @@ public final class BoltProtocolV42Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -441,7 +451,7 @@ public final class BoltProtocolV42Test {
         if (autoCommitTx) {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(initialBookmark);
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -466,7 +476,12 @@ public final class BoltProtocolV42Test {
         Connection connection = connectionMock("foo", protocol);
         if (autoCommitTx) {
             ResultCursorFactory factory = protocol.runInAutoCommitTransaction(
-                    connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE);
+                    connection,
+                    QUERY,
+                    BookmarkHolder.NO_OP,
+                    TransactionConfig.empty(),
+                    UNLIMITED_FETCH_SIZE,
+                    Logging.none());
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -475,8 +490,8 @@ public final class BoltProtocolV42Test {
             verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -493,8 +508,8 @@ public final class BoltProtocolV42Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null);
+        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -518,7 +533,7 @@ public final class BoltProtocolV42Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v42/MessageWriterV42Test.java
@@ -47,6 +47,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.messaging.Message;
@@ -115,14 +116,16 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -133,7 +136,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -141,7 +145,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -152,7 +157,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -160,7 +166,8 @@ class MessageWriterV42Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))));
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v43/MessageWriterV43Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -120,14 +121,16 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -138,7 +141,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -146,7 +150,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -157,7 +162,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -165,7 +171,8 @@ class MessageWriterV43Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/BoltProtocolV44Test.java
@@ -178,13 +178,18 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithoutBookmark() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage =
-                protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+        CompletionStage<Void> stage = protocol.beginTransaction(
+                connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
                         eq(new BeginMessage(
-                                InternalBookmark.empty(), TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                                InternalBookmark.empty(),
+                                TransactionConfig.empty(),
+                                defaultDatabase(),
+                                WRITE,
+                                null,
+                                Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -194,11 +199,13 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx100");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, TransactionConfig.empty());
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, bookmark, TransactionConfig.empty(), Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                bookmark, TransactionConfig.empty(), defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -207,11 +214,13 @@ public class BoltProtocolV44Test {
     void shouldBeginTransactionWithConfig() {
         Connection connection = connectionMock(protocol);
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig);
+        CompletionStage<Void> stage =
+                protocol.beginTransaction(connection, InternalBookmark.empty(), txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(
+                                InternalBookmark.empty(), txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -221,11 +230,11 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock(protocol);
         Bookmark bookmark = InternalBookmark.parse("neo4j:bookmark:v1:tx4242");
 
-        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig);
+        CompletionStage<Void> stage = protocol.beginTransaction(connection, bookmark, txConfig, Logging.none());
 
         verify(connection)
                 .writeAndFlush(
-                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null)),
+                        eq(new BeginMessage(bookmark, txConfig, defaultDatabase(), WRITE, null, Logging.none())),
                         any(BeginTxResponseHandler.class));
         assertNull(await(stage));
     }
@@ -332,7 +341,7 @@ public class BoltProtocolV44Test {
     @Test
     void shouldSupportDatabaseNameInBeginTransaction() {
         CompletionStage<Void> txStage = protocol.beginTransaction(
-                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty());
+                connectionMock("foo", protocol), InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
 
         assertDoesNotThrow(() -> await(txStage));
     }
@@ -344,7 +353,8 @@ public class BoltProtocolV44Test {
                 new Query("RETURN 1"),
                 BookmarkHolder.NO_OP,
                 TransactionConfig.empty(),
-                UNLIMITED_FETCH_SIZE));
+                UNLIMITED_FETCH_SIZE,
+                Logging.none()));
     }
 
     private Class<? extends MessageFormat> expectedMessageFormatType() {
@@ -358,7 +368,7 @@ public class BoltProtocolV44Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -384,7 +394,7 @@ public class BoltProtocolV44Test {
         BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(bookmark);
 
         CompletableFuture<AsyncResultCursor> cursorFuture = protocol.runInAutoCommitTransaction(
-                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                        connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                 .asyncResult()
                 .toCompletableFuture();
 
@@ -441,7 +451,7 @@ public class BoltProtocolV44Test {
         if (autoCommitTx) {
             BookmarkHolder bookmarkHolder = new DefaultBookmarkHolder(initialBookmark);
             cursorStage = protocol.runInAutoCommitTransaction(
-                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE)
+                            connection, QUERY, bookmarkHolder, config, UNLIMITED_FETCH_SIZE, Logging.none())
                     .asyncResult();
         } else {
             cursorStage = protocol.runInUnmanagedTransaction(
@@ -466,7 +476,12 @@ public class BoltProtocolV44Test {
         Connection connection = connectionMock("foo", protocol);
         if (autoCommitTx) {
             ResultCursorFactory factory = protocol.runInAutoCommitTransaction(
-                    connection, QUERY, BookmarkHolder.NO_OP, TransactionConfig.empty(), UNLIMITED_FETCH_SIZE);
+                    connection,
+                    QUERY,
+                    BookmarkHolder.NO_OP,
+                    TransactionConfig.empty(),
+                    UNLIMITED_FETCH_SIZE,
+                    Logging.none());
             CompletionStage<AsyncResultCursor> resultStage = factory.asyncResult();
             ResponseHandler runHandler = verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -475,8 +490,8 @@ public class BoltProtocolV44Test {
             verifySessionRunInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
         } else {
-            CompletionStage<Void> txStage =
-                    protocol.beginTransaction(connection, InternalBookmark.empty(), TransactionConfig.empty());
+            CompletionStage<Void> txStage = protocol.beginTransaction(
+                    connection, InternalBookmark.empty(), TransactionConfig.empty(), Logging.none());
             await(txStage);
             verifyBeginInvoked(
                     connection, InternalBookmark.empty(), TransactionConfig.empty(), AccessMode.WRITE, database("foo"));
@@ -493,8 +508,8 @@ public class BoltProtocolV44Test {
             TransactionConfig config,
             AccessMode mode,
             DatabaseName databaseName) {
-        RunWithMetadataMessage runMessage =
-                RunWithMetadataMessage.autoCommitTxRunMessage(QUERY, config, databaseName, mode, bookmark, null);
+        RunWithMetadataMessage runMessage = RunWithMetadataMessage.autoCommitTxRunMessage(
+                QUERY, config, databaseName, mode, bookmark, null, Logging.none());
         return verifyRunInvoked(connection, runMessage);
     }
 
@@ -518,7 +533,7 @@ public class BoltProtocolV44Test {
             AccessMode mode,
             DatabaseName databaseName) {
         ArgumentCaptor<ResponseHandler> beginHandlerCaptor = ArgumentCaptor.forClass(ResponseHandler.class);
-        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null);
+        BeginMessage beginMessage = new BeginMessage(bookmark, config, databaseName, mode, null, Logging.none());
         verify(connection).writeAndFlush(eq(beginMessage), beginHandlerCaptor.capture());
         assertThat(beginHandlerCaptor.getValue(), instanceOf(BeginTxResponseHandler.class));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/v44/MessageWriterV44Test.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
@@ -120,14 +121,16 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         singletonMap("key", value(42)),
                         READ,
                         defaultDatabase(),
-                        null),
+                        null,
+                        Logging.none()),
                 new BeginMessage(
                         InternalBookmark.parse("neo4j:bookmark:v1:tx123"),
                         ofSeconds(5),
                         singletonMap("key", value(42)),
                         WRITE,
                         database("foo"),
-                        null),
+                        null,
+                        Logging.none()),
                 COMMIT,
                 ROLLBACK,
                 RESET,
@@ -138,7 +141,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN 1"),
                         ofSeconds(5),
@@ -146,7 +150,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.parse("neo4j:bookmark:v1:tx1"),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN 1")),
 
                 // Bolt V3 messages with struct values
@@ -157,7 +162,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         defaultDatabase(),
                         READ,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 autoCommitTxRunMessage(
                         new Query("RETURN $x", singletonMap("x", value(ZonedDateTime.now()))),
                         ofSeconds(1),
@@ -165,7 +171,8 @@ public class MessageWriterV44Test extends AbstractMessageWriterTestBase {
                         database("foo"),
                         WRITE,
                         InternalBookmark.empty(),
-                        null),
+                        null,
+                        Logging.none()),
                 unmanagedTxRunMessage(new Query("RETURN $x", singletonMap("x", point(42, 1, 2, 3)))),
 
                 // New 4.3 Messages


### PR DESCRIPTION
Cherry-pick: #1451

* Update sub millisecond transaction timeout handling

If transaction timeout value has a sub millisecond value, it gets rounded up to next millisecond value.

* Add additional test