### PR TITLE
feat: Introduce Value and Record mapping to custom object types

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -633,4 +633,16 @@
         <method>org.neo4j.driver.net.ServerAddress of(java.lang.String)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Value</className>
+        <differenceType>7012</differenceType>
+        <method>java.lang.Object as(java.lang.Class)</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Record</className>
+        <differenceType>7012</differenceType>
+        <method>java.lang.Object as(java.lang.Class)</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/module-info.java
+++ b/driver/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.neo4j.driver {
     exports org.neo4j.driver.util;
     exports org.neo4j.driver.exceptions;
     exports org.neo4j.driver.exceptions.value;
+    exports org.neo4j.driver.mapping;
 
     requires org.neo4j.bolt.connection;
     requires org.neo4j.bolt.connection.netty;

--- a/driver/src/main/java/org/neo4j/driver/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/Record.java
@@ -19,9 +19,14 @@ package org.neo4j.driver;
 import java.util.List;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.neo4j.driver.exceptions.value.LossyCoercion;
+import org.neo4j.driver.exceptions.value.Uncoercible;
+import org.neo4j.driver.mapping.Property;
+import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.MapAccessorWithDefaultValue;
 import org.neo4j.driver.util.Immutable;
 import org.neo4j.driver.util.Pair;
+import org.neo4j.driver.util.Preview;
 
 /**
  * Container for Cypher result values.
@@ -78,4 +83,75 @@ public interface Record extends MapAccessorWithDefaultValue {
      * @throws NoSuchRecordException if the associated underlying record is not available
      */
     List<Pair<String, Value>> fields();
+
+    /**
+     * Maps values of this record to properties of the given type providing that is it supported.
+     * <p>
+     * Example (using the <a href=https://github.com/neo4j-graph-examples/movies>Neo4j Movies Database</a>):
+     * <pre>
+     * {@code
+     * // assuming the following Java record
+     * public record MovieInfo(String title, String director, List<String> actors) {}
+     * // the record values may be mapped to MovieInfo instances
+     * var movies = driver.executableQuery("MATCH (actor:Person)-[:ACTED_IN]->(movie:Movie)<-[:DIRECTED]-(director:Person) RETURN movie.title as title, director.name AS director, collect(actor.name) AS actors")
+     *         .execute()
+     *         .records()
+     *         .stream()
+     *         .map(record -> record.as(MovieInfo.class))
+     *         .toList();
+     * }
+     * </pre>
+     * <p>
+     * Note that Object Mapping is an alternative to accessing the user-defined values in a {@link MapAccessor}.
+     * If Object Graph Mapping (OGM) is needed, please use a higher level solution built on top of the driver, like
+     * <a href="https://neo4j.com/docs/getting-started/languages-guides/java/spring-data-neo4j/">Spring Data Neo4j</a>.
+     * <p>
+     * The mapping is done by matching user-defined property names to target type constructor parameters. Therefore, the
+     * constructor parameters must either have {@link Property} annotation or have a matching name that is available
+     * at runtime (note that the constructor parameter names are typically changed by the compiler unless either the
+     * compiler {@code -parameters} option is used or they belong to the cannonical constructor of
+     * {@link java.lang.Record java.lang.Record}). The name matching is case-sensitive.
+     * <p>
+     * Additionally, the {@link Property} annotation may be used when mapping a property with a different name to
+     * {@link java.lang.Record java.lang.Record} cannonical constructor parameter.
+     * <p>
+     * The constructor selection criteria is the following (top priority first):
+     * <ol>
+     *     <li>Maximum matching properties.</li>
+     *     <li>Minimum mismatching properties.</li>
+     * </ol>
+     * The constructor search is done in the order defined by the {@link Class#getDeclaredConstructors} and is
+     * finished either when a full match is found with no mismatches or once all constructors have been visited.
+     * <p>
+     * At least 1 property match must be present for mapping to work.
+     * <p>
+     * A {@code null} value is used for arguments that don't have a matching property. If the argument does not accept
+     * {@code null} value (this includes primitive types), an alternative constructor that excludes it must be
+     * available.
+     * <p>
+     * Types with generic parameters defined at the class level are not supported. However, constructor arguments with
+     * specific types are permitted, see the {@code actors} parameter in the example above.
+     * <p>
+     * On the contrary, the following record would not be mapped because the type information is insufficient:
+     * <pre>
+     * {@code
+     * public record MovieInfo(String title, String director, List<T> actors) {}
+     * }
+     * </pre>
+     * Wildcard type value is not supported.
+     *
+     * @param targetClass the target class to map to
+     * @param <T>         the target type to map to
+     * @return the mapped value
+     * @throws Uncoercible when mapping to the target type is not possible
+     * @throws LossyCoercion when mapping cannot be achieved without losing precision
+     * @see Property
+     * @see Value#as(Class)
+     * @since 5.28.5
+     */
+    @Preview(name = "Object mapping")
+    default <T> T as(Class<T> targetClass) {
+        // for backwards compatibility only
+        throw new UnsupportedOperationException("not supported");
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/Value.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.value.LossyCoercion;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.value.NullValue;
+import org.neo4j.driver.mapping.Property;
 import org.neo4j.driver.types.Entity;
 import org.neo4j.driver.types.IsoDuration;
 import org.neo4j.driver.types.MapAccessor;
@@ -41,6 +42,7 @@ import org.neo4j.driver.types.Relationship;
 import org.neo4j.driver.types.Type;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.driver.util.Immutable;
+import org.neo4j.driver.util.Preview;
 
 /**
  * A unit of data that adheres to the Neo4j type system.
@@ -52,7 +54,7 @@ import org.neo4j.driver.util.Immutable;
  * For example, a common String value should be tested for using <code>isString</code>
  * and extracted using <code>stringValue</code>.
  * <h2>Navigating a tree structure</h2>
- *
+ * <p>
  * Because Neo4j often handles dynamic structures, this interface is designed to help
  * you handle such structures in Java. Specifically, {@link Value} lets you navigate arbitrary tree
  * structures without having to resort to type casting.
@@ -69,14 +71,14 @@ import org.neo4j.driver.util.Immutable;
  * }
  * }
  * </pre>
- *
+ * <p>
  * You can retrieve the name of the second user, John, like so:
  * <pre class="docTest:ValueDocIT#classDocTreeExample">
  * {@code
  * String username = value.get("users").get(1).get("name").asString();
  * }
  * </pre>
- *
+ * <p>
  * You can also easily iterate over the users:
  * <pre class="docTest:ValueDocIT#classDocIterationExample">
  * {@code
@@ -87,6 +89,7 @@ import org.neo4j.driver.util.Immutable;
  * }
  * }
  * </pre>
+ *
  * @since 1.0
  */
 @Immutable
@@ -133,14 +136,16 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      */
     Value get(int index);
 
-    /** @return The type of this value as defined in the Neo4j type system */
+    /**
+     * @return The type of this value as defined in the Neo4j type system
+     */
     Type type();
 
     /**
      * Test if this value is a value of the given type
      *
      * @param type the given type
-     * @return type.isTypeOf( this )
+     * @return type.isTypeOf(this)
      */
     boolean hasType(Type type);
 
@@ -184,7 +189,7 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *     <li>{@link TypeSystem#RELATIONSHIP()} - {@link Relationship}</li>
      *     <li>{@link TypeSystem#PATH()} - {@link Path}</li>
      * </ul>
-     *
+     * <p>
      * Note that the types in {@link TypeSystem} refers to the Neo4j type system
      * where {@link TypeSystem#INTEGER()} and {@link TypeSystem#FLOAT()} are both
      * 64-bit precision. This is why these types return java {@link Long} and
@@ -197,9 +202,10 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
 
     /**
      * Apply the mapping function on the value if the value is not a {@link NullValue}, or the default value if the value is a {@link NullValue}.
-     * @param mapper The mapping function defines how to map a {@link Value} to T.
+     *
+     * @param mapper       The mapping function defines how to map a {@link Value} to T.
      * @param defaultValue the value to return if the value is a {@link NullValue}
-     * @param <T> The return type
+     * @param <T>          The return type
      * @return The value after applying the given mapping function or the default value if the value is {@link NullValue}.
      */
     <T> T computeOrDefault(Function<Value, T> mapper, T defaultValue);
@@ -218,21 +224,21 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
     boolean asBoolean(boolean defaultValue);
 
     /**
-     *  @return the value as a Java byte array, if possible.
-     *  @throws Uncoercible if value types are incompatible.
+     * @return the value as a Java byte array, if possible.
+     * @throws Uncoercible if value types are incompatible.
      */
     byte[] asByteArray();
 
     /**
-     *  @param defaultValue default to this value if the original value is a {@link NullValue}
-     *  @return the value as a Java byte array, if possible.
-     *  @throws Uncoercible if value types are incompatible.
+     * @param defaultValue default to this value if the original value is a {@link NullValue}
+     * @return the value as a Java byte array, if possible.
+     * @throws Uncoercible if value types are incompatible.
      */
     byte[] asByteArray(byte[] defaultValue);
 
     /**
-     *  @return the value as a Java String, if possible.
-     *  @throws Uncoercible if value types are incompatible.
+     * @return the value as a Java String, if possible.
+     * @throws Uncoercible if value types are incompatible.
      */
     String asString();
 
@@ -254,16 +260,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *
      * @return the value as a Java long.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     long asLong();
 
     /**
      * Returns a Java long if no precision is lost in the conversion.
+     *
      * @param defaultValue return this default value if the value is a {@link NullValue}.
      * @return the value as a Java long.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     long asLong(long defaultValue);
 
@@ -272,16 +279,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *
      * @return the value as a Java int.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     int asInt();
 
     /**
      * Returns a Java int if no precision is lost in the conversion.
+     *
      * @param defaultValue return this default value if the value is a {@link NullValue}.
      * @return the value as a Java int.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     int asInt(int defaultValue);
 
@@ -290,16 +298,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *
      * @return the value as a Java double.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     double asDouble();
 
     /**
      * Returns a Java double if no precision is lost in the conversion.
+     *
      * @param defaultValue default to this value if the value is a {@link NullValue}.
      * @return the value as a Java double.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     double asDouble(double defaultValue);
 
@@ -308,16 +317,17 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *
      * @return the value as a Java float.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     float asFloat();
 
     /**
      * Returns a Java float if no precision is lost in the conversion.
+     *
      * @param defaultValue default to this value if the value is a {@link NullValue}
      * @return the value as a Java float.
      * @throws LossyCoercion if it is not possible to convert the value without loosing precision.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible   if value types are incompatible.
      */
     float asFloat(float defaultValue);
 
@@ -325,8 +335,8 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      * If the underlying type can be viewed as a list, returns a java list of
      * values, where each value has been converted using {@link #asObject()}.
      *
-     * @see #asObject()
      * @return the value as a Java list of values, if possible
+     * @see #asObject()
      */
     List<Object> asList();
 
@@ -334,28 +344,28 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      * If the underlying type can be viewed as a list, returns a java list of
      * values, where each value has been converted using {@link #asObject()}.
      *
-     * @see #asObject()
      * @param defaultValue default to this value if the value is a {@link NullValue}
      * @return the value as a Java list of values, if possible
+     * @see #asObject()
      */
     List<Object> asList(List<Object> defaultValue);
 
     /**
      * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
-     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
-     * @param <T> the type of target list elements
-     * @see Values for a long list of built-in conversion functions
+     *                    as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param <T>         the type of target list elements
      * @return the value as a list of T obtained by mapping from the list elements, if possible
+     * @see Values for a long list of built-in conversion functions
      */
     <T> List<T> asList(Function<Value, T> mapFunction);
 
     /**
-     * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
-     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
-     * @param <T> the type of target list elements
+     * @param mapFunction  a function to map from Value to T. See {@link Values} for some predefined functions, such
+     *                     as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param <T>          the type of target list elements
      * @param defaultValue default to this value if the value is a {@link NullValue}
-     * @see Values for a long list of built-in conversion functions
      * @return the value as a list of T obtained by mapping from the list elements, if possible
+     * @see Values for a long list of built-in conversion functions
      */
     <T> List<T> asList(Function<Value, T> mapFunction, List<T> defaultValue);
 
@@ -409,14 +419,14 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
 
     /**
      * @return the value as a {@link java.time.OffsetDateTime}, if possible.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible       if value types are incompatible.
      * @throws DateTimeException if zone information supplied by server is not supported by driver runtime.
      */
     OffsetDateTime asOffsetDateTime();
 
     /**
      * @return the value as a {@link ZonedDateTime}, if possible.
-     * @throws Uncoercible if value types are incompatible.
+     * @throws Uncoercible       if value types are incompatible.
      * @throws DateTimeException if zone information supplied by server is not supported by driver runtime.
      */
     ZonedDateTime asZonedDateTime();
@@ -501,14 +511,216 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
     Map<String, Object> asMap(Map<String, Object> defaultValue);
 
     /**
-     * @param mapFunction a function to map from Value to T. See {@link Values} for some predefined functions, such
-     * as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
-     * @param <T> the type of map values
+     * @param mapFunction  a function to map from Value to T. See {@link Values} for some predefined functions, such
+     *                     as {@link Values#ofBoolean()}, {@link Values#ofList(Function)}.
+     * @param <T>          the type of map values
      * @param defaultValue default to this value if the value is a {@link NullValue}
-     * @see Values for a long list of built-in conversion functions
      * @return the value as a map from string keys to values of type T obtained from mapping he original map values, if possible
+     * @see Values for a long list of built-in conversion functions
      */
     <T> Map<String, T> asMap(Function<Value, T> mapFunction, Map<String, T> defaultValue);
+
+    /**
+     * Maps this value to the given type providing that is it supported.
+     * <p>
+     * <b>Basic Mapping</b>
+     * <p>
+     * Supported destination types depend on the value {@link Type}, please see the table below for more details.
+     * <table>
+     *     <caption>Supported Mappings</caption>
+     *     <thead>
+     *      <tr>
+     *          <td>Value Type</td>
+     *          <td>Supported Target Types</td>
+     *      </tr>
+     *     </thead>
+     *     <tbody>
+     *         <tr>
+     *             <td>{@link TypeSystem#BOOLEAN}</td>
+     *             <td>{@code boolean}, {@link Boolean}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#BYTES}</td>
+     *             <td>{@code byte[]}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#STRING}</td>
+     *             <td>{@link String}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#INTEGER}</td>
+     *             <td>{@code long}, {@link Long}, {@code int}, {@link Integer}, {@code double}, {@link Double}, {@code float}, {@link Float}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#FLOAT}</td>
+     *             <td>{@code long}, {@link Long}, {@code int}, {@link Integer}, {@code double}, {@link Double}, {@code float}, {@link Float}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#PATH}</td>
+     *             <td>{@link Path}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#POINT}</td>
+     *             <td>{@link Point}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#DATE}</td>
+     *             <td>{@link LocalDate}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#TIME}</td>
+     *             <td>{@link OffsetTime}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#LOCAL_TIME}</td>
+     *             <td>{@link LocalTime}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#LOCAL_DATE_TIME}</td>
+     *             <td>{@link LocalDateTime}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#DATE_TIME}</td>
+     *             <td>{@link ZonedDateTime}, {@link OffsetDateTime}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#DURATION}</td>
+     *             <td>{@link IsoDuration}, {@link java.time.Period} (only when {@code seconds = 0} and {@code nanoseconds = 0} and no overflow happens),
+     *             {@link java.time.Duration} (only when {@code months = 0} and {@code days = 0} and no overflow happens)</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#NULL}</td>
+     *             <td>{@code null}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#LIST}</td>
+     *             <td>{@link List}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#MAP}</td>
+     *             <td>{@link Map}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#NODE}</td>
+     *             <td>{@link Node}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#RELATIONSHIP}</td>
+     *             <td>{@link Relationship}</td>
+     *         </tr>
+     *     </tbody>
+     * </table>
+     *
+     * <p>
+     * <b>Object Mapping</b>
+     * <p>
+     * Mapping of user-defined properties to user-defined types is supported for the following value types:
+     * <ul>
+     *     <li>{@link TypeSystem#NODE}</li>
+     *     <li>{@link TypeSystem#RELATIONSHIP}</li>
+     *     <li>{@link TypeSystem#MAP}</li>
+     * </ul>
+     * <p>
+     * Example (using the <a href=https://github.com/neo4j-graph-examples/movies>Neo4j Movies Database</a>):
+     * <pre>
+     * {@code
+     * // assuming the following Java record
+     * public record Movie(String title, String tagline, long released) {}
+     * // the nodes may be mapped to Movie instances
+     * var movies = driver.executableQuery("MATCH (movie:Movie) RETURN movie")
+     *         .execute()
+     *         .records()
+     *         .stream()
+     *         .map(record -> record.get("movie").as(Movie.class))
+     *         .toList();
+     * }
+     * </pre>
+     * <p>
+     * Note that Object Mapping is an alternative to accessing the user-defined values in a {@link MapAccessor}.
+     * If Object Graph Mapping (OGM) is needed, please use a higher level solution built on top of the driver, like
+     * <a href="https://neo4j.com/docs/getting-started/languages-guides/java/spring-data-neo4j/">Spring Data Neo4j</a>.
+     * <p>
+     * The mapping is done by matching user-defined property names to target type constructor parameters. Therefore, the
+     * constructor parameters must either have {@link Property} annotation or have a matching name that is available
+     * at runtime (note that the constructor parameter names are typically changed by the compiler unless either the
+     * compiler {@code -parameters} option is used or they belong to the cannonical constructor of
+     * {@link java.lang.Record java.lang.Record}). The name matching is case-sensitive.
+     * <p>
+     * Additionally, the {@link Property} annotation may be used when mapping a property with a different name to
+     * {@link java.lang.Record java.lang.Record} cannonical constructor parameter.
+     * <p>
+     * The constructor selection criteria is the following (top priority first):
+     * <ol>
+     *     <li>Maximum matching properties.</li>
+     *     <li>Minimum mismatching properties.</li>
+     * </ol>
+     * The constructor search is done in the order defined by the {@link Class#getDeclaredConstructors} and is
+     * finished either when a full match is found with no mismatches or once all constructors have been visited.
+     * <p>
+     * At least 1 property match must be present for mapping to work.
+     * <p>
+     * A {@code null} value is used for arguments that don't have a matching property. If the argument does not accept
+     * {@code null} value (this includes primitive types), an alternative constructor that excludes it must be
+     * available.
+     * <p>
+     * Example with optional property (using the <a href=https://github.com/neo4j-graph-examples/movies>Neo4j Movies Database</a>):
+     * <pre>
+     * {@code
+     * // assuming the following Java record
+     * public record Person(String name, long born) {
+     *     // alternative constructor for values that don't have 'born' property available
+     *     public Person(@Property("name") String name) {
+     *         this(name, -1);
+     *     }
+     * }
+     * // the nodes may be mapped to Person instances
+     * var persons = driver.executableQuery("MATCH (person:Person) RETURN person")
+     *         .execute()
+     *         .records()
+     *         .stream()
+     *         .map(record -> record.get("person").as(Person.class))
+     *         .toList();
+     * }
+     * </pre>
+     * <p>
+     * Types with generic parameters defined at the class level are not supported. However, constructor arguments with
+     * specific types are permitted.
+     * <p>
+     * Example (using the <a href=https://github.com/neo4j-graph-examples/movies>Neo4j Movies Database</a>):
+     * <pre>
+     * {@code
+     * // assuming the following Java record
+     * public record Acted(List<String> roles) {}
+     * // the relationships may be mapped to Acted instances
+     * var actedList = driver.executableQuery("MATCH ()-[acted:ACTED_IN]-() RETURN acted")
+     *         .execute()
+     *         .records()
+     *         .stream()
+     *         .map(record -> record.get("acted").as(Acted.class))
+     *         .toList();
+     * }
+     * </pre>
+     * On the contrary, the following record would not be mapped because the type information is insufficient:
+     * <pre>
+     * {@code
+     * public record Acted<T>(List<T> roles) {}
+     * }
+     * </pre>
+     * Wildcard type value is not supported.
+     *
+     * @param targetClass the target class to map to
+     * @param <T>         the target type to map to
+     * @return the mapped value
+     * @throws Uncoercible when mapping to the target type is not possible
+     * @throws LossyCoercion when mapping cannot be achieved without losing precision
+     * @see Property
+     * @since 5.28.5
+     */
+    @Preview(name = "Object mapping")
+    default <T> T as(Class<T> targetClass) {
+        // for backwards compatibility only
+        throw new UnsupportedOperationException("not supported");
+    }
 
     @Override
     boolean equals(Object other);

--- a/driver/src/main/java/org/neo4j/driver/exceptions/value/ValueException.java
+++ b/driver/src/main/java/org/neo4j/driver/exceptions/value/ValueException.java
@@ -19,6 +19,7 @@ package org.neo4j.driver.exceptions.value;
 import java.io.Serial;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.GqlStatusError;
+import org.neo4j.driver.util.Preview;
 
 /**
  * A <em>ValueException</em> indicates that the client has carried out an operation on values incorrectly.
@@ -33,12 +34,23 @@ public class ValueException extends ClientException {
      * @param message the message
      */
     public ValueException(String message) {
+        this(message, null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the message
+     * @param cause the cause
+     * @since 5.28.5
+     */
+    @Preview(name = "Object mapping")
+    public ValueException(String message, Throwable cause) {
         super(
                 GqlStatusError.UNKNOWN.getStatus(),
                 GqlStatusError.UNKNOWN.getStatusDescription(message),
                 "N/A",
                 message,
                 GqlStatusError.DIAGNOSTIC_RECORD,
-                null);
+                cause);
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalRecord.java
@@ -30,9 +30,11 @@ import java.util.stream.Collectors;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalMapAccessorWithDefaultValue;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.internal.util.QueryKeys;
+import org.neo4j.driver.internal.value.mapping.MapAccessorMapperProvider;
 import org.neo4j.driver.util.Pair;
 
 public class InternalRecord extends InternalMapAccessorWithDefaultValue implements Record {
@@ -114,6 +116,16 @@ public class InternalRecord extends InternalMapAccessorWithDefaultValue implemen
     @Override
     public <T> Map<String, T> asMap(Function<Value, T> mapper) {
         return Extract.map(this, mapper);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Record.class)) {
+            return targetClass.cast(this);
+        }
+        return MapAccessorMapperProvider.mapper(this, targetClass)
+                .map(mapper -> mapper.map(this, targetClass))
+                .orElseThrow(() -> new Uncoercible(getClass().getCanonicalName(), targetClass.getCanonicalName()));
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/BooleanValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/BooleanValue.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.driver.internal.value;
 
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -57,6 +58,17 @@ public abstract class BooleanValue extends ValueAdapter {
             return true;
         }
 
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T as(Class<T> targetClass) {
+            if (targetClass.isAssignableFrom(Boolean.class)) {
+                return targetClass.cast(Boolean.TRUE);
+            } else if (targetClass.isAssignableFrom(boolean.class)) {
+                return (T) Boolean.TRUE;
+            }
+            throw new Uncoercible(type().name(), targetClass.getCanonicalName());
+        }
+
         @Override
         public boolean isTrue() {
             return true;
@@ -88,6 +100,17 @@ public abstract class BooleanValue extends ValueAdapter {
         @Override
         public boolean asBoolean() {
             return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T as(Class<T> targetClass) {
+            if (targetClass.isAssignableFrom(Boolean.class)) {
+                return targetClass.cast(Boolean.FALSE);
+            } else if (targetClass.isAssignableFrom(boolean.class)) {
+                return (T) Boolean.FALSE;
+            }
+            throw new Uncoercible(type().name(), targetClass.getCanonicalName());
         }
 
         @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/BytesValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/BytesValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.util.Arrays;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -48,6 +49,14 @@ public class BytesValue extends ValueAdapter {
     @Override
     public byte[] asByteArray() {
         return val;
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(byte[].class)) {
+            return targetClass.cast(asByteArray());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/DateTimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/DateTimeValue.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.internal.value;
 
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -44,5 +45,15 @@ public class DateTimeValue extends ObjectValueAdapter<ZonedDateTime> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.DATE_TIME);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(ZonedDateTime.class)) {
+            return targetClass.cast(asZonedDateTime());
+        } else if (targetClass.isAssignableFrom(OffsetDateTime.class)) {
+            return targetClass.cast(asOffsetDateTime());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/DateValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/DateValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.time.LocalDate;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -38,5 +39,13 @@ public class DateValue extends ObjectValueAdapter<LocalDate> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.DATE);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(LocalDate.class)) {
+            return targetClass.cast(asLocalDate());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/DurationValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/DurationValue.java
@@ -39,4 +39,12 @@ public class DurationValue extends ObjectValueAdapter<IsoDuration> {
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.DURATION);
     }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(IsoDuration.class)) {
+            return targetClass.cast(asIsoDuration());
+        }
+        return asMapped(targetClass);
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/FloatValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/FloatValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import org.neo4j.driver.exceptions.value.LossyCoercion;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -70,6 +71,29 @@ public class FloatValue extends NumberValueAdapter<Double> {
         }
 
         return floatVal;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.equals(double.class)) {
+            return (T) Double.valueOf(asDouble());
+        } else if (targetClass.isAssignableFrom(Double.class)) {
+            return targetClass.cast(asDouble());
+        } else if (targetClass.equals(long.class)) {
+            return (T) Long.valueOf(asLong());
+        } else if (targetClass.equals(Long.class)) {
+            return targetClass.cast(asLong());
+        } else if (targetClass.equals(int.class)) {
+            return (T) Integer.valueOf(asInt());
+        } else if (targetClass.equals(Integer.class)) {
+            return targetClass.cast(asInt());
+        } else if (targetClass.equals(float.class)) {
+            return (T) Float.valueOf(asFloat());
+        } else if (targetClass.equals(Float.class)) {
+            return targetClass.cast(asFloat());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/IntegerValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/IntegerValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import org.neo4j.driver.exceptions.value.LossyCoercion;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -63,6 +64,29 @@ public class IntegerValue extends NumberValueAdapter<Long> {
     @Override
     public float asFloat() {
         return (float) val;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.equals(long.class)) {
+            return (T) Long.valueOf(asLong());
+        } else if (targetClass.isAssignableFrom(Long.class)) {
+            return targetClass.cast(asLong());
+        } else if (targetClass.equals(int.class)) {
+            return (T) Integer.valueOf(asInt());
+        } else if (targetClass.equals(Integer.class)) {
+            return targetClass.cast(asInt());
+        } else if (targetClass.equals(double.class)) {
+            return (T) Double.valueOf(asDouble());
+        } else if (targetClass.equals(Double.class)) {
+            return targetClass.cast(asDouble());
+        } else if (targetClass.equals(float.class)) {
+            return (T) Float.valueOf(asFloat());
+        } else if (targetClass.equals(Float.class)) {
+            return targetClass.cast(asFloat());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/InternalValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/InternalValue.java
@@ -16,7 +16,10 @@
  */
 package org.neo4j.driver.internal.value;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.AsValue;
 import org.neo4j.driver.internal.types.TypeConstructor;
 
@@ -24,4 +27,18 @@ public interface InternalValue extends Value, AsValue {
     TypeConstructor typeConstructor();
 
     BoltValue asBoltValue();
+
+    default Object as(Type type) {
+        if (type instanceof ParameterizedType parameterizedType) {
+            return as(parameterizedType);
+        } else if (type instanceof Class<?> classType) {
+            return as(classType);
+        } else {
+            throw new Uncoercible(type().name(), type.toString());
+        }
+    }
+
+    default Object as(ParameterizedType type) {
+        throw new Uncoercible(type().name(), type.toString());
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ListValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ListValue.java
@@ -18,12 +18,14 @@ package org.neo4j.driver.internal.value;
 
 import static org.neo4j.driver.Values.ofObject;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.types.Type;
@@ -56,6 +58,29 @@ public class ListValue extends ValueAdapter {
     @Override
     public <T> List<T> asList(Function<Value, T> mapFunction) {
         return Extract.list(values, mapFunction);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(List.class)) {
+            return targetClass.cast(asList());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
+    }
+
+    @Override
+    public Object as(ParameterizedType type) {
+        var rawType = type.getRawType();
+        if (rawType instanceof Class<?> cls) {
+            if (cls.isAssignableFrom(List.class)) {
+                return asList(v -> {
+                    var value = (InternalValue) v;
+                    var typeArgument = type.getActualTypeArguments()[0];
+                    return value.as(typeArgument);
+                });
+            }
+        }
+        throw new Uncoercible(type().name(), type.toString());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/LocalDateTimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/LocalDateTimeValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.time.LocalDateTime;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -38,5 +39,13 @@ public class LocalDateTimeValue extends ObjectValueAdapter<LocalDateTime> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.LOCAL_DATE_TIME);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(LocalDateTime.class)) {
+            return targetClass.cast(asLocalDateTime());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/LocalTimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/LocalTimeValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.time.LocalTime;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -38,5 +39,13 @@ public class LocalTimeValue extends ObjectValueAdapter<LocalTime> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.LOCAL_TIME);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(LocalTime.class)) {
+            return targetClass.cast(asLocalTime());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/MapValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/MapValue.java
@@ -20,10 +20,12 @@ import static org.neo4j.driver.Values.ofObject;
 import static org.neo4j.driver.Values.ofValue;
 import static org.neo4j.driver.internal.util.Format.formatPairs;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.function.Function;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.types.Type;
@@ -46,6 +48,34 @@ public class MapValue extends ValueAdapter {
     @Override
     public Map<String, Object> asObject() {
         return asMap(ofObject());
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Map.class)) {
+            return targetClass.cast(asMap());
+        }
+        return asMapped(targetClass);
+    }
+
+    @Override
+    public Object as(ParameterizedType type) {
+        var rawType = type.getRawType();
+        if (rawType instanceof Class<?> cls) {
+            if (cls.isAssignableFrom(Map.class)) {
+                var keyType = type.getActualTypeArguments()[0];
+                if (keyType instanceof Class<?> keyCls) {
+                    if (keyCls.isAssignableFrom(String.class)) {
+                        var valueType = type.getActualTypeArguments()[1];
+                        return asMap(v -> {
+                            var value = (InternalValue) v;
+                            return value.as(valueType);
+                        });
+                    }
+                }
+            }
+        }
+        throw new Uncoercible(type().name(), type.toString());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/NodeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/NodeValue.java
@@ -39,4 +39,12 @@ public class NodeValue extends EntityValueAdapter<Node> {
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.NODE);
     }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Node.class)) {
+            return targetClass.cast(asNode());
+        }
+        return asMapped(targetClass);
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/NullValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/NullValue.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.driver.internal.value;
 
+import java.lang.reflect.ParameterizedType;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
@@ -38,6 +39,16 @@ public final class NullValue extends ValueAdapter {
     @Override
     public String asString() {
         return "null";
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        return null;
+    }
+
+    @Override
+    public Object as(ParameterizedType type) {
+        return null;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/PathValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/PathValue.java
@@ -44,4 +44,12 @@ public class PathValue extends ObjectValueAdapter<Path> {
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.PATH);
     }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Path.class)) {
+            return targetClass.cast(asPath());
+        }
+        return asMapped(targetClass);
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/PointValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/PointValue.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.driver.internal.value;
 
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Point;
 import org.neo4j.driver.types.Type;
@@ -38,5 +39,13 @@ public class PointValue extends ObjectValueAdapter<Point> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.POINT);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Point.class)) {
+            return targetClass.cast(asPoint());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/RelationshipValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/RelationshipValue.java
@@ -39,4 +39,12 @@ public class RelationshipValue extends EntityValueAdapter<Relationship> {
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.RELATIONSHIP);
     }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(Relationship.class)) {
+            return targetClass.cast(asRelationship());
+        }
+        return asMapped(targetClass);
+    }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/StringValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/StringValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.util.Objects;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -48,6 +49,14 @@ public class StringValue extends ValueAdapter {
     @Override
     public String asString() {
         return val;
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(String.class)) {
+            return targetClass.cast(asString());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/TimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/TimeValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.time.OffsetTime;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -38,5 +39,13 @@ public class TimeValue extends ObjectValueAdapter<OffsetTime> {
     @Override
     public BoltValue asBoltValue() {
         return new BoltValue(this, org.neo4j.bolt.connection.values.Type.TIME);
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(OffsetTime.class)) {
+            return targetClass.cast(asOffsetTime());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/UnsupportedDateTimeValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/UnsupportedDateTimeValue.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.time.DateTimeException;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
 
@@ -38,6 +39,11 @@ public class UnsupportedDateTimeValue extends ValueAdapter {
     @Override
     public ZonedDateTime asZonedDateTime() {
         throw instantiateDateTimeException();
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -36,6 +36,7 @@ import org.neo4j.driver.exceptions.value.Unsizable;
 import org.neo4j.driver.internal.types.InternalMapAccessorWithDefaultValue;
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.internal.types.TypeRepresentation;
+import org.neo4j.driver.internal.value.mapping.MapAccessorMapperProvider;
 import org.neo4j.driver.types.Entity;
 import org.neo4j.driver.types.IsoDuration;
 import org.neo4j.driver.types.Node;
@@ -341,6 +342,12 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     @Override
     public final TypeConstructor typeConstructor() {
         return ((TypeRepresentation) type()).constructor();
+    }
+
+    protected <T> T asMapped(Class<T> targetClass) {
+        return MapAccessorMapperProvider.mapper(this, targetClass)
+                .map(mapper -> mapper.map(this, targetClass))
+                .orElseThrow(() -> new Uncoercible(type().name(), targetClass.getCanonicalName()));
     }
 
     // Force implementation

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/Argument.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/Argument.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.lang.reflect.Type;
+import org.neo4j.driver.internal.value.InternalValue;
+
+record Argument(String propertyName, Type type, InternalValue value) {}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ConstructorFinder.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ConstructorFinder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.value.InternalValue;
+import org.neo4j.driver.mapping.Property;
+import org.neo4j.driver.types.MapAccessor;
+
+class ConstructorFinder {
+    @SuppressWarnings("unchecked")
+    public <T> Optional<ObjectMetadata<T>> findConstructor(MapAccessor mapAccessor, Class<T> targetClass) {
+        PropertiesMatch<T> bestPropertiesMatch = null;
+        var constructors = targetClass.getDeclaredConstructors();
+        var propertyNamesSize = mapAccessor.size();
+        for (var constructor : constructors) {
+            var accessible = false;
+            try {
+                accessible = constructor.canAccess(null);
+            } catch (Throwable e) {
+                // ignored
+            }
+            if (!accessible) {
+                continue;
+            }
+            var matchNumbers = matchPropertyNames(mapAccessor, constructor);
+            if (bestPropertiesMatch == null
+                    || (matchNumbers.match() >= bestPropertiesMatch.match()
+                            && matchNumbers.mismatch() < bestPropertiesMatch.mismatch())) {
+                bestPropertiesMatch = (PropertiesMatch<T>) matchNumbers;
+                if (bestPropertiesMatch.match() == propertyNamesSize && bestPropertiesMatch.mismatch() == 0) {
+                    break;
+                }
+            }
+        }
+        if (bestPropertiesMatch == null || bestPropertiesMatch.match() == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ObjectMetadata<>(bestPropertiesMatch.constructor(), bestPropertiesMatch.arguments()));
+    }
+
+    private <T> PropertiesMatch<T> matchPropertyNames(MapAccessor mapAccessor, Constructor<T> constructor) {
+        var match = 0;
+        var mismatch = 0;
+        var parameters = constructor.getParameters();
+        var arguments = new ArrayList<Argument>(parameters.length);
+        for (var parameter : parameters) {
+            var propertyNameAnnotation = parameter.getAnnotation(Property.class);
+            var propertyName = propertyNameAnnotation != null ? propertyNameAnnotation.value() : parameter.getName();
+            var value = mapAccessor.get(propertyName);
+            if (value != null) {
+                match++;
+            } else {
+                mismatch++;
+            }
+            arguments.add(new Argument(
+                    propertyName,
+                    parameter.getParameterizedType(),
+                    value != null ? (InternalValue) value : (InternalValue) Values.NULL));
+        }
+        return new PropertiesMatch<>(match, mismatch, constructor, arguments);
+    }
+
+    private record PropertiesMatch<T>(int match, int mismatch, Constructor<T> constructor, List<Argument> arguments) {}
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/DurationMapper.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/DurationMapper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.value.LossyCoercion;
+import org.neo4j.driver.exceptions.value.Uncoercible;
+import org.neo4j.driver.types.MapAccessor;
+import org.neo4j.driver.types.TypeSystem;
+
+class DurationMapper implements MapAccessorMapper<TemporalAmount> {
+    private static final TypeSystem TS = TypeSystem.getDefault();
+
+    @Override
+    public boolean supports(MapAccessor mapAccessor, Class<?> targetClass) {
+        return (mapAccessor instanceof Value value && TS.DURATION().equals(value.type()))
+                && (targetClass.isAssignableFrom(Period.class) || targetClass.isAssignableFrom(Duration.class));
+    }
+
+    @Override
+    public TemporalAmount map(MapAccessor mapAccessor, Class<TemporalAmount> targetClass) {
+        if (mapAccessor instanceof Value value) {
+            var isoDuration = value.asIsoDuration();
+            if (targetClass.isAssignableFrom(TemporalAmount.class)) {
+                return isoDuration;
+            } else if (targetClass.isAssignableFrom(Period.class)) {
+                if (isoDuration.seconds() != 0 || isoDuration.nanoseconds() != 0) {
+                    throw new LossyCoercion(value.type().name(), targetClass.getCanonicalName());
+                }
+                var totalMonths = isoDuration.months();
+                var splitYears = totalMonths / 12;
+                var splitMonths = totalMonths % 12;
+                try {
+                    return Period.of(
+                                    Math.toIntExact(splitYears),
+                                    Math.toIntExact(splitMonths),
+                                    Math.toIntExact(isoDuration.days()))
+                            .normalized();
+                } catch (ArithmeticException e) {
+                    throw new LossyCoercion(value.type().name(), targetClass.getCanonicalName());
+                }
+            } else if (targetClass.isAssignableFrom(Duration.class)) {
+                if (isoDuration.months() != 0 || isoDuration.days() != 0) {
+                    throw new LossyCoercion(value.type().name(), targetClass.getCanonicalName());
+                }
+                return Duration.ofSeconds(isoDuration.seconds()).plusNanos(isoDuration.nanoseconds());
+            }
+            throw new Uncoercible(value.type().name(), targetClass.getCanonicalName());
+        } else {
+            throw new Uncoercible(mapAccessor.getClass().getCanonicalName(), targetClass.getCanonicalName());
+        }
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/MapAccessorMapper.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/MapAccessorMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import org.neo4j.driver.types.MapAccessor;
+
+public interface MapAccessorMapper<T> {
+
+    boolean supports(MapAccessor mapAccessor, Class<?> targetClass);
+
+    T map(MapAccessor mapAccessor, Class<T> targetClass);
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/MapAccessorMapperProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/MapAccessorMapperProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.util.List;
+import java.util.Optional;
+import org.neo4j.driver.types.MapAccessor;
+
+public class MapAccessorMapperProvider {
+    private static final List<? extends MapAccessorMapper<?>> mapAccessorMappers =
+            List.of(new ObjectMapper<>(), new DurationMapper());
+
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<? extends MapAccessorMapper<T>> mapper(MapAccessor mapAccessor, Class<T> targetClass) {
+        return (Optional<? extends MapAccessorMapper<T>>) mapAccessorMappers.stream()
+                .filter(mapper -> mapper.supports(mapAccessor, targetClass))
+                .findFirst();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectInstantiator.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectInstantiator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.util.List;
+import org.neo4j.driver.exceptions.value.ValueException;
+
+class ObjectInstantiator {
+
+    <T> T instantiate(ObjectMetadata<T> metadata) {
+        var constructor = metadata.constructor();
+        var targetTypeName = constructor.getDeclaringClass().getCanonicalName();
+        var initargs = initargs(targetTypeName, metadata.arguments());
+        try {
+            return constructor.newInstance(initargs);
+        } catch (Throwable e) {
+            throw new ValueException("Failed to instantiate '%s'".formatted(targetTypeName), e);
+        }
+    }
+
+    private Object[] initargs(String targetTypeName, List<Argument> arguments) {
+        var initargs = new Object[arguments.size()];
+        for (var i = 0; i < initargs.length; i++) {
+            var argument = arguments.get(i);
+            var type = argument.type();
+            try {
+                initargs[i] = argument.value().as(type);
+            } catch (Throwable e) {
+                throw new ValueException(
+                        "Failed to map '%s' property to '%s' for '%s' instantiation"
+                                .formatted(argument.propertyName(), type.getTypeName(), targetTypeName),
+                        e);
+            }
+        }
+        return initargs;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectMapper.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.util.Set;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.value.ValueException;
+import org.neo4j.driver.types.MapAccessor;
+import org.neo4j.driver.types.Type;
+import org.neo4j.driver.types.TypeSystem;
+
+class ObjectMapper<T> implements MapAccessorMapper<T> {
+    private static final TypeSystem TS = TypeSystem.getDefault();
+
+    private static final Set<Type> SUPPORTED_VALUE_TYPES = Set.of(TS.MAP(), TS.NODE(), TS.RELATIONSHIP());
+
+    private static final ConstructorFinder CONSTRUCTOR_FINDER = new ConstructorFinder();
+
+    private static final ObjectInstantiator OBJECT_INSTANTIATOR = new ObjectInstantiator();
+
+    @Override
+    public boolean supports(MapAccessor mapAccessor, Class<?> targetClass) {
+        return mapAccessor instanceof Value value
+                ? SUPPORTED_VALUE_TYPES.contains(value.type())
+                : mapAccessor instanceof org.neo4j.driver.Record;
+    }
+
+    @Override
+    public T map(MapAccessor mapAccessor, Class<T> targetClass) {
+        return CONSTRUCTOR_FINDER
+                .findConstructor(mapAccessor, targetClass)
+                .map(OBJECT_INSTANTIATOR::instantiate)
+                .orElseThrow(() -> new ValueException(
+                        "No suitable constructor has been found for '%s'".formatted(targetClass.getCanonicalName())));
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectMetadata.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/mapping/ObjectMetadata.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value.mapping;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+record ObjectMetadata<T>(Constructor<T> constructor, List<Argument> arguments) {}

--- a/driver/src/main/java/org/neo4j/driver/mapping/Property.java
+++ b/driver/src/main/java/org/neo4j/driver/mapping/Property.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.neo4j.driver.util.Preview;
+
+/**
+ * Defines property name that should be mapped to the annotated parameter.
+ *
+ * @since 5.28.5
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Preview(name = "Object mapping")
+public @interface Property {
+    /**
+     * The property name that should be mapped to the annotated parameter.
+     *
+     * @return the property name
+     */
+    String value();
+}

--- a/driver/src/test/java/org/neo4j/driver/ObjectMappingTests.java
+++ b/driver/src/test/java/org/neo4j/driver/ObjectMappingTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.internal.InternalIsoDuration;
+import org.neo4j.driver.internal.InternalNode;
+import org.neo4j.driver.internal.InternalPoint2D;
+import org.neo4j.driver.internal.InternalPoint3D;
+import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.InternalRelationship;
+import org.neo4j.driver.internal.value.NodeValue;
+import org.neo4j.driver.internal.value.RelationshipValue;
+import org.neo4j.driver.mapping.Property;
+import org.neo4j.driver.types.IsoDuration;
+import org.neo4j.driver.types.Point;
+
+class ObjectMappingTests {
+    @ParameterizedTest
+    @MethodSource("shouldMapValueArgs")
+    void shouldMapValue(Function<Map<String, Value>, ValueHolder> valueFunction) {
+        // given
+        var string = "string";
+        var listWithString = List.of(string, string);
+        var listWithStringValueHolder = List.of(new StringValueHolder(string), new StringValueHolder(string));
+        var bytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        var bool = false;
+        var boltInteger = Long.MIN_VALUE;
+        var boltFloat = Double.MIN_VALUE;
+        var date = LocalDate.now();
+        var time = OffsetTime.now();
+        var dateTime = ZonedDateTime.now();
+        var localDateTime = LocalDateTime.now();
+        var duration = new InternalIsoDuration(Duration.ZERO);
+        var period = Period.ofYears(1000);
+        var javaDuration = Duration.of(1000, ChronoUnit.MINUTES);
+        var point2d = new InternalPoint2D(0, 0, 0);
+        var point3d = new InternalPoint3D(0, 0, 0, 0);
+
+        var properties = Map.ofEntries(
+                Map.entry("string", Values.value(string)),
+                Map.entry("nullValue", Values.value((Object) null)),
+                Map.entry("listWithString", Values.value(listWithString)),
+                // also verifies MapValue
+                Map.entry(
+                        "listWithStringValueHolder",
+                        Values.value(listWithStringValueHolder.stream()
+                                .map(v -> Map.of("string", Values.value(v.string())))
+                                .toList())),
+                Map.entry("bytes", Values.value(bytes)),
+                Map.entry("bool", Values.value(bool)),
+                Map.entry("boltInteger", Values.value(boltInteger)),
+                Map.entry("boltFloat", Values.value(boltFloat)),
+                Map.entry("date", Values.value(date)),
+                Map.entry("time", Values.value(time)),
+                Map.entry("dateTime", Values.value(dateTime)),
+                Map.entry("localDateTime", Values.value(localDateTime)),
+                Map.entry("duration", Values.value(duration)),
+                Map.entry("period", Values.value(period)),
+                Map.entry("javaDuration", Values.value(javaDuration)),
+                Map.entry("point2d", Values.value(point2d)),
+                Map.entry("point3d", Values.value(point3d)));
+
+        // when
+        var valueHolder = valueFunction.apply(properties);
+
+        // then
+        assertEquals(string, valueHolder.string());
+        assertNull(valueHolder.nullValue());
+        assertEquals(listWithString, valueHolder.listWithString());
+        assertEquals(listWithStringValueHolder, valueHolder.listWithStringValueHolder());
+        assertEquals(bytes, valueHolder.bytes());
+        assertEquals(bool, valueHolder.bool());
+        assertEquals(boltInteger, valueHolder.boltInteger());
+        assertEquals(boltFloat, valueHolder.boltFloat());
+        assertEquals(date, valueHolder.date());
+        assertEquals(time, valueHolder.time());
+        assertEquals(dateTime, valueHolder.dateTime());
+        assertEquals(localDateTime, valueHolder.localDateTime());
+        assertEquals(duration, valueHolder.duration());
+        assertEquals(period, valueHolder.period());
+        assertEquals(javaDuration, valueHolder.javaDuration());
+        assertEquals(point2d, valueHolder.point2d());
+        assertEquals(point3d, valueHolder.point3d());
+    }
+
+    static Stream<Arguments> shouldMapValueArgs() {
+        return Stream.of(
+                Arguments.of(Named.<Function<Map<String, Value>, ValueHolder>>of(
+                        "node", properties -> new NodeValue(new InternalNode(0L, Set.of("Product"), properties))
+                                .as(ValueHolder.class))),
+                Arguments.of(Named.<Function<Map<String, Value>, ValueHolder>>of(
+                        "relationship",
+                        properties -> new RelationshipValue(new InternalRelationship(0L, 0L, 0L, "Product", properties))
+                                .as(ValueHolder.class))),
+                Arguments.of(Named.<Function<Map<String, Value>, ValueHolder>>of(
+                        "map", properties -> Values.value(properties).as(ValueHolder.class))),
+                Arguments.of(Named.<Function<Map<String, Value>, ValueHolder>>of("record", properties -> {
+                    var keys = new ArrayList<String>();
+                    var values = new Value[properties.size()];
+                    var i = 0;
+                    for (var entry : properties.entrySet()) {
+                        keys.add(entry.getKey());
+                        values[i] = entry.getValue();
+                        i++;
+                    }
+                    return new InternalRecord(keys, values).as(ValueHolder.class);
+                })));
+    }
+
+    public record ValueHolder(
+            String string,
+            Object nullValue,
+            List<String> listWithString,
+            List<StringValueHolder> listWithStringValueHolder,
+            byte[] bytes,
+            boolean bool,
+            long boltInteger,
+            double boltFloat,
+            LocalDate date,
+            OffsetTime time,
+            ZonedDateTime dateTime,
+            LocalDateTime localDateTime,
+            IsoDuration duration,
+            Period period,
+            Duration javaDuration,
+            Point point2d,
+            Point point3d) {}
+
+    public record StringValueHolder(String string) {}
+
+    @Test
+    void shouldUseConstructorWithMaxMatchesAndMinMismatches() {
+        // given
+        var string = "string";
+        var bytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        var bool = false;
+
+        var properties = Map.ofEntries(
+                Map.entry("string", Values.value(string)),
+                Map.entry("bytes", Values.value(bytes)),
+                Map.entry("bool", Values.value(bool)));
+
+        // when
+        var valueHolder = Values.value(properties).as(ValueHolderWithOptionalNumber.class);
+
+        // then
+        assertEquals(string, valueHolder.string());
+        assertEquals(bytes, valueHolder.bytes());
+        assertEquals(bool, valueHolder.bool());
+        assertEquals(Long.MIN_VALUE, valueHolder.number());
+    }
+
+    public record ValueHolderWithOptionalNumber(String string, byte[] bytes, boolean bool, long number) {
+        public ValueHolderWithOptionalNumber(
+                @Property("string") String string, @Property("bytes") byte[] bytes, @Property("bool") boolean bool) {
+            this(string, bytes, bool, Long.MIN_VALUE);
+        }
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/value/BooleanValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/BooleanValueTest.java
@@ -19,12 +19,18 @@ package org.neo4j.driver.internal.value;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.internal.value.BooleanValue.FALSE;
 import static org.neo4j.driver.internal.value.BooleanValue.TRUE;
 
+import java.io.Serializable;
+import java.lang.constant.Constable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.types.TypeSystem;
@@ -87,5 +93,16 @@ class BooleanValueTest {
         assertFalse(BooleanValue.FALSE.asBoolean());
         assertThat(TRUE.asObject(), equalTo((Object) Boolean.TRUE));
         assertThat(FALSE.asObject(), equalTo((Object) Boolean.FALSE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldMapToType(boolean expected) {
+        var value = Values.value(expected);
+        assertEquals(expected, value.as(boolean.class));
+        assertEquals(expected, value.as(Boolean.class));
+        assertEquals(expected, value.as(Serializable.class));
+        assertEquals(expected, value.as(Constable.class));
+        assertEquals(expected, value.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/BytesValueTest.java
@@ -19,10 +19,13 @@ package org.neo4j.driver.internal.value;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.types.TypeSystem;
@@ -85,5 +88,13 @@ class BytesValueTest {
     void shouldHaveBytesType() {
         InternalValue value = new BytesValue(TEST_BYTES);
         assertThat(value.type(), equalTo(InternalTypeSystem.TYPE_SYSTEM.BYTES()));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var bytes = new byte[] {0};
+        var values = Values.value(bytes);
+        assertEquals(bytes, values.as(byte[].class));
+        assertNotNull(values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DateTimeValueTest.java
@@ -19,10 +19,16 @@ package org.neo4j.driver.internal.value;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
@@ -65,5 +71,19 @@ class DateTimeValueTest {
         var dateTimeValue = new DateTimeValue(dateTime);
 
         assertThrows(Uncoercible.class, dateTimeValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = ZonedDateTime.now();
+        var values = Values.value(date);
+        assertEquals(date, values.as(ZonedDateTime.class));
+        assertEquals(date, values.as(Temporal.class));
+        assertEquals(date, values.as(TemporalAccessor.class));
+        assertEquals(date, values.as(ChronoZonedDateTime.class));
+        assertEquals(date, values.as(Comparable.class));
+        assertEquals(date, values.as(Serializable.class));
+        assertEquals(date, values.as(Object.class));
+        assertEquals(date.toOffsetDateTime(), values.as(OffsetDateTime.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DateValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DateValueTest.java
@@ -19,8 +19,13 @@ package org.neo4j.driver.internal.value;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.chrono.ChronoLocalDate;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
@@ -52,5 +57,18 @@ class DateValueTest {
         var dateValue = new DateValue(localDate);
 
         assertThrows(Uncoercible.class, dateValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = LocalDate.now();
+        var values = Values.value(date);
+        assertEquals(date, values.as(LocalDate.class));
+        assertEquals(date, values.as(Temporal.class));
+        assertEquals(date, values.as(TemporalAdjuster.class));
+        assertEquals(date, values.as(ChronoLocalDate.class));
+        assertEquals(date, values.as(Comparable.class));
+        assertEquals(date, values.as(Serializable.class));
+        assertEquals(date, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/DurationValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/DurationValueTest.java
@@ -18,8 +18,11 @@ package org.neo4j.driver.internal.value;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
+import java.time.temporal.TemporalAmount;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.InternalIsoDuration;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
@@ -53,6 +56,15 @@ class DurationValueTest {
         var durationValue = new DurationValue(duration);
 
         assertThrows(Uncoercible.class, durationValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = mock(IsoDuration.class);
+        var values = Values.value(date);
+        assertEquals(date, values.as(IsoDuration.class));
+        assertEquals(date, values.as(TemporalAmount.class));
+        assertEquals(date, values.as(Object.class));
     }
 
     private static IsoDuration newDuration(long months, long days, long seconds, int nanoseconds) {

--- a/driver/src/test/java/org/neo4j/driver/internal/value/FloatValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/FloatValueTest.java
@@ -19,11 +19,16 @@ package org.neo4j.driver.internal.value;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.LossyCoercion;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -116,5 +121,26 @@ class FloatValueTest {
 
         assertThat(value1.asInt(), equalTo(Integer.MIN_VALUE));
         assertThrows(LossyCoercion.class, value2::asInt);
+    }
+
+    @SuppressWarnings("ConstantValue")
+    @Test
+    void shouldMapToType() {
+        var expected = 0.0;
+        var value = Values.value(expected);
+        assertEquals(expected, value.as(double.class));
+        assertEquals(expected, value.as(Double.class));
+        assertEquals(expected, value.as(Number.class));
+        assertEquals(expected, value.as(Serializable.class));
+        assertEquals(expected, value.as(Comparable.class));
+        assertEquals(expected, value.as(Constable.class));
+        assertEquals(expected, value.as(ConstantDesc.class));
+        assertEquals(expected, value.as(Object.class));
+        assertEquals((long) expected, value.as(long.class));
+        assertEquals((long) expected, value.as(Long.class));
+        assertEquals((int) expected, value.as(int.class));
+        assertEquals((int) expected, value.as(Integer.class));
+        assertEquals((float) expected, value.as(float.class));
+        assertEquals((float) expected, value.as(Float.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
@@ -19,11 +19,16 @@ package org.neo4j.driver.internal.value;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.LossyCoercion;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
@@ -123,5 +128,25 @@ class IntegerValueTest {
 
         assertThat(value1.asDouble(), equalTo(9007199254740992D));
         assertThrows(LossyCoercion.class, value2::asDouble);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var expected = 0L;
+        var value = Values.value(expected);
+        assertEquals(expected, value.as(long.class));
+        assertEquals(expected, value.as(Long.class));
+        assertEquals(expected, value.as(Number.class));
+        assertEquals(expected, value.as(Serializable.class));
+        assertEquals(expected, value.as(Comparable.class));
+        assertEquals(expected, value.as(Constable.class));
+        assertEquals(expected, value.as(ConstantDesc.class));
+        assertEquals((int) expected, value.as(int.class));
+        assertEquals((int) expected, value.as(Integer.class));
+        assertEquals(expected, value.as(Object.class));
+        assertEquals(expected, value.as(double.class));
+        assertEquals(expected, value.as(Double.class));
+        assertEquals((float) expected, value.as(float.class));
+        assertEquals((float) expected, value.as(Float.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
@@ -18,10 +18,14 @@ package org.neo4j.driver.internal.value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.Values.value;
 
+import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
 class ListValueTest {
@@ -37,6 +41,16 @@ class ListValueTest {
         var listValue = listValue();
 
         assertThat(listValue.type(), equalTo(InternalTypeSystem.TYPE_SYSTEM.LIST()));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var list = List.of(0L);
+        var values = Values.value(list);
+        assertEquals(list, values.as(List.class));
+        assertEquals(list, values.as(Collection.class));
+        assertEquals(list, values.as(Iterable.class));
+        assertEquals(list, values.as(Object.class));
     }
 
     private ListValue listValue(Value... values) {

--- a/driver/src/test/java/org/neo4j/driver/internal/value/LocalDateTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/LocalDateTimeValueTest.java
@@ -22,8 +22,13 @@ import static java.time.Month.JANUARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
@@ -55,5 +60,18 @@ class LocalDateTimeValueTest {
         var dateTimeValue = new LocalDateTimeValue(dateTime);
 
         assertThrows(Uncoercible.class, dateTimeValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = LocalDateTime.now();
+        var values = Values.value(date);
+        assertEquals(date, values.as(LocalDateTime.class));
+        assertEquals(date, values.as(Temporal.class));
+        assertEquals(date, values.as(TemporalAdjuster.class));
+        assertEquals(date, values.as(ChronoLocalDateTime.class));
+        assertEquals(date, values.as(Comparable.class));
+        assertEquals(date, values.as(Serializable.class));
+        assertEquals(date, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/LocalTimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/LocalTimeValueTest.java
@@ -19,8 +19,12 @@ package org.neo4j.driver.internal.value;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
 import java.time.LocalTime;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
@@ -52,5 +56,17 @@ class LocalTimeValueTest {
         var timeValue = new LocalTimeValue(time);
 
         assertThrows(Uncoercible.class, timeValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = LocalTime.now();
+        var values = Values.value(date);
+        assertEquals(date, values.as(LocalTime.class));
+        assertEquals(date, values.as(Temporal.class));
+        assertEquals(date, values.as(TemporalAdjuster.class));
+        assertEquals(date, values.as(Comparable.class));
+        assertEquals(date, values.as(Serializable.class));
+        assertEquals(date, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/MapValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/MapValueTest.java
@@ -18,12 +18,15 @@ package org.neo4j.driver.internal.value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.neo4j.driver.Values.value;
 
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
 class MapValueTest {
@@ -52,6 +55,14 @@ class MapValueTest {
         var map = mapValue();
 
         assertFalse(map.isNull());
+    }
+
+    @Test
+    void shouldMapToType() {
+        var map = Map.of("key", "value");
+        var values = Values.value(map);
+        assertEquals(map, values.as(Map.class));
+        assertEquals(map, values.as(Object.class));
     }
 
     private MapValue mapValue() {

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NodeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NodeValueTest.java
@@ -24,8 +24,13 @@ import static org.neo4j.driver.internal.util.ValueFactory.emptyNodeValue;
 import static org.neo4j.driver.internal.util.ValueFactory.filledNodeValue;
 
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
+import org.neo4j.driver.types.Entity;
+import org.neo4j.driver.types.MapAccessor;
+import org.neo4j.driver.types.Node;
 
 class NodeValueTest {
     @Test
@@ -54,5 +59,15 @@ class NodeValueTest {
     void shouldTypeAsNode() {
         InternalValue value = emptyNodeValue();
         assertThat(value.typeConstructor(), equalTo(TypeConstructor.NODE));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var node = new InternalNode(0);
+        var values = Values.value(node);
+        assertEquals(node, values.as(Node.class));
+        assertEquals(node, values.as(Entity.class));
+        assertEquals(node, values.as(MapAccessor.class));
+        assertEquals(node, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/NullValueTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.Values.isoDuration;
 import static org.neo4j.driver.Values.ofValue;
@@ -34,6 +35,7 @@ import java.time.ZonedDateTime;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.TypeConstructor;
 
 class NullValueTest {
@@ -118,6 +120,14 @@ class NullValueTest {
     void shouldReturnAsDefaultValue() {
         assertComputeOrDefaultReturnDefault(Value::asObject, "null string");
         assertComputeOrDefaultReturnDefault(Value::asNumber, 10);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var values = Values.value((Object) null);
+        // unlike asString(), this returns null
+        assertNull(values.as(String.class));
+        assertNull(values.as(Object.class));
     }
 
     private static <T> void assertComputeOrDefaultReturnDefault(Function<Value, T> f, T defaultAndExpectedValue) {

--- a/driver/src/test/java/org/neo4j/driver/internal/value/PathValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/PathValueTest.java
@@ -24,7 +24,12 @@ import static org.neo4j.driver.internal.util.ValueFactory.filledPathValue;
 
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.InternalNode;
+import org.neo4j.driver.internal.InternalPath;
+import org.neo4j.driver.internal.InternalRelationship;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.types.Path;
 
 class PathValueTest {
     @Test
@@ -41,5 +46,15 @@ class PathValueTest {
     @Test
     void shouldHaveCorrectType() {
         assertThat(filledPathValue().type(), equalTo(InternalTypeSystem.TYPE_SYSTEM.PATH()));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var path = new InternalPath(
+                new InternalNode(42L), new InternalRelationship(43L, 42L, 44L, "T"), new InternalNode(44L));
+        var values = Values.value(path);
+        assertEquals(path, values.as(Path.class));
+        assertEquals(path, values.as(Iterable.class));
+        assertEquals(path, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/PointValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/PointValueTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Point;
+
+class PointValueTest {
+
+    @Test
+    void shouldMapToType() {
+        var point = mock(Point.class);
+        var values = Values.value(point);
+        assertEquals(point, values.as(Point.class));
+        assertEquals(point, values.as(Object.class));
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/value/RelationshipValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/RelationshipValueTest.java
@@ -25,7 +25,12 @@ import static org.neo4j.driver.internal.util.ValueFactory.filledRelationshipValu
 
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.InternalRelationship;
 import org.neo4j.driver.internal.types.TypeConstructor;
+import org.neo4j.driver.types.Entity;
+import org.neo4j.driver.types.MapAccessor;
+import org.neo4j.driver.types.Relationship;
 
 class RelationshipValueTest {
     @Test
@@ -50,5 +55,15 @@ class RelationshipValueTest {
     void shouldTypeAsRelationship() {
         InternalValue value = emptyRelationshipValue();
         assertThat(value.typeConstructor(), equalTo(TypeConstructor.RELATIONSHIP));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var relationship = new InternalRelationship(0, 0, 0, "value");
+        var values = Values.value(relationship);
+        assertEquals(relationship, values.as(Relationship.class));
+        assertEquals(relationship, values.as(Entity.class));
+        assertEquals(relationship, values.as(MapAccessor.class));
+        assertEquals(relationship, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
@@ -19,10 +19,15 @@ package org.neo4j.driver.internal.value;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.io.Serializable;
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.types.TypeConstructor;
 import org.neo4j.driver.types.TypeSystem;
@@ -83,5 +88,18 @@ class StringValueTest {
     void shouldHaveStringType() {
         InternalValue value = new StringValue("Spongebob");
         assertThat(value.type(), equalTo(InternalTypeSystem.TYPE_SYSTEM.STRING()));
+    }
+
+    @Test
+    void shouldMapToType() {
+        var string = "value";
+        var values = Values.value(string);
+        assertEquals(string, values.as(String.class));
+        assertEquals(string, values.as(Serializable.class));
+        assertEquals(string, values.as(Comparable.class));
+        assertEquals(string, values.as(CharSequence.class));
+        assertEquals(string, values.as(Constable.class));
+        assertEquals(string, values.as(ConstantDesc.class));
+        assertEquals(string, values.as(Object.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/TimeValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/TimeValueTest.java
@@ -19,9 +19,13 @@ package org.neo4j.driver.internal.value;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 
@@ -53,5 +57,17 @@ class TimeValueTest {
         var timeValue = new TimeValue(time);
 
         assertThrows(Uncoercible.class, timeValue::asLong);
+    }
+
+    @Test
+    void shouldMapToType() {
+        var date = OffsetTime.now();
+        var values = Values.value(date);
+        assertEquals(date, values.as(OffsetTime.class));
+        assertEquals(date, values.as(Temporal.class));
+        assertEquals(date, values.as(TemporalAdjuster.class));
+        assertEquals(date, values.as(Comparable.class));
+        assertEquals(date, values.as(Serializable.class));
+        assertEquals(date, values.as(Object.class));
     }
 }


### PR DESCRIPTION
Please note that this is a [feature preview](https://github.com/neo4j/neo4j-java-driver/blob/5.0/README.md#preview-features).

This update brings support for mapping `org.neo4j.driver.Value` and `org.neo4j.driver.Record` to custom object types.

 ## org.neo4j.driver.Value

The following new method has been introduced to `org.neo4j.driver.Value`:
```java
<T> T as(Class<T> targetClass)
```

It maps the value to the given type providing that is it supported.

 ### Basic Mapping

Supported destination types depend on the value `org.neo4j.driver.types.Type`, please see the supported mappings below.

- `TypeSystem#BOOLEAN` -> `boolean`, `Boolean`
- `TypeSystem#BYTES` -> `byte[]`
- `TypeSystem#STRING` -> `String`
- `TypeSystem#INTEGER` -> `long`, `Long`, `int`, `Integer`, `double`, `Double`, `float`, `Float`
- `TypeSystem#FLOAT` -> `long`, `Long`, `int`, `Integer`, `double`, `Double`, `float`, `Float`
- `TypeSystem#PATH` -> `Path`
- `TypeSystem#POINT` -> `Point`
- `TypeSystem#DATE` -> `LocalDate`
- `TypeSystem#TIME` -> `OffsetTime`
- `TypeSystem#LOCAL_TIME` -> `LocalTime`
- `TypeSystem#LOCAL_DATE_TIME` -> `LocalDateTime`
- `TypeSystem#DATE_TIME` -> `ZonedDateTime`, `OffsetDateTime`
- `TypeSystem#DURATION` -> `IsoDuration`, `java.time.Period` (only when `seconds = 0` and `nanoseconds = 0` and no overflow happens), `java.time.Duration` (only when `months = 0` and `days = 0` and no overflow happens)
- `TypeSystem#NULL` -> `null`
- `TypeSystem#LIST` -> `List`
- `TypeSystem#MAP` -> `Map`
- `TypeSystem#NODE` -> `Node`
- `TypeSystem#RELATIONSHIP` -> `Relationship`

 ### Object Mapping

Mapping of user-defined properties to user-defined types is supported for the following value types:
- `TypeSystem#NODE`
- `TypeSystem#RELATIONSHIP`
- `TypeSystem#MAP`

Example (using the [Neo4j Movies Database](https://github.com/neo4j-graph-examples/movies)):
```java
// assuming the following Java record
public record Movie(String title, String tagline, long released) {}
// the nodes may be mapped to Movie instances
var movies = driver.executableQuery("MATCH (movie:Movie) RETURN movie")
        .execute()
        .records()
        .stream()
        .map(record -> record.get("movie").as(Movie.class))
        .toList();
}
```
Note that Object Mapping is an alternative to accessing the user-defined values in a `org.neo4j.driver.types.MapAccessor`. If Object Graph Mapping (OGM) is needed, please use a higher level solution built on top of the driver, like [Spring Data Neo4j](https://neo4j.com/docs/getting-started/languages-guides/java/spring-data-neo4j/).

The mapping is done by matching user-defined property names to target type constructor parameters. Therefore, the constructor parameters must either have `org.neo4j.driver.mapping.Property` annotation or have a matching name that is available at runtime (note that the constructor parameter names are typically changed by the compiler unless either the compiler `-parameters` option is used or they belong to the cannonical constructor of `java.lang.Record`). The name matching is case-sensitive.

Additionally, the `org.neo4j.driver.mapping.Property` annotation may be used when mapping a property with a different name to `java.lang.Record` cannonical constructor parameter.

The constructor selection criteria is the following (top priority first):
- Maximum matching properties.
- Minimum mismatching properties.

The constructor search is done in the order defined by the `java.lang.Class#getDeclaredConstructors` and is finished either when a full match is found with no mismatches or once all constructors have been visited.

At least 1 property match must be present for mapping to work.

A `null` value is used for arguments that don't have a matching property. If the argument does not accept `null` value (this includes primitive types), an alternative constructor that excludes it must be available.

Example with optional property (using the [Neo4j Movies Database](https://github.com/neo4j-graph-examples/movies)):
```java
// assuming the following Java record
public record Person(String name, long born) {
    // alternative constructor for values that don't have 'born' property available
    public Person(@Property("name") String name) {
        this(name, -1);
    }
}
// the nodes may be mapped to Person instances
var persons = driver.executableQuery("MATCH (person:Person) RETURN person")
        .execute()
        .records()
        .stream()
        .map(record -> record.get("person").as(Person.class))
        .toList();
```
Types with generic parameters defined at the class level are not supported. However, constructor arguments with specific types are permitted.

Example (using the [Neo4j Movies Database](https://github.com/neo4j-graph-examples/movies)):
```java
// assuming the following Java record
public record Acted(List<String> roles) {}
// the relationships may be mapped to Acted instances
var actedList = driver.executableQuery("MATCH ()-[acted:ACTED_IN]-() RETURN acted")
        .execute()
        .records()
        .stream()
        .map(record -> record.get("acted").as(Acted.class))
        .toList();
```
On the contrary, the following record would not be mapped because the type information is insufficient:
```java
public record Acted<T>(List<T> roles) {}
```
Wildcard type value is not supported.

 ## org.neo4j.driver.Record

The following new method has been introduced to `org.neo4j.driver.Record`:
```java
<T> T as(Class<T> targetClass)
```

It maps values of this record to properties of the given type providing that is it supported.

Example (using the [Neo4j Movies Database](https://github.com/neo4j-graph-examples/movies)):
```java
// assuming the following Java record
public record MovieInfo(String title, String director, List<String> actors) {}
// the record values may be mapped to MovieInfo instances
var movies = driver.executableQuery("MATCH (actor:Person)-[:ACTED_IN]->(movie:Movie)<-[:DIRECTED]-(director:Person) RETURN movie.title as title, director.name AS director, collect(actor.name) Ators")
        .execute()
        .records()
        .stream()
        .map(record -> record.as(MovieInfo.class))
        .toList();
}
```

It follows the same set of rules and has the same requirements as described in the `Object Mapping` `Value` section above.