### PR TITLE
feat(bookmarks): delete deprecated multi value support in Bookmark

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -682,4 +682,34 @@
         <differenceType>8001</differenceType>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Bookmark</className>
+        <differenceType>7002</differenceType>
+        <method>org.neo4j.driver.Bookmark from(java.util.Set)</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Bookmark</className>
+        <differenceType>7002</differenceType>
+        <method>boolean isEmpty()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Bookmark</className>
+        <differenceType>7002</differenceType>
+        <method>java.util.Set values()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Session</className>
+        <differenceType>7002</differenceType>
+        <method>org.neo4j.driver.Bookmark lastBookmark()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/async/AsyncSession</className>
+        <differenceType>7002</differenceType>
+        <method>org.neo4j.driver.Bookmark lastBookmark()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Bookmark.java
+++ b/driver/src/main/java/org/neo4j/driver/Bookmark.java
@@ -16,8 +16,6 @@
  */
 package org.neo4j.driver;
 
-import java.util.Collections;
-import java.util.Set;
 import org.neo4j.driver.internal.InternalBookmark;
 
 /**
@@ -40,38 +38,12 @@ public interface Bookmark {
     String value();
 
     /**
-     * Returns a read-only set of bookmark strings that this bookmark instance identifies.
-     *
-     * @return a read-only set of bookmark strings that this bookmark instance identifies.
-     */
-    @Deprecated
-    Set<String> values();
-
-    /**
      * Reconstruct bookmark from bookmark string value.
      *
      * @param value value obtained from a previous bookmark.
      * @return A bookmark.
      */
     static Bookmark from(String value) {
-        return InternalBookmark.parse(Collections.singleton(value));
+        return new InternalBookmark(value);
     }
-
-    /**
-     * Reconstruct bookmark from bookmarks string values.
-     *
-     * @param values values obtained from a previous bookmark.
-     * @return A bookmark.
-     */
-    @Deprecated
-    static Bookmark from(Set<String> values) {
-        return InternalBookmark.parse(values);
-    }
-
-    /**
-     * Return true if the bookmark is empty.
-     * @return true if the bookmark is empty.
-     */
-    @Deprecated
-    boolean isEmpty();
 }

