### PR TITLE
Update `Neo4jException.gqlCause`

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/Neo4jException.java
@@ -244,10 +244,10 @@ public class Neo4jException extends RuntimeException {
         if (cause == null) {
             return Optional.empty();
         }
-        if (cause.getClass().isAssignableFrom(targetCls)) {
+        if (targetCls.isAssignableFrom(cause.getClass())) {
             return Optional.of(targetCls.cast(cause));
         } else {
-            return findFirstGqlCause(cause, targetCls);
+            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
This update fixes `Neo4jException.gqlCause` that did not return subtypes of `Neo4jException`.