### PR TITLE
Introduce home database resolution cache

### DIFF
--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/NettyBoltConnectionProvider.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/NettyBoltConnectionProvider.java
@@ -116,7 +116,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
             String impersonatedUser,
             BoltProtocolVersion minVersion,
             NotificationConfig notificationConfig,
-            Consumer<DatabaseName> databaseNameConsumer) {
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters) {
         synchronized (this) {
             if (closeFuture != null) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Connection provider is closed."));
@@ -189,7 +190,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(BoltConnection::close);
     }
 
@@ -204,7 +206,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(boltConnection -> {
                     var supports = boltConnection.protocolVersion().compareTo(BoltProtocolV4.VERSION) >= 0;
                     return boltConnection.close().thenApply(ignored -> supports);
@@ -222,7 +225,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(boltConnection -> {
                     var supports = BoltProtocolV51.VERSION.compareTo(boltConnection.protocolVersion()) <= 0;
                     return boltConnection.close().thenApply(ignored -> supports);

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/NetworkConnection.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/NetworkConnection.java
@@ -53,6 +53,7 @@ public class NetworkConnection implements Connection {
     private final String serverAgent;
     private final BoltServerAddress serverAddress;
     private final boolean telemetryEnabled;
+    private final boolean ssrEnabled;
     private final BoltProtocol protocol;
 
     private final Long connectionReadTimeout;
@@ -67,6 +68,7 @@ public class NetworkConnection implements Connection {
         this.serverAgent = ChannelAttributes.serverAgent(channel);
         this.serverAddress = ChannelAttributes.serverAddress(channel);
         this.telemetryEnabled = ChannelAttributes.telemetryEnabled(channel);
+        this.ssrEnabled = ChannelAttributes.ssrEnabled(channel);
         this.protocol = BoltProtocol.forChannel(channel);
         this.connectionReadTimeout =
                 ChannelAttributes.connectionReadTimeout(channel).orElse(null);
@@ -109,6 +111,11 @@ public class NetworkConnection implements Connection {
     @Override
     public boolean isTelemetryEnabled() {
         return telemetryEnabled;
+    }
+
+    @Override
+    public boolean isSsrEnabled() {
+        return ssrEnabled;
     }
 
     @Override

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/BoltProtocolUtil.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/BoltProtocolUtil.java
@@ -27,7 +27,7 @@ import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v41.BoltProtocolV
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v42.BoltProtocolV42;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v44.BoltProtocolV44;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v5.BoltProtocolV5;
-import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v57.BoltProtocolV57;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v58.BoltProtocolV58;
 
 public final class BoltProtocolUtil {
     public static final int BOLT_MAGIC_PREAMBLE = 0x6060B017;
@@ -39,7 +39,7 @@ public final class BoltProtocolUtil {
 
     private static final ByteBuf HANDSHAKE_BUF = unreleasableBuffer(copyInt(
                     BOLT_MAGIC_PREAMBLE,
-                    BoltProtocolV57.VERSION.toIntRange(BoltProtocolV5.VERSION),
+                    BoltProtocolV58.VERSION.toIntRange(BoltProtocolV5.VERSION),
                     BoltProtocolV44.VERSION.toIntRange(BoltProtocolV42.VERSION),
                     BoltProtocolV41.VERSION.toInt(),
                     BoltProtocolV3.VERSION.toInt()))

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/ChannelAttributes.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/ChannelAttributes.java
@@ -45,8 +45,8 @@ public final class ChannelAttributes {
 
     // configuration hints provided by the server
     private static final AttributeKey<Long> CONNECTION_READ_TIMEOUT = newInstance("connectionReadTimeout");
-
     private static final AttributeKey<Boolean> TELEMETRY_ENABLED = newInstance("telemetryEnabled");
+    private static final AttributeKey<Boolean> SSR_ENABLED = newInstance("ssr.enabled");
 
     private ChannelAttributes() {}
 
@@ -151,6 +151,14 @@ public final class ChannelAttributes {
 
     public static boolean telemetryEnabled(Channel channel) {
         return Optional.ofNullable(get(channel, TELEMETRY_ENABLED)).orElse(false);
+    }
+
+    public static void setSsrEnabled(Channel channel, Boolean telemetryEnabled) {
+        setOnce(channel, SSR_ENABLED, telemetryEnabled);
+    }
+
+    public static boolean ssrEnabled(Channel channel) {
+        return Optional.ofNullable(get(channel, SSR_ENABLED)).orElse(false);
     }
 
     private static <T> T get(Channel channel, AttributeKey<T> key) {

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/handlers/HelloV51ResponseHandler.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/handlers/HelloV51ResponseHandler.java
@@ -19,6 +19,7 @@ package org.neo4j.driver.internal.bolt.basicimpl.impl.handlers;
 import static org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes.setConnectionId;
 import static org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes.setConnectionReadTimeout;
 import static org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes.setServerAgent;
+import static org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes.setSsrEnabled;
 import static org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes.setTelemetryEnabled;
 import static org.neo4j.driver.internal.bolt.basicimpl.impl.util.MetadataExtractor.extractServer;
 
@@ -35,6 +36,7 @@ public class HelloV51ResponseHandler implements ResponseHandler {
     public static final String CONFIGURATION_HINTS_KEY = "hints";
     public static final String CONNECTION_RECEIVE_TIMEOUT_SECONDS_KEY = "connection.recv_timeout_seconds";
     public static final String TELEMETRY_ENABLED_KEY = "telemetry.enabled";
+    public static final String SSR_ENABLED_KEY = "ssr.enabled";
 
     private final Channel channel;
     private final CompletableFuture<String> helloFuture;
@@ -85,6 +87,12 @@ public class HelloV51ResponseHandler implements ResponseHandler {
                         return !value.isNull() && value.asBoolean();
                     })
                     .ifPresent(telemetryEnabled -> setTelemetryEnabled(channel, telemetryEnabled));
+
+            getFromSupplierOrEmptyOnException(() -> {
+                        var value = configurationHints.get(SSR_ENABLED_KEY);
+                        return !value.isNull() && value.asBoolean();
+                    })
+                    .ifPresent(telemetryEnabled -> setSsrEnabled(channel, telemetryEnabled));
         }
     }
 

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/handlers/RunResponseHandler.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/handlers/RunResponseHandler.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.internal.bolt.basicimpl.impl.handlers;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
@@ -38,8 +39,10 @@ public class RunResponseHandler implements ResponseHandler {
         var queryKeys = metadataExtractor.extractQueryKeys(metadata);
         var resultAvailableAfter = metadataExtractor.extractResultAvailableAfter(metadata);
         var queryId = metadataExtractor.extractQueryId(metadata);
+        var db = metadata.get("db");
+        var databaseName = db != null ? db.asString() : null;
 
-        runFuture.complete(new RunResponseImpl(queryId, queryKeys, resultAvailableAfter));
+        runFuture.complete(new RunResponseImpl(queryId, queryKeys, resultAvailableAfter, databaseName));
     }
 
     @Override
@@ -52,5 +55,11 @@ public class RunResponseHandler implements ResponseHandler {
         throw new UnsupportedOperationException();
     }
 
-    private record RunResponseImpl(long queryId, List<String> keys, long resultAvailableAfter) implements RunSummary {}
+    private record RunResponseImpl(long queryId, List<String> keys, long resultAvailableAfter, String database)
+            implements RunSummary {
+        @Override
+        public Optional<String> databaseName() {
+            return Optional.ofNullable(database);
+        }
+    }
 }

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/BoltProtocol.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/BoltProtocol.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.internal.bolt.api.NotificationConfig;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
 import org.neo4j.driver.internal.bolt.api.exception.BoltClientException;
 import org.neo4j.driver.internal.bolt.api.exception.BoltUnsupportedFeatureException;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.DiscardSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RouteSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
@@ -53,6 +54,7 @@ import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v54.BoltProtocolV
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v55.BoltProtocolV55;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v56.BoltProtocolV56;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v57.BoltProtocolV57;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v58.BoltProtocolV58;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.spi.Connection;
 
 public interface BoltProtocol {
@@ -90,7 +92,7 @@ public interface BoltProtocol {
             Map<String, Value> txMetadata,
             String txType,
             NotificationConfig notificationConfig,
-            MessageHandler<Void> handler,
+            MessageHandler<BeginSummary> handler,
             LoggingProvider logging,
             ValueFactory valueFactory);
 
@@ -182,6 +184,8 @@ public interface BoltProtocol {
             return BoltProtocolV56.INSTANCE;
         } else if (BoltProtocolV57.VERSION.equals(version)) {
             return BoltProtocolV57.INSTANCE;
+        } else if (BoltProtocolV58.VERSION.equals(version)) {
+            return BoltProtocolV58.INSTANCE;
         }
         throw new BoltClientException("Unknown protocol version: " + version);
     }

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v58/BoltProtocolV58.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v58/BoltProtocolV58.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v58;
+
+import org.neo4j.driver.internal.bolt.api.BoltProtocolVersion;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.BoltProtocol;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v57.BoltProtocolV57;
+
+public class BoltProtocolV58 extends BoltProtocolV57 {
+    public static final BoltProtocolVersion VERSION = new BoltProtocolVersion(5, 8);
+    public static final BoltProtocol INSTANCE = new BoltProtocolV58();
+
+    @Override
+    public BoltProtocolVersion version() {
+        return VERSION;
+    }
+}

--- a/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/spi/Connection.java
+++ b/bolt-api-netty/src/main/java/org/neo4j/driver/internal/bolt/basicimpl/impl/spi/Connection.java
@@ -35,6 +35,8 @@ public interface Connection {
 
     boolean isTelemetryEnabled();
 
+    boolean isSsrEnabled();
+
     String serverAgent();
 
     BoltServerAddress serverAddress();

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/BoltProtocolUtilTest.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/async/connection/BoltProtocolUtilTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v3.BoltProtocolV3;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v41.BoltProtocolV41;
 import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v44.BoltProtocolV44;
-import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v57.BoltProtocolV57;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v58.BoltProtocolV58;
 
 class BoltProtocolUtilTest {
     @Test
@@ -38,7 +38,7 @@ class BoltProtocolUtilTest {
         assertByteBufContains(
                 handshakeBuf(),
                 BOLT_MAGIC_PREAMBLE,
-                (7 << 16) | BoltProtocolV57.VERSION.toInt(),
+                (8 << 16) | BoltProtocolV58.VERSION.toInt(),
                 (2 << 16) | BoltProtocolV44.VERSION.toInt(),
                 BoltProtocolV41.VERSION.toInt(),
                 BoltProtocolV3.VERSION.toInt());
@@ -46,7 +46,7 @@ class BoltProtocolUtilTest {
 
     @Test
     void shouldReturnHandshakeString() {
-        assertEquals("[0x6060b017, 460549, 132100, 260, 3]", handshakeString());
+        assertEquals("[0x6060b017, 526341, 132100, 260, 3]", handshakeString());
     }
 
     @Test

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v3/BoltProtocolV3Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v3/BoltProtocolV3Test.java
@@ -58,6 +58,7 @@ import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
 import org.neo4j.driver.internal.bolt.api.exception.BoltClientException;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RouteSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
@@ -261,7 +262,7 @@ public class BoltProtocolV3Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -305,7 +306,7 @@ public class BoltProtocolV3Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -350,7 +351,7 @@ public class BoltProtocolV3Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -394,7 +395,7 @@ public class BoltProtocolV3Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -587,7 +588,7 @@ public class BoltProtocolV3Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var future = protocol.beginTransaction(
                             connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v4/BoltProtocolV4Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v4/BoltProtocolV4Test.java
@@ -54,6 +54,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RouteSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
@@ -248,7 +249,7 @@ public final class BoltProtocolV4Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -292,7 +293,7 @@ public final class BoltProtocolV4Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -337,7 +338,7 @@ public final class BoltProtocolV4Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -381,7 +382,7 @@ public final class BoltProtocolV4Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -842,7 +843,7 @@ public final class BoltProtocolV4Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v41/BoltProtocolV41Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v41/BoltProtocolV41Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -184,7 +185,7 @@ public final class BoltProtocolV41Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -228,7 +229,7 @@ public final class BoltProtocolV41Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -273,7 +274,7 @@ public final class BoltProtocolV41Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -317,7 +318,7 @@ public final class BoltProtocolV41Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -773,7 +774,7 @@ public final class BoltProtocolV41Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v42/BoltProtocolV42Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v42/BoltProtocolV42Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -184,7 +185,7 @@ public final class BoltProtocolV42Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -228,7 +229,7 @@ public final class BoltProtocolV42Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -273,7 +274,7 @@ public final class BoltProtocolV42Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -317,7 +318,7 @@ public final class BoltProtocolV42Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -773,7 +774,7 @@ public final class BoltProtocolV42Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v43/BoltProtocolV43Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v43/BoltProtocolV43Test.java
@@ -54,6 +54,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RouteSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
@@ -249,7 +250,7 @@ public final class BoltProtocolV43Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -293,7 +294,7 @@ public final class BoltProtocolV43Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -338,7 +339,7 @@ public final class BoltProtocolV43Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -382,7 +383,7 @@ public final class BoltProtocolV43Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -838,7 +839,7 @@ public final class BoltProtocolV43Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v44/BoltProtocolV44Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v44/BoltProtocolV44Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -183,7 +184,7 @@ public class BoltProtocolV44Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -227,7 +228,7 @@ public class BoltProtocolV44Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -272,7 +273,7 @@ public class BoltProtocolV44Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -727,7 +728,7 @@ public class BoltProtocolV44Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v5/BoltProtocolV5Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v5/BoltProtocolV5Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -183,7 +184,7 @@ public class BoltProtocolV5Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -227,7 +228,7 @@ public class BoltProtocolV5Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -272,7 +273,7 @@ public class BoltProtocolV5Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -316,7 +317,7 @@ public class BoltProtocolV5Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -772,7 +773,7 @@ public class BoltProtocolV5Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v51/BoltProtocolV51Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v51/BoltProtocolV51Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -159,7 +160,7 @@ public class BoltProtocolV51Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -203,7 +204,7 @@ public class BoltProtocolV51Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -248,7 +249,7 @@ public class BoltProtocolV51Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -292,7 +293,7 @@ public class BoltProtocolV51Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -748,7 +749,7 @@ public class BoltProtocolV51Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v52/BoltProtocolV52Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v52/BoltProtocolV52Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -160,7 +161,7 @@ public class BoltProtocolV52Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -204,7 +205,7 @@ public class BoltProtocolV52Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -249,7 +250,7 @@ public class BoltProtocolV52Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -293,7 +294,7 @@ public class BoltProtocolV52Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -749,7 +750,7 @@ public class BoltProtocolV52Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v53/BoltProtocolV53Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v53/BoltProtocolV53Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -160,7 +161,7 @@ public class BoltProtocolV53Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -204,7 +205,7 @@ public class BoltProtocolV53Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -249,7 +250,7 @@ public class BoltProtocolV53Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -293,7 +294,7 @@ public class BoltProtocolV53Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -749,7 +750,7 @@ public class BoltProtocolV53Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v54/BoltProtocolV54Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v54/BoltProtocolV54Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -160,7 +161,7 @@ public class BoltProtocolV54Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -204,7 +205,7 @@ public class BoltProtocolV54Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -249,7 +250,7 @@ public class BoltProtocolV54Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -293,7 +294,7 @@ public class BoltProtocolV54Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -750,7 +751,7 @@ public class BoltProtocolV54Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v55/BoltProtocolV55Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v55/BoltProtocolV55Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -161,7 +162,7 @@ public class BoltProtocolV55Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -205,7 +206,7 @@ public class BoltProtocolV55Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -250,7 +251,7 @@ public class BoltProtocolV55Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -294,7 +295,7 @@ public class BoltProtocolV55Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -751,7 +752,7 @@ public class BoltProtocolV55Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v56/BoltProtocolV56Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v56/BoltProtocolV56Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -161,7 +162,7 @@ public class BoltProtocolV56Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -205,7 +206,7 @@ public class BoltProtocolV56Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -250,7 +251,7 @@ public class BoltProtocolV56Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -294,7 +295,7 @@ public class BoltProtocolV56Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -751,7 +752,7 @@ public class BoltProtocolV56Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v57/BoltProtocolV57Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v57/BoltProtocolV57Test.java
@@ -52,6 +52,7 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.bolt.api.test.values.TestValueFactory;
 import org.neo4j.driver.internal.bolt.api.AccessMode;
 import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
 import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
 import org.neo4j.driver.internal.bolt.api.values.Value;
 import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
@@ -160,7 +161,7 @@ public class BoltProtocolV57Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -204,7 +205,7 @@ public class BoltProtocolV57Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
 
         var stage = protocol.beginTransaction(
@@ -249,7 +250,7 @@ public class BoltProtocolV57Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
         var stage = protocol.beginTransaction(
                 connection,
@@ -293,7 +294,7 @@ public class BoltProtocolV57Test {
             return expectedStage;
         });
         @SuppressWarnings("unchecked")
-        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
         var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
 
         var stage = protocol.beginTransaction(
@@ -741,7 +742,7 @@ public class BoltProtocolV57Test {
                 return expectedStage;
             });
             @SuppressWarnings("unchecked")
-            var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
 
             var stage = protocol.beginTransaction(
                     connection,

--- a/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v58/BoltProtocolV58Test.java
+++ b/bolt-api-netty/src/test/java/org/neo4j/driver/internal/bolt/basicimpl/impl/messaging/v58/BoltProtocolV58Test.java
@@ -1,0 +1,783 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v58;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.driver.internal.bolt.api.DatabaseNameUtil.database;
+import static org.neo4j.driver.internal.bolt.api.DatabaseNameUtil.defaultDatabase;
+import static org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.RunWithMetadataMessage.autoCommitTxRunMessage;
+import static org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.RunWithMetadataMessage.unmanagedTxRunMessage;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.stubbing.Answer;
+import org.neo4j.bolt.api.test.values.TestValueFactory;
+import org.neo4j.driver.internal.bolt.api.AccessMode;
+import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.summary.BeginSummary;
+import org.neo4j.driver.internal.bolt.api.summary.RunSummary;
+import org.neo4j.driver.internal.bolt.api.values.Value;
+import org.neo4j.driver.internal.bolt.api.values.ValueFactory;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.NoopLoggingProvider;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.async.connection.ChannelAttributes;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.async.inbound.InboundMessageDispatcher;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.handlers.BeginTxResponseHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.handlers.CommitTxResponseHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.handlers.PullResponseHandlerImpl;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.handlers.RollbackTxResponseHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.handlers.RunResponseHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.BoltProtocol;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.MessageFormat;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.MessageHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.PullMessageHandler;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.BeginMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.CommitMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.HelloMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.LogonMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.PullMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.RollbackMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.request.TelemetryMessage;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.messaging.v57.MessageFormatV57;
+import org.neo4j.driver.internal.bolt.basicimpl.impl.spi.Connection;
+
+public class BoltProtocolV58Test {
+    private static final ValueFactory valueFactory = TestValueFactory.INSTANCE;
+    private static final String query = "RETURN $x";
+    private static final Map<String, Value> query_params = singletonMap("x", value(42));
+    private static final long UNLIMITED_FETCH_SIZE = -1;
+    private static final Duration txTimeout = ofSeconds(12);
+    private static final Map<String, Value> txMetadata = singletonMap("x", value(42));
+
+    protected final BoltProtocol protocol = createProtocol();
+    private final EmbeddedChannel channel = new EmbeddedChannel();
+    private final InboundMessageDispatcher messageDispatcher =
+            new InboundMessageDispatcher(channel, NoopLoggingProvider.INSTANCE);
+
+    @SuppressWarnings("SameReturnValue")
+    protected BoltProtocol createProtocol() {
+        return BoltProtocolV58.INSTANCE;
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        ChannelAttributes.setMessageDispatcher(channel, messageDispatcher);
+    }
+
+    @AfterEach
+    void afterEach() {
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void shouldCreateMessageFormat() {
+        assertInstanceOf(expectedMessageFormatType(), protocol.createMessageFormat());
+    }
+
+    @Test
+    void shouldInitializeChannel() {
+        var clock = mock(Clock.class);
+        var time = 1L;
+        when(clock.millis()).thenReturn(time);
+
+        var latestAuthMillisFuture = new CompletableFuture<Long>();
+
+        var future = protocol.initializeChannel(
+                        channel,
+                        "MyDriver/0.0.1",
+                        null,
+                        Collections.emptyMap(),
+                        RoutingContext.EMPTY,
+                        null,
+                        clock,
+                        latestAuthMillisFuture,
+                        valueFactory)
+                .toCompletableFuture();
+
+        assertEquals(2, channel.outboundMessages().size());
+        assertInstanceOf(HelloMessage.class, channel.outboundMessages().poll());
+        assertInstanceOf(LogonMessage.class, channel.outboundMessages().poll());
+        assertEquals(2, messageDispatcher.queuedHandlersCount());
+        assertFalse(future.isDone());
+
+        var metadata = Map.of(
+                "server", value("Neo4j/3.5.0"),
+                "connection_id", value("bolt-42"));
+
+        messageDispatcher.handleSuccessMessage(metadata);
+        messageDispatcher.handleSuccessMessage(Collections.emptyMap());
+
+        assertTrue(future.isDone());
+        assertEquals(channel, future.join());
+        verify(clock).millis();
+        assertTrue(latestAuthMillisFuture.isDone());
+        assertEquals(time, latestAuthMillisFuture.join());
+    }
+
+    @Test
+    void shouldBeginTransactionWithoutBookmark() {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var beginHandler = (BeginTxResponseHandler) invocation.getArgument(1);
+            beginHandler.onSuccess(emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
+
+        var stage = protocol.beginTransaction(
+                connection,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                Collections.emptySet(),
+                null,
+                Collections.emptyMap(),
+                null,
+                null,
+                handler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, stage);
+        var message = new BeginMessage(
+                Collections.emptySet(),
+                null,
+                Collections.emptyMap(),
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(message), any(BeginTxResponseHandler.class));
+        then(handler).should().onSummary(any());
+    }
+
+    @Test
+    void shouldBeginTransactionWithBookmarks() {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var beginHandler = (BeginTxResponseHandler) invocation.getArgument(1);
+            beginHandler.onSuccess(emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
+        var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx100");
+
+        var stage = protocol.beginTransaction(
+                connection,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                bookmarks,
+                null,
+                Collections.emptyMap(),
+                null,
+                null,
+                handler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, stage);
+        var message = new BeginMessage(
+                bookmarks,
+                null,
+                Collections.emptyMap(),
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(message), any(BeginTxResponseHandler.class));
+        then(handler).should().onSummary(any());
+    }
+
+    @Test
+    void shouldBeginTransactionWithConfig() {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var beginHandler = (BeginTxResponseHandler) invocation.getArgument(1);
+            beginHandler.onSuccess(emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
+
+        var stage = protocol.beginTransaction(
+                connection,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                Collections.emptySet(),
+                txTimeout,
+                txMetadata,
+                null,
+                null,
+                handler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, stage);
+        var message = new BeginMessage(
+                Collections.emptySet(),
+                txTimeout,
+                txMetadata,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(message), any(BeginTxResponseHandler.class));
+        then(handler).should().onSummary(any());
+    }
+
+    @Test
+    void shouldBeginTransactionWithBookmarksAndConfig() {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var beginHandler = (BeginTxResponseHandler) invocation.getArgument(1);
+            beginHandler.onSuccess(emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
+        var bookmarks = Collections.singleton("neo4j:bookmark:v1:tx4242");
+
+        var stage = protocol.beginTransaction(
+                connection,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                bookmarks,
+                txTimeout,
+                txMetadata,
+                null,
+                null,
+                handler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, stage);
+        var message = new BeginMessage(
+                bookmarks,
+                txTimeout,
+                txMetadata,
+                defaultDatabase(),
+                AccessMode.WRITE,
+                null,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(message), any(BeginTxResponseHandler.class));
+        then(handler).should().onSummary(any());
+    }
+
+    @Test
+    void shouldCommitTransaction() {
+        var bookmarkString = "neo4j:bookmark:v1:tx4242";
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var commitHandler = (CommitTxResponseHandler) invocation.getArgument(1);
+            commitHandler.onSuccess(Map.of("bookmark", value(bookmarkString)));
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<String>) mock(MessageHandler.class);
+
+        var stage = protocol.commitTransaction(connection, handler);
+
+        assertEquals(expectedStage, stage);
+        then(connection).should().write(eq(CommitMessage.COMMIT), any(CommitTxResponseHandler.class));
+        then(handler).should().onSummary(bookmarkString);
+    }
+
+    @Test
+    void shouldRollbackTransaction() {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var rollbackHandler = (RollbackTxResponseHandler) invocation.getArgument(1);
+            rollbackHandler.onSuccess(Collections.emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<Void>) mock(MessageHandler.class);
+
+        var stage = protocol.rollbackTransaction(connection, handler);
+
+        assertEquals(expectedStage, stage);
+        then(connection).should().write(eq(RollbackMessage.ROLLBACK), any(RollbackTxResponseHandler.class));
+        then(handler).should().onSummary(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitTransactionAndWaitForRunResponse(AccessMode mode) {
+        testRunAndWaitForRunResponse(true, null, Collections.emptyMap(), mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitWithConfigTransactionAndWaitForRunResponse(AccessMode mode) {
+        testRunAndWaitForRunResponse(true, txTimeout, txMetadata, mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitTransactionAndWaitForSuccessRunResponse(AccessMode mode) {
+        testSuccessfulRunInAutoCommitTxWithWaitingForResponse(
+                Collections.emptySet(), null, Collections.emptyMap(), mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitTransactionWithBookmarkAndConfigAndWaitForSuccessRunResponse(AccessMode mode) {
+        testSuccessfulRunInAutoCommitTxWithWaitingForResponse(
+                Collections.singleton("neo4j:bookmark:v1:tx65"), txTimeout, txMetadata, mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitTransactionAndWaitForFailureRunResponse(AccessMode mode) {
+        testFailedRunInAutoCommitTxWithWaitingForResponse(Collections.emptySet(), null, Collections.emptyMap(), mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInAutoCommitTransactionWithBookmarkAndConfigAndWaitForFailureRunResponse(AccessMode mode) {
+        testFailedRunInAutoCommitTxWithWaitingForResponse(
+                Collections.singleton("neo4j:bookmark:v1:tx163"), txTimeout, txMetadata, mode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AccessMode.class)
+    void shouldRunInUnmanagedTransactionAndWaitForRunResponse(AccessMode mode) {
+        testRunAndWaitForRunResponse(false, null, Collections.emptyMap(), mode);
+    }
+
+    @Test
+    void shouldRunInUnmanagedTransactionAndWaitForSuccessRunResponse() {
+        testRunInUnmanagedTransactionAndWaitForRunResponse(true);
+    }
+
+    @Test
+    void shouldRunInUnmanagedTransactionAndWaitForFailureRunResponse() {
+        testRunInUnmanagedTransactionAndWaitForRunResponse(false);
+    }
+
+    @Test
+    void databaseNameInBeginTransaction() {
+        testDatabaseNameSupport(false);
+    }
+
+    @Test
+    void databaseNameForAutoCommitTransactions() {
+        testDatabaseNameSupport(true);
+    }
+
+    @Test
+    void shouldSupportDatabaseNameInBeginTransaction() {
+        var connection = mock(Connection.class);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willReturn(expectedStage);
+        var future = protocol.beginTransaction(
+                connection,
+                database("foo"),
+                AccessMode.WRITE,
+                null,
+                Collections.emptySet(),
+                null,
+                Collections.emptyMap(),
+                null,
+                null,
+                mock(),
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, future);
+        then(connection).should().write(any(), any());
+    }
+
+    @Test
+    void shouldNotSupportDatabaseNameForAutoCommitTransactions() {
+        var connection = mock(Connection.class);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willReturn(expectedStage);
+        var future = protocol.runAuto(
+                connection,
+                database("foo"),
+                AccessMode.WRITE,
+                null,
+                query,
+                query_params,
+                Collections.emptySet(),
+                txTimeout,
+                txMetadata,
+                null,
+                mock(),
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+
+        assertEquals(expectedStage, future);
+        then(connection).should().write(any(), any());
+    }
+
+    @Test
+    void shouldTelemetrySendTelemetryMessage() {
+        var connection = mock(Connection.class);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        var expectedApi = 1;
+        given(connection.write(any(), any())).willReturn(expectedStage);
+
+        var future = protocol.telemetry(connection, expectedApi, mock());
+
+        assertEquals(expectedStage, future);
+        then(connection).should().write(eq(new TelemetryMessage(expectedApi)), any());
+    }
+
+    private Class<? extends MessageFormat> expectedMessageFormatType() {
+        return MessageFormatV57.class;
+    }
+
+    private void testFailedRunInAutoCommitTxWithWaitingForResponse(
+            Set<String> bookmarks, Duration txTimeout, Map<String, Value> txMetadata, AccessMode mode) {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        Throwable error = new RuntimeException();
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var runHandler = (RunResponseHandler) invocation.getArgument(1);
+            runHandler.onFailure(error);
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<RunSummary>) mock(MessageHandler.class);
+
+        var stage = protocol.runAuto(
+                connection,
+                defaultDatabase(),
+                mode,
+                null,
+                query,
+                query_params,
+                bookmarks,
+                txTimeout,
+                txMetadata,
+                null,
+                handler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        assertEquals(expectedStage, stage);
+        var message = autoCommitTxRunMessage(
+                query,
+                query_params,
+                txTimeout,
+                txMetadata,
+                defaultDatabase(),
+                mode,
+                bookmarks,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(message), any(RunResponseHandler.class));
+        then(handler).should().onError(error);
+    }
+
+    private void testSuccessfulRunInAutoCommitTxWithWaitingForResponse(
+            Set<String> bookmarks, Duration txTimeout, Map<String, Value> txMetadata, AccessMode mode) {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedRunStage = CompletableFuture.<Void>completedStage(null);
+        var expectedPullStage = CompletableFuture.<Void>completedStage(null);
+        var newBookmarkValue = "neo4j:bookmark:v1:tx98765";
+        given(connection.write(any(), any()))
+                .willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+                    var runHandler = (RunResponseHandler) invocation.getArgument(1);
+                    runHandler.onSuccess(emptyMap());
+                    return expectedRunStage;
+                })
+                .willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+                    var pullHandler = (PullResponseHandlerImpl) invocation.getArgument(1);
+                    pullHandler.onSuccess(Map.of("has_more", value(false), "bookmark", value(newBookmarkValue)));
+                    return expectedPullStage;
+                });
+        @SuppressWarnings("unchecked")
+        var runHandler = (MessageHandler<RunSummary>) mock(MessageHandler.class);
+        var pullHandler = mock(PullMessageHandler.class);
+
+        var runStage = protocol.runAuto(
+                connection,
+                defaultDatabase(),
+                mode,
+                null,
+                query,
+                query_params,
+                bookmarks,
+                txTimeout,
+                txMetadata,
+                null,
+                runHandler,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        var pullStage = protocol.pull(connection, 0, UNLIMITED_FETCH_SIZE, pullHandler, valueFactory);
+
+        assertEquals(expectedRunStage, runStage);
+        assertEquals(expectedPullStage, pullStage);
+        var runMessage = autoCommitTxRunMessage(
+                query,
+                query_params,
+                txTimeout,
+                txMetadata,
+                defaultDatabase(),
+                mode,
+                bookmarks,
+                null,
+                null,
+                false,
+                NoopLoggingProvider.INSTANCE,
+                valueFactory);
+        then(connection).should().write(eq(runMessage), any(RunResponseHandler.class));
+        var pullMessage = new PullMessage(UNLIMITED_FETCH_SIZE, 0L, valueFactory);
+        then(connection).should().write(eq(pullMessage), any(PullResponseHandlerImpl.class));
+        then(runHandler).should().onSummary(any());
+        then(pullHandler)
+                .should()
+                .onSummary(new PullResponseHandlerImpl.PullSummaryImpl(
+                        false, Map.of("has_more", value(false), "bookmark", value(newBookmarkValue))));
+    }
+
+    protected void testRunInUnmanagedTransactionAndWaitForRunResponse(boolean success) {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        Throwable error = new RuntimeException();
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var runHandler = (RunResponseHandler) invocation.getArgument(1);
+            if (success) {
+                runHandler.onSuccess(emptyMap());
+            } else {
+                runHandler.onFailure(error);
+            }
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<RunSummary>) mock(MessageHandler.class);
+
+        var stage = protocol.run(connection, query, query_params, handler);
+
+        assertEquals(expectedStage, stage);
+        var message = unmanagedTxRunMessage(query, query_params);
+        then(connection).should().write(eq(message), any(RunResponseHandler.class));
+        if (success) {
+            then(handler).should().onSummary(any());
+        } else {
+            then(handler).should().onError(error);
+        }
+    }
+
+    protected void testRunAndWaitForRunResponse(
+            boolean autoCommitTx, Duration txTimeout, Map<String, Value> txMetadata, AccessMode mode) {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+            var runHandler = (RunResponseHandler) invocation.getArgument(1);
+            runHandler.onSuccess(emptyMap());
+            return expectedStage;
+        });
+        @SuppressWarnings("unchecked")
+        var handler = (MessageHandler<RunSummary>) mock(MessageHandler.class);
+        var initialBookmarks = Collections.singleton("neo4j:bookmark:v1:tx987");
+
+        if (autoCommitTx) {
+            var stage = protocol.runAuto(
+                    connection,
+                    defaultDatabase(),
+                    mode,
+                    null,
+                    query,
+                    query_params,
+                    initialBookmarks,
+                    txTimeout,
+                    txMetadata,
+                    null,
+                    handler,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+            assertEquals(expectedStage, stage);
+            var message = autoCommitTxRunMessage(
+                    query,
+                    query_params,
+                    txTimeout,
+                    txMetadata,
+                    defaultDatabase(),
+                    mode,
+                    initialBookmarks,
+                    null,
+                    null,
+                    false,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+
+            then(connection).should().write(eq(message), any(RunResponseHandler.class));
+            then(handler).should().onSummary(any());
+        } else {
+            var stage = protocol.run(connection, query, query_params, handler);
+
+            assertEquals(expectedStage, stage);
+            var message = unmanagedTxRunMessage(query, query_params);
+            then(connection).should().write(eq(message), any(RunResponseHandler.class));
+            then(handler).should().onSummary(any());
+        }
+    }
+
+    private void testDatabaseNameSupport(boolean autoCommitTx) {
+        var connection = mock(Connection.class);
+        given(connection.protocol()).willReturn(protocol);
+        var expectedStage = CompletableFuture.<Void>completedStage(null);
+        if (autoCommitTx) {
+            given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+                var runHandler = (RunResponseHandler) invocation.getArgument(1);
+                runHandler.onSuccess(Collections.emptyMap());
+                return expectedStage;
+            });
+            @SuppressWarnings("unchecked")
+            var handler = (MessageHandler<RunSummary>) mock(MessageHandler.class);
+
+            var stage = protocol.runAuto(
+                    connection,
+                    defaultDatabase(),
+                    AccessMode.WRITE,
+                    null,
+                    query,
+                    query_params,
+                    Collections.emptySet(),
+                    txTimeout,
+                    txMetadata,
+                    null,
+                    handler,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+            assertEquals(expectedStage, stage);
+            var message = autoCommitTxRunMessage(
+                    query,
+                    query_params,
+                    txTimeout,
+                    txMetadata,
+                    defaultDatabase(),
+                    AccessMode.WRITE,
+                    Collections.emptySet(),
+                    null,
+                    null,
+                    false,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+            then(connection).should().write(eq(message), any(RunResponseHandler.class));
+            then(handler).should().onSummary(any());
+        } else {
+            given(connection.write(any(), any())).willAnswer((Answer<CompletionStage<Void>>) invocation -> {
+                var beginHandler = (BeginTxResponseHandler) invocation.getArgument(1);
+                beginHandler.onSuccess(emptyMap());
+                return expectedStage;
+            });
+            @SuppressWarnings("unchecked")
+            var handler = (MessageHandler<BeginSummary>) mock(MessageHandler.class);
+
+            var stage = protocol.beginTransaction(
+                    connection,
+                    defaultDatabase(),
+                    AccessMode.WRITE,
+                    null,
+                    Collections.emptySet(),
+                    null,
+                    Collections.emptyMap(),
+                    null,
+                    null,
+                    handler,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+
+            assertEquals(expectedStage, stage);
+            var message = new BeginMessage(
+                    Collections.emptySet(),
+                    null,
+                    Collections.emptyMap(),
+                    defaultDatabase(),
+                    AccessMode.WRITE,
+                    null,
+                    null,
+                    null,
+                    false,
+                    NoopLoggingProvider.INSTANCE,
+                    valueFactory);
+            then(connection).should().write(eq(message), any(BeginTxResponseHandler.class));
+            then(handler).should().onSummary(any());
+        }
+    }
+
+    private static Value value(Object value) {
+        return valueFactory.value(value);
+    }
+}

--- a/bolt-api-pooled/src/main/java/org/neo4j/driver/internal/bolt/pooledimpl/PooledBoltConnectionProvider.java
+++ b/bolt-api-pooled/src/main/java/org/neo4j/driver/internal/bolt/pooledimpl/PooledBoltConnectionProvider.java
@@ -135,7 +135,8 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
             String impersonatedUser,
             BoltProtocolVersion minVersion,
             NotificationConfig notificationConfig,
-            Consumer<DatabaseName> databaseNameConsumer) {
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters) {
         synchronized (this) {
             if (closeStage != null) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Connection provider is closed."));
@@ -341,7 +342,8 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
                                 impersonatedUser,
                                 minVersion,
                                 notificationConfig,
-                                (ignored) -> {})
+                                (ignored) -> {},
+                                Collections.emptyMap())
                         .whenComplete((boltConnection, throwable) -> {
                             var error = FutureUtil.completionExceptionCause(throwable);
                             if (error != null) {
@@ -407,6 +409,7 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
             var connection = connectionEntry.connection;
             // unusable
             if (connection.state() != BoltConnectionState.OPEN) {
+                connection.close();
                 iterator.remove();
                 continue;
             }
@@ -507,7 +510,8 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(BoltConnection::close);
     }
 
@@ -522,7 +526,8 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(boltConnection -> {
                     var supports = boltConnection.protocolVersion().compareTo(new BoltProtocolVersion(4, 0)) >= 0;
                     return boltConnection.close().thenApply(ignored -> supports);
@@ -540,7 +545,8 @@ public class PooledBoltConnectionProvider implements BoltConnectionProvider {
                         null,
                         null,
                         null,
-                        (ignored) -> {})
+                        (ignored) -> {},
+                        Collections.emptyMap())
                 .thenCompose(boltConnection -> {
                     var supports = new BoltProtocolVersion(5, 1).compareTo(boltConnection.protocolVersion()) <= 0;
                     return boltConnection.close().thenApply(ignored -> supports);

--- a/bolt-api-pooled/src/main/java/org/neo4j/driver/internal/bolt/pooledimpl/impl/PooledBoltConnection.java
+++ b/bolt-api-pooled/src/main/java/org/neo4j/driver/internal/bolt/pooledimpl/impl/PooledBoltConnection.java
@@ -345,6 +345,11 @@ public class PooledBoltConnection implements BoltConnection {
         return delegate.telemetrySupported();
     }
 
+    @Override
+    public boolean serverSideRoutingEnabled() {
+        return delegate.serverSideRoutingEnabled();
+    }
+
     // internal use only
     public BoltConnection delegate() {
         return delegate;

--- a/bolt-api-pooled/src/test/java/org/neo4j/driver/internal/bolt/pooledimpl/PooledBoltConnectionProviderTest.java
+++ b/bolt-api-pooled/src/test/java/org/neo4j/driver/internal/bolt/pooledimpl/PooledBoltConnectionProviderTest.java
@@ -138,6 +138,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
 
@@ -151,7 +152,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -169,6 +171,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any());
         assertEquals(1, provider.inUse());
         assertEquals(1, provider.size());
@@ -187,6 +190,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider = new PooledBoltConnectionProvider(
@@ -201,7 +205,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -215,7 +220,8 @@ class PooledBoltConnectionProviderTest {
                 null,
                 minVersion,
                 notificationConfig,
-                databaseNameConsumer);
+                databaseNameConsumer,
+                Collections.emptyMap());
 
         // then
         var completionException = assertThrows(
@@ -243,6 +249,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         var connection = provider.connect(
@@ -254,7 +261,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -291,6 +299,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider.connect(
@@ -302,7 +311,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -320,7 +330,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -354,6 +365,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider.connect(
@@ -365,7 +377,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -399,6 +412,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
 
@@ -419,6 +433,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any());
         then(connection).should().reset();
         then(connection).should().flush(any());
@@ -445,6 +460,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
 
@@ -466,6 +482,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any());
         then(connection).should().reset();
         then(connection).should().flush(any());
@@ -498,6 +515,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
 
@@ -519,6 +537,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(null),
                         eq(null),
+                        any(),
                         any());
         then(connection).should().reset();
         then(connection).should().flush(any());
@@ -551,6 +570,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider.connect(
@@ -562,7 +582,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -579,7 +600,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         new BoltProtocolVersion(5, 5),
                         NotificationConfig.defaultConfig(),
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture();
 
         // then
@@ -609,6 +631,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection))
                 .willReturn(CompletableFuture.completedStage(connection2));
@@ -621,7 +644,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -639,7 +663,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         NotificationConfig.defaultConfig(),
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -675,6 +700,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider.connect(
@@ -686,7 +712,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -704,7 +731,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         NotificationConfig.defaultConfig(),
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 
@@ -745,6 +773,7 @@ class PooledBoltConnectionProviderTest {
                         eq(null),
                         eq(minVersion),
                         eq(notificationConfig),
+                        any(),
                         any()))
                 .willReturn(CompletableFuture.completedStage(connection));
         provider.connect(
@@ -756,7 +785,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join()
                 .close()
@@ -773,7 +803,8 @@ class PooledBoltConnectionProviderTest {
                         null,
                         minVersion,
                         NotificationConfig.defaultConfig(),
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        Collections.emptyMap())
                 .toCompletableFuture()
                 .join();
 

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/RoutedBoltConnection.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/RoutedBoltConnection.java
@@ -302,6 +302,11 @@ public class RoutedBoltConnection implements BoltConnection {
         return delegate.telemetrySupported();
     }
 
+    @Override
+    public boolean serverSideRoutingEnabled() {
+        return delegate.serverSideRoutingEnabled();
+    }
+
     private Throwable handledError(Throwable receivedError, boolean notifyHandler) {
         var error = FutureUtil.completionExceptionCause(receivedError);
 

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RediscoveryImpl.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RediscoveryImpl.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -368,7 +369,8 @@ public class RediscoveryImpl implements Rediscovery {
                                 null,
                                 minVersion,
                                 null,
-                                (ignored) -> {}))
+                                (ignored) -> {},
+                                Collections.emptyMap()))
                 .thenApply(connection -> {
                     connectionRef.set(connection);
                     return connection;

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandler.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandler.java
@@ -43,4 +43,6 @@ public interface RoutingTableHandler extends RoutingErrorHandler {
     CompletionStage<RoutingTable> updateRoutingTable(ClusterCompositionLookupResult compositionLookupResult);
 
     RoutingTable routingTable();
+
+    boolean staleRoutingTable(AccessMode mode);
 }

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandlerImpl.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandlerImpl.java
@@ -208,4 +208,12 @@ public class RoutingTableHandlerImpl implements RoutingTableHandler {
     public RoutingTable routingTable() {
         return routingTable;
     }
+
+    @Override
+    public synchronized boolean staleRoutingTable(AccessMode mode) {
+        if (refreshRoutingTableFuture != null) {
+            return true;
+        }
+        return routingTable.isStaleFor(mode);
+    }
 }

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistry.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistry.java
@@ -46,7 +46,8 @@ public interface RoutingTableRegistry {
             Set<String> rediscoveryBookmarks,
             String impersonatedUser,
             Supplier<CompletionStage<Map<String, Value>>> authMapStageSupplier,
-            BoltProtocolVersion minVersion);
+            BoltProtocolVersion minVersion,
+            String homeDatabaseHint);
 
     /**
      * @return all servers in the registry

--- a/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistryImpl.java
+++ b/bolt-api-routed/src/main/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistryImpl.java
@@ -103,7 +103,16 @@ public class RoutingTableRegistryImpl implements RoutingTableRegistry {
             Set<String> rediscoveryBookmarks,
             String impersonatedUser,
             Supplier<CompletionStage<Map<String, Value>>> authMapStageSupplier,
-            BoltProtocolVersion minVersion) {
+            BoltProtocolVersion minVersion,
+            String homeDatabaseHint) {
+        if (!databaseNameFuture.isDone()) {
+            if (homeDatabaseHint != null) {
+                var handler = routingTableHandlers.get(DatabaseNameUtil.database(homeDatabaseHint));
+                if (handler != null && !handler.staleRoutingTable(mode)) {
+                    return CompletableFuture.completedFuture(handler);
+                }
+            }
+        }
         return ensureDatabaseNameIsCompleted(
                         securityPlan,
                         databaseNameFuture,

--- a/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RediscoveryTest.java
+++ b/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RediscoveryTest.java
@@ -676,7 +676,7 @@ class RediscoveryTest {
         given(domainNameResolver.resolve(initialRouter.host())).willReturn(new InetAddress[] {address});
         var table = routingTableMock(true);
         var pool = mock(BoltConnectionProvider.class);
-        given(pool.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(pool.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(failedFuture(new BoltServiceUnavailableException("not available")));
         var logging = mock(LoggingProvider.class);
         var logger = mock(System.Logger.class);
@@ -722,7 +722,7 @@ class RediscoveryTest {
             var boltConnection = setupConnection(entry.getValue());
 
             var boltConnectionProvider = mock(BoltConnectionProvider.class);
-            given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                     .willReturn(completedFuture(boltConnection));
 
             addressToProvider.put(entry.getKey(), boltConnectionProvider);

--- a/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandlerTest.java
+++ b/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableHandlerTest.java
@@ -180,7 +180,8 @@ class RoutingTableHandlerTest {
                     Set<String> rediscoveryBookmarks,
                     String impersonatedUser,
                     Supplier<CompletionStage<Map<String, Value>>> authMapStageSupplier,
-                    BoltProtocolVersion minVersion) {
+                    BoltProtocolVersion minVersion,
+                    String homeDatabaseHint) {
                 throw new UnsupportedOperationException();
             }
 
@@ -251,7 +252,8 @@ class RoutingTableHandlerTest {
         Function<BoltServerAddress, BoltConnectionProvider> connectionProviderGetter = requestedAddress -> {
             var boltConnectionProvider = mock(BoltConnectionProvider.class);
             var connection = mock(BoltConnection.class);
-            given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            given(boltConnectionProvider.connect(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), Collections.emptyMap()))
                     .willReturn(completedFuture(connection));
             return boltConnectionProvider;
         };
@@ -280,7 +282,8 @@ class RoutingTableHandlerTest {
         Function<BoltServerAddress, BoltConnectionProvider> connectionProviderGetter = requestedAddress -> {
             var boltConnectionProvider = mock(BoltConnectionProvider.class);
             var connection = mock(BoltConnection.class);
-            given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            given(boltConnectionProvider.connect(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), Collections.emptyMap()))
                     .willReturn(completedFuture(connection));
             return boltConnectionProvider;
         };
@@ -340,14 +343,16 @@ class RoutingTableHandlerTest {
         return requestedAddress -> {
             var boltConnectionProvider = mock(BoltConnectionProvider.class);
             if (unavailableAddresses.contains(requestedAddress)) {
-                given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                given(boltConnectionProvider.connect(
+                                any(), any(), any(), any(), any(), any(), any(), any(), any(), Collections.emptyMap()))
                         .willReturn(CompletableFuture.failedFuture(
                                 new BoltServiceUnavailableException(requestedAddress + " is unavailable!")));
                 return boltConnectionProvider;
             }
             var connection = mock(BoltConnection.class);
             when(connection.serverAddress()).thenReturn(requestedAddress);
-            given(boltConnectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            given(boltConnectionProvider.connect(
+                            any(), any(), any(), any(), any(), any(), any(), any(), any(), Collections.emptyMap()))
                     .willReturn(completedFuture(connection));
             return boltConnectionProvider;
         };

--- a/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistryImplTest.java
+++ b/bolt-api-routed/src/test/java/org/neo4j/driver/internal/bolt/routedimpl/impl/cluster/RoutingTableRegistryImplTest.java
@@ -106,7 +106,8 @@ class RoutingTableRegistryImplTest {
                 Collections.emptySet(),
                 null,
                 () -> CompletableFuture.completedStage(Collections.emptyMap()),
-                new BoltProtocolVersion(4, 1));
+                new BoltProtocolVersion(4, 1),
+                null);
 
         // Then
         assertTrue(map.containsKey(database));
@@ -136,7 +137,8 @@ class RoutingTableRegistryImplTest {
                         Collections.emptySet(),
                         null,
                         authStageSupplier,
-                        new BoltProtocolVersion(4, 1))
+                        new BoltProtocolVersion(4, 1),
+                        null)
                 .toCompletableFuture()
                 .join();
 
@@ -173,7 +175,8 @@ class RoutingTableRegistryImplTest {
                         Collections.emptySet(),
                         null,
                         authStageSupplier,
-                        new BoltProtocolVersion(4, 1))
+                        new BoltProtocolVersion(4, 1),
+                        null)
                 .toCompletableFuture()
                 .join();
 

--- a/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/BoltConnection.java
+++ b/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/BoltConnection.java
@@ -90,4 +90,6 @@ public interface BoltConnection {
     BoltProtocolVersion protocolVersion();
 
     boolean telemetrySupported();
+
+    boolean serverSideRoutingEnabled();
 }

--- a/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/BoltConnectionProvider.java
+++ b/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/BoltConnectionProvider.java
@@ -41,7 +41,8 @@ public interface BoltConnectionProvider {
             String impersonatedUser,
             BoltProtocolVersion minVersion,
             NotificationConfig notificationConfig,
-            Consumer<DatabaseName> databaseNameConsumer);
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters);
 
     CompletionStage<Void> verifyConnectivity(SecurityPlan securityPlan, Map<String, Value> authMap);
 

--- a/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/summary/BeginSummary.java
+++ b/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/summary/BeginSummary.java
@@ -16,4 +16,8 @@
  */
 package org.neo4j.driver.internal.bolt.api.summary;
 
-public interface BeginSummary {}
+import java.util.Optional;
+
+public interface BeginSummary {
+    Optional<String> databaseName();
+}

--- a/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/summary/RunSummary.java
+++ b/bolt-api/src/main/java/org/neo4j/driver/internal/bolt/api/summary/RunSummary.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.bolt.api.summary;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RunSummary {
     long queryId();
@@ -24,4 +25,6 @@ public interface RunSummary {
     List<String> keys();
 
     long resultAvailableAfter();
+
+    Optional<String> databaseName();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/AdaptingDriverBoltConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/AdaptingDriverBoltConnection.java
@@ -223,4 +223,9 @@ final class AdaptingDriverBoltConnection implements DriverBoltConnection {
     public boolean telemetrySupported() {
         return connection.telemetrySupported();
     }
+
+    @Override
+    public boolean serverSideRoutingEnabled() {
+        return connection.serverSideRoutingEnabled();
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/AdaptingDriverBoltConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/AdaptingDriverBoltConnectionProvider.java
@@ -74,7 +74,8 @@ public class AdaptingDriverBoltConnectionProvider implements DriverBoltConnectio
             String impersonatedUser,
             BoltProtocolVersion minVersion,
             NotificationConfig notificationConfig,
-            Consumer<DatabaseName> databaseNameConsumer) {
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters) {
         return delegate.connect(
                         securityPlan,
                         databaseName,
@@ -84,7 +85,8 @@ public class AdaptingDriverBoltConnectionProvider implements DriverBoltConnectio
                         impersonatedUser,
                         minVersion,
                         notificationConfig,
-                        databaseNameConsumer)
+                        databaseNameConsumer,
+                        additionalParameters)
                 .exceptionally(errorMapper::mapAndTrow)
                 .thenApply(boltConnection -> new AdaptingDriverBoltConnection(
                         boltConnection,

--- a/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/DriverBoltConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/DriverBoltConnection.java
@@ -100,4 +100,6 @@ public interface DriverBoltConnection {
     BoltProtocolVersion protocolVersion();
 
     boolean telemetrySupported();
+
+    boolean serverSideRoutingEnabled();
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/DriverBoltConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/DriverBoltConnectionProvider.java
@@ -51,7 +51,8 @@ public interface DriverBoltConnectionProvider {
             String impersonatedUser,
             BoltProtocolVersion minVersion,
             NotificationConfig notificationConfig,
-            Consumer<DatabaseName> databaseNameConsumer);
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters);
 
     CompletionStage<Void> verifyConnectivity(SecurityPlan securityPlan, Map<String, Value> authMap);
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/DelegatingBoltConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/DelegatingBoltConnection.java
@@ -194,4 +194,9 @@ public abstract class DelegatingBoltConnection implements DriverBoltConnection {
     public boolean telemetrySupported() {
         return delegate.telemetrySupported();
     }
+
+    @Override
+    public boolean serverSideRoutingEnabled() {
+        return delegate.serverSideRoutingEnabled();
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.Logging;
 import org.neo4j.driver.NotificationConfig;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnectionProvider;
 import org.neo4j.driver.internal.bolt.api.DatabaseName;
+import org.neo4j.driver.internal.homedb.HomeDatabaseCache;
 import org.neo4j.driver.internal.retry.RetryLogic;
 import org.neo4j.driver.internal.security.BoltSecurityPlanManager;
 import org.neo4j.driver.internal.util.Futures;
@@ -52,7 +53,8 @@ public class LeakLoggingNetworkSession extends NetworkSession {
             NotificationConfig notificationConfig,
             AuthToken overrideAuthToken,
             boolean telemetryDisabled,
-            AuthTokenManager authTokenManager) {
+            AuthTokenManager authTokenManager,
+            HomeDatabaseCache homeDatabaseCache) {
         super(
                 securityPlanManager,
                 connectionProvider,
@@ -68,7 +70,8 @@ public class LeakLoggingNetworkSession extends NetworkSession {
                 notificationConfig,
                 overrideAuthToken,
                 telemetryDisabled,
-                authTokenManager);
+                authTokenManager,
+                homeDatabaseCache);
         this.stackTrace = captureStackTrace();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/boltlistener/BoltConnectionListener.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/boltlistener/BoltConnectionListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.boltlistener;
+
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+import org.neo4j.driver.internal.bolt.api.BoltConnectionProvider;
+
+public interface BoltConnectionListener {
+    void onOpen(BoltConnection boltConnection);
+
+    void onClose(BoltConnection boltConnection);
+
+    static BoltConnectionProvider listeningBoltConnectionProvider(
+            BoltConnectionProvider provider, BoltConnectionListener boltConnectionListener) {
+        return new ListeningBoltConnectionProvider(provider, boltConnectionListener);
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/boltlistener/ListeningBoltConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/boltlistener/ListeningBoltConnection.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.boltlistener;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.neo4j.driver.internal.bolt.api.AccessMode;
+import org.neo4j.driver.internal.bolt.api.AuthData;
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+import org.neo4j.driver.internal.bolt.api.BoltConnectionState;
+import org.neo4j.driver.internal.bolt.api.BoltProtocolVersion;
+import org.neo4j.driver.internal.bolt.api.BoltServerAddress;
+import org.neo4j.driver.internal.bolt.api.DatabaseName;
+import org.neo4j.driver.internal.bolt.api.NotificationConfig;
+import org.neo4j.driver.internal.bolt.api.ResponseHandler;
+import org.neo4j.driver.internal.bolt.api.TelemetryApi;
+import org.neo4j.driver.internal.bolt.api.TransactionType;
+import org.neo4j.driver.internal.bolt.api.values.Value;
+
+final class ListeningBoltConnection implements BoltConnection {
+    private final BoltConnection delegate;
+    private final BoltConnectionListener boltConnectionListener;
+
+    public ListeningBoltConnection(BoltConnection delegate, BoltConnectionListener boltConnectionListener) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.boltConnectionListener = Objects.requireNonNull(boltConnectionListener);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> onLoop() {
+        return delegate.onLoop().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> route(
+            DatabaseName databaseName, String impersonatedUser, Set<String> bookmarks) {
+        return delegate.route(databaseName, impersonatedUser, bookmarks).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> beginTransaction(
+            DatabaseName databaseName,
+            AccessMode accessMode,
+            String impersonatedUser,
+            Set<String> bookmarks,
+            TransactionType transactionType,
+            Duration txTimeout,
+            Map<String, Value> txMetadata,
+            String txType,
+            NotificationConfig notificationConfig) {
+        return delegate.beginTransaction(
+                        databaseName,
+                        accessMode,
+                        impersonatedUser,
+                        bookmarks,
+                        transactionType,
+                        txTimeout,
+                        txMetadata,
+                        txType,
+                        notificationConfig)
+                .thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> runInAutoCommitTransaction(
+            DatabaseName databaseName,
+            AccessMode accessMode,
+            String impersonatedUser,
+            Set<String> bookmarks,
+            String query,
+            Map<String, Value> parameters,
+            Duration txTimeout,
+            Map<String, Value> txMetadata,
+            NotificationConfig notificationConfig) {
+        return delegate.runInAutoCommitTransaction(
+                        databaseName,
+                        accessMode,
+                        impersonatedUser,
+                        bookmarks,
+                        query,
+                        parameters,
+                        txTimeout,
+                        txMetadata,
+                        notificationConfig)
+                .thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> run(String query, Map<String, Value> parameters) {
+        return delegate.run(query, parameters).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> pull(long qid, long request) {
+        return delegate.pull(qid, request).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> discard(long qid, long number) {
+        return delegate.discard(qid, number).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> commit() {
+        return delegate.commit().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> rollback() {
+        return delegate.rollback().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> reset() {
+        return delegate.reset().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> logoff() {
+        return delegate.logoff().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> logon(Map<String, Value> authMap) {
+        return delegate.logon(authMap).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> telemetry(TelemetryApi telemetryApi) {
+        return delegate.telemetry(telemetryApi).thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> clear() {
+        return delegate.clear().thenApply(ignored -> this);
+    }
+
+    @Override
+    public CompletionStage<Void> flush(ResponseHandler handler) {
+        return delegate.flush(handler);
+    }
+
+    @Override
+    public CompletionStage<Void> forceClose(String reason) {
+        return delegate.forceClose(reason).whenComplete((ignored, throwable) -> boltConnectionListener.onClose(this));
+    }
+
+    @Override
+    public CompletionStage<Void> close() {
+        return delegate.close().whenComplete((ignored, throwable) -> boltConnectionListener.onClose(this));
+    }
+
+    @Override
+    public BoltConnectionState state() {
+        return delegate.state();
+    }
+
+    @Override
+    public CompletionStage<AuthData> authData() {
+        return delegate.authData();
+    }
+
+    @Override
+    public String serverAgent() {
+        return delegate.serverAgent();
+    }
+
+    @Override
+    public BoltServerAddress serverAddress() {
+        return delegate.serverAddress();
+    }
+
+    @Override
+    public BoltProtocolVersion protocolVersion() {
+        return delegate.protocolVersion();
+    }
+
+    @Override
+    public boolean telemetrySupported() {
+        return delegate.telemetrySupported();
+    }
+
+    @Override
+    public boolean serverSideRoutingEnabled() {
+        return delegate.serverSideRoutingEnabled();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/boltlistener/ListeningBoltConnectionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/boltlistener/ListeningBoltConnectionProvider.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.boltlistener;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.neo4j.driver.internal.bolt.api.AccessMode;
+import org.neo4j.driver.internal.bolt.api.BoltAgent;
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+import org.neo4j.driver.internal.bolt.api.BoltConnectionProvider;
+import org.neo4j.driver.internal.bolt.api.BoltProtocolVersion;
+import org.neo4j.driver.internal.bolt.api.BoltServerAddress;
+import org.neo4j.driver.internal.bolt.api.DatabaseName;
+import org.neo4j.driver.internal.bolt.api.MetricsListener;
+import org.neo4j.driver.internal.bolt.api.NotificationConfig;
+import org.neo4j.driver.internal.bolt.api.RoutingContext;
+import org.neo4j.driver.internal.bolt.api.SecurityPlan;
+import org.neo4j.driver.internal.bolt.api.values.Value;
+
+final class ListeningBoltConnectionProvider implements BoltConnectionProvider {
+    private final BoltConnectionProvider delegate;
+    private final BoltConnectionListener boltConnectionListener;
+
+    public ListeningBoltConnectionProvider(
+            BoltConnectionProvider delegate, BoltConnectionListener boltConnectionListener) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.boltConnectionListener = Objects.requireNonNull(boltConnectionListener);
+    }
+
+    @Override
+    public CompletionStage<Void> init(
+            BoltServerAddress address,
+            RoutingContext routingContext,
+            BoltAgent boltAgent,
+            String userAgent,
+            int connectTimeoutMillis,
+            MetricsListener metricsListener) {
+        return delegate.init(address, routingContext, boltAgent, userAgent, connectTimeoutMillis, metricsListener);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> connect(
+            SecurityPlan securityPlan,
+            DatabaseName databaseName,
+            Supplier<CompletionStage<Map<String, Value>>> authMapStageSupplier,
+            AccessMode mode,
+            Set<String> bookmarks,
+            String impersonatedUser,
+            BoltProtocolVersion minVersion,
+            NotificationConfig notificationConfig,
+            Consumer<DatabaseName> databaseNameConsumer,
+            Map<String, Object> additionalParameters) {
+        return delegate.connect(
+                        securityPlan,
+                        databaseName,
+                        authMapStageSupplier,
+                        mode,
+                        bookmarks,
+                        impersonatedUser,
+                        minVersion,
+                        notificationConfig,
+                        databaseNameConsumer,
+                        additionalParameters)
+                .thenApply(boltConnection -> {
+                    boltConnection = new ListeningBoltConnection(boltConnection, boltConnectionListener);
+                    boltConnectionListener.onOpen(boltConnection);
+                    return boltConnection;
+                });
+    }
+
+    @Override
+    public CompletionStage<Void> verifyConnectivity(SecurityPlan securityPlan, Map<String, Value> authMap) {
+        return delegate.verifyConnectivity(securityPlan, authMap);
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsMultiDb(SecurityPlan securityPlan, Map<String, Value> authMap) {
+        return delegate.supportsMultiDb(securityPlan, authMap);
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsSessionAuth(SecurityPlan securityPlan, Map<String, Value> authMap) {
+        return delegate.supportsSessionAuth(securityPlan, authMap);
+    }
+
+    @Override
+    public CompletionStage<Void> close() {
+        return delegate.close();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
@@ -78,6 +78,11 @@ public class RxResultCursorImpl extends AbstractRecordStateResponseHandler
         public long resultAvailableAfter() {
             return -1;
         }
+
+        @Override
+        public Optional<String> databaseName() {
+            return Optional.empty();
+        }
     };
     private final Logger log;
     private final DriverBoltConnection boltConnection;

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/DriverHomeDatabaseCacheKey.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/DriverHomeDatabaseCacheKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+final class DriverHomeDatabaseCacheKey implements HomeDatabaseCacheKey {
+    static final DriverHomeDatabaseCacheKey INSTANCE = new DriverHomeDatabaseCacheKey();
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCache.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCache.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import java.time.Clock;
+import java.util.Optional;
+import org.neo4j.driver.internal.boltlistener.BoltConnectionListener;
+
+public interface HomeDatabaseCache extends BoltConnectionListener {
+    Optional<String> get(HomeDatabaseCacheKey key);
+
+    void put(HomeDatabaseCacheKey key, String value);
+
+    static HomeDatabaseCache newInstance(boolean routed) {
+        return routed ? new HomeDatabaseCacheImpl(1000, Clock.systemUTC()) : new NoopHomeDatabaseCache();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import java.time.Clock;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+
+final class HomeDatabaseCacheImpl implements HomeDatabaseCache {
+    private final Map<HomeDatabaseCacheKey, Entry> keyToEntry = new HashMap<>();
+    private final Set<BoltConnection> ssrEnabledBoltConnections = new HashSet<>();
+    private final Set<BoltConnection> ssrDisabledBoltConnections = new HashSet<>();
+    private final int sizeLimit;
+    private final int pruneSize;
+    private final Clock clock;
+    private boolean enabled;
+
+    public HomeDatabaseCacheImpl(int sizeLimit, Clock clock) {
+        this.sizeLimit = sizeLimit;
+        this.pruneSize = Math.max(
+                (int) Math.min(sizeLimit, ((1 / Math.log(Integer.MAX_VALUE)) * 0.8) * sizeLimit * Math.log(sizeLimit)),
+                1);
+        this.clock = Objects.requireNonNull(clock);
+    }
+
+    @Override
+    public synchronized Optional<String> get(HomeDatabaseCacheKey key) {
+        return enabled
+                ? Optional.ofNullable(keyToEntry.computeIfPresent(
+                                key, (ignored, entry) -> new Entry(entry.database(), clock.millis())))
+                        .map(Entry::database)
+                : Optional.empty();
+    }
+
+    @Override
+    public synchronized void put(HomeDatabaseCacheKey key, String value) {
+        prune();
+        keyToEntry.put(key, new Entry(value, -1));
+    }
+
+    @Override
+    public synchronized void onOpen(BoltConnection boltConnection) {
+        if (boltConnection.serverSideRoutingEnabled()) {
+            ssrEnabledBoltConnections.add(boltConnection);
+        } else {
+            ssrDisabledBoltConnections.add(boltConnection);
+        }
+        updateEnabled();
+    }
+
+    @Override
+    public synchronized void onClose(BoltConnection boltConnection) {
+        if (boltConnection.serverSideRoutingEnabled()) {
+            ssrEnabledBoltConnections.remove(boltConnection);
+        } else {
+            ssrDisabledBoltConnections.remove(boltConnection);
+        }
+        updateEnabled();
+    }
+
+    private synchronized void prune() {
+        if (keyToEntry.size() >= sizeLimit) {
+            var pruningList = keyToEntry.values().stream()
+                    .sorted(Comparator.comparing(Entry::lastUsed))
+                    .limit(pruneSize)
+                    .toList();
+            keyToEntry.values().removeAll(pruningList);
+        }
+    }
+
+    private synchronized void updateEnabled() {
+        enabled = !ssrEnabledBoltConnections.isEmpty() && ssrDisabledBoltConnections.isEmpty();
+    }
+
+    synchronized int size() {
+        return keyToEntry.size();
+    }
+
+    private record Entry(String database, long lastUsed) {}
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheKey.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheKey.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import java.util.Collections;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.internal.security.InternalAuthToken;
+
+public interface HomeDatabaseCacheKey {
+    static HomeDatabaseCacheKey of(AuthToken overrideAuthToken, String impersonatedUser) {
+        HomeDatabaseCacheKey key;
+        if (impersonatedUser != null) {
+            key = new MapHomeDatabaseCacheKey(
+                    Collections.singletonMap(InternalAuthToken.PRINCIPAL_KEY, impersonatedUser));
+        } else if (overrideAuthToken != null) {
+            var tokenMap = ((InternalAuthToken) overrideAuthToken).toMap();
+            var scheme = tokenMap.get(InternalAuthToken.SCHEME_KEY);
+            if (scheme.asString().equals("basic")) {
+                key = new MapHomeDatabaseCacheKey(Collections.singletonMap(
+                        InternalAuthToken.PRINCIPAL_KEY, tokenMap.get(InternalAuthToken.PRINCIPAL_KEY)));
+            } else {
+                key = new MapHomeDatabaseCacheKey(tokenMap);
+            }
+        } else {
+            key = DriverHomeDatabaseCacheKey.INSTANCE;
+        }
+        return key;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/MapHomeDatabaseCacheKey.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/MapHomeDatabaseCacheKey.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import java.util.Map;
+
+record MapHomeDatabaseCacheKey(Map<?, ?> map) implements HomeDatabaseCacheKey {}

--- a/driver/src/main/java/org/neo4j/driver/internal/homedb/NoopHomeDatabaseCache.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/homedb/NoopHomeDatabaseCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import java.util.Optional;
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+
+final class NoopHomeDatabaseCache implements HomeDatabaseCache {
+    @Override
+    public Optional<String> get(HomeDatabaseCacheKey key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void put(HomeDatabaseCacheKey key, String value) {}
+
+    @Override
+    public void onOpen(BoltConnection boltConnection) {}
+
+    @Override
+    public void onClose(BoltConnection boltConnection) {}
+}

--- a/driver/src/test/java/org/neo4j/driver/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ParametersTest.java
@@ -117,7 +117,8 @@ class ParametersTest {
                 Config.defaultConfig().notificationConfig(),
                 null,
                 false,
-                mock(AuthTokenManager.class));
+                mock(AuthTokenManager.class),
+                mock());
         return new InternalSession(session);
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -46,6 +46,7 @@ import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnectionProvider;
 import org.neo4j.driver.internal.async.LeakLoggingNetworkSession;
 import org.neo4j.driver.internal.async.NetworkSession;
 import org.neo4j.driver.internal.bolt.basicimpl.BootstrapFactory;
+import org.neo4j.driver.internal.homedb.HomeDatabaseCache;
 import org.neo4j.driver.internal.metrics.DevNullMetricsProvider;
 import org.neo4j.driver.internal.metrics.InternalMetricsProvider;
 import org.neo4j.driver.internal.metrics.MicrometerMetricsProvider;
@@ -157,9 +158,10 @@ class DriverFactoryTest {
                 DriverBoltConnectionProvider connectionProvider,
                 RetryLogic retryLogic,
                 Config config,
-                AuthTokenManager authTokenManager) {
+                AuthTokenManager authTokenManager,
+                HomeDatabaseCache homeDatabaseCache) {
             var sessionFactory = super.createSessionFactory(
-                    securityPlanManager, connectionProvider, retryLogic, config, authTokenManager);
+                    securityPlanManager, connectionProvider, retryLogic, config, authTokenManager, homeDatabaseCache);
             capturedSessionFactory = sessionFactory;
             return sessionFactory;
         }
@@ -183,7 +185,8 @@ class DriverFactoryTest {
                 DriverBoltConnectionProvider connectionProvider,
                 RetryLogic retryLogic,
                 Config config,
-                AuthTokenManager authTokenManager) {
+                AuthTokenManager authTokenManager,
+                HomeDatabaseCache homeDatabaseCache) {
             return sessionFactory;
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalResultTest.java
@@ -345,7 +345,7 @@ class InternalResultTest {
         when(connection.protocolVersion()).thenReturn(new BoltProtocolVersion(4, 3));
         when(connection.serverAgent()).thenReturn("Neo4j/4.2.5");
 
-        var resultCursor = new ResultCursorImpl(connection, query, -1, ignored -> {}, false, null, null);
+        var resultCursor = new ResultCursorImpl(connection, query, -1, ignored -> {}, false, null, ignored -> {}, null);
         var runSummary = mock(RunSummary.class);
         given(runSummary.keys()).willReturn(asList("k1", "k2"));
         resultCursor.onRunSummary(runSummary);

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalTransactionTest.java
@@ -69,7 +69,7 @@ class InternalTransactionTest {
         connection = connectionMock(new BoltProtocolVersion(4, 0));
         var connectionProvider = mock(DriverBoltConnectionProvider.class);
         given(connection.onLoop()).willReturn(CompletableFuture.completedStage(connection));
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(CompletableFuture.completedFuture(connection));
         given(connection.beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(CompletableFuture.completedStage(connection));

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -82,6 +82,7 @@ class SessionFactoryImplTest {
                 mock(DriverBoltConnectionProvider.class),
                 new FixedRetryLogic(0),
                 config,
-                mock(AuthTokenManager.class));
+                mock(AuthTokenManager.class),
+                mock());
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
@@ -100,7 +100,7 @@ class InternalAsyncSessionTest {
         given(connection.onLoop()).willReturn(CompletableFuture.completedStage(connection));
         given(connection.close()).willReturn(completedFuture(null));
         connectionProvider = mock(DriverBoltConnectionProvider.class);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var database = (DatabaseName) invocation.getArguments()[1];
                     @SuppressWarnings("unchecked")
@@ -311,7 +311,7 @@ class InternalAsyncSessionTest {
         var e = assertThrows(Exception.class, () -> executeTransaction(asyncSession, transactionMode, work));
         assertEquals(error, e);
 
-        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         verify(connection).beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any());
         verifyRollbackTx(connection);
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncTransactionTest.java
@@ -75,7 +75,7 @@ class InternalAsyncTransactionTest {
         connection = connectionMock(new BoltProtocolVersion(4, 0));
         given(connection.onLoop()).willReturn(CompletableFuture.completedStage(connection));
         var connectionProvider = mock(DriverBoltConnectionProvider.class);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var database = (DatabaseName) invocation.getArguments()[1];
                     @SuppressWarnings("unchecked")

--- a/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
@@ -145,12 +145,13 @@ class LeakLoggingNetworkSessionTest {
                 NotificationConfig.defaultConfig(),
                 null,
                 true,
-                AuthTokenManagers.basic(AuthTokens::none));
+                AuthTokenManagers.basic(AuthTokens::none),
+                mock());
     }
 
     private static DriverBoltConnectionProvider connectionProviderMock(DriverBoltConnection connection) {
         var provider = mock(DriverBoltConnectionProvider.class);
-        when(provider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(provider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(connection));
         return provider;
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -91,7 +91,7 @@ class NetworkSessionTest {
         given(connection.onLoop()).willReturn(CompletableFuture.completedStage(connection));
         given(connection.close()).willReturn(completedFuture(null));
         connectionProvider = mock(DriverBoltConnectionProvider.class);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var database = (DatabaseName) invocation.getArguments()[1];
                     @SuppressWarnings("unchecked")
@@ -241,7 +241,7 @@ class NetworkSessionTest {
 
         run(session, query);
 
-        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -259,7 +259,8 @@ class NetworkSessionTest {
     void resetDoesNothingWhenNoTransactionAndNoConnection() {
         await(session.resetAsync());
 
-        verify(connectionProvider, never()).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, never())
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -268,7 +269,8 @@ class NetworkSessionTest {
 
         close(session);
 
-        verify(connectionProvider, never()).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, never())
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -277,7 +279,7 @@ class NetworkSessionTest {
         var tx = beginTransaction(session);
 
         assertNotNull(tx);
-        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -334,7 +336,7 @@ class NetworkSessionTest {
                             handler.onComplete();
                         }));
         var tx = beginTransaction(session);
-        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider).connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         then(connection).should().flush(any());
         var query = "RETURN 42";
         await(tx.runAsync(new Query(query)));
@@ -419,7 +421,8 @@ class NetworkSessionTest {
         var session2 = newSession(connectionProvider, mode);
         beginTransaction(session2);
         var argument = ArgumentCaptor.forClass(org.neo4j.driver.internal.bolt.api.AccessMode.class);
-        verify(connectionProvider).connect(any(), any(), any(), argument.capture(), any(), any(), any(), any(), any());
+        verify(connectionProvider)
+                .connect(any(), any(), any(), argument.capture(), any(), any(), any(), any(), any(), any());
         assertEquals(
                 switch (mode) {
                     case READ -> org.neo4j.driver.internal.bolt.api.AccessMode.READ;
@@ -446,7 +449,7 @@ class NetworkSessionTest {
     void shouldDoNothingWhenClosingWithoutAcquiredConnection() {
         var error = new RuntimeException("Hi");
         Mockito.reset(connectionProvider);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(failedFuture(error));
 
         var e = assertThrows(Exception.class, () -> run(session, "RETURN 1"));
@@ -459,7 +462,7 @@ class NetworkSessionTest {
     void shouldRunAfterRunFailure() {
         var error = new RuntimeException("Hi");
         Mockito.reset(connectionProvider);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(failedFuture(error))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var databaseName = (DatabaseName) invocation.getArguments()[1];
@@ -479,7 +482,8 @@ class NetworkSessionTest {
 
         run(session, query);
 
-        verify(connectionProvider, times(2)).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, times(2))
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         verifyAutocommitRunAndPull(connection, query);
     }
 
@@ -494,7 +498,7 @@ class NetworkSessionTest {
         given(connection2.close()).willReturn(CompletableFuture.completedStage(null));
 
         Mockito.reset(connectionProvider);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var databaseName = (DatabaseName) invocation.getArguments()[1];
                     @SuppressWarnings("unchecked")
@@ -522,7 +526,8 @@ class NetworkSessionTest {
 
         run(session, query);
 
-        verify(connectionProvider, times(2)).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, times(2))
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         then(connection1).should().beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any());
         verifyAutocommitRunAndPull(connection2, "RETURN 2");
     }
@@ -544,7 +549,7 @@ class NetworkSessionTest {
         }));
 
         Mockito.reset(connectionProvider);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var databaseName = (DatabaseName) invocation.getArguments()[1];
                     @SuppressWarnings("unchecked")
@@ -570,7 +575,8 @@ class NetworkSessionTest {
 
         beginTransaction(session);
 
-        verify(connectionProvider, times(2)).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, times(2))
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         then(connection1).should().beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any());
         then(connection2).should().beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
@@ -579,7 +585,7 @@ class NetworkSessionTest {
     void shouldBeginTxAfterRunFailureToAcquireConnection() {
         var error = new RuntimeException("Hi");
         Mockito.reset(connectionProvider);
-        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        given(connectionProvider.connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(failedFuture(error))
                 .willAnswer((Answer<CompletionStage<DriverBoltConnection>>) invocation -> {
                     var databaseName = (DatabaseName) invocation.getArguments()[1];
@@ -596,7 +602,8 @@ class NetworkSessionTest {
 
         beginTransaction(session);
 
-        verify(connectionProvider, times(2)).connect(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(connectionProvider, times(2))
+                .connect(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         then(connection).should().beginTransaction(any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -260,6 +260,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
@@ -292,6 +293,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
@@ -316,6 +318,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         tx.markTerminated(null);
@@ -344,6 +347,7 @@ class UnmanagedTransactionTest {
                 resultCursorsHolder,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         tx.markTerminated(terminationCause);
@@ -370,6 +374,7 @@ class UnmanagedTransactionTest {
                 resultCursorsHolder,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         tx.markTerminated(terminationCause);
@@ -397,6 +402,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         tx.markTerminated(terminationCause);
@@ -421,6 +427,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         tx.markTerminated(null);
@@ -449,6 +456,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         await(tx.closeAsync());
@@ -478,6 +486,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
         var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
@@ -510,6 +519,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
         var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
@@ -550,6 +560,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         var initialStage = mapTransactionAction(initialAction, tx).get();
@@ -612,6 +623,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         var originalActionStage = mapTransactionAction(initialAction, tx).get();
@@ -672,6 +684,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
 
         var originalActionStage = mapTransactionAction(originalAction, tx).get();
@@ -875,6 +888,7 @@ class UnmanagedTransactionTest {
                 -1,
                 null,
                 apiTelemetryWork,
+                mock(),
                 Logging.none());
         return await(tx.beginAsync(initialBookmarks, TransactionConfig.empty(), null, true));
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/ResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/ResultCursorImplTest.java
@@ -70,7 +70,8 @@ class ResultCursorImplTest {
     void beforeEach() {
         openMocks(this);
         given(connection.protocolVersion()).willReturn(new BoltProtocolVersion(5, 5));
-        cursor = new ResultCursorImpl(connection, query, fetchSize, bookmarkConsumer, closeOnSummary, null, null);
+        cursor = new ResultCursorImpl(
+                connection, query, fetchSize, bookmarkConsumer, closeOnSummary, null, ignored -> {}, null);
         cursor.onRunSummary(runSummary);
     }
 

--- a/driver/src/test/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/homedb/HomeDatabaseCacheImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.homedb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.time.Clock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.neo4j.driver.internal.bolt.api.BoltConnection;
+
+class HomeDatabaseCacheImplTest {
+    HomeDatabaseCacheImpl cache;
+
+    @Mock
+    BoltConnection boltConnection;
+
+    @Mock
+    Clock clock;
+
+    @BeforeEach
+    @SuppressWarnings("resource")
+    void beforeEach() {
+        openMocks(this);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 10, 100, 1000, 10000})
+    void testPruning(int sizeLimit) {
+        cache = new HomeDatabaseCacheImpl(sizeLimit, clock);
+        given(boltConnection.serverSideRoutingEnabled()).willReturn(true);
+        cache.onOpen(boltConnection);
+
+        for (var i = 0L; i < sizeLimit + 1L; i++) {
+            var key = HomeDatabaseCacheKey.of(null, String.valueOf(i));
+            cache.put(key, String.valueOf(i));
+            given(clock.millis()).willReturn(i);
+            cache.get(key);
+        }
+
+        assertTrue(cache.size() <= sizeLimit);
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
@@ -225,7 +225,8 @@ public final class TestUtil {
                 Config.defaultConfig().notificationConfig(),
                 null,
                 telemetryDisabled,
-                mock(AuthTokenManager.class));
+                mock(AuthTokenManager.class),
+                mock());
     }
 
     public static void setupConnectionAnswers(

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -44,6 +44,7 @@ public class GetFeatures implements TestkitRequest {
             "Feature:Bolt:5.5",
             "Feature:Bolt:5.6",
             "Feature:Bolt:5.7",
+            "Feature:Bolt:5.8",
             "AuthorizationExpiredTreatment",
             "ConfHint:connection.recv_timeout_seconds",
             "Feature:Auth:Bearer",
@@ -73,7 +74,9 @@ public class GetFeatures implements TestkitRequest {
             "Feature:API:Driver.SupportsSessionAuth",
             "Feature:API:RetryableExceptions",
             "Feature:API:SSLClientCertificate",
-            "Feature:API:Summary:GqlStatusObjects"));
+            "Feature:API:Summary:GqlStatusObjects",
+            "Feature:API:Driver:MaxConnectionLifetime",
+            "Optimization:HomeDatabaseCache"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -108,6 +108,8 @@ public class NewDriver implements TestkitRequest {
                         .map(NotificationClassification::valueOf)
                         .collect(Collectors.toSet()))
                 .ifPresent(configBuilder::withDisabledNotificationClassifications);
+        Optional.ofNullable(data.maxConnectionLifetimeMs)
+                .ifPresent(timeout -> configBuilder.withMaxConnectionLifetime(timeout, TimeUnit.MILLISECONDS));
         configBuilder.withDriverMetrics();
         var clientCertificateManager = Optional.ofNullable(data.getClientCertificateProviderId())
                 .map(testkitState::getClientCertificateManager)
@@ -299,6 +301,7 @@ public class NewDriver implements TestkitRequest {
         private Boolean telemetryDisabled;
         private ClientCertificate clientCertificate;
         private String clientCertificateProviderId;
+        private Long maxConnectionLifetimeMs;
     }
 
     @RequiredArgsConstructor

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -73,6 +73,8 @@ public class StartTest implements TestkitRequest {
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestConnectionAcquisitionTimeoutMs\\.test_should_encompass_the_version_handshake_(in_time|time_out)$",
                 skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.TestHomeDbMixedCluster\\.test_connection_acquisition_timeout_during_fallback$", skipMessage);
         skipMessage = "This test needs updating to implement expected behaviour";
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestAuthenticationSchemes[^.]+\\.test_custom_scheme_empty$", skipMessage);


### PR DESCRIPTION
This update adds support for Bolt protocol 5.8 and introduces home database resolution cache that works with Bolt protocol 5.8+ when routing scheme is used. The cache is maintained by the driver internally and is not exposed in the API, its purpose is to reduce the number of Bolt exchanges when home database resolution is needed.
