### PR TITLE
Improve transaction failure handling

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TransactionIT.java
@@ -422,7 +422,7 @@ class TransactionIT {
                     result.list();
                 }
             });
-            assertEquals(terminationException, exception);
+            assertEquals(terminationException, exception.getCause());
         }
         tx.close();
     }
@@ -441,8 +441,8 @@ class TransactionIT {
 
         // Then
         for (var result : List.of(result0, result1)) {
-            var exception = assertThrows(ClientException.class, result::consume);
-            assertEquals(terminationException, exception);
+            var exception = assertThrows(TransactionTerminatedException.class, result::consume);
+            assertEquals(terminationException, exception.getCause());
         }
         tx.close();
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveTransactionIT.java
@@ -63,7 +63,7 @@ class ReactiveTransactionIT {
         for (var result : List.of(result0, result1)) {
             var exception = assertThrows(
                     ClientException.class, () -> Flux.from(result.records()).blockFirst());
-            assertEquals(terminationException, exception);
+            assertEquals(terminationException, exception.getCause());
         }
         Mono.fromDirect(tx.close()).block();
     }
@@ -92,7 +92,7 @@ class ReactiveTransactionIT {
         for (var result : List.of(result0, result1)) {
             var exception = assertThrows(ClientException.class, () -> Mono.fromDirect(result.consume())
                     .block());
-            assertEquals(terminationException, exception);
+            assertEquals(terminationException, exception.getCause());
         }
         Mono.fromDirect(tx.close()).block();
     }


### PR DESCRIPTION
If Bolt exchange fails for whatever reason, subsequent runs should emit a failed transaction error.