### PR TITLE
feat(logging): add support for System.Logger and deprecate Logging

### DIFF
--- a/benchkit-backend/src/main/java/neo4j/org/testkit/backend/Config.java
+++ b/benchkit-backend/src/main/java/neo4j/org/testkit/backend/Config.java
@@ -17,12 +17,10 @@
 package neo4j.org.testkit.backend;
 
 import java.net.URI;
-import java.util.logging.Level;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Logging;
 
-public record Config(int port, URI uri, AuthToken authToken, Logging logging) {
+public record Config(int port, URI uri, AuthToken authToken) {
     static Config load() {
         var env = System.getenv();
         var port = Integer.parseInt(env.getOrDefault("TEST_BACKEND_PORT", "9000"));
@@ -31,12 +29,9 @@ public record Config(int port, URI uri, AuthToken authToken, Logging logging) {
         var neo4jScheme = env.getOrDefault("TEST_NEO4J_SCHEME", "neo4j");
         var neo4jUser = env.getOrDefault("TEST_NEO4J_USER", "neo4j");
         var neo4jPassword = env.getOrDefault("TEST_NEO4J_PASS", "password");
-        var level = env.get("TEST_BACKEND_LOGGING_LEVEL");
-        var logging = level == null || level.isEmpty() ? Logging.none() : Logging.console(Level.parse(level));
         return new Config(
                 port,
                 URI.create(String.format("%s://%s:%d", neo4jScheme, neo4jHost, neo4jPort)),
-                AuthTokens.basic(neo4jUser, neo4jPassword),
-                logging);
+                AuthTokens.basic(neo4jUser, neo4jPassword));
     }
 }

--- a/benchkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
+++ b/benchkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
@@ -33,16 +33,12 @@ import org.neo4j.driver.GraphDatabase;
 public class Runner {
     public static void main(String[] args) throws InterruptedException {
         var config = Config.load();
-        var driver = GraphDatabase.driver(
-                config.uri(),
-                config.authToken(),
-                org.neo4j.driver.Config.builder().withLogging(config.logging()).build());
+        var driver = GraphDatabase.driver(config.uri(), config.authToken());
 
         EventLoopGroup group = new NioEventLoopGroup();
-        var logging = config.logging();
         var executor = Executors.newCachedThreadPool();
-        var workloadHandler = new WorkloadHandler(driver, executor, logging);
-        var readyHandler = new ReadyHandler(driver, logging);
+        var workloadHandler = new WorkloadHandler(driver, executor);
+        var readyHandler = new ReadyHandler(driver);
         try {
             var bootstrap = new ServerBootstrap();
             bootstrap
@@ -55,7 +51,7 @@ public class Runner {
                             var pipeline = channel.pipeline();
                             pipeline.addLast("codec", new HttpServerCodec());
                             pipeline.addLast("aggregator", new HttpObjectAggregator(512 * 1024));
-                            pipeline.addLast(new HttpRequestHandler(workloadHandler, readyHandler, logging));
+                            pipeline.addLast(new HttpRequestHandler(workloadHandler, readyHandler));
                         }
                     });
             var server = bootstrap.bind().sync();

--- a/benchkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/HttpRequestHandler.java
+++ b/benchkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/HttpRequestHandler.java
@@ -37,19 +37,16 @@ import java.util.concurrent.CompletionStage;
 import neo4j.org.testkit.backend.handler.ReadyHandler;
 import neo4j.org.testkit.backend.handler.WorkloadHandler;
 import neo4j.org.testkit.backend.request.WorkloadRequest;
-import org.neo4j.driver.Logger;
-import org.neo4j.driver.Logging;
 
 public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private static final System.Logger LOGGER = System.getLogger(WorkloadHandler.class.getName());
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WorkloadHandler workloadHandler;
     private final ReadyHandler readyHandler;
-    private final Logger logger;
 
-    public HttpRequestHandler(WorkloadHandler workloadHandler, ReadyHandler readyHandler, Logging logging) {
+    public HttpRequestHandler(WorkloadHandler workloadHandler, ReadyHandler readyHandler) {
         this.workloadHandler = Objects.requireNonNull(workloadHandler);
         this.readyHandler = Objects.requireNonNull(readyHandler);
-        this.logger = logging.getLog(getClass());
     }
 
     @Override
@@ -73,7 +70,8 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
         } else if ("/ready".equals(request.uri()) && HttpMethod.GET.equals(request.method())) {
             responseStage = readyHandler.ready(request.protocolVersion());
         } else {
-            logger.warn("Unknown request %s with %s method.", request.uri(), request.method());
+            LOGGER.log(
+                    System.Logger.Level.WARNING, "Unknown request %s with %s method.", request.uri(), request.method());
             responseStage = CompletableFuture.completedFuture(
                     new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.INTERNAL_SERVER_ERROR));
         }
@@ -90,7 +88,7 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        logger.error("An unexpected error occured.", cause);
+        LOGGER.log(System.Logger.Level.ERROR, "An unexpected error occured.", cause);
         ctx.close();
     }
 }

