### PR TITLE
feat(config): delete deprecated TrustStrategy.certFile()

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -800,4 +800,10 @@
         <method>org.neo4j.driver.reactive.ReactiveSession reactiveSession(org.neo4j.driver.SessionConfig)</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/Config$TrustStrategy</className>
+        <differenceType>7002</differenceType>
+        <method>java.io.File certFile()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -958,17 +958,6 @@ public final class Config implements Serializable {
         }
 
         /**
-         * Return the configured certificate file.
-         *
-         * @return configured certificate or {@code null} if trust strategy does not require a certificate.
-         * @deprecated superseded by {@link TrustStrategy#certFiles()}
-         */
-        @Deprecated
-        public File certFile() {
-            return certFiles.isEmpty() ? null : certFiles.get(0);
-        }
-
-        /**
          * Return the configured certificate files.
          *
          * @return configured certificate files or empty list if trust strategy does not require certificates.


### PR DESCRIPTION
BREAKING CHANGE: the deprecated `org.neo4j.driver.Config.TrustStrategy#certFile()` has been deleted, please use `org.neo4j.driver.Config.TrustStrategy#certFiles()`.