--- a/driver/src/main/java/org/neo4j/driver/Session.java
+++ b/driver/src/main/java/org/neo4j/driver/Session.java
@@ -309,17 +309,6 @@ public interface Session extends BaseSession, Resource, QueryRunner {
     Result run(Query query, TransactionConfig config);
 
     /**
-     * Return the last bookmark of this session.
-     * <p>
-     * When no new bookmark is received, the initial bookmarks are returned as a composite {@link Bookmark} containing all initial bookmarks. This may happen
-     * when no work has been done using the session. If no initial bookmarks have been provided, an empty {@link Bookmark} is returned.
-     *
-     * @return the last bookmark.
-     */
-    @Deprecated
-    Bookmark lastBookmark();
-
-    /**
      * Return a set of last bookmarks.
      * <p>
      * When no new bookmark is received, the initial bookmarks are returned. This may happen when no work has been done using the session. Multivalued {@link

--- a/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/async/AsyncSession.java
@@ -382,17 +382,6 @@ public interface AsyncSession extends BaseSession, AsyncQueryRunner {
     CompletionStage<ResultCursor> runAsync(Query query, TransactionConfig config);
 
     /**
-     * Return the last bookmark of this session.
-     * <p>
-     * When no new bookmark is received, the initial bookmarks are returned as a composite {@link Bookmark} containing all initial bookmarks. This may happen
-     * when no work has been done using the session. If no initial bookmarks have been provided, an empty {@link Bookmark} is returned.
-     *
-     * @return the last bookmark.
-     */
-    @Deprecated
-    Bookmark lastBookmark();
-
-    /**
      * Return a set of last bookmarks.
      * <p>
      * When no new bookmark is received, the initial bookmarks are returned. This may happen when no work has been done using the session. Multivalued {@link

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalBookmark.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalBookmark.java
@@ -18,120 +18,14 @@ package org.neo4j.driver.internal;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
 import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.internal.util.Iterables;
 
-public final class InternalBookmark implements Bookmark, Serializable {
-    @Serial
-    private static final long serialVersionUID = 8196096018245038950L;
-
-    private static final InternalBookmark EMPTY = new InternalBookmark(Collections.emptySet());
-
-    @SuppressWarnings("serial")
-    private final Set<String> values;
-
-    private InternalBookmark(Set<String> values) {
-        requireNonNull(values);
-        this.values = values;
-    }
-
-    public static Bookmark empty() {
-        return EMPTY;
-    }
-
-    @SuppressWarnings("deprecation")
-    public static Bookmark from(Iterable<Bookmark> bookmarks) {
-        if (bookmarks == null) {
-            return empty();
+public record InternalBookmark(String value) implements Bookmark, Serializable {
+    public InternalBookmark {
+        requireNonNull(value);
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("The value must not be empty");
         }
-
-        var size = Iterables.count(bookmarks);
-        if (size == 0) {
-            return empty();
-        } else if (size == 1) {
-            return from(bookmarks.iterator().next());
-        }
-
-        Set<String> newValues = new HashSet<>();
-        for (var value : bookmarks) {
-            if (value == null) {
-                continue; // skip any null bookmark value
-            }
-            newValues.addAll(value.values());
-        }
-        return new InternalBookmark(newValues);
-    }
-
-    private static Bookmark from(Bookmark bookmark) {
-        if (bookmark == null) {
-            return empty();
-        }
-        // it is safe to return the given bookmark as bookmarks values can not be modified once it is created.
-        return bookmark;
-    }
-
-    /**
-     * Used to extract bookmark from metadata from server.
-     */
-    public static Bookmark parse(String value) {
-        if (value == null) {
-            return empty();
-        }
-        return new InternalBookmark(Collections.singleton(value));
-    }
-
-    /**
-     * Used to reconstruct bookmark from values.
-     */
-    public static Bookmark parse(Set<String> values) {
-        if (values == null) {
-            return empty();
-        }
-        return new InternalBookmark(values);
-    }
-
-    @Override
-    @Deprecated
-    public boolean isEmpty() {
-        return values.isEmpty();
-    }
-
-    @Override
-    public String value() {
-        return values.isEmpty() ? null : values.iterator().next();
-    }
-
-    @Override
-    @Deprecated
-    public Set<String> values() {
-        return Collections.unmodifiableSet(values);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        var bookmark = (InternalBookmark) o;
-        return Objects.equals(values, bookmark.values);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(values);
-    }
-
-    @Override
-    public String toString() {
-        return "Bookmark{values=" + values + "}";
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalSession.java
@@ -133,12 +133,6 @@ public class InternalSession extends AbstractQueryRunner implements Session {
     }
 
     @Override
-    @Deprecated
-    public Bookmark lastBookmark() {
-        return InternalBookmark.from(session.lastBookmarks());
-    }
-
-    @Override
     public Set<Bookmark> lastBookmarks() {
         return session.lastBookmarks();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -101,16 +101,8 @@ public class SessionFactoryImpl implements SessionFactory {
         if (bookmarks != null) {
             for (var bookmark : bookmarks) {
                 if (bookmark != null) {
-                    @SuppressWarnings("deprecation")
-                    var values = bookmark.values();
-                    var size = values.size();
-                    if (size == 1) {
-                        set.add(bookmark);
-                    } else if (size > 1) {
-                        for (var value : values) {
-                            set.add(Bookmark.from(value));
-                        }
-                    }
+                    var values = bookmark.value();
+                    set.add(bookmark);
                 }
             }
         }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/InternalAsyncSession.java
@@ -36,7 +36,6 @@ import org.neo4j.driver.async.AsyncTransactionWork;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.GqlStatusError;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.telemetry.ApiTelemetryWork;
 import org.neo4j.driver.internal.util.Futures;
 
@@ -120,12 +119,6 @@ public class InternalAsyncSession extends AsyncAbstractQueryRunner implements As
     public <T> CompletionStage<T> executeWriteAsync(
             AsyncTransactionCallback<CompletionStage<T>> callback, TransactionConfig config) {
         return writeTransactionAsync(tx -> callback.execute(new DelegatingAsyncTransactionContext(tx)), config);
-    }
-
-    @Override
-    @Deprecated
-    public Bookmark lastBookmark() {
-        return InternalBookmark.from(session.lastBookmarks());
     }
 
     @Override

--- a/driver/src/test/java/org/neo4j/driver/SessionConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/SessionConfigTest.java
@@ -26,15 +26,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.neo4j.driver.SessionConfig.builder;
 import static org.neo4j.driver.SessionConfig.defaultConfig;
-import static org.neo4j.driver.internal.InternalBookmark.parse;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -126,8 +126,8 @@ class SessionConfigTest {
 
     @Test
     void shouldAcceptBookmarks() {
-        var one = parse("one");
-        var two = parse("two");
+        var one = Bookmark.from("one");
+        var two = Bookmark.from("two");
         var config = builder().withBookmarks(one, two).build();
         assertEquals(Arrays.asList(one, two), config.bookmarks());
 
@@ -137,8 +137,8 @@ class SessionConfigTest {
 
     @Test
     void shouldAcceptNullInBookmarks() {
-        var one = parse("one");
-        var two = parse("two");
+        var one = Bookmark.from("one");
+        var two = Bookmark.from("two");
         var config = builder().withBookmarks(one, two, null).build();
         assertEquals(Arrays.asList(one, two, null), config.bookmarks());
 
@@ -148,26 +148,26 @@ class SessionConfigTest {
 
     @Test
     void shouldSaveBookmarksCopyFromArray() {
-        var bookmark1 = parse("one");
-        var bookmark2 = parse("two");
+        var bookmark1 = Bookmark.from("one");
+        var bookmark2 = Bookmark.from("two");
         var bookmarks = new Bookmark[] {bookmark1, bookmark2};
         var config = builder().withBookmarks(bookmarks).build();
         assertEquals(List.of(bookmark1, bookmark2), config.bookmarks());
 
-        bookmarks[0] = parse("three");
+        bookmarks[0] = Bookmark.from("three");
 
         assertEquals(List.of(bookmark1, bookmark2), config.bookmarks());
     }
 
     @Test
     void shouldSaveBookmarksCopyFromIterable() {
-        var bookmark1 = parse("one");
-        var bookmark2 = parse("two");
+        var bookmark1 = Bookmark.from("one");
+        var bookmark2 = Bookmark.from("two");
         var bookmarks = new ArrayList<>(List.of(bookmark1, bookmark2));
         var config = builder().withBookmarks(bookmarks).build();
         assertEquals(List.of(bookmark1, bookmark2), config.bookmarks());
 
-        bookmarks.add(parse("three"));
+        bookmarks.add(Bookmark.from("three"));
 
         assertEquals(List.of(bookmark1, bookmark2), config.bookmarks());
     }
@@ -196,12 +196,14 @@ class SessionConfigTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldSerialize() throws Exception {
+        var bookmarks = Set.of(
+                Bookmark.from("bookmarkA"),
+                Bookmark.from("bookmarkB"),
+                Bookmark.from("bookmarkC"),
+                Bookmark.from("bookmarkD"));
         var config = SessionConfig.builder()
-                .withBookmarks(
-                        Bookmark.from(new HashSet<>(Arrays.asList("bookmarkA", "bookmarkB"))),
-                        Bookmark.from(new HashSet<>(Arrays.asList("bookmarkC", "bookmarkD"))))
+                .withBookmarks(bookmarks)
                 .withDefaultAccessMode(AccessMode.WRITE)
                 .withFetchSize(54321L)
                 .withDatabase("testing")
@@ -215,11 +217,9 @@ class SessionConfigTest {
 
         assertNotNull(verify.bookmarks());
 
-        List<Set<String>> bookmarks = new ArrayList<>();
-        verify.bookmarks().forEach(b -> bookmarks.add(b.values()));
-        assertEquals(2, bookmarks.size());
-        assertTrue(bookmarks.get(0).containsAll(Arrays.asList("bookmarkA", "bookmarkB")));
-        assertTrue(bookmarks.get(1).containsAll(Arrays.asList("bookmarkC", "bookmarkD")));
+        assertEquals(
+                bookmarks,
+                StreamSupport.stream(verify.bookmarks().spliterator(), false).collect(Collectors.toUnmodifiableSet()));
 
         assertEquals(config.defaultAccessMode(), verify.defaultAccessMode());
         assertEquals(config.fetchSize(), verify.fetchSize());

--- a/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/BookmarkIT.java
@@ -16,19 +16,19 @@
  */
 package org.neo4j.driver.integration;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.SessionConfig.builder;
-import static org.neo4j.driver.internal.InternalBookmark.parse;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkContainsSingleValue;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkIsEmpty;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarksContainsSingleUniqueValues;
+import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkContainsValue;
 
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.ClientException;
@@ -37,6 +37,7 @@ import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.Neo4jFeature;
 import org.neo4j.driver.testutil.ParallelizableIT;
 import org.neo4j.driver.testutil.SessionExtension;
+import org.testcontainers.shaded.com.google.common.collect.Streams;
 
 @ParallelizableIT
 class BookmarkIT {
@@ -54,37 +55,34 @@ class BookmarkIT {
 
     @Test
     @DisabledOnNeo4jWith(Neo4jFeature.BOLT_V4)
-    @SuppressWarnings("deprecation")
     void shouldReceiveBookmarkOnSuccessfulCommit() {
         // Given
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         // When
         createNodeInTx(session);
 
         // Then
-        assertBookmarkContainsSingleValue(session.lastBookmark(), startsWith("neo4j:bookmark:v1:tx"));
+        assertEquals(1, session.lastBookmarks().size());
+        assertBookmarkContainsValue(session.lastBookmarks().iterator().next(), startsWith("neo4j:bookmark:v1:tx"));
     }
 
     @Test
     @EnabledOnNeo4jWith(Neo4jFeature.BOLT_V4)
-    @SuppressWarnings("deprecation")
     void shouldReceiveNewBookmarkOnSuccessfulCommit() {
         // Given
-        var initialBookmark = session.lastBookmark();
-        assertBookmarkIsEmpty(initialBookmark);
+        assertTrue(session.lastBookmarks().isEmpty());
 
         // When
         createNodeInTx(session);
 
         // Then
-        assertBookmarkContainsSingleValue(session.lastBookmark());
-        assertNotEquals(initialBookmark, session.lastBookmark());
+        assertEquals(1, session.lastBookmarks().size());
     }
 
     @Test
     void shouldThrowForInvalidBookmark() {
-        var invalidBookmark = parse("hi, this is an invalid bookmark");
+        var invalidBookmark = Bookmark.from("hi, this is an invalid bookmark");
 
         try (var session =
                 driver.session(builder().withBookmarks(invalidBookmark).build())) {
@@ -93,103 +91,100 @@ class BookmarkIT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void bookmarkRemainsAfterRolledBackTx() {
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         createNodeInTx(session);
 
-        var bookmark = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark);
+        var bookmarks = session.lastBookmarks();
+        assertFalse(bookmarks.isEmpty());
 
         try (var tx = session.beginTransaction()) {
             tx.run("CREATE (a:Person)");
             tx.rollback();
         }
 
-        assertEquals(bookmark, session.lastBookmark());
+        assertEquals(bookmarks, session.lastBookmarks());
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void bookmarkRemainsAfterTxFailure() {
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         createNodeInTx(session);
 
-        var bookmark = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark);
+        var bookmarks = session.lastBookmarks();
+        assertFalse(bookmarks.isEmpty());
 
         var tx = session.beginTransaction();
 
         assertThrows(ClientException.class, () -> tx.run("RETURN"));
-        assertEquals(bookmark, session.lastBookmark());
+        assertEquals(bookmarks, session.lastBookmarks());
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void bookmarkRemainsAfterSuccessfulSessionRun() {
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         createNodeInTx(session);
 
-        var bookmark = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark);
+        var bookmarks = session.lastBookmarks();
+        assertFalse(bookmarks.isEmpty());
 
         session.run("RETURN 1").consume();
 
-        assertEquals(bookmark, session.lastBookmark());
+        assertEquals(bookmarks, session.lastBookmarks());
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void bookmarkRemainsAfterFailedSessionRun() {
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         createNodeInTx(session);
 
-        var bookmark = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark);
+        var bookmarks = session.lastBookmarks();
+        assertFalse(bookmarks.isEmpty());
 
         assertThrows(ClientException.class, () -> session.run("RETURN").consume());
-        assertEquals(bookmark, session.lastBookmark());
+        assertEquals(bookmarks, session.lastBookmarks());
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void bookmarkIsUpdatedOnEveryCommittedTx() {
-        assertBookmarkIsEmpty(session.lastBookmark());
+        assertTrue(session.lastBookmarks().isEmpty());
 
         createNodeInTx(session);
-        var bookmark1 = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark1);
+        var bookmarks1 = session.lastBookmarks();
+        assertEquals(1, bookmarks1.size());
 
         createNodeInTx(session);
-        var bookmark2 = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark2);
+        var bookmarks2 = session.lastBookmarks();
+        assertEquals(1, bookmarks2.size());
 
         createNodeInTx(session);
-        var bookmark3 = session.lastBookmark();
-        assertBookmarkContainsSingleValue(bookmark3);
+        var bookmarks3 = session.lastBookmarks();
+        assertEquals(1, bookmarks3.size());
 
-        assertBookmarksContainsSingleUniqueValues(bookmark1, bookmark2, bookmark3);
+        var uniqueNumber = Streams.concat(bookmarks1.stream(), bookmarks2.stream(), bookmarks3.stream())
+                .map(Bookmark::value)
+                .collect(Collectors.toSet())
+                .size();
+        assertEquals(3, uniqueNumber);
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void createSessionWithInitialBookmark() {
-        var bookmark = parse("TheBookmark");
+        var bookmark = Bookmark.from("TheBookmark");
         try (var session = driver.session(builder().withBookmarks(bookmark).build())) {
-            assertEquals(bookmark, session.lastBookmark());
+            assertEquals(bookmark, session.lastBookmarks().iterator().next());
         }
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void createSessionWithAccessModeAndInitialBookmark() {
-        var bookmark = parse("TheBookmark");
+        var bookmark = Bookmark.from("TheBookmark");
         try (var session = driver.session(builder().withBookmarks(bookmark).build())) {
-            assertEquals(bookmark, session.lastBookmark());
+            assertEquals(bookmark, session.lastBookmarks().iterator().next());
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionBoltV3IT.java
@@ -165,61 +165,59 @@ class SessionBoltV3IT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldUseBookmarksForAutoCommitTransactions() {
         @SuppressWarnings("resource")
         var session = driver.session();
-        var initialBookmark = session.lastBookmark();
+        var initialBookmarks = session.lastBookmarks();
 
         session.run("CREATE ()").consume();
-        var bookmark1 = session.lastBookmark();
-        assertNotNull(bookmark1);
-        assertNotEquals(initialBookmark, bookmark1);
+        var bookmarks1 = session.lastBookmarks();
+        assertNotNull(bookmarks1);
+        assertNotEquals(initialBookmarks, bookmarks1);
 
         session.run("CREATE ()").consume();
-        var bookmark2 = session.lastBookmark();
-        assertNotNull(bookmark2);
-        assertNotEquals(initialBookmark, bookmark2);
-        assertNotEquals(bookmark1, bookmark2);
+        var bookmarks2 = session.lastBookmarks();
+        assertNotNull(bookmarks2);
+        assertNotEquals(initialBookmarks, bookmarks2);
+        assertNotEquals(bookmarks1, bookmarks2);
 
         session.run("CREATE ()").consume();
-        var bookmark3 = session.lastBookmark();
-        assertNotNull(bookmark3);
-        assertNotEquals(initialBookmark, bookmark3);
-        assertNotEquals(bookmark1, bookmark3);
-        assertNotEquals(bookmark2, bookmark3);
+        var bookmarks3 = session.lastBookmarks();
+        assertNotNull(bookmarks3);
+        assertNotEquals(initialBookmarks, bookmarks3);
+        assertNotEquals(bookmarks1, bookmarks3);
+        assertNotEquals(bookmarks2, bookmarks3);
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldUseBookmarksForAutoCommitAndUnmanagedTransactions() {
         @SuppressWarnings("resource")
         var session = driver.session();
-        var initialBookmark = session.lastBookmark();
+        var initialBookmarks = session.lastBookmarks();
 
         try (var tx = session.beginTransaction()) {
             tx.run("CREATE ()");
             tx.commit();
         }
-        var bookmark1 = session.lastBookmark();
-        assertNotNull(bookmark1);
-        assertNotEquals(initialBookmark, bookmark1);
+        var bookmarks1 = session.lastBookmarks();
+        assertNotNull(bookmarks1);
+        assertNotEquals(initialBookmarks, bookmarks1);
 
         session.run("CREATE ()").consume();
-        var bookmark2 = session.lastBookmark();
-        assertNotNull(bookmark2);
-        assertNotEquals(initialBookmark, bookmark2);
-        assertNotEquals(bookmark1, bookmark2);
+        var bookmarks2 = session.lastBookmarks();
+        assertNotNull(bookmarks2);
+        assertNotEquals(initialBookmarks, bookmarks2);
+        assertNotEquals(bookmarks1, bookmarks2);
 
         try (var tx = session.beginTransaction()) {
             tx.run("CREATE ()");
             tx.commit();
         }
-        var bookmark3 = session.lastBookmark();
-        assertNotNull(bookmark3);
-        assertNotEquals(initialBookmark, bookmark3);
-        assertNotEquals(bookmark1, bookmark3);
-        assertNotEquals(bookmark2, bookmark3);
+        var bookmarks3 = session.lastBookmarks();
+        assertNotNull(bookmarks3);
+        assertNotEquals(initialBookmarks, bookmarks3);
+        assertNotEquals(bookmarks1, bookmarks3);
+        assertNotEquals(bookmarks2, bookmarks3);
     }
 
     @Test
@@ -227,25 +225,25 @@ class SessionBoltV3IT {
     void shouldUseBookmarksForAutoCommitTransactionsAndTransactionFunctions() {
         @SuppressWarnings("resource")
         var session = driver.session();
-        var initialBookmark = session.lastBookmark();
+        var initialBookmarks = session.lastBookmarks();
 
         session.writeTransaction(tx -> tx.run("CREATE ()").consume());
-        var bookmark1 = session.lastBookmark();
-        assertNotNull(bookmark1);
-        assertNotEquals(initialBookmark, bookmark1);
+        var bookmarks1 = session.lastBookmarks();
+        assertNotNull(bookmarks1);
+        assertNotEquals(initialBookmarks, bookmarks1);
 
         session.run("CREATE ()").consume();
-        var bookmark2 = session.lastBookmark();
-        assertNotNull(bookmark2);
-        assertNotEquals(initialBookmark, bookmark2);
-        assertNotEquals(bookmark1, bookmark2);
+        var bookmarks2 = session.lastBookmarks();
+        assertNotNull(bookmarks2);
+        assertNotEquals(initialBookmarks, bookmarks2);
+        assertNotEquals(bookmarks1, bookmarks2);
 
         session.writeTransaction(tx -> tx.run("CREATE ()").consume());
-        var bookmark3 = session.lastBookmark();
-        assertNotNull(bookmark3);
-        assertNotEquals(initialBookmark, bookmark3);
-        assertNotEquals(bookmark1, bookmark3);
-        assertNotEquals(bookmark2, bookmark3);
+        var bookmarks3 = session.lastBookmarks();
+        assertNotNull(bookmarks3);
+        assertNotEquals(initialBookmarks, bookmarks3);
+        assertNotEquals(bookmarks1, bookmarks3);
+        assertNotEquals(bookmarks2, bookmarks3);
     }
 
     //    @Test

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -41,9 +41,6 @@ import static org.neo4j.driver.SessionConfig.builder;
 import static org.neo4j.driver.SessionConfig.forDatabase;
 import static org.neo4j.driver.Values.parameters;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkContainsSingleValue;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkIsEmpty;
-import static org.neo4j.driver.internal.util.BookmarkUtil.assertBookmarkIsNotEmpty;
 import static org.neo4j.driver.internal.util.Matchers.arithmeticError;
 import static org.neo4j.driver.internal.util.Matchers.connectionAcquisitionTimeoutError;
 import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V4;
@@ -299,14 +296,14 @@ class SessionIT {
     void readTxCommittedWithoutTxSuccess() {
         try (var driver = newDriverWithoutRetries();
                 var session = driver.session()) {
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
 
             long answer = session.readTransaction(
                     tx -> tx.run("RETURN 42").single().get(0).asLong());
             assertEquals(42, answer);
 
             // bookmark should be not-null after commit
-            assertBookmarkContainsSingleValue(session.lastBookmark());
+            assertEquals(1, session.lastBookmarks().size());
         }
     }
 
@@ -334,7 +331,7 @@ class SessionIT {
     void readTxRolledBackWithTxFailure() {
         try (var driver = newDriverWithoutRetries();
                 var session = driver.session()) {
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
 
             long answer = session.readTransaction(tx -> {
                 var result = tx.run("RETURN 42");
@@ -345,7 +342,7 @@ class SessionIT {
             assertEquals(42, answer);
 
             // bookmark should remain null after rollback
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
         }
     }
 
@@ -375,7 +372,7 @@ class SessionIT {
     void readTxRolledBackWhenExceptionIsThrown() {
         try (var driver = newDriverWithoutRetries();
                 var session = driver.session()) {
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
 
             assertThrows(
                     IllegalStateException.class,
@@ -388,7 +385,7 @@ class SessionIT {
                     }));
 
             // bookmark should remain null after rollback
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
         }
     }
 
@@ -453,7 +450,7 @@ class SessionIT {
     void readTxCommittedWhenCommitAndThrowsException() {
         try (var driver = newDriverWithoutRetries();
                 var session = driver.session()) {
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
 
             assertThrows(
                     IllegalStateException.class,
@@ -464,7 +461,7 @@ class SessionIT {
                     }));
 
             // We successfully committed
-            assertBookmarkIsNotEmpty(session.lastBookmark());
+            assertFalse(session.lastBookmarks().isEmpty());
         }
     }
 
@@ -494,7 +491,7 @@ class SessionIT {
     void readRolledBackWhenRollbackAndThrowsException() {
         try (var driver = newDriverWithoutRetries();
                 var session = driver.session()) {
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
 
             assertThrows(
                     IllegalStateException.class,
@@ -505,7 +502,7 @@ class SessionIT {
                     }));
 
             // bookmark should remain null after rollback
-            assertBookmarkIsEmpty(session.lastBookmark());
+            assertTrue(session.lastBookmarks().isEmpty());
         }
     }
 

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncSessionIT.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.async.AsyncSession;
@@ -77,7 +78,6 @@ import org.neo4j.driver.exceptions.ResultConsumedException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.exceptions.TransientException;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.util.DisabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.EnabledOnNeo4jWith;
 import org.neo4j.driver.internal.util.Futures;
@@ -524,7 +524,7 @@ class AsyncSessionIT {
     @DisabledOnNeo4jWith(BOLT_V3)
     @SuppressWarnings("resource")
     void shouldRunAfterBeginTxFailureOnBookmark() {
-        var illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
+        var illegalBookmark = Bookmark.from("Illegal Bookmark");
         session = neo4j.driver()
                 .session(
                         AsyncSession.class,
@@ -540,7 +540,7 @@ class AsyncSessionIT {
     @Test
     @SuppressWarnings("resource")
     void shouldNotBeginTxAfterBeginTxFailureOnBookmark() {
-        var illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
+        var illegalBookmark = Bookmark.from("Illegal Bookmark");
         session = neo4j.driver()
                 .session(
                         AsyncSession.class,
@@ -553,7 +553,7 @@ class AsyncSessionIT {
     @EnabledOnNeo4jWith(BOLT_V3)
     @SuppressWarnings("resource")
     void shouldNotRunAfterBeginTxFailureOnBookmark() {
-        var illegalBookmark = InternalBookmark.parse("Illegal Bookmark");
+        var illegalBookmark = Bookmark.from("Illegal Bookmark");
         session = neo4j.driver()
                 .session(
                         AsyncSession.class,

--- a/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/async/AsyncTransactionIT.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.driver.SessionConfig.builder;
 import static org.neo4j.driver.Values.parameters;
-import static org.neo4j.driver.internal.InternalBookmark.parse;
 import static org.neo4j.driver.internal.util.Iterables.single;
 import static org.neo4j.driver.internal.util.Matchers.containsResultAvailableAfterAndResultConsumedAfter;
 import static org.neo4j.driver.internal.util.Matchers.syntaxError;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.ClientException;
@@ -79,29 +79,27 @@ class AsyncTransactionIT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldBePossibleToCommitEmptyTx() {
-        var bookmarkBefore = session.lastBookmark();
+        var bookmarksBefore = session.lastBookmarks();
 
         var tx = await(session.beginTransactionAsync());
         assertThat(await(tx.commitAsync()), is(nullValue()));
 
-        var bookmarkAfter = session.lastBookmark();
+        var bookmarksAfter = session.lastBookmarks();
 
-        assertNotNull(bookmarkAfter);
-        assertNotEquals(bookmarkBefore, bookmarkAfter);
+        assertNotNull(bookmarksAfter);
+        assertNotEquals(bookmarksBefore, bookmarksAfter);
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldBePossibleToRollbackEmptyTx() {
-        var bookmarkBefore = session.lastBookmark();
+        var bookmarksBefore = session.lastBookmarks();
 
         var tx = await(session.beginTransactionAsync());
         assertThat(await(tx.rollbackAsync()), is(nullValue()));
 
-        var bookmarkAfter = session.lastBookmark();
-        assertEquals(bookmarkBefore, bookmarkAfter);
+        var bookmarksAfter = session.lastBookmarks();
+        assertEquals(bookmarksBefore, bookmarksAfter);
     }
 
     @Test
@@ -270,7 +268,9 @@ class AsyncTransactionIT {
         var session = neo4j.driver()
                 .session(
                         AsyncSession.class,
-                        builder().withBookmarks(parse("InvalidBookmark")).build());
+                        builder()
+                                .withBookmarks(Bookmark.from("InvalidBookmark"))
+                                .build());
 
         var e = assertThrows(ClientException.class, () -> await(session.beginTransactionAsync()));
         assertTrue(e.getMessage().contains("InvalidBookmark")
@@ -592,17 +592,16 @@ class AsyncTransactionIT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldUpdateSessionBookmarkAfterCommit() {
-        var bookmarkBefore = session.lastBookmark();
+        var bookmarksBefore = session.lastBookmarks();
 
         await(session.beginTransactionAsync()
                 .thenCompose(tx -> tx.runAsync("CREATE (:MyNode)").thenCompose(ignore -> tx.commitAsync())));
 
-        var bookmarkAfter = session.lastBookmark();
+        var bookmarksAfter = session.lastBookmarks();
 
-        assertNotNull(bookmarkAfter);
-        assertNotEquals(bookmarkBefore, bookmarkAfter);
+        assertNotNull(bookmarksAfter);
+        assertNotEquals(bookmarksBefore, bookmarksAfter);
     }
 
     @Test

--- a/driver/src/test/java/org/neo4j/driver/internal/InternalBookmarkTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/InternalBookmarkTest.java
@@ -16,147 +16,26 @@
  */
 package org.neo4j.driver.internal;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.neo4j.driver.internal.InternalBookmark.parse;
-import static org.neo4j.driver.testutil.TestUtil.asSet;
 
-import java.util.Arrays;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Bookmark;
 
 class InternalBookmarkTest {
     @Test
-    @SuppressWarnings("deprecation")
-    void isEmptyForEmptyBookmark() {
-        var bookmark = InternalBookmark.empty();
-        assertTrue(bookmark.isEmpty());
-        assertEquals(emptySet(), bookmark.values());
+    void shouldReturnValue() {
+        var bookmark = Bookmark.from("SomeBookmark");
+        assertEquals("SomeBookmark", bookmark.value());
     }
 
     @Test
-    void shouldSetToEmptyForNullBookmark() {
-        var bookmark = InternalBookmark.from(null);
-        assertEquals(InternalBookmark.empty(), bookmark);
+    void shouldThrowOnNullValue() {
+        assertThrows(NullPointerException.class, () -> Bookmark.from(null));
     }
 
     @Test
-    void shouldSetToEmptyForEmptyBookmarkIterator() {
-        var bookmark = InternalBookmark.from(emptyList());
-        assertEquals(InternalBookmark.empty(), bookmark);
-    }
-
-    @Test
-    void shouldSetToEmptyForNullBookmarkList() {
-        var bookmark = InternalBookmark.from(singletonList(null));
-        assertEquals(InternalBookmark.empty(), bookmark);
-    }
-
-    @Test
-    void shouldIgnoreNullAndEmptyInBookmarkList() {
-        var bookmark = InternalBookmark.from(Arrays.asList(InternalBookmark.empty(), null, null));
-        assertEquals(InternalBookmark.empty(), bookmark);
-    }
-
-    @Test
-    void shouldReserveBookmarkValuesCorrectly() {
-        var one = parse("one");
-        var two = parse("two");
-        var empty = InternalBookmark.empty();
-        var bookmark = InternalBookmark.from(Arrays.asList(one, two, null, empty));
-        verifyValues(bookmark, "one", "two");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void isNotEmptyForNonEmptyBookmark() {
-        var bookmark = InternalBookmark.parse("SomeBookmark");
-        assertFalse(bookmark.isEmpty());
-    }
-
-    @Test
-    void asBeginTransactionParametersForNonEmptyBookmark() {
-        var bookmark = InternalBookmark.parse("SomeBookmark");
-        verifyValues(bookmark, "SomeBookmark");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void bookmarkFromString() {
-        var bookmark = InternalBookmark.parse("Cat");
-        assertEquals(singleton("Cat"), bookmark.values());
-        verifyValues(bookmark, "Cat");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void bookmarkFromNullString() {
-        var bookmark = InternalBookmark.parse((String) null);
-        assertTrue(bookmark.isEmpty());
-    }
-
-    @Test
-    void bookmarkFromSet() {
-        var input = asSet("neo4j:bookmark:v1:tx42", "neo4j:bookmark:v1:tx10", "neo4j:bookmark:v1:tx12");
-        var bookmark = InternalBookmark.parse(input);
-        verifyValues(bookmark, "neo4j:bookmark:v1:tx42", "neo4j:bookmark:v1:tx10", "neo4j:bookmark:v1:tx12");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void bookmarkFromNullIterable() {
-        var bookmark = InternalBookmark.parse((Set<String>) null);
-        assertTrue(bookmark.isEmpty());
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void bookmarkFromEmptyIterable() {
-        var bookmark = InternalBookmark.parse(emptySet());
-        assertTrue(bookmark.isEmpty());
-    }
-
-    @Test
-    void asBeginTransactionParametersForBookmarkWithInvalidValue() {
-        var bookmark = InternalBookmark.parse(
-                asSet("neo4j:bookmark:v1:tx1", "neo4j:bookmark:v1:txcat", "neo4j:bookmark:v1:tx3"));
-        verifyValues(bookmark, "neo4j:bookmark:v1:tx1", "neo4j:bookmark:v1:txcat", "neo4j:bookmark:v1:tx3");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void shouldReturnAllBookmarks() {
-        assertIterableEquals(emptyList(), InternalBookmark.empty().values());
-        assertIterableEquals(
-                singleton("neo4j:bookmark:v1:tx42"),
-                InternalBookmark.parse("neo4j:bookmark:v1:tx42").values());
-
-        var bookmarks = asSet("neo4j:bookmark:v1:tx1", "neo4j:bookmark:v1:tx2", "neo4j:bookmark:v1:tx3");
-        assertIterableEquals(bookmarks, InternalBookmark.parse(bookmarks).values());
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void valueShouldBeReadOnly() {
-        var bookmark = InternalBookmark.parse(asSet("first", "second"));
-        var values = bookmark.values();
-        assertThrows(UnsupportedOperationException.class, () -> values.add("third"));
-    }
-
-    @SuppressWarnings("deprecation")
-    private static void verifyValues(Bookmark bookmark, String... expectedValues) {
-        assertThat(bookmark.values().size(), equalTo(expectedValues.length));
-        assertThat(bookmark.values(), hasItems(expectedValues));
+    void shouldThrowOnEmptyValue() {
+        assertThrows(IllegalArgumentException.class, () -> Bookmark.from(""));
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/InternalAsyncSessionTest.java
@@ -74,6 +74,7 @@ import org.neo4j.bolt.connection.message.RollbackMessage;
 import org.neo4j.bolt.connection.summary.BeginSummary;
 import org.neo4j.bolt.connection.summary.RollbackSummary;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.Value;
@@ -84,7 +85,6 @@ import org.neo4j.driver.async.AsyncTransactionWork;
 import org.neo4j.driver.async.ResultCursor;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnection;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnectionProvider;
@@ -275,7 +275,7 @@ class InternalAsyncSessionTest {
 
     @Test
     void shouldReturnBookmark() {
-        session = newSession(connectionProvider, Collections.singleton(InternalBookmark.parse("Bookmark1")));
+        session = newSession(connectionProvider, Collections.singleton(Bookmark.from("Bookmark1")));
         asyncSession = new InternalAsyncSession(session);
 
         assertThat(asyncSession.lastBookmarks(), equalTo(session.lastBookmarks()));

--- a/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/NetworkSessionTest.java
@@ -83,10 +83,10 @@ import org.neo4j.bolt.connection.summary.RollbackSummary;
 import org.neo4j.bolt.connection.summary.RunSummary;
 import org.neo4j.bolt.connection.summary.TelemetrySummary;
 import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.exceptions.ClientException;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnection;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnectionProvider;
 import org.neo4j.driver.internal.adaptedbolt.DriverResponseHandler;
@@ -336,7 +336,7 @@ class NetworkSessionTest {
 
     @Test
     void updatesBookmarkWhenTxIsClosed() {
-        var bookmarkAfterCommit = InternalBookmark.parse("TheBookmark");
+        var bookmarkAfterCommit = Bookmark.from("TheBookmark");
         setupConnectionAnswers(
                 connection,
                 List.of(
@@ -429,7 +429,7 @@ class NetworkSessionTest {
 
     @Test
     void bookmarkIsPropagatedFromSession() {
-        var bookmarks = Collections.singleton(InternalBookmark.parse("Bookmarks"));
+        var bookmarks = Collections.singleton(Bookmark.from("Bookmarks"));
         var session = newSession(connectionProvider, bookmarks);
         setupSuccessfulBegin(connection);
 
@@ -445,8 +445,8 @@ class NetworkSessionTest {
 
     @Test
     void bookmarkIsPropagatedBetweenTransactions() {
-        var bookmark1 = InternalBookmark.parse("Bookmark1");
-        var bookmark2 = InternalBookmark.parse("Bookmark2");
+        var bookmark1 = Bookmark.from("Bookmark1");
+        var bookmark2 = Bookmark.from("Bookmark2");
 
         var session = newSession(connectionProvider);
 
@@ -521,7 +521,7 @@ class NetworkSessionTest {
 
     @Test
     void testPassingNoBookmarkShouldRetainBookmark() {
-        var bookmarks = Collections.singleton(InternalBookmark.parse("X"));
+        var bookmarks = Collections.singleton(Bookmark.from("X"));
         var session = newSession(connectionProvider, bookmarks);
         setupSuccessfulBegin(connection);
         beginTransaction(session);
@@ -607,7 +607,7 @@ class NetworkSessionTest {
                     return completedFuture(connection2);
                 });
 
-        var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx42"));
+        var bookmarks = Collections.singleton(Bookmark.from("neo4j:bookmark:v1:tx42"));
         var session = newSession(connectionProvider, bookmarks);
 
         var e = assertThrows(Exception.class, () -> beginTransaction(session));
@@ -666,7 +666,7 @@ class NetworkSessionTest {
                     return completedFuture(connection2);
                 });
 
-        var bookmarks = Collections.singleton(InternalBookmark.parse("neo4j:bookmark:v1:tx42"));
+        var bookmarks = Collections.singleton(Bookmark.from("neo4j:bookmark:v1:tx42"));
         var session = newSession(connectionProvider, bookmarks);
 
         var e = assertThrows(Exception.class, () -> beginTransaction(session));

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -83,7 +83,6 @@ import org.neo4j.driver.exceptions.ConnectionReadTimeoutException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.TransactionTerminatedException;
 import org.neo4j.driver.internal.FailableCursor;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnection;
 import org.neo4j.driver.internal.adaptedbolt.DriverResponseHandler;
 import org.neo4j.driver.internal.adaptedbolt.summary.PullSummary;
@@ -334,7 +333,7 @@ class UnmanagedTransactionTest {
                 mock(),
                 Logging.none());
 
-        var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
+        var bookmarks = Collections.singleton(Bookmark.from("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
 
         var e = assertThrows(RuntimeException.class, () -> await(tx.beginAsync(bookmarks, txConfig, null, true)));
@@ -372,7 +371,7 @@ class UnmanagedTransactionTest {
                 mock(),
                 Logging.none());
 
-        var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
+        var bookmarks = Collections.singleton(Bookmark.from("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
 
         await(tx.beginAsync(bookmarks, txConfig, null, true));
@@ -575,7 +574,7 @@ class UnmanagedTransactionTest {
                 apiTelemetryWork,
                 mock(),
                 Logging.none());
-        var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
+        var bookmarks = Collections.singleton(Bookmark.from("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
 
         var actualException = assertThrows(
@@ -613,7 +612,7 @@ class UnmanagedTransactionTest {
                 apiTelemetryWork,
                 mock(),
                 Logging.none());
-        var bookmarks = Collections.singleton(InternalBookmark.parse("SomeBookmark"));
+        var bookmarks = Collections.singleton(Bookmark.from("SomeBookmark"));
         var txConfig = TransactionConfig.empty();
 
         var actualException = assertThrows(

--- a/driver/src/test/java/org/neo4j/driver/internal/util/BookmarkUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/BookmarkUtil.java
@@ -17,74 +17,21 @@
 package org.neo4j.driver.internal.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.neo4j.driver.internal.util.Iterables.asList;
 
-import java.util.HashSet;
 import org.hamcrest.Matcher;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.InternalBookmark;
 
 public class BookmarkUtil {
     /**
-     * Bookmark is empty.
+     * Bookmark contains the value that matches the requirement set by matcher.
      */
-    @SuppressWarnings("deprecation")
-    public static void assertBookmarkIsEmpty(Bookmark bookmark) {
-        assertNotNull(bookmark);
-        assertThat(bookmark, instanceOf(InternalBookmark.class));
-        assertTrue(bookmark.isEmpty());
-    }
-
-    /**
-     * Bookmark is not empty but I do not care what value it has.
-     */
-    @SuppressWarnings("deprecation")
-    public static void assertBookmarkIsNotEmpty(Bookmark bookmark) {
-        assertNotNull(bookmark);
-        assertThat(bookmark, instanceOf(InternalBookmark.class));
-        assertFalse(bookmark.isEmpty());
-    }
-
-    /**
-     * Bookmark contains one single value
-     */
-    public static void assertBookmarkContainsSingleValue(Bookmark bookmark) {
-        assertBookmarkContainsSingleValue(bookmark, notNullValue(String.class));
-    }
-
-    /**
-     * Bookmark contains one single value and the value matches the requirement set by matcher.
-     */
-    @SuppressWarnings("deprecation")
-    public static void assertBookmarkContainsSingleValue(Bookmark bookmark, Matcher<String> matcher) {
+    public static void assertBookmarkContainsValue(Bookmark bookmark, Matcher<String> matcher) {
         assertNotNull(bookmark);
         assertThat(bookmark, instanceOf(InternalBookmark.class));
 
-        var values = asList((bookmark).values());
-        assertThat(values.size(), equalTo(1));
-        assertThat(values.get(0), matcher);
-    }
-
-    /**
-     * Each bookmark contains one single value and the values are all different from each other.
-     */
-    @SuppressWarnings("deprecation")
-    public static void assertBookmarksContainsSingleUniqueValues(Bookmark... bookmarks) {
-        var count = bookmarks.length;
-        var bookmarkStrings = new HashSet<String>();
-
-        for (var bookmark : bookmarks) {
-            assertBookmarkContainsSingleValue(bookmark);
-            var values = asList((bookmark).values());
-            bookmarkStrings.addAll(values);
-        }
-        assertEquals(count, bookmarkStrings.size());
+        assertThat(bookmark.value(), matcher);
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -155,8 +155,8 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
 
     @Test
     void asyncApiBigDataTest() throws Throwable {
-        var bookmark = createNodesAsync(bigDataTestBatchCount(), driver);
-        readNodesAsync(driver, bookmark);
+        var bookmarks = createNodesAsync(bigDataTestBatchCount(), driver);
+        readNodesAsync(driver, bookmarks);
     }
 
     @Test
@@ -441,8 +441,8 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
     }
 
     @SuppressWarnings("deprecation")
-    private static Bookmark createNodesBlocking(int batchCount, Driver driver) {
-        Bookmark bookmark;
+    private static Set<Bookmark> createNodesBlocking(int batchCount, Driver driver) {
+        Set<Bookmark> bookmarks;
 
         var start = System.nanoTime();
         try (var session = driver.session()) {
@@ -451,18 +451,18 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
                 session.writeTransaction(
                         tx -> createNodesInTx(tx, batchIndex, AbstractStressTestBase.BIG_DATA_TEST_BATCH_SIZE));
             }
-            bookmark = session.lastBookmark();
+            bookmarks = session.lastBookmarks();
         }
         var end = System.nanoTime();
         System.out.println("Node creation with blocking API took: " + NANOSECONDS.toMillis(end - start) + "ms");
 
-        return bookmark;
+        return bookmarks;
     }
 
     @SuppressWarnings("deprecation")
-    private static void readNodesBlocking(Driver driver, Bookmark bookmark) {
+    private static void readNodesBlocking(Driver driver, Set<Bookmark> bookmarks) {
         var start = System.nanoTime();
-        try (var session = driver.session(builder().withBookmarks(bookmark).build())) {
+        try (var session = driver.session(builder().withBookmarks(bookmarks).build())) {
             int nodesProcessed = session.readTransaction(tx -> {
                 var result = tx.run("MATCH (n:Node) RETURN n");
 
@@ -488,7 +488,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
     }
 
     @SuppressWarnings("deprecation")
-    private static Bookmark createNodesAsync(int batchCount, Driver driver) throws Throwable {
+    private static Set<Bookmark> createNodesAsync(int batchCount, Driver driver) throws Throwable {
         var start = System.nanoTime();
 
         var session = driver.session(AsyncSession.class);
@@ -511,15 +511,15 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
         var end = System.nanoTime();
         System.out.println("Node creation with async API took: " + NANOSECONDS.toMillis(end - start) + "ms");
 
-        return session.lastBookmark();
+        return session.lastBookmarks();
     }
 
     @SuppressWarnings("deprecation")
-    private static void readNodesAsync(Driver driver, Bookmark bookmark) throws Throwable {
+    private static void readNodesAsync(Driver driver, Set<Bookmark> bookmarks) throws Throwable {
         var start = System.nanoTime();
 
         var session = driver.session(
-                AsyncSession.class, builder().withBookmarks(bookmark).build());
+                AsyncSession.class, builder().withBookmarks(bookmarks).build());
         var nodesSeen = new AtomicInteger();
 
         var readQuery = session.readTransactionAsync(tx -> tx.runAsync("MATCH (n:Node) RETURN n")

--- a/driver/src/test/java/org/neo4j/driver/testutil/SessionExtension.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/SessionExtension.java
@@ -16,11 +16,8 @@
  */
 package org.neo4j.driver.testutil;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -111,22 +108,8 @@ public class SessionExtension extends DatabaseExtension implements Session, Befo
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public Bookmark lastBookmark() {
-        return realSession.lastBookmark();
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
     public Set<Bookmark> lastBookmarks() {
-        var bookmark = lastBookmark();
-        if (bookmark == null || bookmark.isEmpty()) {
-            return Collections.emptySet();
-        } else if (bookmark.values().size() == 1) {
-            return Collections.singleton(bookmark);
-        } else {
-            return bookmark.values().stream().map(Bookmark::from).collect(Collectors.toCollection(HashSet::new));
-        }
+        return realSession.lastBookmarks();
     }
 
     @Override

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
@@ -36,10 +36,10 @@ import neo4j.org.testkit.backend.messages.responses.Session;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.NotificationClassification;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.async.AsyncSession;
-import org.neo4j.driver.internal.InternalBookmark;
 import org.neo4j.driver.internal.InternalNotificationSeverity;
 import org.neo4j.driver.reactive.ReactiveSession;
 import reactor.core.publisher.Mono;
@@ -84,8 +84,7 @@ public class NewSession implements TestkitRequest {
                 .ifPresent(builder::withDefaultAccessMode);
 
         Optional.ofNullable(data.bookmarks)
-                .map(bookmarks ->
-                        bookmarks.stream().map(InternalBookmark::parse).collect(Collectors.toList()))
+                .map(bookmarks -> bookmarks.stream().map(Bookmark::from).collect(Collectors.toList()))
                 .ifPresent(builder::withBookmarks);
 
         Optional.ofNullable(data.database).ifPresent(builder::withDatabase);

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "5.0"
+    "ref": "6.x"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: the `org.neo4j.driver.Bookmark` no longer supports having multiple bookmark values, multiple values are supportted by simply having multiple instances of `Bookmark`