### PR TITLE
feat(object-mapping): Add support for mapping list value to array

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Record.java
+++ b/driver/src/main/java/org/neo4j/driver/Record.java
@@ -129,6 +129,8 @@ public interface Record extends MapAccessorWithDefaultValue {
      * {@code null} value (this includes primitive types), an alternative constructor that excludes it must be
      * available.
      * <p>
+     * The mapping only works for types with directly accessible constructors, not interfaces or abstract types.
+     * <p>
      * Types with generic parameters defined at the class level are not supported. However, constructor arguments with
      * specific types are permitted, see the {@code actors} parameter in the example above.
      * <p>

--- a/driver/src/main/java/org/neo4j/driver/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/Value.java
@@ -545,11 +545,11 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *         </tr>
      *         <tr>
      *             <td>{@link TypeSystem#STRING}</td>
-     *             <td>{@link String}</td>
+     *             <td>{@link String}, {@code char}, {@link Character}</td>
      *         </tr>
      *         <tr>
      *             <td>{@link TypeSystem#INTEGER}</td>
-     *             <td>{@code long}, {@link Long}, {@code int}, {@link Integer}, {@code double}, {@link Double}, {@code float}, {@link Float}</td>
+     *             <td>{@code long}, {@link Long}, {@code int}, {@link Integer}, {@code short}, {@link Short}, {@code double}, {@link Double}, {@code float}, {@link Float}</td>
      *         </tr>
      *         <tr>
      *             <td>{@link TypeSystem#FLOAT}</td>
@@ -594,7 +594,9 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *         </tr>
      *         <tr>
      *             <td>{@link TypeSystem#LIST}</td>
-     *             <td>{@link List}</td>
+     *             <td>{@link List}, {@code T[]} as long as list elements may be mapped to the array component type
+     *             (for example, {@code char[]}, {@code boolean[]}, {@code String[]}, {@code long[]}, {@code int[]},
+     *             {@code short[]}, {@code double[]}, {@code float[]})</td>
      *         </tr>
      *         <tr>
      *             <td>{@link TypeSystem#MAP}</td>
@@ -662,6 +664,8 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      * A {@code null} value is used for arguments that don't have a matching property. If the argument does not accept
      * {@code null} value (this includes primitive types), an alternative constructor that excludes it must be
      * available.
+     * <p>
+     * The mapping only works for types with directly accessible constructors, not interfaces or abstract types.
      * <p>
      * Example with optional property (using the <a href=https://github.com/neo4j-graph-examples/movies>Neo4j Movies Database</a>):
      * <pre>

--- a/driver/src/main/java/org/neo4j/driver/internal/value/IntegerValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/IntegerValue.java
@@ -85,8 +85,19 @@ public class IntegerValue extends NumberValueAdapter<Long> {
             return (T) Float.valueOf(asFloat());
         } else if (targetClass.equals(Float.class)) {
             return targetClass.cast(asFloat());
+        } else if (targetClass.equals(short.class)) {
+            return (T) Short.valueOf(asShort());
+        } else if (targetClass.equals(Short.class)) {
+            return targetClass.cast(asShort());
         }
         throw new Uncoercible(type().name(), targetClass.getCanonicalName());
+    }
+
+    private short asShort() {
+        if (val > Short.MAX_VALUE || val < Short.MIN_VALUE) {
+            throw new LossyCoercion(type().name(), "Java short");
+        }
+        return (short) val;
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ListValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ListValue.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.internal.value;
 
 import static org.neo4j.driver.Values.ofObject;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
+import org.neo4j.driver.exceptions.value.ValueException;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.internal.util.Extract;
 import org.neo4j.driver.types.Type;
@@ -64,6 +66,22 @@ public class ListValue extends ValueAdapter {
     public <T> T as(Class<T> targetClass) {
         if (targetClass.isAssignableFrom(List.class)) {
             return targetClass.cast(asList());
+        } else if (targetClass.isArray()) {
+            var componentType = targetClass.componentType();
+            var array = Array.newInstance(componentType, values.length);
+            for (var i = 0; i < values.length; i++) {
+                Object value;
+                try {
+                    value = values[i].as(componentType);
+                } catch (Throwable throwable) {
+                    throw new ValueException(
+                            "Failed to map LIST value to %s - an error occured while mapping the element at index %d"
+                                    .formatted(targetClass.getCanonicalName(), i),
+                            throwable);
+                }
+                Array.set(array, i, value);
+            }
+            return targetClass.cast(array);
         }
         throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/value/StringValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/StringValue.java
@@ -17,6 +17,7 @@
 package org.neo4j.driver.internal.value;
 
 import java.util.Objects;
+import org.neo4j.driver.exceptions.value.LossyCoercion;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.types.InternalTypeSystem;
 import org.neo4j.driver.types.Type;
@@ -51,10 +52,17 @@ public class StringValue extends ValueAdapter {
         return val;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T as(Class<T> targetClass) {
         if (targetClass.isAssignableFrom(String.class)) {
             return targetClass.cast(asString());
+        } else if ((targetClass.isAssignableFrom(char.class) || targetClass.isAssignableFrom(Character.class))) {
+            if (val.length() == 1) {
+                return (T) Character.valueOf(val.charAt(0));
+            } else {
+                throw new LossyCoercion(type().name(), targetClass.getCanonicalName());
+            }
         }
         throw new Uncoercible(type().name(), targetClass.getCanonicalName());
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/IntegerValueTest.java
@@ -148,5 +148,7 @@ class IntegerValueTest {
         assertEquals(expected, value.as(Double.class));
         assertEquals((float) expected, value.as(float.class));
         assertEquals((float) expected, value.as(Float.class));
+        assertEquals((short) expected, value.as(short.class));
+        assertEquals((short) expected, value.as(Short.class));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/ListValueTest.java
@@ -18,9 +18,12 @@ package org.neo4j.driver.internal.value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.Values.value;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -51,6 +54,107 @@ class ListValueTest {
         assertEquals(list, values.as(Collection.class));
         assertEquals(list, values.as(Iterable.class));
         assertEquals(list, values.as(Object.class));
+    }
+
+    @Test
+    void shouldMapCharValuesToArray() {
+        var array = new char[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(char[].class));
+    }
+
+    @Test
+    void shouldMapBooleanValuesToArray() {
+        var array = new boolean[] {false};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(boolean[].class));
+    }
+
+    @Test
+    void shouldMapStringValuesToArray() {
+        var array = new String[] {"value"};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(String[].class));
+    }
+
+    @Test
+    void shouldMapLongValuesToArray() {
+        var array = new long[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(long[].class));
+        assertArrayEquals(Arrays.stream(array).mapToInt(l -> (int) l).toArray(), values.as(int[].class));
+        assertArrayEquals(Arrays.stream(array).mapToDouble(l -> (double) l).toArray(), values.as(double[].class));
+        var expectedFloats = new float[array.length];
+        for (var i = 0; i < array.length; i++) expectedFloats[i] = (float) array[i];
+        assertArrayEquals(expectedFloats, values.as(float[].class));
+    }
+
+    @Test
+    void shouldMapIntegerValuesToArray() {
+        var array = new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(int[].class));
+        assertArrayEquals(Arrays.stream(array).mapToLong(l -> (long) l).toArray(), values.as(long[].class));
+        assertArrayEquals(Arrays.stream(array).mapToDouble(l -> (double) l).toArray(), values.as(double[].class));
+        var expectedFloats = new float[array.length];
+        for (var i = 0; i < array.length; i++) expectedFloats[i] = (float) array[i];
+        assertArrayEquals(expectedFloats, values.as(float[].class));
+    }
+
+    @Test
+    void shouldMapShortValuesToArray() {
+        var array = new short[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(short[].class));
+    }
+
+    @Test
+    void shouldMapDoubleValuesToArray() {
+        var array = new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(double[].class));
+        assertArrayEquals(Arrays.stream(array).mapToLong(l -> (long) l).toArray(), values.as(long[].class));
+        assertArrayEquals(Arrays.stream(array).mapToInt(l -> (int) l).toArray(), values.as(int[].class));
+        var expectedFloats = new float[array.length];
+        for (var i = 0; i < array.length; i++) expectedFloats[i] = (float) array[i];
+        assertArrayEquals(expectedFloats, values.as(float[].class));
+    }
+
+    @Test
+    void shouldMapFloatValuesToArray() {
+        var array = new float[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(float[].class));
+        var expectedDoubles = new double[array.length];
+        for (var i = 0; i < array.length; i++) expectedDoubles[i] = array[i];
+        assertArrayEquals(expectedDoubles, values.as(double[].class));
+        var expectedLongs = new long[array.length];
+        for (var i = 0; i < array.length; i++) expectedLongs[i] = (long) array[i];
+        assertArrayEquals(expectedLongs, values.as(long[].class));
+        var expectedIntegers = new int[array.length];
+        for (var i = 0; i < array.length; i++) expectedIntegers[i] = (int) array[i];
+        assertArrayEquals(expectedIntegers, values.as(int[].class));
+    }
+
+    @Test
+    void shouldMapObjectsToArray() {
+        var string = "value";
+        var localDateTime = LocalDateTime.now();
+        var array = new Object[] {string, localDateTime};
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(Object[].class));
+    }
+
+    @Test
+    void shouldMapMatrixValuesToArrays() {
+        var array = new long[10][10];
+        for (var i = 0; i < array.length; i++) {
+            for (var j = 0; j < 10; j++) {
+                array[i][j] = i * j;
+            }
+        }
+        var values = Values.value(array);
+        assertArrayEquals(array, values.as(long[][].class));
     }
 
     private ListValue listValue(Value... values) {

--- a/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/value/StringValueTest.java
@@ -92,9 +92,11 @@ class StringValueTest {
 
     @Test
     void shouldMapToType() {
-        var string = "value";
+        var string = "0";
         var values = Values.value(string);
         assertEquals(string, values.as(String.class));
+        assertEquals(string.charAt(0), values.as(char.class));
+        assertEquals(string.charAt(0), values.as(Character.class));
         assertEquals(string, values.as(Serializable.class));
         assertEquals(string, values.as(Comparable.class));
         assertEquals(string, values.as(CharSequence.class));


### PR DESCRIPTION
The main objective of this update is to add support for mapping list value to array. Given that `org.neo4j.driver.Values#value(Object)` method allows creating list value from array (excluding `byte[]`), it makes sense to support the mapping back from list value to array.

Example:
```java
var array = new float[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
var values = Values.value(array);
assertArrayEquals(array, values.as(float[].class));
```

As `org.neo4j.driver.Values#value(Object)` supports mapping `char[]` and `short[]` to list values, the supported mappings from string and integer values have also been extended.

Updated list of supported mappings:
- `TypeSystem#LIST` -> `List`, `T[]` as long as list elements may be mapped to the array component type (for example, `char[]`, `boolean[]`, `String[]`, `long[]`, `int[]`, `short[]`, `double[]`, `float[]`)
- `TypeSystem#STRING` -> `String`, `char`, `Character`
- `TypeSystem#INTEGER` -> `long`, `Long`, `int`, `Integer`, `short`, `Short`, `double`, `Double`, `float`, `Float`
