### PR TITLE
Introduce Testkit backend logging level support

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
@@ -37,6 +37,7 @@ import neo4j.org.testkit.backend.holder.SessionHolder;
 import neo4j.org.testkit.backend.holder.TransactionHolder;
 import neo4j.org.testkit.backend.messages.requests.TestkitCallbackResult;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.internal.cluster.RoutingTableRegistry;
 import reactor.core.publisher.Mono;
 
@@ -60,6 +61,7 @@ public class TestkitState {
     private final Map<String, TransactionHolder> transactionIdToTransactionHolder = new HashMap<>();
     private final Map<String, AsyncTransactionHolder> transactionIdToAsyncTransactionHolder = new HashMap<>();
     private final Map<String, RxTransactionHolder> transactionIdToRxTransactionHolder = new HashMap<>();
+    private final Logging logging;
 
     @Getter
     private final Map<String, Exception> errors = new HashMap<>();
@@ -72,8 +74,9 @@ public class TestkitState {
     @Getter
     private final Map<String, CompletableFuture<TestkitCallbackResult>> callbackIdToFuture = new HashMap<>();
 
-    public TestkitState(Consumer<TestkitResponse> responseWriter) {
+    public TestkitState(Consumer<TestkitResponse> responseWriter, Logging logging) {
         this.responseWriter = responseWriter;
+        this.logging = logging;
     }
 
     public String newId() {
@@ -158,6 +161,10 @@ public class TestkitState {
 
     public Mono<RxResultHolder> getRxResultHolder(String id) {
         return getRx(id, resultIdToRxResultHolder, RESULT_NOT_FOUND_MESSAGE);
+    }
+
+    public Logging getLogging() {
+        return logging;
     }
 
     private <T> String add(T value, Map<String, T> idToT) {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
@@ -26,13 +26,21 @@ import io.netty.channel.ChannelPromise;
 import neo4j.org.testkit.backend.messages.TestkitModule;
 import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
+import org.neo4j.driver.Logger;
+import org.neo4j.driver.Logging;
 
 public class TestkitRequestResponseMapperHandler extends ChannelDuplexHandler {
+    private final Logger log;
     private final ObjectMapper objectMapper = newObjectMapper();
+
+    public TestkitRequestResponseMapperHandler(Logging logging) {
+        log = logging.getLog(getClass());
+    }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         String testkitMessage = (String) msg;
+        log.debug("Inbound Testkit message '%s'", testkitMessage.trim());
         TestkitRequest testkitRequest;
         testkitRequest = objectMapper.readValue(testkitMessage, TestkitRequest.class);
         ctx.fireChannelRead(testkitRequest);
@@ -42,6 +50,7 @@ public class TestkitRequestResponseMapperHandler extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         TestkitResponse testkitResponse = (TestkitResponse) msg;
         String responseStr = objectMapper.writeValueAsString(testkitResponse);
+        log.debug("Outbound Testkit message '%s'", responseStr.trim());
         ctx.writeAndFlush(responseStr, promise);
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -113,6 +113,7 @@ public class NewDriver implements TestkitRequest {
         Optional.ofNullable(data.connectionAcquisitionTimeoutMs)
                 .ifPresent(timeout -> configBuilder.withConnectionAcquisitionTimeout(timeout, TimeUnit.MILLISECONDS));
         configBuilder.withDriverMetrics();
+        configBuilder.withLogging(testkitState.getLogging());
         org.neo4j.driver.Driver driver;
         Config config = configBuilder.build();
         try {


### PR DESCRIPTION
Cherry-pick:  #1406

This update introduces support for setting logging levels in Testkit backend. The selected level and the logging is shared by both the backend and the drivers created by the backend.

The backend itself logs exchanges with the Testkit.

Example:
```
2023-04-06T13:20:14.769459 FINE neo4j.org.testkit.backend.channel.handler.TestkitRequestResponseMapperHandler - Inbound Testkit message '{"name": "NewSession", "data": {"driverId": "0", "accessMode": null, "bookmarks": null, "database": null, "fetchSize": null, "impersonatedUser": null, "notificationsMinSeverity": "WARNING"}}'
2023-04-06T13:20:14.781204 FINE neo4j.org.testkit.backend.channel.handler.TestkitRequestResponseMapperHandler - Outbound Testkit message '{"name":"Session","data":{"id":"1"}}'
```

The level is selected by setting a `TESTKIT_BACKEND_LOGGING_LEVEL` environment variable to one of the values supported by the `java.util.logging.Level.parse(String)`. The absence of the value or an empty string turns the logging off.

This feature is meant for debugging purposes only.