### PR TITLE
Support neo4j-bolt-connection testing

### DIFF
--- a/testkit/build.py
+++ b/testkit/build.py
@@ -10,6 +10,10 @@ def run(args):
     subprocess.run(
         args, universal_newlines=True, stderr=subprocess.STDOUT, check=True)
 
-
 if __name__ == "__main__" and "TEST_SKIP_BUILD" not in os.environ:
-    run(["mvn", "--show-version", "--batch-mode", "clean", "install", "-P", "!determine-revision", "-DskipTests"])
+    if os.getenv("TEST_NEO4J_BOLT_CONNECTION", "false") == "true" :
+        run(["mvn", "-f", "/driver/bolt-connection/pom.xml", "--show-version", "--batch-mode", "clean", "versions:set", "-DnewVersion=0.0.0"])
+        run(["mvn", "-f", "/driver/bolt-connection/pom.xml", "--show-version", "--batch-mode", "clean", "install", "-DskipTests"])
+        run(["mvn", "--show-version", "--batch-mode", "clean", "install", "-P", "!determine-revision", "-DskipTests", "-Dneo4j-bolt-connection-bom.version=0.0.0"])
+    else:
+        run(["mvn", "--show-version", "--batch-mode", "clean", "install", "-P", "!determine-revision", "-DskipTests"])


### PR DESCRIPTION
Providing that Testkit build is started with `TEST_NEO4J_BOLT_CONNECTION=true`, the driver build will expect to have a `bolt-connection` subfolder with `neo4j-bolt-connection` project that it will use during the driver build.