--- a/benchkit-backend/src/main/java/neo4j/org/testkit/backend/handler/ReadyHandler.java
+++ b/benchkit-backend/src/main/java/neo4j/org/testkit/backend/handler/ReadyHandler.java
@@ -23,16 +23,13 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Logger;
-import org.neo4j.driver.Logging;
 
 public class ReadyHandler {
+    private static final System.Logger LOGGER = System.getLogger(ReadyHandler.class.getName());
     private final Driver driver;
-    private final Logger logger;
 
-    public ReadyHandler(Driver driver, Logging logging) {
+    public ReadyHandler(Driver driver) {
         this.driver = driver;
-        this.logger = logging.getLog(getClass());
     }
 
     public CompletionStage<FullHttpResponse> ready(HttpVersion httpVersion) {
@@ -41,7 +38,7 @@ public class ReadyHandler {
                 .handle((ignored, throwable) -> {
                     HttpResponseStatus status;
                     if (throwable != null) {
-                        logger.error("An error occured during workload handling.", throwable);
+                        LOGGER.log(System.Logger.Level.ERROR, "An error occured during workload handling.", throwable);
                         status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
                     } else {
                         status = HttpResponseStatus.NO_CONTENT;

--- a/benchkit-backend/src/main/java/neo4j/org/testkit/backend/handler/WorkloadHandler.java
+++ b/benchkit-backend/src/main/java/neo4j/org/testkit/backend/handler/WorkloadHandler.java
@@ -33,8 +33,6 @@ import java.util.stream.Stream;
 import neo4j.org.testkit.backend.request.WorkloadRequest;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Logger;
-import org.neo4j.driver.Logging;
 import org.neo4j.driver.QueryConfig;
 import org.neo4j.driver.RoutingControl;
 import org.neo4j.driver.Session;
@@ -43,14 +41,13 @@ import org.neo4j.driver.SimpleQueryRunner;
 import org.neo4j.driver.TransactionCallback;
 
 public class WorkloadHandler {
+    private static final System.Logger LOGGER = System.getLogger(WorkloadHandler.class.getName());
     private final Driver driver;
     private final Executor executor;
-    private final Logger logger;
 
-    public WorkloadHandler(Driver driver, Executor executor, Logging logging) {
+    public WorkloadHandler(Driver driver, Executor executor) {
         this.driver = Objects.requireNonNull(driver);
         this.executor = Objects.requireNonNull(executor);
-        this.logger = logging.getLog(getClass());
     }
 
     public CompletionStage<FullHttpResponse> handle(HttpVersion httpVersion, WorkloadRequest workloadRequest) {
@@ -67,7 +64,7 @@ public class WorkloadHandler {
                 .handle((ignored, throwable) -> {
                     HttpResponseStatus status;
                     if (throwable != null) {
-                        logger.error("An error occured during workload handling.", throwable);
+                        LOGGER.log(System.Logger.Level.ERROR, "An error occured during workload handling.", throwable);
                         status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
                     } else {
                         status = HttpResponseStatus.NO_CONTENT;

--- a/driver-it/LICENSES.txt
+++ b/driver-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/NOTICE.txt
+++ b/driver-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/jul-to-slf4j-log4j-it/LICENSES.txt
+++ b/driver-it/jul-to-slf4j-log4j-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/jul-to-slf4j-log4j-it/NOTICE.txt
+++ b/driver-it/jul-to-slf4j-log4j-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/jul-to-slf4j-log4j-it/pom.xml
+++ b/driver-it/jul-to-slf4j-log4j-it/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-it</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-jul-to-slf4j-log4j-it</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Neo4j Java Driver (JUL to SLF4J with Log4j IT)</name>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-proc:none</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/driver-it/jul-to-slf4j-log4j-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/InMemoryAppender.java
+++ b/driver-it/jul-to-slf4j-log4j-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/InMemoryAppender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.jul.to.slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+final class InMemoryAppender extends AbstractAppender {
+    private final List<LogEvent> logEvents = new ArrayList<>();
+
+    InMemoryAppender(String name, Filter filter) {
+        super(name, filter, PatternLayout.createDefaultLayout(), false, null);
+        start();
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        logEvents.add(event);
+    }
+
+    List<LogEvent> getLogs() {
+        return logEvents;
+    }
+}

--- a/driver-it/jul-to-slf4j-log4j-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/LoggingIT.java
+++ b/driver-it/jul-to-slf4j-log4j-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/LoggingIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.jul.to.slf4j;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.internal.DriverFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+class LoggingIT {
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setup() {
+        java.util.logging.LogManager.getLogManager().reset();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+        var julLogger = java.util.logging.Logger.getLogger(DriverFactory.class.getName());
+        julLogger.setLevel(java.util.logging.Level.INFO);
+
+        Configurator.setLevel(DriverFactory.class.getName(), Level.INFO);
+        var logger = (Logger) LogManager.getLogger(DriverFactory.class.getName());
+        appender = new InMemoryAppender("Appender", null);
+        logger.addAppender(appender);
+        logger.setAdditive(false);
+    }
+
+    @Test
+    void shouldLog() {
+        var driver = GraphDatabase.driver("bolt://localhost:7687");
+
+        assertFalse(appender.getLogs().isEmpty());
+    }
+}

--- a/driver-it/jul-to-slf4j-logback-it/LICENSES.txt
+++ b/driver-it/jul-to-slf4j-logback-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/jul-to-slf4j-logback-it/NOTICE.txt
+++ b/driver-it/jul-to-slf4j-logback-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/jul-to-slf4j-logback-it/pom.xml
+++ b/driver-it/jul-to-slf4j-logback-it/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-it</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-jul-to-slf4j-logback-it</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Neo4j Java Driver (JUL to SLF4J with Logback IT)</name>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/driver-it/jul-to-slf4j-logback-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/InMemoryAppender.java
+++ b/driver-it/jul-to-slf4j-logback-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/InMemoryAppender.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.jul.to.slf4j;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import java.util.ArrayList;
+import java.util.List;
+
+final class InMemoryAppender extends AppenderBase<ILoggingEvent> {
+    private final List<ILoggingEvent> logs = new ArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent iLoggingEvent) {
+        logs.add(iLoggingEvent);
+    }
+
+    List<ILoggingEvent> getLogs() {
+        return logs;
+    }
+}

--- a/driver-it/jul-to-slf4j-logback-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/LoggingIT.java
+++ b/driver-it/jul-to-slf4j-logback-it/src/test/java/org/neo4j/driver/it/jul/to/slf4j/LoggingIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.jul.to.slf4j;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import java.util.logging.LogManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.internal.DriverFactory;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+class LoggingIT {
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setup() {
+        LogManager.getLogManager().reset();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+        var julLogger = java.util.logging.Logger.getLogger(DriverFactory.class.getName());
+        julLogger.setLevel(java.util.logging.Level.INFO);
+
+        var root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.OFF);
+        var logger = (Logger) LoggerFactory.getLogger(DriverFactory.class.getName());
+        appender = new InMemoryAppender();
+        appender.setContext(logger.getLoggerContext());
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
+    }
+
+    @Test
+    void shouldLog() {
+        var driver = GraphDatabase.driver("bolt://localhost:7687");
+
+        assertFalse(appender.getLogs().isEmpty());
+    }
+}

--- a/driver-it/log4j-it/LICENSES.txt
+++ b/driver-it/log4j-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/log4j-it/NOTICE.txt
+++ b/driver-it/log4j-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/log4j-it/pom.xml
+++ b/driver-it/log4j-it/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-it</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-log4j-it</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Neo4j Java Driver (Log4j IT)</name>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-proc:none</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/driver-it/log4j-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
+++ b/driver-it/log4j-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+final class InMemoryAppender extends AbstractAppender {
+    private final List<LogEvent> logEvents = new ArrayList<>();
+
+    InMemoryAppender(String name, Filter filter) {
+        super(name, filter, PatternLayout.createDefaultLayout(), false, null);
+        start();
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        logEvents.add(event);
+    }
+
+    List<LogEvent> getLogs() {
+        return logEvents;
+    }
+}

--- a/driver-it/log4j-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
+++ b/driver-it/log4j-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.internal.DriverFactory;
+
+class LoggingIT {
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setup() {
+        Configurator.setLevel(DriverFactory.class.getName(), Level.INFO);
+        var logger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(DriverFactory.class.getName());
+        appender = new InMemoryAppender("Appender", null);
+        logger.addAppender(appender);
+        logger.setAdditive(false);
+    }
+
+    @Test
+    void shouldLog() {
+        var driver = GraphDatabase.driver("bolt://localhost:7687");
+
+        assertFalse(appender.getLogs().isEmpty());
+    }
+}

--- a/driver-it/pom.xml
+++ b/driver-it/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-parent</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-it</artifactId>
+
+    <packaging>pom</packaging>
+    <name>Neo4j Java Driver (Integration tests)</name>
+    <description>Parent project for the integration tests</description>
+
+    <modules>
+        <module>slf4j-logback-it</module>
+        <module>jul-to-slf4j-logback-it</module>
+        <module>log4j-it</module>
+        <module>slf4j-log4j-it</module>
+        <module>jul-to-slf4j-log4j-it</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+</project>

--- a/driver-it/slf4j-log4j-it/LICENSES.txt
+++ b/driver-it/slf4j-log4j-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/slf4j-log4j-it/NOTICE.txt
+++ b/driver-it/slf4j-log4j-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/slf4j-log4j-it/pom.xml
+++ b/driver-it/slf4j-log4j-it/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-it</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-slf4j-log4j-it</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Neo4j Java Driver (SLF4J with Log4j IT)</name>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk-platform-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-proc:none</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/driver-it/slf4j-log4j-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
+++ b/driver-it/slf4j-log4j-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+final class InMemoryAppender extends AbstractAppender {
+    private final List<LogEvent> logEvents = new ArrayList<>();
+
+    InMemoryAppender(String name, Filter filter) {
+        super(name, filter, PatternLayout.createDefaultLayout(), false, null);
+        start();
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        logEvents.add(event);
+    }
+
+    List<LogEvent> getLogs() {
+        return logEvents;
+    }
+}

--- a/driver-it/slf4j-log4j-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
+++ b/driver-it/slf4j-log4j-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.internal.DriverFactory;
+
+class LoggingIT {
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setup() {
+        Configurator.setLevel(DriverFactory.class.getName(), Level.INFO);
+        var logger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(DriverFactory.class.getName());
+        appender = new InMemoryAppender("Appender", null);
+        logger.addAppender(appender);
+        logger.setAdditive(false);
+    }
+
+    @Test
+    void shouldLog() {
+        var driver = GraphDatabase.driver("bolt://localhost:7687");
+
+        assertFalse(appender.getLogs().isEmpty());
+    }
+}

--- a/driver-it/slf4j-logback-it/LICENSES.txt
+++ b/driver-it/slf4j-logback-it/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/driver-it/slf4j-logback-it/NOTICE.txt
+++ b/driver-it/slf4j-logback-it/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/driver-it/slf4j-logback-it/pom.xml
+++ b/driver-it/slf4j-logback-it/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver-it</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-java-driver-slf4j-logback-it</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Neo4j Java Driver (SLF4J with Logback IT)</name>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j-java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j-java-driver.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j-java-driver</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk-platform-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/driver-it/slf4j-logback-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
+++ b/driver-it/slf4j-logback-it/src/test/java/org/neo4j/driver/it/slf4j/InMemoryAppender.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import java.util.ArrayList;
+import java.util.List;
+
+final class InMemoryAppender extends AppenderBase<ILoggingEvent> {
+    private final List<ILoggingEvent> logs = new ArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent iLoggingEvent) {
+        logs.add(iLoggingEvent);
+    }
+
+    List<ILoggingEvent> getLogs() {
+        return logs;
+    }
+}

--- a/driver-it/slf4j-logback-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
+++ b/driver-it/slf4j-logback-it/src/test/java/org/neo4j/driver/it/slf4j/LoggingIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.it.slf4j;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.internal.DriverFactory;
+import org.slf4j.LoggerFactory;
+
+class LoggingIT {
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setup() {
+        var root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.OFF);
+        var logger = (Logger) LoggerFactory.getLogger(DriverFactory.class.getName());
+        appender = new InMemoryAppender();
+        appender.setContext(logger.getLoggerContext());
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
+    }
+
+    @Test
+    void shouldLog() {
+        var driver = GraphDatabase.driver("bolt://localhost:7687");
+
+        assertFalse(appender.getLogs().isEmpty());
+    }
+}

--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -800,4 +800,10 @@
         <method>org.neo4j.driver.reactive.ReactiveSession reactiveSession(org.neo4j.driver.SessionConfig)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Logging</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.Logging systemLogging()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -17,7 +17,6 @@
 package org.neo4j.driver;
 
 import static java.lang.String.format;
-import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 import static org.neo4j.driver.internal.util.DriverInfoUtil.driverVersion;
 
 import io.netty.channel.EventLoop;
@@ -32,7 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.UnsupportedFeatureException;
@@ -83,6 +81,7 @@ public final class Config implements Serializable {
     /**
      * User defined logging
      */
+    @SuppressWarnings("deprecation")
     private final Logging logging;
 
     /**
@@ -187,7 +186,10 @@ public final class Config implements Serializable {
      * Logging provider
      *
      * @return the Logging provider to use
+     * @deprecated the logging abstraction has been deprecated in favour of the {@link System.Logger} that the driver uses
+     * by default
      */
+    @Deprecated
     public Logging logging() {
         return logging;
     }
@@ -408,7 +410,9 @@ public final class Config implements Serializable {
      * Used to build new config instances
      */
     public static final class ConfigBuilder {
-        private Logging logging = DEV_NULL_LOGGING;
+        @SuppressWarnings("deprecation")
+        private Logging logging = Logging.systemLogging();
+
         private boolean logLeakedSessions;
         private int maxConnectionPoolSize = 100;
         private long idleTimeBeforeConnectionTest = -1;
@@ -432,7 +436,7 @@ public final class Config implements Serializable {
         private ConfigBuilder() {}
 
         /**
-         * Provide a logging implementation for the driver to use. Java logging framework {@link java.util.logging} with {@link Level#INFO} is used by default.
+         * Provide a logging implementation for the driver to use. {@link Logging#systemLogging()} is used by default.
          * Callers are expected to either implement {@link Logging} interface or provide one of the existing implementations available from static factory
          * methods in the {@link Logging} interface.
          * <p>
@@ -441,7 +445,10 @@ public final class Config implements Serializable {
          * @param logging the logging instance to use
          * @return this builder
          * @see Logging
+         * @deprecated the logging abstraction has been deprecated in favour of the {@link System.Logger} that the driver uses
+         * by default
          */
+        @Deprecated
         public ConfigBuilder withLogging(Logging logging) {
             this.logging = logging;
             return this;

--- a/driver/src/main/java/org/neo4j/driver/GraphDatabase.java
+++ b/driver/src/main/java/org/neo4j/driver/GraphDatabase.java
@@ -361,6 +361,7 @@ public final class GraphDatabase {
         return driverFactory.newInstance(uri, new StaticAuthTokenManager(authToken), clientCertificateManager, config);
     }
 
+    @SuppressWarnings("deprecation")
     private static Driver driver(
             URI uri,
             AuthTokenManager authTokenManager,

--- a/driver/src/main/java/org/neo4j/driver/Logger.java
+++ b/driver/src/main/java/org/neo4j/driver/Logger.java
@@ -23,7 +23,9 @@ package org.neo4j.driver;
  * message only if the needed logging level is enabled. Driver expects formatting to be done using {@link String#format(String, Object...)} method.
  * Thus, all supplied message templates will contain "%s" as parameter placeholders. This is different from all SLF4J-compatible logging frameworks
  * where parameter placeholder is "{}". Implementations of this interface should adapt placeholders from "%s" to "{}", if required.
+ * @deprecated the logging abstraction has been deprecated in favour of the {@link System.Logger}
  */
+@Deprecated
 public interface Logger {
     /**
      * Logs errors from this driver.

--- a/driver/src/main/java/org/neo4j/driver/Logging.java
+++ b/driver/src/main/java/org/neo4j/driver/Logging.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import org.neo4j.driver.internal.logging.ConsoleLogging;
 import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.internal.logging.Slf4jLogging;
+import org.neo4j.driver.internal.logging.SystemLogging;
 
 /**
  * Accessor for {@link Logger} instances. Configured once for a driver instance using {@link Config.ConfigBuilder#withLogging(Logging)} builder method.
@@ -82,7 +83,10 @@ import org.neo4j.driver.internal.logging.Slf4jLogging;
  *
  * @see Logger
  * @see Config.ConfigBuilder#withLogging(Logging)
+ * @deprecated the logging abstraction has been deprecated in favour of the {@link System.Logger} that the driver uses
+ * by default
  */
+@Deprecated
 public interface Logging extends Serializable {
     /**
      * Obtain a {@link Logger} instance by class, its name will be the fully qualified name of the class.
@@ -102,6 +106,16 @@ public interface Logging extends Serializable {
      * @return {@link Logger} instance
      */
     Logger getLog(String name);
+
+    /**
+     * Returns logging implementation that uses {@link System.Logger}.
+     *
+     * @return logging implementation
+     * @since 6.0.0
+     */
+    static Logging systemLogging() {
+        return SystemLogging.INSTANCE;
+    }
 
     /**
      * Create logging implementation that uses SLF4J.

--- a/driver/src/main/java/org/neo4j/driver/internal/BoltLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltLogger.java
@@ -20,9 +20,10 @@ import java.util.ResourceBundle;
 import org.neo4j.driver.Logger;
 
 public class BoltLogger implements System.Logger {
+    @SuppressWarnings("deprecation")
     private final Logger logger;
 
-    public BoltLogger(Logger logger) {
+    public BoltLogger(@SuppressWarnings("deprecation") Logger logger) {
         this.logger = logger;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/BoltLoggingProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/BoltLoggingProvider.java
@@ -20,9 +20,10 @@ import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.driver.Logging;
 
 public class BoltLoggingProvider implements LoggingProvider {
+    @SuppressWarnings("deprecation")
     private final Logging logging;
 
-    public BoltLoggingProvider(Logging logging) {
+    public BoltLoggingProvider(@SuppressWarnings("deprecation") Logging logging) {
         this.logging = logging;
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -82,6 +82,7 @@ public class DriverFactory {
         return newInstance(uri, authTokenManager, clientCertificateManager, config, null, null, null);
     }
 
+    @SuppressWarnings("deprecation")
     public final Driver newInstance(
             URI uri,
             AuthTokenManager authTokenManager,
@@ -141,6 +142,7 @@ public class DriverFactory {
                 rediscoverySupplier);
     }
 
+    @SuppressWarnings("deprecation")
     protected static MetricsProvider getOrCreateMetricsProvider(Config config, Clock clock) {
         var metricsAdapter = config.metricsAdapter();
         // This can actually only happen when someone mocks the config
@@ -154,6 +156,7 @@ public class DriverFactory {
         };
     }
 
+    @SuppressWarnings("deprecation")
     private InternalDriver createDriver(
             URI uri,
             BoltSecurityPlanManager securityPlanManager,
@@ -263,6 +266,7 @@ public class DriverFactory {
                 connectTimeoutMillis);
     }
 
+    @SuppressWarnings("deprecation")
     protected BoltConnectionProvider createBoltConnectionProvider(
             URI uri,
             Config config,
@@ -397,6 +401,7 @@ public class DriverFactory {
      * <p>
      * <b>This method is protected only for testing</b>
      */
+    @SuppressWarnings("deprecation")
     protected InternalDriver createDriver(
             BoltSecurityPlanManager securityPlanManager,
             SessionFactory sessionFactory,
@@ -442,7 +447,9 @@ public class DriverFactory {
      * <b>This method is protected only for testing</b>
      */
     protected RetryLogic createRetryLogic(
-            long maxTransactionRetryTime, EventExecutorGroup eventExecutorGroup, Logging logging) {
+            long maxTransactionRetryTime,
+            EventExecutorGroup eventExecutorGroup,
+            @SuppressWarnings("deprecation") Logging logging) {
         return new ExponentialBackoffRetryLogic(maxTransactionRetryTime, eventExecutorGroup, createClock(), logging);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/InternalDriver.java
@@ -59,6 +59,8 @@ public class InternalDriver implements Driver {
             BookmarkManagers.defaultManager(BookmarkManagerConfig.builder().build());
     private final BoltSecurityPlanManager securityPlanManager;
     private final SessionFactory sessionFactory;
+
+    @SuppressWarnings("deprecation")
     private final Logger log;
 
     private final boolean telemetryDisabled;
@@ -75,7 +77,7 @@ public class InternalDriver implements Driver {
             boolean telemetryDisabled,
             NotificationConfig notificationConfig,
             Supplier<CompletionStage<Void>> shutdownSupplier,
-            Logging logging) {
+            @SuppressWarnings("deprecation") Logging logging) {
         this.securityPlanManager = securityPlanManager;
         this.sessionFactory = sessionFactory;
         this.metricsProvider = metricsProvider;

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -48,12 +48,16 @@ public class SessionFactoryImpl implements SessionFactory {
     private final BoltSecurityPlanManager securityPlanManager;
     private final DriverBoltConnectionProvider connectionProvider;
     private final RetryLogic retryLogic;
+
+    @SuppressWarnings("deprecation")
     private final Logging logging;
+
     private final boolean leakedSessionsLoggingEnabled;
     private final long defaultFetchSize;
     private final AuthTokenManager authTokenManager;
     private final HomeDatabaseCache homeDatabaseCache;
 
+    @SuppressWarnings("deprecation")
     SessionFactoryImpl(
             BoltSecurityPlanManager securityPlanManager,
             DriverBoltConnectionProvider connectionProvider,
@@ -167,7 +171,7 @@ public class SessionFactoryImpl implements SessionFactory {
             Set<Bookmark> bookmarks,
             long fetchSize,
             String impersonatedUser,
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             BookmarkManager bookmarkManager,
             NotificationConfig driverNotificationConfig,
             NotificationConfig notificationConfig,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
@@ -47,7 +47,7 @@ public class LeakLoggingNetworkSession extends NetworkSession {
             Set<Bookmark> bookmarks,
             String impersonatedUser,
             long fetchSize,
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             BookmarkManager bookmarkManager,
             NotificationConfig driverNotificationConfig,
             NotificationConfig notificationConfig,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -94,7 +94,11 @@ public class NetworkSession {
     private final NetworkSessionConnectionContext connectionContext;
     private final AccessMode mode;
     private final RetryLogic retryLogic;
+
+    @SuppressWarnings("deprecation")
     private final Logging logging;
+
+    @SuppressWarnings("deprecation")
     protected final Logger log;
 
     private final long fetchSize;
@@ -122,7 +126,7 @@ public class NetworkSession {
             Set<Bookmark> bookmarks,
             String impersonatedUser,
             long fetchSize,
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             BookmarkManager bookmarkManager,
             org.neo4j.driver.NotificationConfig driverNotificationConfig,
             org.neo4j.driver.NotificationConfig notificationConfig,
@@ -723,7 +727,10 @@ public class NetworkSession {
     public static class RunRxResponseHandler implements DriverResponseHandler {
         private static final Lock NOOP_LOCK = new NoopLock();
         final CompletableFuture<RxResultCursor> cursorFuture = new CompletableFuture<>();
+
+        @SuppressWarnings("deprecation")
         private final Logging logging;
+
         private final DriverBoltConnection connection;
         private final Query query;
         private final Consumer<DatabaseBookmark> bookmarkConsumer;
@@ -734,7 +741,7 @@ public class NetworkSession {
         private int ignoredCount;
 
         public RunRxResponseHandler(
-                Logging logging,
+                @SuppressWarnings("deprecation") Logging logging,
                 DriverBoltConnection connection,
                 Query query,
                 Consumer<DatabaseBookmark> bookmarkConsumer,

--- a/driver/src/main/java/org/neo4j/driver/internal/async/TerminationAwareBoltConnection.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/TerminationAwareBoltConnection.java
@@ -31,13 +31,17 @@ import org.neo4j.driver.internal.adaptedbolt.DriverResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
 
 final class TerminationAwareBoltConnection extends DelegatingBoltConnection {
+    @SuppressWarnings("deprecation")
     private final Logging logging;
+
+    @SuppressWarnings("deprecation")
     private final Logger log;
+
     private final TerminationAwareStateLockingExecutor executor;
     private final Consumer<Throwable> throwableConsumer;
 
     public TerminationAwareBoltConnection(
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             DriverBoltConnection delegate,
             TerminationAwareStateLockingExecutor executor,
             Consumer<Throwable> throwableConsumer) {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/TerminationAwareResponseHandler.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/TerminationAwareResponseHandler.java
@@ -25,12 +25,14 @@ import org.neo4j.driver.internal.adaptedbolt.DriverResponseHandler;
 import org.neo4j.driver.internal.util.Futures;
 
 final class TerminationAwareResponseHandler extends DelegatingResponseHandler {
+    @SuppressWarnings("deprecation")
     private final Logger log;
+
     private final TerminationAwareStateLockingExecutor executor;
     private final Consumer<Throwable> throwableConsumer;
 
     TerminationAwareResponseHandler(
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             DriverResponseHandler delegate,
             TerminationAwareStateLockingExecutor executor,
             Consumer<Throwable> throwableConsumer) {

--- a/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/UnmanagedTransaction.java
@@ -104,7 +104,9 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
             "Can't rollback, transaction has been requested to be committed";
     private static final EnumSet<State> OPEN_STATES = EnumSet.of(State.ACTIVE, State.TERMINATED);
 
+    @SuppressWarnings("deprecation")
     private final Logging logging;
+
     private final TerminationAwareBoltConnection connection;
     private final Consumer<DatabaseBookmark> bookmarkConsumer;
     private final ResultCursorsHolder resultCursors;
@@ -135,7 +137,7 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
             NotificationConfig notificationConfig,
             ApiTelemetryWork apiTelemetryWork,
             Consumer<String> databaseNameConsumer,
-            Logging logging) {
+            @SuppressWarnings("deprecation") Logging logging) {
         this(
                 connection,
                 databaseName,
@@ -161,7 +163,7 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
             NotificationConfig notificationConfig,
             ApiTelemetryWork apiTelemetryWork,
             Consumer<String> databaseNameConsumer,
-            Logging logging) {
+            @SuppressWarnings("deprecation") Logging logging) {
         this.logging = logging;
         this.connection = new TerminationAwareBoltConnection(logging, connection, this, this::markTerminated);
         this.databaseName = databaseName;
@@ -678,7 +680,10 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
 
     private static class RunRxResponseHandler implements DriverResponseHandler {
         final CompletableFuture<RxResultCursor> cursorFuture = new CompletableFuture<>();
+
+        @SuppressWarnings("deprecation")
         private final Logging logging;
+
         private final ApiTelemetryWork apiTelemetryWork;
         private final CompletableFuture<UnmanagedTransaction> beginFuture;
         private final DriverBoltConnection connection;
@@ -688,7 +693,7 @@ public class UnmanagedTransaction implements TerminationAwareStateLockingExecuto
         private int ignoredCount;
 
         private RunRxResponseHandler(
-                Logging logging,
+                @SuppressWarnings("deprecation") Logging logging,
                 ApiTelemetryWork apiTelemetryWork,
                 CompletableFuture<UnmanagedTransaction> beginFuture,
                 DriverBoltConnection connection,

--- a/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cursor/RxResultCursorImpl.java
@@ -85,7 +85,10 @@ public class RxResultCursorImpl extends AbstractRecordStateResponseHandler
             return Optional.empty();
         }
     };
+
+    @SuppressWarnings("deprecation")
     private final Logger log;
+
     private final DriverBoltConnection boltConnection;
     private final Query query;
     private final RunSummary runSummary;
@@ -121,7 +124,7 @@ public class RxResultCursorImpl extends AbstractRecordStateResponseHandler
             Throwable runError,
             Consumer<DatabaseBookmark> bookmarkConsumer,
             boolean closeOnSummary,
-            Logging logging) {
+            @SuppressWarnings("deprecation") Logging logging) {
         this.boltConnection = Objects.requireNonNull(boltConnection);
         this.legacyNotifications = new BoltProtocolVersion(5, 5).compareTo(boltConnection.protocolVersion()) > 0;
         this.query = query;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ConsoleLogging.java
@@ -37,6 +37,7 @@ import org.neo4j.driver.Logging;
  *
  * @see Logging#console(Level)
  */
+@SuppressWarnings("deprecation")
 public class ConsoleLogging implements Logging, Serializable {
     @Serial
     private static final long serialVersionUID = 9205935204074879150L;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogger.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.internal.logging;
 
 import org.neo4j.driver.Logger;
 
+@SuppressWarnings("deprecation")
 public class DevNullLogger implements Logger {
     public static final Logger DEV_NULL_LOGGER = new DevNullLogger();
 

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/DevNullLogging.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
 
+@SuppressWarnings("deprecation")
 public class DevNullLogging implements Logging, Serializable {
     @Serial
     private static final long serialVersionUID = -2632752338512373821L;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JULogger.java
@@ -19,6 +19,7 @@ package org.neo4j.driver.internal.logging;
 import java.util.logging.Level;
 import org.neo4j.driver.Logger;
 
+@SuppressWarnings("deprecation")
 public class JULogger implements Logger {
     private final java.util.logging.Logger delegate;
     private final boolean debugEnabled;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/JULogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/JULogging.java
@@ -28,6 +28,7 @@ import org.neo4j.driver.Logging;
  *
  * @see Logging#javaUtilLogging(Level)
  */
+@SuppressWarnings("deprecation")
 public class JULogging implements Logging, Serializable {
     @Serial
     private static final long serialVersionUID = -1145576859241657833L;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/PrefixedLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/PrefixedLogger.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.internal.logging;
 
 import org.neo4j.driver.Logger;
 
+@SuppressWarnings("deprecation")
 public class PrefixedLogger extends ReformattedLogger {
     private final String messagePrefix;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/ReformattedLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/ReformattedLogger.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.neo4j.driver.Logger;
 
+@SuppressWarnings("deprecation")
 public abstract class ReformattedLogger implements Logger {
     private final Logger delegate;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogger.java
@@ -19,6 +19,7 @@ package org.neo4j.driver.internal.logging;
 import java.util.Objects;
 import org.neo4j.driver.Logger;
 
+@SuppressWarnings("deprecation")
 class Slf4jLogger implements Logger {
     private final org.slf4j.Logger delegate;
 

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/Slf4jLogging.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see Logging#slf4j()
  */
+@SuppressWarnings("deprecation")
 public class Slf4jLogging implements Logging, Serializable {
     @Serial
     private static final long serialVersionUID = 4120390028025944991L;

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/SystemLogger.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/SystemLogger.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import java.util.Objects;
+import org.neo4j.driver.Logger;
+
+@SuppressWarnings("deprecation")
+final class SystemLogger implements Logger {
+    private final System.Logger delegate;
+    private final boolean isDebugEnabled;
+    private final boolean isTraceEnabled;
+
+    SystemLogger(System.Logger delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.isDebugEnabled = delegate.isLoggable(System.Logger.Level.DEBUG);
+        this.isTraceEnabled = delegate.isLoggable(System.Logger.Level.TRACE);
+    }
+
+    @Override
+    public void error(String message, Throwable cause) {
+        delegate.log(System.Logger.Level.ERROR, message, cause);
+    }
+
+    @Override
+    public void info(String message, Object... params) {
+        try {
+            delegate.log(System.Logger.Level.INFO, message.formatted(params));
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    @Override
+    public void warn(String message, Object... params) {
+        try {
+            delegate.log(System.Logger.Level.WARNING, message.formatted(params));
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    @Override
+    public void warn(String message, Throwable cause) {
+        delegate.log(System.Logger.Level.WARNING, message, cause);
+    }
+
+    @Override
+    public void debug(String message, Object... params) {
+        try {
+            delegate.log(System.Logger.Level.DEBUG, message.formatted(params));
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        delegate.log(System.Logger.Level.DEBUG, message, throwable);
+    }
+
+    @Override
+    public void trace(String message, Object... params) {
+        try {
+            delegate.log(System.Logger.Level.TRACE, message.formatted(params));
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return isTraceEnabled;
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return isDebugEnabled;
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/logging/SystemLogging.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/logging/SystemLogging.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.logging;
+
+import java.io.Serial;
+import org.neo4j.driver.Logger;
+import org.neo4j.driver.Logging;
+
+@SuppressWarnings("deprecation")
+public final class SystemLogging implements Logging {
+    public static final SystemLogging INSTANCE = new SystemLogging();
+
+    @Serial
+    private static final long serialVersionUID = -2244895422671419713L;
+
+    @Override
+    public Logger getLog(Class<?> clazz) {
+        return new SystemLogger(System.getLogger(clazz.getName()));
+    }
+
+    @Override
+    public Logger getLog(String name) {
+        return new SystemLogger(System.getLogger(name));
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetrics.java
@@ -36,9 +36,11 @@ import org.neo4j.driver.Metrics;
 final class InternalMetrics implements Metrics, MetricsListener {
     private final Map<String, ConnectionPoolMetrics> connectionPoolMetrics;
     private final Clock clock;
+
+    @SuppressWarnings("deprecation")
     private final Logger log;
 
-    InternalMetrics(Clock clock, Logging logging) {
+    InternalMetrics(Clock clock, @SuppressWarnings("deprecation") Logging logging) {
         Objects.requireNonNull(clock);
         this.connectionPoolMetrics = new ConcurrentHashMap<>();
         this.clock = clock;

--- a/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetricsProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/metrics/InternalMetricsProvider.java
@@ -24,7 +24,7 @@ import org.neo4j.driver.Metrics;
 public final class InternalMetricsProvider implements MetricsProvider {
     private final InternalMetrics metrics;
 
-    public InternalMetricsProvider(Clock clock, Logging logging) {
+    public InternalMetricsProvider(Clock clock, @SuppressWarnings("deprecation") Logging logging) {
         this.metrics = new InternalMetrics(clock, logging);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogic.java
@@ -56,10 +56,15 @@ public class ExponentialBackoffRetryLogic implements RetryLogic {
     private final EventExecutorGroup eventExecutorGroup;
     private final Clock clock;
     private final SleepTask sleepTask;
+
+    @SuppressWarnings("deprecation")
     private final Logger log;
 
     public ExponentialBackoffRetryLogic(
-            long maxTransactionRetryTime, EventExecutorGroup eventExecutorGroup, Clock clock, Logging logging) {
+            long maxTransactionRetryTime,
+            EventExecutorGroup eventExecutorGroup,
+            Clock clock,
+            @SuppressWarnings("deprecation") Logging logging) {
         this(maxTransactionRetryTime, eventExecutorGroup, clock, logging, Thread::sleep);
     }
 
@@ -67,7 +72,7 @@ public class ExponentialBackoffRetryLogic implements RetryLogic {
             long maxTransactionRetryTime,
             EventExecutorGroup eventExecutorGroup,
             Clock clock,
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             SleepTask sleepTask) {
         this(
                 maxTransactionRetryTime,
@@ -87,7 +92,7 @@ public class ExponentialBackoffRetryLogic implements RetryLogic {
             double jitterFactor,
             EventExecutorGroup eventExecutorGroup,
             Clock clock,
-            Logging logging,
+            @SuppressWarnings("deprecation") Logging logging,
             SleepTask sleepTask) {
         this.maxRetryTimeMs = maxRetryTimeMs;
         this.initialRetryDelayMs = initialRetryDelayMs;

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SSLContextManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SSLContextManager.java
@@ -45,7 +45,10 @@ import org.neo4j.driver.internal.util.Futures;
 class SSLContextManager {
     private final ClientCertificateManager clientCertificateManager;
     private final SecurityPlan.SSLContextSupplier sslContextSupplier;
+
+    @SuppressWarnings("deprecation")
     private final Logger logger;
+
     private CompletableFuture<SSLContext> sslContextFuture;
     private SSLContext sslContext;
     private Throwable throwable;
@@ -53,7 +56,7 @@ class SSLContextManager {
     public SSLContextManager(
             ClientCertificateManager clientCertificateManager,
             SecurityPlan.SSLContextSupplier sslContextSupplier,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws NoSuchAlgorithmException, KeyManagementException {
         this.clientCertificateManager = clientCertificateManager;
         this.sslContextSupplier = sslContextSupplier;

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlanImpl.java
@@ -41,7 +41,7 @@ public class SecurityPlanImpl implements SecurityPlan {
             boolean requiresHostnameVerification,
             RevocationCheckingStrategy revocationCheckingStrategy,
             ClientCertificateManager clientCertificateManager,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws NoSuchAlgorithmException, KeyManagementException {
         return new SecurityPlanImpl(
                 SSLContexts::forAnyCertificate,
@@ -56,7 +56,7 @@ public class SecurityPlanImpl implements SecurityPlan {
             boolean requiresHostnameVerification,
             RevocationCheckingStrategy revocationCheckingStrategy,
             ClientCertificateManager clientCertificateManager,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws GeneralSecurityException, IOException {
         var trustManagerFactory = TrustManagerFactories.forCertificates(certFiles, map(revocationCheckingStrategy));
         return new SecurityPlanImpl(
@@ -71,7 +71,7 @@ public class SecurityPlanImpl implements SecurityPlan {
             boolean requiresHostnameVerification,
             RevocationCheckingStrategy revocationCheckingStrategy,
             ClientCertificateManager clientCertificateManager,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws GeneralSecurityException, IOException {
         var trustManagerFactory = TrustManagerFactories.forSystemCertificates(map(revocationCheckingStrategy));
         return new SecurityPlanImpl(
@@ -97,7 +97,7 @@ public class SecurityPlanImpl implements SecurityPlan {
             boolean requiresHostnameVerification,
             RevocationCheckingStrategy revocationCheckingStrategy,
             ClientCertificateManager clientCertificateManager,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws NoSuchAlgorithmException, KeyManagementException {
         this.requiresEncryption = true;
         this.requiresHostnameVerification = requiresHostnameVerification;

--- a/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlans.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/SecurityPlans.java
@@ -36,7 +36,7 @@ public class SecurityPlans {
             SecuritySettings settings,
             String uriScheme,
             ClientCertificateManager clientCertificateManager,
-            Logging logging) {
+            @SuppressWarnings("deprecation") Logging logging) {
         Scheme.validateScheme(uriScheme);
         try {
             if (isSecurityScheme(uriScheme)) {
@@ -91,7 +91,9 @@ public class SecurityPlans {
     }
 
     private static SecurityPlan createSecurityPlanFromScheme(
-            String scheme, ClientCertificateManager clientCertificateManager, Logging logging)
+            String scheme,
+            ClientCertificateManager clientCertificateManager,
+            @SuppressWarnings("deprecation") Logging logging)
             throws GeneralSecurityException, IOException {
         if (isHighTrustScheme(scheme)) {
             return SecurityPlanImpl.forSystemCASignedCertificates(
@@ -110,7 +112,7 @@ public class SecurityPlans {
             boolean encrypted,
             Config.TrustStrategy trustStrategy,
             ClientCertificateManager clientCertificateManager,
-            Logging logging)
+            @SuppressWarnings("deprecation") Logging logging)
             throws GeneralSecurityException, IOException {
         if (encrypted) {
             var hostnameVerificationEnabled = trustStrategy.isHostnameVerificationEnabled();

--- a/driver/src/main/java/org/neo4j/driver/internal/security/ValidatingAuthTokenManager.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/security/ValidatingAuthTokenManager.java
@@ -30,10 +30,12 @@ import org.neo4j.driver.exceptions.AuthTokenManagerExecutionException;
 import org.neo4j.driver.exceptions.SecurityException;
 
 public class ValidatingAuthTokenManager implements AuthTokenManager {
+    @SuppressWarnings("deprecation")
     private final Logger log;
+
     private final AuthTokenManager delegate;
 
-    public ValidatingAuthTokenManager(AuthTokenManager delegate, Logging logging) {
+    public ValidatingAuthTokenManager(AuthTokenManager delegate, @SuppressWarnings("deprecation") Logging logging) {
         requireNonNull(delegate, "delegate must not be null");
         requireNonNull(logging, "logging must not be null");
         this.delegate = delegate;

--- a/driver/src/main/java/org/neo4j/driver/internal/svm/MicrometerSubstitutions.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/svm/MicrometerSubstitutions.java
@@ -38,7 +38,7 @@ final class Target_org_neo4j_driver_internal_DriverFactory {
      * @return A metrics provider, never null
      */
     @Substitute
-    @SuppressWarnings("ProtectedMemberInFinalClass")
+    @SuppressWarnings({"ProtectedMemberInFinalClass", "deprecation"})
     protected static MetricsProvider getOrCreateMetricsProvider(Config config, Clock clock) {
         var metricsAdapter = config.metricsAdapter();
         if (metricsAdapter == null) {

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -407,6 +407,7 @@ class ConfigTest {
 
     @Nested
     class SerializationTest {
+        @SuppressWarnings("deprecation")
         @Test
         void shouldSerialize() throws Exception {
             var config = Config.builder()
@@ -438,7 +439,7 @@ class ConfigTest {
             assertEquals(config.connectionAcquisitionTimeoutMillis(), verify.connectionAcquisitionTimeoutMillis());
             assertEquals(config.idleTimeBeforeConnectionTest(), verify.idleTimeBeforeConnectionTest());
             assertEquals(config.maxConnectionLifetimeMillis(), verify.maxConnectionLifetimeMillis());
-            assertSame(DevNullLogging.DEV_NULL_LOGGING, verify.logging());
+            assertEquals(Logging.systemLogging().getClass(), verify.logging().getClass());
             assertEquals(config.maxTransactionRetryTimeMillis(), verify.maxTransactionRetryTimeMillis());
             assertEquals(config.fetchSize(), verify.fetchSize());
             assertEquals(config.eventLoopThreads(), verify.eventLoopThreads());
@@ -469,11 +470,13 @@ class ConfigTest {
 
         @Test
         void shouldSerializeSerializableLogging() throws IOException, ClassNotFoundException {
+            @SuppressWarnings("deprecation")
             var config = Config.builder()
                     .withLogging(Logging.javaUtilLogging(Level.ALL))
                     .build();
 
             var verify = TestUtil.serializeAndReadBack(config, Config.class);
+            @SuppressWarnings("deprecation")
             var logging = verify.logging();
             assertInstanceOf(JULogging.class, logging);
 
@@ -492,7 +495,8 @@ class ConfigTest {
 
         @ParameterizedTest
         @ValueSource(classes = {DevNullLogging.class, JULogging.class, ConsoleLogging.class, Slf4jLogging.class})
-        void officialLoggingProvidersShouldBeSerializable(Class<? extends Logging> loggingClass) {
+        void officialLoggingProvidersShouldBeSerializable(
+                @SuppressWarnings("deprecation") Class<? extends Logging> loggingClass) {
             assertTrue(Serializable.class.isAssignableFrom(loggingClass));
         }
     }

--- a/driver/src/test/java/org/neo4j/driver/GraphDatabaseTest.java
+++ b/driver/src/test/java/org/neo4j/driver/GraphDatabaseTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.neo4j.driver.Logging.none;
 import static org.neo4j.driver.internal.logging.DevNullLogging.DEV_NULL_LOGGING;
 
 import java.io.IOException;
@@ -36,8 +35,9 @@ import org.neo4j.driver.internal.security.StaticAuthTokenManager;
 import org.neo4j.driver.testutil.TestUtil;
 
 class GraphDatabaseTest {
+    @SuppressWarnings("deprecation")
     private static final Config INSECURE_CONFIG =
-            Config.builder().withoutEncryption().withLogging(none()).build();
+            Config.builder().withoutEncryption().withLogging(Logging.none()).build();
 
     @Test
     @SuppressWarnings("resource")
@@ -181,6 +181,7 @@ class GraphDatabaseTest {
     }
 
     private static Config createConfig(boolean encrypted, int timeoutMillis) {
+        @SuppressWarnings("deprecation")
         var configBuilder = Config.builder()
                 .withConnectionTimeout(timeoutMillis, MILLISECONDS)
                 .withLogging(DEV_NULL_LOGGING);

--- a/driver/src/test/java/org/neo4j/driver/integration/CredentialsIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/CredentialsIT.java
@@ -106,6 +106,7 @@ class CredentialsIT {
     }
 
     private void testDriverFailureOnWrongCredentials(String uri) {
+        @SuppressWarnings("deprecation")
         var config = Config.builder().withLogging(DEV_NULL_LOGGING).build();
         var authToken = AuthTokens.basic("neo4j", "wrongSecret");
 

--- a/driver/src/test/java/org/neo4j/driver/integration/LoggingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/LoggingIT.java
@@ -37,6 +37,7 @@ class LoggingIT {
     @RegisterExtension
     static final DatabaseExtension neo4j = new DatabaseExtension();
 
+    @SuppressWarnings("deprecation")
     @Test
     void logShouldRecordDebugAndTraceInfo() {
         // Given

--- a/driver/src/test/java/org/neo4j/driver/integration/ResolverIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ResolverIT.java
@@ -22,11 +22,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.driver.Logging.none;
 
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Logging;
 import org.neo4j.driver.net.ServerAddress;
 import org.neo4j.driver.net.ServerAddressResolver;
 
@@ -36,9 +36,10 @@ class ResolverIT {
         var resolver = mock(ServerAddressResolver.class);
         when(resolver.resolve(any(ServerAddress.class))).thenThrow(new RuntimeException("Resolution failure!"));
 
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withoutEncryption()
-                .withLogging(none())
+                .withLogging(Logging.none())
                 .withResolver(resolver)
                 .build();
         @SuppressWarnings("resource")

--- a/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SessionIT.java
@@ -643,7 +643,6 @@ class SessionIT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldNotRetryOnConnectionAcquisitionTimeout() {
         var maxPoolSize = 3;
         var config = Config.builder()
@@ -779,6 +778,7 @@ class SessionIT {
     @Test
     void shouldAllowLongRunningQueryWithConnectTimeout() throws Exception {
         var connectionTimeoutMs = 3_000;
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withLogging(DEV_NULL_LOGGING)
                 .withConnectionTimeout(connectionTimeoutMs, TimeUnit.MILLISECONDS)
@@ -1191,6 +1191,7 @@ class SessionIT {
     }
 
     private Driver newDriverWithLimitedRetries(int maxTxRetryTime) {
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withLogging(DEV_NULL_LOGGING)
                 .withMaxTransactionRetryTime(maxTxRetryTime, TimeUnit.SECONDS)
@@ -1198,6 +1199,7 @@ class SessionIT {
         return GraphDatabase.driver(neo4j.uri(), neo4j.authTokenManager(), config);
     }
 
+    @SuppressWarnings("deprecation")
     private static Config noLoggingConfig() {
         return Config.builder().withLogging(DEV_NULL_LOGGING).build();
     }

--- a/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/reactive/ReactiveStreamsSessionIT.java
@@ -81,6 +81,7 @@ public class ReactiveStreamsSessionIT {
     @SuppressWarnings("BusyWait")
     void shouldReleaseResultsOnSubscriptionCancellation(boolean request) throws InterruptedException {
         var messages = Collections.synchronizedList(new ArrayList<String>());
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withDriverMetrics()
                 .withLogging(LoggingUtil.boltLogging(messages))

--- a/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/DriverFactoryTest.java
@@ -118,6 +118,7 @@ class DriverFactoryTest {
     @Test
     void shouldCreateDriverMetricsIfMonitoringEnabled() {
         // Given
+        @SuppressWarnings("deprecation")
         var config =
                 Config.builder().withDriverMetrics().withLogging(Logging.none()).build();
         // When
@@ -129,6 +130,7 @@ class DriverFactoryTest {
     @Test
     void shouldCreateMicrometerDriverMetricsIfMonitoringEnabled() {
         // Given
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withDriverMetrics()
                 .withMetricsAdapter(MetricsAdapter.MICROMETER)

--- a/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/SessionFactoryImplTest.java
@@ -35,6 +35,7 @@ import org.neo4j.driver.internal.util.FixedRetryLogic;
 class SessionFactoryImplTest {
     @Test
     void createsNetworkSessions() {
+        @SuppressWarnings("deprecation")
         var config = Config.builder().withLogging(DEV_NULL_LOGGING).build();
         var factory = newSessionFactory(config);
 
@@ -55,6 +56,7 @@ class SessionFactoryImplTest {
 
     @Test
     void createsLeakLoggingNetworkSessions() {
+        @SuppressWarnings("deprecation")
         var config = Config.builder()
                 .withLogging(DEV_NULL_LOGGING)
                 .withLeakedSessionsLogging()

--- a/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
@@ -64,7 +64,9 @@ import org.neo4j.driver.testutil.TestUtil;
 class LeakLoggingNetworkSessionTest {
     @Test
     void logsNothingDuringFinalizationIfClosed() throws Exception {
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var log = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(log);
         var connection = TestUtil.connectionMock();
@@ -98,7 +100,9 @@ class LeakLoggingNetworkSessionTest {
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     void logsMessageWithStacktraceDuringFinalizationIfLeaked(TestInfo testInfo) throws Exception {
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var log = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(log);
         var connection = TestUtil.connectionMock();
@@ -143,7 +147,8 @@ class LeakLoggingNetworkSessionTest {
         finalizeMethod.invoke(session);
     }
 
-    private static LeakLoggingNetworkSession newSession(Logging logging, DriverBoltConnection connection) {
+    private static LeakLoggingNetworkSession newSession(
+            @SuppressWarnings("deprecation") Logging logging, DriverBoltConnection connection) {
         return new LeakLoggingNetworkSession(
                 BoltSecurityPlanManager.insecure(),
                 connectionProviderMock(connection),

--- a/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/UnmanagedTransactionTest.java
@@ -321,6 +321,7 @@ class UnmanagedTransactionTest {
         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -359,6 +360,7 @@ class UnmanagedTransactionTest {
         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -384,6 +386,7 @@ class UnmanagedTransactionTest {
         var connection = connectionMock();
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -412,6 +415,7 @@ class UnmanagedTransactionTest {
 
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
         var resultCursorsHolder = mockResultCursorWith(terminationCause);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -439,6 +443,7 @@ class UnmanagedTransactionTest {
         var terminationCause = new ClientException("Custom exception");
         var resultCursorsHolder = mockResultCursorWith(new ClientException("Cursor error"));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -468,6 +473,7 @@ class UnmanagedTransactionTest {
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var terminationCause = new ClientException("Custom exception");
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -493,6 +499,7 @@ class UnmanagedTransactionTest {
         var connection = connectionMock();
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -528,6 +535,7 @@ class UnmanagedTransactionTest {
         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -563,6 +571,7 @@ class UnmanagedTransactionTest {
         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -601,6 +610,7 @@ class UnmanagedTransactionTest {
         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -659,6 +669,7 @@ class UnmanagedTransactionTest {
                         }));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -737,6 +748,7 @@ class UnmanagedTransactionTest {
         setupConnectionAnswers(connection, List.of(messageHandler));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -812,6 +824,7 @@ class UnmanagedTransactionTest {
         setupConnectionAnswers(connection, List.of(messageHandler));
         given(connection.close()).willReturn(CompletableFuture.completedStage(null));
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),
@@ -1076,6 +1089,7 @@ class UnmanagedTransactionTest {
 
     private static UnmanagedTransaction beginTx(DriverBoltConnection connection, Set<Bookmark> initialBookmarks) {
         var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.UNMANAGED_TRANSACTION);
+        @SuppressWarnings("deprecation")
         var tx = new UnmanagedTransaction(
                 connection,
                 DatabaseNameUtil.defaultDatabase(),

--- a/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cursor/RxResultCursorImplTest.java
@@ -68,6 +68,7 @@ class RxResultCursorImplTest {
         // given
         var runError = mock(Throwable.class);
         given(connection.serverAddress()).willReturn(new BoltServerAddress("localhost"));
+        @SuppressWarnings("deprecation")
         var cursor = new RxResultCursorImpl(connection, query, null, runError, bookmarkConsumer, false, Logging.none());
         if (getRunError) {
             assertEquals(runError, cursor.getRunError());
@@ -89,6 +90,7 @@ class RxResultCursorImplTest {
         // given
         var runError = mock(Throwable.class);
         given(connection.serverAddress()).willReturn(new BoltServerAddress("localhost"));
+        @SuppressWarnings("deprecation")
         var cursor = new RxResultCursorImpl(connection, query, null, runError, bookmarkConsumer, false, Logging.none());
         if (getRunError) {
             assertEquals(runError, cursor.getRunError());
@@ -107,6 +109,7 @@ class RxResultCursorImplTest {
         // given
         var keys = List.of("a", "b");
         given(runSummary.keys()).willReturn(keys);
+        @SuppressWarnings("deprecation")
         var cursor =
                 new RxResultCursorImpl(connection, query, runSummary, null, bookmarkConsumer, false, Logging.none());
 

--- a/driver/src/test/java/org/neo4j/driver/internal/logging/PrefixedLoggerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/logging/PrefixedLoggerTest.java
@@ -215,10 +215,12 @@ class PrefixedLoggerTest {
         verify(delegate).trace("Output Hello World!");
     }
 
+    @SuppressWarnings("deprecation")
     private static Logger newLoggerMock() {
         return newLoggerMock(false, false);
     }
 
+    @SuppressWarnings("deprecation")
     private static Logger newLoggerMock(boolean debugEnabled, boolean traceEnabled) {
         var logger = mock(Logger.class);
         when(logger.isDebugEnabled()).thenReturn(debugEnabled);

--- a/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/retry/ExponentialBackoffRetryLogicTest.java
@@ -765,7 +765,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnClientExceptionWithRetryableCause() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -785,7 +787,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnAuthorizationExpiredException() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -805,7 +809,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnConnectionReadTimeoutException() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -825,7 +831,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesNotRetryOnRandomClientException() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
         var logic =
@@ -848,7 +856,9 @@ class ExponentialBackoffRetryLogicTest {
     void eachRetryIsLogged() {
         var retries = 9;
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic = new ExponentialBackoffRetryLogic(
@@ -863,7 +873,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnClientExceptionWithRetryableCauseAsync() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
 
@@ -884,7 +896,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnAuthorizationExpiredExceptionAsync() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -904,7 +918,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesNotRetryOnRandomClientExceptionAsync() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
 
@@ -929,7 +945,9 @@ class ExponentialBackoffRetryLogicTest {
         var result = "The Result";
         var retries = 9;
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
 
@@ -947,7 +965,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnClientExceptionWithRetryableCauseRx() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
 
@@ -968,7 +988,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnAuthorizationExpiredExceptionRx() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -988,7 +1010,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesRetryOnAsyncResourceCleanupRuntimeExceptionRx() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var logic =
@@ -1008,7 +1032,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void doesNotRetryOnRandomClientExceptionRx() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
 
@@ -1033,7 +1059,9 @@ class ExponentialBackoffRetryLogicTest {
         var result = "The Result";
         var retries = 9;
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
 
@@ -1050,7 +1078,9 @@ class ExponentialBackoffRetryLogicTest {
 
     @Test
     void nothingIsLoggedOnFatalFailure() {
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
         var logic = new ExponentialBackoffRetryLogic(
@@ -1067,7 +1097,9 @@ class ExponentialBackoffRetryLogicTest {
 
     @Test
     void nothingIsLoggedOnFatalFailureAsync() {
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
         var logic = new ExponentialBackoffRetryLogic(
@@ -1083,7 +1115,9 @@ class ExponentialBackoffRetryLogicTest {
 
     @Test
     void nothingIsLoggedOnFatalFailureRx() {
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(anyString())).thenReturn(logger);
         var logic = new ExponentialBackoffRetryLogic(
@@ -1099,7 +1133,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void correctNumberOfRetiesAreLoggedOnFailure() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var settings = RetrySettings.DEFAULT;
@@ -1130,7 +1166,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void correctNumberOfRetiesAreLoggedOnFailureAsync() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var settings = RetrySettings.DEFAULT;
@@ -1163,7 +1201,9 @@ class ExponentialBackoffRetryLogicTest {
     @Test
     void correctNumberOfRetiesAreLoggedOnFailureRx() {
         var clock = mock(Clock.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         when(logging.getLog(any(Class.class))).thenReturn(logger);
         var settings = RetrySettings.DEFAULT;

--- a/driver/src/test/java/org/neo4j/driver/internal/security/SSLContextManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/SSLContextManagerTest.java
@@ -53,7 +53,9 @@ class SSLContextManagerTest {
         var clientManager = mock(ClientCertificateManager.class);
         given(clientManager.getClientCertificate()).willReturn(CompletableFuture.completedStage(null));
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new SSLContextManager(clientManager, contextSupplier, logging);
@@ -85,7 +87,9 @@ class SSLContextManagerTest {
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         var keyManagers = new KeyManager[0];
         given(contextSupplier.get(keyManagers)).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new ExtendedSSLContextManager(clientManager, contextSupplier, logging, ignored -> new KeyManager[0]);
@@ -110,7 +114,9 @@ class SSLContextManagerTest {
         given(clientManager.getClientCertificate())
                 .willReturn(CompletableFuture.completedStage(certificate), CompletableFuture.completedStage(null));
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         Function<InternalClientCertificate, KeyManager[]> keyManagersFunction = mock(Function.class);
@@ -146,7 +152,9 @@ class SSLContextManagerTest {
         var context = mock(SSLContext.class);
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         given(contextSupplier.get(any())).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         Function<InternalClientCertificate, KeyManager[]> keyManagersFunction = mock(Function.class);
@@ -182,7 +190,9 @@ class SSLContextManagerTest {
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         var keyManagers = new KeyManager[0];
         given(contextSupplier.get(keyManagers)).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new SSLContextManager(null, contextSupplier, logging);
@@ -199,7 +209,7 @@ class SSLContextManagerTest {
         public ExtendedSSLContextManager(
                 ClientCertificateManager clientCertificateManager,
                 SecurityPlan.SSLContextSupplier sslContextSupplier,
-                Logging logging,
+                @SuppressWarnings("deprecation") Logging logging,
                 Function<InternalClientCertificate, KeyManager[]> keyManagersFunction)
                 throws NoSuchAlgorithmException, KeyManagementException {
             super(clientCertificateManager, sslContextSupplier, logging);

--- a/driver/src/test/java/org/neo4j/driver/internal/security/SSLContextManagerTests.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/SSLContextManagerTests.java
@@ -53,7 +53,9 @@ class SSLContextManagerTests {
         var clientManager = mock(ClientCertificateManager.class);
         given(clientManager.getClientCertificate()).willReturn(CompletableFuture.completedStage(null));
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new SSLContextManager(clientManager, contextSupplier, logging);
@@ -85,7 +87,9 @@ class SSLContextManagerTests {
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         var keyManagers = new KeyManager[0];
         given(contextSupplier.get(keyManagers)).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new ExtendedSSLContextManager(clientManager, contextSupplier, logging, ignored -> new KeyManager[0]);
@@ -110,7 +114,9 @@ class SSLContextManagerTests {
         given(clientManager.getClientCertificate())
                 .willReturn(CompletableFuture.completedStage(certificate), CompletableFuture.completedStage(null));
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         Function<InternalClientCertificate, KeyManager[]> keyManagersFunction = mock(Function.class);
@@ -146,7 +152,9 @@ class SSLContextManagerTests {
         var context = mock(SSLContext.class);
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         given(contextSupplier.get(any())).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         Function<InternalClientCertificate, KeyManager[]> keyManagersFunction = mock(Function.class);
@@ -182,7 +190,9 @@ class SSLContextManagerTests {
         var contextSupplier = mock(SecurityPlan.SSLContextSupplier.class);
         var keyManagers = new KeyManager[0];
         given(contextSupplier.get(keyManagers)).willReturn(context);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var logger = mock(Logger.class);
         given(logging.getLog(any(Class.class))).willReturn(logger);
         manager = new SSLContextManager(null, contextSupplier, logging);
@@ -199,7 +209,7 @@ class SSLContextManagerTests {
         public ExtendedSSLContextManager(
                 ClientCertificateManager clientCertificateManager,
                 SecurityPlan.SSLContextSupplier sslContextSupplier,
-                Logging logging,
+                @SuppressWarnings("deprecation") Logging logging,
                 Function<InternalClientCertificate, KeyManager[]> keyManagersFunction)
                 throws NoSuchAlgorithmException, KeyManagementException {
             super(clientCertificateManager, sslContextSupplier, logging);

--- a/driver/src/test/java/org/neo4j/driver/internal/security/SecurityPlansTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/SecurityPlansTest.java
@@ -54,6 +54,7 @@ class SecurityPlansTest {
     void testEncryptionSchemeEnablesEncryption(String scheme) {
         var securitySettings = new SecuritySettings.SecuritySettingsBuilder().build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertTrue(securityPlan.requiresEncryption());
@@ -64,6 +65,7 @@ class SecurityPlansTest {
     void testSystemCertCompatibleConfiguration(String scheme) {
         var securitySettings = new SecuritySettings.SecuritySettingsBuilder().build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertTrue(securityPlan.requiresEncryption());
@@ -76,6 +78,7 @@ class SecurityPlansTest {
     void testSelfSignedCertConfigDisablesHostnameVerification(String scheme) {
         var securitySettings = new SecuritySettings.SecuritySettingsBuilder().build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertTrue(securityPlan.requiresEncryption());
@@ -88,6 +91,7 @@ class SecurityPlansTest {
         var securitySettings =
                 new SecuritySettings.SecuritySettingsBuilder().withEncryption().build();
 
+        @SuppressWarnings("deprecation")
         var ex = assertThrows(
                 ClientException.class,
                 () -> SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none()));
@@ -104,6 +108,7 @@ class SecurityPlansTest {
                 .withTrustStrategy(Config.TrustStrategy.trustAllCertificates())
                 .build();
 
+        @SuppressWarnings("deprecation")
         var ex = assertThrows(
                 ClientException.class,
                 () -> SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none()));
@@ -121,6 +126,7 @@ class SecurityPlansTest {
                 .withEncryption()
                 .build();
 
+        @SuppressWarnings("deprecation")
         var ex = assertThrows(
                 ClientException.class,
                 () -> SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none()));
@@ -135,6 +141,7 @@ class SecurityPlansTest {
     void testNoEncryption(String scheme) {
         var securitySettings = new SecuritySettings.SecuritySettingsBuilder().build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertFalse(securityPlan.requiresEncryption());
@@ -146,6 +153,7 @@ class SecurityPlansTest {
         var securitySettings =
                 new SecuritySettings.SecuritySettingsBuilder().withEncryption().build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertTrue(securityPlan.requiresEncryption());
@@ -159,6 +167,7 @@ class SecurityPlansTest {
                 .withTrustStrategy(Config.TrustStrategy.trustAllCertificates())
                 .build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertTrue(securityPlan.requiresEncryption());
@@ -173,6 +182,7 @@ class SecurityPlansTest {
                 .withEncryption()
                 .build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertEquals(STRICT, securityPlan.revocationCheckingStrategy());
@@ -187,6 +197,7 @@ class SecurityPlansTest {
                 .withEncryption()
                 .build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertEquals(VERIFY_IF_PRESENT, securityPlan.revocationCheckingStrategy());
@@ -200,6 +211,7 @@ class SecurityPlansTest {
                 .withEncryption()
                 .build();
 
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(securitySettings, scheme, null, Logging.none());
 
         assertEquals(NO_CHECKS, securityPlan.revocationCheckingStrategy());

--- a/driver/src/test/java/org/neo4j/driver/internal/security/ValidatingAuthTokenManagerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/security/ValidatingAuthTokenManagerTest.java
@@ -42,6 +42,7 @@ class ValidatingAuthTokenManagerTest {
         // given
         var delegateManager = mock(AuthTokenManager.class);
         given(delegateManager.getToken()).willReturn(completedFuture(null));
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when
@@ -59,6 +60,7 @@ class ValidatingAuthTokenManagerTest {
         var delegateManager = mock(AuthTokenManager.class);
         var exception = mock(RuntimeException.class);
         given(delegateManager.getToken()).willThrow(exception);
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when
@@ -75,6 +77,7 @@ class ValidatingAuthTokenManagerTest {
         // given
         var delegateManager = mock(AuthTokenManager.class);
         given(delegateManager.getToken()).willReturn(null);
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when
@@ -92,6 +95,7 @@ class ValidatingAuthTokenManagerTest {
         var delegateManager = mock(AuthTokenManager.class);
         var token = AuthTokens.none();
         given(delegateManager.getToken()).willReturn(completedFuture(token));
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when
@@ -105,6 +109,7 @@ class ValidatingAuthTokenManagerTest {
     void shouldRejectNullAuthTokenOnHandleSecurityException() {
         // given
         var delegateManager = mock(AuthTokenManager.class);
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when & then
@@ -117,6 +122,7 @@ class ValidatingAuthTokenManagerTest {
     void shouldRejectNullExceptionOnHandleSecurityException() {
         // given
         var delegateManager = mock(AuthTokenManager.class);
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
 
         // when & then
@@ -128,6 +134,7 @@ class ValidatingAuthTokenManagerTest {
     void shouldPassOriginalTokenAndExceptionOnHandleSecurityException() {
         // given
         var delegateManager = mock(AuthTokenManager.class);
+        @SuppressWarnings("deprecation")
         var manager = new ValidatingAuthTokenManager(delegateManager, Logging.none());
         var token = AuthTokens.none();
         var exception = mock(SecurityException.class);
@@ -147,7 +154,9 @@ class ValidatingAuthTokenManagerTest {
         var securityException = mock(SecurityException.class);
         var exception = mock(RuntimeException.class);
         willThrow(exception).given(delegateManager).handleSecurityException(token, securityException);
+        @SuppressWarnings("deprecation")
         var logging = mock(Logging.class);
+        @SuppressWarnings("deprecation")
         var log = mock(Logger.class);
         given(logging.getLog(ValidatingAuthTokenManager.class)).willReturn(log);
         var manager = new ValidatingAuthTokenManager(delegateManager, logging);

--- a/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithFixedRetryLogic.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/DriverFactoryWithFixedRetryLogic.java
@@ -30,7 +30,9 @@ public class DriverFactoryWithFixedRetryLogic extends DriverFactory {
 
     @Override
     protected RetryLogic createRetryLogic(
-            long maxTransactionRetryTime, EventExecutorGroup eventExecutorGroup, Logging logging) {
+            long maxTransactionRetryTime,
+            EventExecutorGroup eventExecutorGroup,
+            @SuppressWarnings("deprecation") Logging logging) {
         return new FixedRetryLogic(retryCount);
     }
 }

--- a/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/AbstractStressTestBase.java
@@ -202,6 +202,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
     abstract Config.ConfigBuilder config(Config.ConfigBuilder builder);
 
     Config config() {
+        @SuppressWarnings("deprecation")
         var builder = Config.builder()
                 .withLogging(logging)
                 .withMaxConnectionPoolSize(100)
@@ -689,6 +690,7 @@ abstract class AbstractStressTestBase<C extends AbstractContext> {
 
     private record ResourcesInfo(long openFileDescriptorCount, Set<String> acquiredLoggerNames) {}
 
+    @SuppressWarnings("deprecation")
     private static class LoggerNameTrackingLogging implements Logging {
         @Serial
         private static final long serialVersionUID = -1100018645191686024L;

--- a/driver/src/test/java/org/neo4j/driver/testutil/LoggingUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/LoggingUtil.java
@@ -27,6 +27,7 @@ import org.neo4j.driver.Logger;
 import org.neo4j.driver.Logging;
 
 public class LoggingUtil {
+    @SuppressWarnings("deprecation")
     public static Logging boltLogging(List<String> messages) {
         var logging = mock(Logging.class);
         var accumulatingLogger = mock(Logger.class);

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <!-- (i.e. due to a security vulnerability or bug) that the -->
     <!-- corresponding server dependency also needs updating.-->
     <reactor-bom.version>2023.0.17</reactor-bom.version>
-    <slf4j-api.version>1.7.36</slf4j-api.version>
+    <slf4j-api.version>2.0.17</slf4j-api.version>
     <hamcrest.version>3.0</hamcrest.version>
     <mockito-core.version>5.17.0</mockito-core.version>
     <junit.version>5.12.2</junit.version>
@@ -53,7 +53,8 @@
     <!-- an optional dependency of commons-compress used by TarArchiveOutputStream -->
     <commons-codec.version>1.18.0</commons-codec.version>
     <bouncycastle-jdk18on.version>1.80</bouncycastle-jdk18on.version>
-    <logback-classic.version>1.2.13</logback-classic.version>
+    <logback-classic.version>1.5.18</logback-classic.version>
+    <log4j.version>2.24.3</log4j.version>
     <jackson.version>2.19.0</jackson.version>
     <lombok.version>1.18.38</lombok.version>
     <svm.version>24.2.1</svm.version>
@@ -68,6 +69,7 @@
   <modules>
     <module>driver</module>
     <module>bundle</module>
+    <module>driver-it</module>
     <module>examples</module>
     <module>testkit-backend</module>
     <module>testkit-tests</module>
@@ -130,8 +132,10 @@
       <!-- Optional dependencies -->
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
+        <artifactId>slf4j-bom</artifactId>
         <version>${slf4j-api.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/Runner.java
@@ -22,20 +22,14 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import java.util.logging.Level;
 import neo4j.org.testkit.backend.channel.handler.TestkitMessageInboundHandler;
 import neo4j.org.testkit.backend.channel.handler.TestkitMessageOutboundHandler;
 import neo4j.org.testkit.backend.channel.handler.TestkitRequestProcessorHandler;
 import neo4j.org.testkit.backend.channel.handler.TestkitRequestResponseMapperHandler;
-import org.neo4j.driver.Logging;
 
 public class Runner {
     public static void main(String[] args) throws InterruptedException {
         var backendMode = getBackendMode(args);
-        var levelString = System.getenv("TESTKIT_BACKEND_LOGGING_LEVEL");
-        var logging = levelString == null || levelString.isEmpty()
-                ? Logging.none()
-                : Logging.console(Level.parse(levelString));
 
         EventLoopGroup group = new NioEventLoopGroup();
         try {
@@ -50,11 +44,9 @@ public class Runner {
                             var responseQueueHanlder = new ResponseQueueHanlder(channel::writeAndFlush);
                             channel.pipeline().addLast(new TestkitMessageInboundHandler());
                             channel.pipeline().addLast(new TestkitMessageOutboundHandler());
+                            channel.pipeline().addLast(new TestkitRequestResponseMapperHandler(responseQueueHanlder));
                             channel.pipeline()
-                                    .addLast(new TestkitRequestResponseMapperHandler(logging, responseQueueHanlder));
-                            channel.pipeline()
-                                    .addLast(new TestkitRequestProcessorHandler(
-                                            backendMode, logging, responseQueueHanlder));
+                                    .addLast(new TestkitRequestProcessorHandler(backendMode, responseQueueHanlder));
                         }
                     });
             var server = bootstrap.bind().sync();

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/TestkitState.java
@@ -42,7 +42,6 @@ import org.neo4j.bolt.connection.routed.impl.cluster.RoutingTableRegistry;
 import org.neo4j.driver.AuthTokenManager;
 import org.neo4j.driver.BookmarkManager;
 import org.neo4j.driver.ClientCertificateManager;
-import org.neo4j.driver.Logging;
 import reactor.core.publisher.Mono;
 
 public class TestkitState {
@@ -74,7 +73,7 @@ public class TestkitState {
     private final Map<String, ReactiveTransactionStreamsHolder> transactionIdToReactiveTransactionStreamsHolder =
             new HashMap<>();
     private final Map<String, BookmarkManager> bookmarkManagerIdToBookmarkManager = new HashMap<>();
-    private final Logging logging;
+
     private final Map<String, AuthTokenManager> authProviderIdToAuthProvider = new HashMap<>();
     private final Map<String, ClientCertificateManager> managerIdToClientCertificateManager = new HashMap<>();
 
@@ -89,9 +88,8 @@ public class TestkitState {
     @Getter
     private final Map<String, CompletableFuture<TestkitCallbackResult>> callbackIdToFuture = new HashMap<>();
 
-    public TestkitState(Consumer<TestkitResponse> responseWriter, Logging logging) {
+    public TestkitState(Consumer<TestkitResponse> responseWriter) {
         this.responseWriter = responseWriter;
-        this.logging = logging;
     }
 
     public String newId() {
@@ -214,10 +212,6 @@ public class TestkitState {
         if (bookmarkManagerIdToBookmarkManager.remove(id) == null) {
             throw new RuntimeException(BOOKMARK_MANAGER_NOT_FOUND_MESSAGE);
         }
-    }
-
-    public Logging getLogging() {
-        return logging;
     }
 
     public void addAuthProvider(String id, AuthTokenManager authProvider) {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestProcessorHandler.java
@@ -35,7 +35,6 @@ import neo4j.org.testkit.backend.messages.responses.BackendError;
 import neo4j.org.testkit.backend.messages.responses.DriverError;
 import neo4j.org.testkit.backend.messages.responses.GqlError;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
-import org.neo4j.driver.Logging;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.NoSuchRecordException;
 import org.neo4j.driver.exceptions.RetryableException;
@@ -49,15 +48,14 @@ public class TestkitRequestProcessorHandler extends ChannelInboundHandlerAdapter
     private final ResponseQueueHanlder responseQueueHanlder;
     private Channel channel;
 
-    public TestkitRequestProcessorHandler(
-            BackendMode backendMode, Logging logging, ResponseQueueHanlder responseQueueHanlder) {
+    public TestkitRequestProcessorHandler(BackendMode backendMode, ResponseQueueHanlder responseQueueHanlder) {
         switch (backendMode) {
             case ASYNC -> processorImpl = TestkitRequest::processAsync;
             case REACTIVE -> processorImpl =
                     (request, state) -> request.processReactive(state).toFuture();
             default -> processorImpl = TestkitRequestProcessorHandler::wrapSyncRequest;
         }
-        testkitState = new TestkitState(this::writeAndFlush, logging);
+        testkitState = new TestkitState(this::writeAndFlush);
         this.responseQueueHanlder = responseQueueHanlder;
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/channel/handler/TestkitRequestResponseMapperHandler.java
@@ -25,23 +25,20 @@ import neo4j.org.testkit.backend.ResponseQueueHanlder;
 import neo4j.org.testkit.backend.messages.TestkitModule;
 import neo4j.org.testkit.backend.messages.requests.TestkitRequest;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
-import org.neo4j.driver.Logger;
-import org.neo4j.driver.Logging;
 
 public class TestkitRequestResponseMapperHandler extends ChannelDuplexHandler {
-    private final Logger log;
+    private static final System.Logger LOGGER = System.getLogger(TestkitRequestResponseMapperHandler.class.getName());
     private final ObjectMapper objectMapper = newObjectMapper();
     private final ResponseQueueHanlder responseQueueHanlder;
 
-    public TestkitRequestResponseMapperHandler(Logging logging, ResponseQueueHanlder responseQueueHanlder) {
-        log = logging.getLog(getClass());
+    public TestkitRequestResponseMapperHandler(ResponseQueueHanlder responseQueueHanlder) {
         this.responseQueueHanlder = responseQueueHanlder;
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         var testkitMessage = (String) msg;
-        log.debug("Inbound Testkit message '%s'", testkitMessage.trim());
+        LOGGER.log(System.Logger.Level.DEBUG, "Inbound Testkit message ''{0}''", testkitMessage.trim());
         responseQueueHanlder.increaseRequestCountAndDispatchFirstResponse();
         var testkitRequest = objectMapper.readValue(testkitMessage, TestkitRequest.class);
         ctx.fireChannelRead(testkitRequest);
@@ -51,7 +48,7 @@ public class TestkitRequestResponseMapperHandler extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         var testkitResponse = (TestkitResponse) msg;
         var responseStr = objectMapper.writeValueAsString(testkitResponse);
-        log.debug("Outbound Testkit message '%s'", responseStr.trim());
+        LOGGER.log(System.Logger.Level.DEBUG, "Outbound Testkit message ''{0}''", responseStr.trim());
         ctx.writeAndFlush(responseStr, promise);
     }
 

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -67,6 +67,7 @@ import reactor.core.publisher.Mono;
 public class NewDriver implements TestkitRequest {
     private NewDriverBody data;
 
+    @SuppressWarnings("deprecation")
     @Override
     public TestkitResponse process(TestkitState testkitState) {
         var id = testkitState.newId();
@@ -121,7 +122,6 @@ public class NewDriver implements TestkitRequest {
                                 certificateData.getPassword()))
                         .map(ClientCertificateManagers::rotating))
                 .orElse(null);
-        configBuilder.withLogging(testkitState.getLogging());
         org.neo4j.driver.Driver driver;
         var config = configBuilder.build();
         try {
@@ -226,6 +226,7 @@ public class NewDriver implements TestkitRequest {
             TestkitState testkitState,
             String driverId) {
         var securitySettings = securitySettingsBuilder.build();
+        @SuppressWarnings("deprecation")
         var securityPlan = SecurityPlans.createSecurityPlan(
                 securitySettings, uri.getScheme(), clientCertificateManager, config.logging());
         return new DriverFactoryWithDomainNameResolver(domainNameResolver, testkitState, driverId)


### PR DESCRIPTION
BREAKING CHANGE: the default driver logging implementation has been changed from `Logging#none()` to `Logging.systemLogging()`.

The logging abstraction has been deprecated in favour of the `System.Logger`. Specifically, this applies to the following::
- `org.neo4j.driver.Logging`
- `org.neo4j.driver.Logger`
- `org.neo4j.driver.Config.ConfigBuilder#withLogging(Logging)`
- `org.neo4j.driver.Config#logging()`

Once the logging abstraction is deleted, the driver is expected to use the `System.Logger` only.