### PR TITLE
feat(notification): delete deprecated Notification#severity()

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -806,4 +806,10 @@
         <method>java.io.File certFile()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7002</differenceType>
+        <method>java.lang.String severity()</method>
+    </difference>
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/summary/Notification.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Notification.java
@@ -73,17 +73,6 @@ public interface Notification extends GqlStatusObject {
     }
 
     /**
-     * The severity level of the notification.
-     *
-     * @deprecated superseded by {@link #severityLevel()} and {@link #rawSeverityLevel()}
-     * @return the severity level of the notification
-     */
-    @Deprecated
-    default String severity() {
-        return rawSeverityLevel().orElse("N/A");
-    }
-
-    /**
      * Returns the severity level of the notification derived from the diagnostic record.
      *
      * @return the severity level of the notification

--- a/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/SummaryIT.java
@@ -229,7 +229,6 @@ class SummaryIT {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void shouldContainNotifications() {
         // When
         var summary =
@@ -243,7 +242,6 @@ class SummaryIT {
         assertThat(notification.code(), notNullValue());
         assertThat(notification.title(), notNullValue());
         assertThat(notification.description(), notNullValue());
-        assertThat(notification.severity(), notNullValue());
         assertThat(notification.severityLevel(), notNullValue());
         assertThat(notification.rawSeverityLevel(), notNullValue());
         assertThat(notification.position(), notNullValue());

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
@@ -250,7 +250,6 @@ class MetadataExtractorTest {
         assertEquals("Almost bad thing", firstNotification.description());
         assertEquals("Neo.DummyNotification", firstNotification.code());
         assertEquals("A title", firstNotification.title());
-        assertEquals("WARNING", firstNotification.severity());
         assertEquals(
                 NotificationSeverity.WARNING, firstNotification.severityLevel().get());
         assertEquals("WARNING", firstNotification.rawSeverityLevel().get());
@@ -280,7 +279,8 @@ class MetadataExtractorTest {
         assertEquals("Almost good thing", secondNotification.description());
         assertEquals("Neo.GoodNotification", secondNotification.code());
         assertEquals("Good", secondNotification.title());
-        assertEquals("INFO", secondNotification.severity());
+        assertFalse(secondNotification.severityLevel().isPresent());
+        assertEquals("INFO", secondNotification.rawSeverityLevel().get());
         assertTrue(secondNotification.inputPosition().isEmpty());
         assertNull(secondNotification.position());
         assertEquals(
@@ -348,7 +348,6 @@ class MetadataExtractorTest {
         assertEquals("notification_description", firstGqlStatusObject.description());
         assertEquals("neo4j_code", firstGqlStatusObject.code());
         assertEquals("title", firstGqlStatusObject.title());
-        assertEquals("WARNING", firstGqlStatusObject.severity());
         assertEquals(
                 NotificationSeverity.WARNING,
                 firstGqlStatusObject.severityLevel().get());

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
@@ -66,7 +66,6 @@ public class SummaryUtil {
                         .title(s.title())
                         .description(s.description())
                         .position(toInputPosition(s.position()))
-                        .severity(s.severity())
                         .severityLevel(s.severityLevel()
                                 .map(InternalNotificationSeverity.class::cast)
                                 .map(InternalNotificationSeverity::type)

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
@@ -121,8 +121,6 @@ public class Summary implements TestkitResponse {
 
         private InputPosition position;
 
-        private String severity;
-
         private String severityLevel;
 
         private String rawSeverityLevel;


### PR DESCRIPTION
BREAKING CHANGE: the deprecated `org.neo4j.driver.summary.Notification#severity()` has been deleted, please use either `org.neo4j.driver.summary.Notification#severityLevel()` or `org.neo4j.driver.summary.Notification#rawSeverityLevel()`.