### PR TITLE
Fix logging IP version 6 addresses with scope in RediscoveryImpl

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -299,13 +299,12 @@ public class RediscoveryImpl implements Rediscovery {
             throw new CompletionException(error);
         }
 
-        // Retriable error happened during discovery.
+        // Retryable error happened during discovery.
         DiscoveryException discoveryError =
                 new DiscoveryException(format(RECOVERABLE_ROUTING_ERROR, routerAddress), error);
         Futures.combineErrors(baseError, discoveryError); // we record each failure here
-        String warningMessage = format(RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER, routerAddress);
-        log.warn(warningMessage);
-        log.debug(warningMessage, discoveryError);
+        log.warn(RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER, routerAddress);
+        log.debug(format(RECOVERABLE_DISCOVERY_ERROR_WITH_SERVER, routerAddress), discoveryError);
         routingTable.forget(routerAddress);
         return null;
     }


### PR DESCRIPTION
Cherry-pick: #1435

The `Inet6Address.getHostAddress()` returns a string with `%scope-id` at the end if it is scoped. For instance, `fe80:0:0:0:ce66:1564:db8q:94b6%6`.

The `RediscoveryImpl` error handling logic used to construct a log message with such address that it logged using the `Logger.warn(String, Object...)` method. Example: `log.warn(message)`.

Some implementations of the `Logger` interface supply the values given directly to the `String.format(String, Object...)` method. Given that the first argument is considered to be a format string, an `IllegalFormatException` may be thrown. That used to happen when the log message contained the scoped IP version 6 `getHostAddress()` value since the log message was treated as the format string.

This update fixes this issue by supplying the format string and the address values individually and letting the logger implementations to do the formatting as the log message should not be seen as the format string value.