### PR TITLE
feat(gql-status-object): Introduce GqlNotification

### DIFF
--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -824,4 +824,29 @@
         <method>org.neo4j.driver.types.Type VECTOR()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>4001</differenceType>
+        <to>org/neo4j/driver/summary/GqlStatusObject</to>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7002</differenceType>
+        <method>java.util.Optional inputPosition()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7002</differenceType>
+        <method>java.util.Optional classification()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/summary/Notification</className>
+        <differenceType>7002</differenceType>
+        <method>java.util.Optional rawClassification()</method>
+    </difference>
+
+
 </differences>

--- a/driver/src/main/java/org/neo4j/driver/NotificationConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/NotificationConfig.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import org.neo4j.driver.internal.InternalNotificationConfig;
 import org.neo4j.driver.internal.InternalNotificationSeverity;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.util.Preview;
 
 /**
  * A notification configuration defining what notifications should be supplied by the server.
@@ -40,7 +39,6 @@ import org.neo4j.driver.util.Preview;
  * @see ResultSummary#notifications()
  * @see org.neo4j.driver.summary.Notification
  */
-@Preview(name = "GQL-status object")
 public sealed interface NotificationConfig extends Serializable permits InternalNotificationConfig {
     /**
      * Returns a default notification configuration.

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalGqlNotification.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalGqlNotification.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.summary;
+
+import java.util.Map;
+import java.util.Optional;
+import org.neo4j.driver.NotificationClassification;
+import org.neo4j.driver.NotificationSeverity;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.summary.GqlNotification;
+import org.neo4j.driver.summary.InputPosition;
+
+public final class InternalGqlNotification extends InternalGqlStatusObject implements GqlNotification {
+    private final InputPosition position;
+    private final NotificationSeverity severityLevel;
+    private final String rawSeverityLevel;
+    private final NotificationClassification classification;
+    private final String rawClassification;
+
+    public InternalGqlNotification(
+            String gqlStatus,
+            String statusDescription,
+            Map<String, Value> diagnosticRecord,
+            InputPosition position,
+            NotificationSeverity severityLevel,
+            String rawSeverityLevel,
+            NotificationClassification classification,
+            String rawClassification) {
+        super(gqlStatus, statusDescription, diagnosticRecord);
+        this.position = position;
+        this.severityLevel = severityLevel;
+        this.rawSeverityLevel = rawSeverityLevel;
+        this.classification = classification;
+        this.rawClassification = rawClassification;
+    }
+
+    @Override
+    public Optional<InputPosition> position() {
+        return Optional.ofNullable(position);
+    }
+
+    @Override
+    public Optional<NotificationSeverity> severity() {
+        return Optional.ofNullable(severityLevel);
+    }
+
+    @Override
+    public Optional<String> rawSeverity() {
+        return Optional.ofNullable(rawSeverityLevel);
+    }
+
+    @Override
+    public Optional<NotificationClassification> classification() {
+        return Optional.ofNullable(classification);
+    }
+
+    @Override
+    public Optional<String> rawClassification() {
+        return Optional.ofNullable(rawClassification);
+    }
+
+    @Override
+    public String toString() {
+        return "InternalGqlNotification{" + "gqlStatus='"
+                + gqlStatus + '\'' + ", statusDescription='"
+                + statusDescription + '\'' + ", diagnosticRecord="
+                + diagnosticRecord + '}';
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalGqlStatusObject.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalGqlStatusObject.java
@@ -22,7 +22,7 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.summary.GqlStatusObject;
 
-public class InternalGqlStatusObject implements GqlStatusObject {
+public sealed class InternalGqlStatusObject implements GqlStatusObject permits InternalGqlNotification {
     public static final GqlStatusObject SUCCESS = new InternalGqlStatusObject(
             "00000",
             "note: successful completion",
@@ -52,9 +52,9 @@ public class InternalGqlStatusObject implements GqlStatusObject {
                     Map.entry("OPERATION", Values.value("")),
                     Map.entry("OPERATION_CODE", Values.value("0"))));
 
-    private final String gqlStatus;
-    private final String statusDescription;
-    private final Map<String, Value> diagnosticRecord;
+    protected final String gqlStatus;
+    protected final String statusDescription;
+    protected final Map<String, Value> diagnosticRecord;
 
     public InternalGqlStatusObject(String gqlStatus, String statusDescription, Map<String, Value> diagnosticRecord) {
         this.gqlStatus = Objects.requireNonNull(gqlStatus);

--- a/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotification.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/summary/InternalNotification.java
@@ -17,17 +17,14 @@
 package org.neo4j.driver.internal.summary;
 
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.neo4j.driver.NotificationCategory;
 import org.neo4j.driver.NotificationClassification;
 import org.neo4j.driver.NotificationSeverity;
-import org.neo4j.driver.Value;
 import org.neo4j.driver.summary.InputPosition;
 import org.neo4j.driver.summary.Notification;
 
-public class InternalNotification extends InternalGqlStatusObject implements Notification {
+public class InternalNotification implements Notification {
     public static Optional<NotificationCategory> valueOf(String value) {
         return Arrays.stream(NotificationClassification.values())
                 .filter(type -> type.toString().equals(value))
@@ -50,52 +47,44 @@ public class InternalNotification extends InternalGqlStatusObject implements Not
     private final String description;
     private final NotificationSeverity severityLevel;
     private final String rawSeverityLevel;
-    private final NotificationClassification classification;
-    private final String rawClassification;
+    private final NotificationCategory category;
+    private final String rawCategory;
     private final InputPosition position;
 
     public InternalNotification(
-            String gqlStatus,
-            String statusDescription,
-            Map<String, Value> diagnosticRecord,
             String code,
             String title,
             String description,
             NotificationSeverity severityLevel,
             String rawSeverityLevel,
-            NotificationClassification classification,
-            String rawClassification,
+            NotificationCategory category,
+            String rawCategory,
             InputPosition position) {
-        super(gqlStatus, statusDescription, diagnosticRecord);
-        this.code = Objects.requireNonNull(code);
+        this.code = code;
         this.title = title;
         this.description = description;
         this.severityLevel = severityLevel;
         this.rawSeverityLevel = rawSeverityLevel;
-        this.classification = classification;
-        this.rawClassification = rawClassification;
+        this.category = category;
+        this.rawCategory = rawCategory;
         this.position = position;
     }
 
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
     @Override
     public String code() {
         return code;
     }
 
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
     @Override
     public String title() {
         return title;
     }
 
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
     @Override
     public String description() {
         return description;
     }
 
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
     @Override
     public InputPosition position() {
         return position;
@@ -112,61 +101,20 @@ public class InternalNotification extends InternalGqlStatusObject implements Not
     }
 
     @Override
-    public Optional<NotificationClassification> classification() {
-        return Optional.ofNullable(classification);
-    }
-
-    @Override
-    public Optional<String> rawClassification() {
-        return Optional.ofNullable(rawClassification);
-    }
-
-    @Override
     public Optional<NotificationCategory> category() {
-        return Optional.ofNullable(classification);
+        return Optional.ofNullable(category);
     }
 
     @Override
     public Optional<String> rawCategory() {
-        return Optional.ofNullable(rawClassification);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        var that = (InternalNotification) o;
-        return Objects.equals(code, that.code)
-                && Objects.equals(title, that.title)
-                && Objects.equals(description, that.description)
-                && Objects.equals(severityLevel, that.severityLevel)
-                && Objects.equals(rawSeverityLevel, that.rawSeverityLevel)
-                && classification == that.classification
-                && Objects.equals(rawClassification, that.rawClassification)
-                && Objects.equals(position, that.position);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                super.hashCode(),
-                code,
-                title,
-                description,
-                severityLevel,
-                rawSeverityLevel,
-                classification,
-                rawClassification,
-                position);
+        return Optional.ofNullable(rawCategory);
     }
 
     @Override
     public String toString() {
         var info = "code=" + code + ", title=" + title + ", description=" + description + ", severityLevel="
-                + severityLevel + ", rawSeverityLevel=" + rawSeverityLevel + ", classification=" + classification
-                + ", rawClassification="
-                + rawClassification;
+                + severityLevel + ", rawSeverityLevel=" + rawSeverityLevel + ", category=" + category + ", rawCategory="
+                + rawCategory;
         return position == null ? info : info + ", position={" + position + "}";
     }
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/util/MetadataExtractor.java
@@ -18,6 +18,8 @@ package org.neo4j.driver.internal.util;
 
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.teeing;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -30,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeSet;
@@ -45,6 +48,7 @@ import org.neo4j.driver.exceptions.ProtocolException;
 import org.neo4j.driver.internal.InternalNotificationSeverity;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnection;
 import org.neo4j.driver.internal.summary.InternalDatabaseInfo;
+import org.neo4j.driver.internal.summary.InternalGqlNotification;
 import org.neo4j.driver.internal.summary.InternalGqlStatusObject;
 import org.neo4j.driver.internal.summary.InternalInputPosition;
 import org.neo4j.driver.internal.summary.InternalNotification;
@@ -104,29 +108,38 @@ public class MetadataExtractor {
         Set<GqlStatusObject> gqlStatusObjects;
         List<Notification> notifications;
         if (legacyNotifications) {
-            var gqlStatusObjectsAndNotifications = extractGqlStatusObjectsFromNotifications(metadata)
+            var gqlStatusObjectsAndNotifications = generateGqlStatusObjectsAndExtractNotifications(metadata)
                     .collect(teeing(
-                            collectingAndThen(
-                                    toCollection(
-                                            () -> (Set<GqlStatusObject>) new TreeSet<>(GQL_STATUS_OBJECT_COMPARATOR)),
-                                    set -> {
-                                        if (gqlStatusObject != null) {
-                                            set.add(gqlStatusObject);
-                                        }
-                                        return unmodifiableSet(set);
-                                    }),
-                            toUnmodifiableList(),
+                            mapping(
+                                    GqlStatusObjectAndNotification::gqlStatusObject,
+                                    collectingAndThen(
+                                            toCollection(() ->
+                                                    (Set<GqlStatusObject>) new TreeSet<>(GQL_STATUS_OBJECT_COMPARATOR)),
+                                            set -> {
+                                                if (gqlStatusObject != null) {
+                                                    set.add(gqlStatusObject);
+                                                }
+                                                return unmodifiableSet(set);
+                                            })),
+                            mapping(GqlStatusObjectAndNotification::notification, toUnmodifiableList()),
                             GqlStatusObjectsAndNotifications::new));
             gqlStatusObjects = gqlStatusObjectsAndNotifications.gqlStatusObjects();
             notifications = gqlStatusObjectsAndNotifications.notifications();
         } else {
-            gqlStatusObjects = extractGqlStatusObjects(metadata)
-                    .collect(collectingAndThen(
-                            toCollection(() -> (Set<GqlStatusObject>) new LinkedHashSet<GqlStatusObject>()),
-                            Collections::unmodifiableSet));
-            notifications = gqlStatusObjects.stream()
-                    .flatMap(status -> status instanceof Notification ? Stream.of((Notification) status) : null)
-                    .toList();
+            var gqlStatusObjectsAndNotifications = extractGqlStatusObjectsAndGenerateNotifications(metadata)
+                    .collect(teeing(
+                            mapping(
+                                    GqlStatusObjectAndNotification::gqlStatusObject,
+                                    collectingAndThen(
+                                            toCollection(
+                                                    () -> (Set<GqlStatusObject>) new LinkedHashSet<GqlStatusObject>()),
+                                            Collections::unmodifiableSet)),
+                            mapping(
+                                    GqlStatusObjectAndNotification::notification,
+                                    filtering(Objects::nonNull, toUnmodifiableList())),
+                            GqlStatusObjectsAndNotifications::new));
+            gqlStatusObjects = gqlStatusObjectsAndNotifications.gqlStatusObjects();
+            notifications = gqlStatusObjectsAndNotifications.notifications();
         }
         return new InternalResultSummary(
                 query,
@@ -200,7 +213,8 @@ public class MetadataExtractor {
         return null;
     }
 
-    private static Stream<Notification> extractGqlStatusObjectsFromNotifications(Map<String, Value> metadata) {
+    private static Stream<GqlStatusObjectAndNotification> generateGqlStatusObjectsAndExtractNotifications(
+            Map<String, Value> metadata) {
         var notificationsValue = metadata.get("notifications");
         if (notificationsValue != null && TypeSystem.getDefault().LIST().isTypeOf(notificationsValue)) {
             var iterable = notificationsValue.values(value -> {
@@ -259,36 +273,37 @@ public class MetadataExtractor {
                                     Values.value(position.column()))));
                 }
 
-                return new InternalNotification(
+                var gqlNotification = new InternalGqlNotification(
                         gqlStatusCode,
                         gqlStatusDescription,
                         Collections.unmodifiableMap(diagnosticRecord),
-                        code,
-                        title,
-                        description,
+                        position,
                         severityLevel,
                         rawSeverityLevel,
                         (NotificationClassification) category,
-                        rawCategory,
-                        position);
+                        rawCategory);
+                var notification = new InternalNotification(
+                        code, title, description, severityLevel, rawSeverityLevel, category, rawCategory, position);
+                return new GqlStatusObjectAndNotification(gqlNotification, notification);
             });
-            return StreamSupport.stream(iterable.spliterator(), false).map(Notification.class::cast);
-        } else {
-            return Stream.empty();
-        }
-    }
-
-    private static Stream<GqlStatusObject> extractGqlStatusObjects(Map<String, Value> metadata) {
-        var statuses = metadata.get("statuses");
-        if (statuses != null && TypeSystem.getDefault().LIST().isTypeOf(statuses)) {
-            var iterable = statuses.values(MetadataExtractor::extractGqlStatusObject);
             return StreamSupport.stream(iterable.spliterator(), false);
         } else {
             return Stream.empty();
         }
     }
 
-    private static GqlStatusObject extractGqlStatusObject(Value value) {
+    private static Stream<GqlStatusObjectAndNotification> extractGqlStatusObjectsAndGenerateNotifications(
+            Map<String, Value> metadata) {
+        var statuses = metadata.get("statuses");
+        if (statuses != null && TypeSystem.getDefault().LIST().isTypeOf(statuses)) {
+            var iterable = statuses.values(MetadataExtractor::extractGqlStatusObjectAndGenerateNotification);
+            return StreamSupport.stream(iterable.spliterator(), false);
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private static GqlStatusObjectAndNotification extractGqlStatusObjectAndGenerateNotification(Value value) {
         var status = value.get("gql_status").asString();
         var description = value.get("status_description").asString();
         Map<String, Value> diagnosticRecord;
@@ -322,7 +337,8 @@ public class MetadataExtractor {
         var neo4jCode = value.get("neo4j_code").asString(null);
 
         if (neo4jCode == null || neo4jCode.trim().isEmpty()) {
-            return new InternalGqlStatusObject(status, description, diagnosticRecord);
+            var gqlStatusObject = new InternalGqlStatusObject(status, description, diagnosticRecord);
+            return new GqlStatusObjectAndNotification(gqlStatusObject, null);
         } else {
             var title = value.get("title").asString();
             var notificationDescription =
@@ -354,10 +370,16 @@ public class MetadataExtractor {
             var classification = (NotificationClassification)
                     InternalNotification.valueOf(rawClassification).orElse(null);
 
-            return new InternalNotification(
+            var gqlNotification = new InternalGqlNotification(
                     status,
                     description,
                     diagnosticRecord,
+                    position,
+                    severity,
+                    rawSeverity,
+                    classification,
+                    rawClassification);
+            var notification = new InternalNotification(
                     neo4jCode,
                     title,
                     notificationDescription,
@@ -366,6 +388,7 @@ public class MetadataExtractor {
                     classification,
                     rawClassification,
                     position);
+            return new GqlStatusObjectAndNotification(gqlNotification, notification);
         }
     }
 
@@ -388,4 +411,6 @@ public class MetadataExtractor {
 
     private record GqlStatusObjectsAndNotifications(
             Set<GqlStatusObject> gqlStatusObjects, List<Notification> notifications) {}
+
+    private record GqlStatusObjectAndNotification(GqlStatusObject gqlStatusObject, Notification notification) {}
 }

--- a/driver/src/main/java/org/neo4j/driver/summary/GqlNotification.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/GqlNotification.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.summary;
+
+import java.util.Optional;
+import org.neo4j.driver.NotificationClassification;
+import org.neo4j.driver.NotificationSeverity;
+import org.neo4j.driver.internal.summary.InternalGqlNotification;
+import org.neo4j.driver.util.Preview;
+
+/**
+ * A notification subtype of the {@link GqlStatusObject}.
+ * @since 5.28.8
+ * @see GqlStatusObject
+ */
+@Preview(name = "GQL-status object")
+public sealed interface GqlNotification extends GqlStatusObject permits InternalGqlNotification {
+
+    /**
+     * Returns a position in the query where this notification points to.
+     * <p>
+     * Not all notifications have a unique position to point to and in that case an empty {@link Optional} is returned.
+     *
+     * @return an {@link Optional} of the {@link InputPosition} if available or an empty {@link Optional} otherwise
+     */
+    Optional<InputPosition> position();
+
+    /**
+     * Returns the severity level of the notification derived from the diagnostic record.
+     *
+     * @return the severity level of the notification
+     * @see #diagnosticRecord()
+     */
+    Optional<NotificationSeverity> severity();
+
+    /**
+     * Returns the raw severity level of the notification as a String value retrieved directly from the diagnostic
+     * record.
+     *
+     * @return the severity level of the notification
+     * @see #diagnosticRecord()
+     */
+    Optional<String> rawSeverity();
+
+    /**
+     * Returns {@link NotificationClassification} derived from the diagnostic record.
+     * @return an {@link Optional} of {@link NotificationClassification} or an empty {@link Optional} when the
+     * classification is either absent or unrecognised
+     * @see #diagnosticRecord()
+     */
+    Optional<NotificationClassification> classification();
+
+    /**
+     * Returns notification classification from the diagnostic record as a {@link String} value retrieved directly from
+     * the diagnostic record.
+     * @return an {@link Optional} of notification classification or an empty {@link Optional} when it is absent
+     * @see #diagnosticRecord()
+     */
+    Optional<String> rawClassification();
+}

--- a/driver/src/main/java/org/neo4j/driver/summary/GqlStatusObject.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/GqlStatusObject.java
@@ -18,15 +18,16 @@ package org.neo4j.driver.summary;
 
 import java.util.Map;
 import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.summary.InternalGqlStatusObject;
 import org.neo4j.driver.util.Preview;
 
 /**
  * The GQL-status object as defined by the GQL standard.
  * @since 5.22.0
- * @see Notification Notification subtype of the GQL-status object
+ * @see GqlNotification Notification subtype of the GQL-status object
  */
 @Preview(name = "GQL-status object")
-public interface GqlStatusObject {
+public sealed interface GqlStatusObject permits GqlNotification, InternalGqlStatusObject {
     /**
      * Returns the GQLSTATUS as defined by the GQL standard.
      * @return the GQLSTATUS value

--- a/driver/src/main/java/org/neo4j/driver/summary/Notification.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/Notification.java
@@ -18,10 +18,8 @@ package org.neo4j.driver.summary;
 
 import java.util.Optional;
 import org.neo4j.driver.NotificationCategory;
-import org.neo4j.driver.NotificationClassification;
 import org.neo4j.driver.NotificationSeverity;
 import org.neo4j.driver.util.Immutable;
-import org.neo4j.driver.util.Preview;
 
 /**
  * Representation for notifications found when executing a query.
@@ -30,7 +28,7 @@ import org.neo4j.driver.util.Preview;
  * @since 1.0
  */
 @Immutable
-public interface Notification extends GqlStatusObject {
+public interface Notification {
     /**
      * Returns a notification code for the discovered issue.
      * @return the notification code
@@ -40,7 +38,6 @@ public interface Notification extends GqlStatusObject {
     /**
      * Returns a short summary of the notification.
      * @return the title of the notification.
-     * @see #gqlStatus()
      */
     String title();
 
@@ -60,62 +57,22 @@ public interface Notification extends GqlStatusObject {
     InputPosition position();
 
     /**
-     * Returns a position in the query where this notification points to.
-     * <p>
-     * Not all notifications have a unique position to point to and in that case an empty {@link Optional} is returned.
-     *
-     * @return an {@link Optional} of the {@link InputPosition} if available or an empty {@link Optional} otherwise
-     * @since 5.22.0
-     */
-    @Preview(name = "GQL-status object")
-    default Optional<InputPosition> inputPosition() {
-        return Optional.ofNullable(position());
-    }
-
-    /**
-     * Returns the severity level of the notification derived from the diagnostic record.
+     * Returns the severity level of the notification.
      *
      * @return the severity level of the notification
      * @since 5.7
-     * @see #diagnosticRecord()
      */
     default Optional<NotificationSeverity> severityLevel() {
         return Optional.empty();
     }
 
     /**
-     * Returns the raw severity level of the notification as a String value retrieved directly from the diagnostic
-     * record.
+     * Returns the raw severity level of the notification as a String returned by the server.
      *
      * @return the severity level of the notification
      * @since 5.7
-     * @see #diagnosticRecord()
      */
     default Optional<String> rawSeverityLevel() {
-        return Optional.empty();
-    }
-
-    /**
-     * Returns {@link NotificationClassification} derived from the diagnostic record.
-     * @return an {@link Optional} of {@link NotificationClassification} or an empty {@link Optional} when the
-     * classification is either absent or unrecognised
-     * @since 5.22.0
-     * @see #diagnosticRecord()
-     */
-    @Preview(name = "GQL-status object")
-    default Optional<NotificationClassification> classification() {
-        return Optional.empty();
-    }
-
-    /**
-     * Returns notification classification from the diagnostic record as a {@link String} value retrieved directly from
-     * the diagnostic record.
-     * @return an {@link Optional} of notification classification or an empty {@link Optional} when it is absent
-     * @since 5.22.0
-     * @see #diagnosticRecord()
-     */
-    @Preview(name = "GQL-status object")
-    default Optional<String> rawClassification() {
         return Optional.empty();
     }
 

--- a/driver/src/main/java/org/neo4j/driver/summary/ResultSummary.java
+++ b/driver/src/main/java/org/neo4j/driver/summary/ResultSummary.java
@@ -95,13 +95,9 @@ public interface ResultSummary {
      * in a client.
      * <p>
      * Unlike failures or errors, notifications do not affect the execution of a query.
-     * <p>
-     * Since {@link Notification} is a subtype of {@link GqlStatusObject}, the list of notifications is a subset of all
-     * GQL-status objects that are of {@link Notification} type. However, the order might be different.
      *
      * @return a list of notifications produced while executing the query. The list will be empty if no
      * notifications produced while executing the query.
-     * @see #gqlStatusObjects()
      */
     List<Notification> notifications();
 

--- a/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/MetadataExtractorTest.java
@@ -51,7 +51,7 @@ import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.value.Uncoercible;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnection;
 import org.neo4j.driver.internal.summary.InternalInputPosition;
-import org.neo4j.driver.summary.Notification;
+import org.neo4j.driver.summary.GqlNotification;
 import org.neo4j.driver.summary.ResultSummary;
 
 class MetadataExtractorTest {
@@ -243,9 +243,13 @@ class MetadataExtractorTest {
 
         var summary = extractor.extractSummary(query(), connectionMock(), 42, metadata, true, null);
 
+        assertEquals(2, summary.gqlStatusObjects().size());
         assertEquals(2, summary.notifications().size());
+        var gqlStatusObjectsIterator = summary.gqlStatusObjects().iterator();
         var firstNotification = summary.notifications().get(0);
+        var firstGqlStatusObject = (GqlNotification) gqlStatusObjectsIterator.next();
         var secondNotification = summary.notifications().get(1);
+        var secondGqlStatusObject = (GqlNotification) gqlStatusObjectsIterator.next();
 
         assertEquals("Almost bad thing", firstNotification.description());
         assertEquals("Neo.DummyNotification", firstNotification.code());
@@ -257,6 +261,18 @@ class MetadataExtractorTest {
                 NotificationCategory.DEPRECATION, firstNotification.category().get());
         assertEquals("DEPRECATION", firstNotification.rawCategory().get());
         assertEquals(new InternalInputPosition(42, 4242, 424242), firstNotification.position());
+
+        assertEquals("Almost bad thing", firstGqlStatusObject.statusDescription());
+        assertEquals(
+                NotificationSeverity.WARNING, firstGqlStatusObject.severity().get());
+        assertEquals("WARNING", firstGqlStatusObject.rawSeverity().get());
+        assertEquals(
+                NotificationCategory.DEPRECATION,
+                firstGqlStatusObject.classification().get());
+        assertEquals("DEPRECATION", firstGqlStatusObject.rawClassification().get());
+        assertEquals(
+                new InternalInputPosition(42, 4242, 424242),
+                firstGqlStatusObject.position().get());
         assertEquals(
                 Map.of(
                         "OPERATION",
@@ -274,29 +290,28 @@ class MetadataExtractorTest {
                                 "offset", 42,
                                 "line", 4242,
                                 "column", 424242)),
-                firstNotification.diagnosticRecord());
+                firstGqlStatusObject.diagnosticRecord());
 
         assertEquals("Almost good thing", secondNotification.description());
         assertEquals("Neo.GoodNotification", secondNotification.code());
         assertEquals("Good", secondNotification.title());
         assertFalse(secondNotification.severityLevel().isPresent());
         assertEquals("INFO", secondNotification.rawSeverityLevel().get());
-        assertTrue(secondNotification.inputPosition().isEmpty());
         assertNull(secondNotification.position());
+
+        assertEquals("Almost good thing", secondGqlStatusObject.statusDescription());
+        assertFalse(secondGqlStatusObject.severity().isPresent());
+        assertEquals("INFO", secondGqlStatusObject.rawSeverity().get());
+        assertFalse(secondGqlStatusObject.classification().isPresent());
+        assertFalse(secondGqlStatusObject.rawClassification().isPresent());
+        assertTrue(secondGqlStatusObject.position().isEmpty());
         assertEquals(
                 Map.of(
                         "OPERATION", Values.value(""),
                         "OPERATION_CODE", Values.value("0"),
                         "CURRENT_SCHEMA", Values.value("/"),
                         "_severity", Values.value("INFO")),
-                secondNotification.diagnosticRecord());
-
-        assertEquals(2, summary.gqlStatusObjects().size());
-        var gqlStatusObjectsIterator = summary.gqlStatusObjects().iterator();
-        var firstGqlStatusObject = (Notification) gqlStatusObjectsIterator.next();
-        var secondGqlStatusObject = (Notification) gqlStatusObjectsIterator.next();
-        assertEquals(firstNotification, firstGqlStatusObject);
-        assertEquals(secondNotification, secondGqlStatusObject);
+                secondGqlStatusObject.diagnosticRecord());
     }
 
     @Test
@@ -339,23 +354,24 @@ class MetadataExtractorTest {
         var summary = extractor.extractSummary(query(), connectionMock(), 42, metadata, false, null);
 
         assertEquals(2, summary.gqlStatusObjects().size());
+        assertEquals(1, summary.notifications().size());
         var gqlStatusObjectsIterator = summary.gqlStatusObjects().iterator();
-        var firstGqlStatusObject = (Notification) gqlStatusObjectsIterator.next();
+        var firstGqlStatusObject = (GqlNotification) gqlStatusObjectsIterator.next();
+        var firstNotification = summary.notifications().get(0);
         var secondGqlStatusObject = gqlStatusObjectsIterator.next();
 
         assertEquals("gql_status", firstGqlStatusObject.gqlStatus());
         assertEquals("status_description", firstGqlStatusObject.statusDescription());
-        assertEquals("notification_description", firstGqlStatusObject.description());
-        assertEquals("neo4j_code", firstGqlStatusObject.code());
-        assertEquals("title", firstGqlStatusObject.title());
         assertEquals(
-                NotificationSeverity.WARNING,
-                firstGqlStatusObject.severityLevel().get());
-        assertEquals("WARNING", firstGqlStatusObject.rawSeverityLevel().get());
+                NotificationSeverity.WARNING, firstGqlStatusObject.severity().get());
+        assertEquals("WARNING", firstGqlStatusObject.rawSeverity().get());
         assertEquals(
-                NotificationCategory.SECURITY, firstGqlStatusObject.category().get());
-        assertEquals("SECURITY", firstGqlStatusObject.rawCategory().get());
-        assertEquals(new InternalInputPosition(42, 4242, 424242), firstGqlStatusObject.position());
+                NotificationCategory.SECURITY,
+                firstGqlStatusObject.classification().get());
+        assertEquals("SECURITY", firstGqlStatusObject.rawClassification().get());
+        assertEquals(
+                new InternalInputPosition(42, 4242, 424242),
+                firstGqlStatusObject.position().get());
         assertEquals(
                 Map.of(
                         "OPERATION",
@@ -375,7 +391,17 @@ class MetadataExtractorTest {
                                 "column", 424242)),
                 firstGqlStatusObject.diagnosticRecord());
 
-        assertFalse(secondGqlStatusObject instanceof Notification);
+        assertEquals("notification_description", firstNotification.description());
+        assertEquals("neo4j_code", firstNotification.code());
+        assertEquals("title", firstNotification.title());
+        assertEquals(
+                NotificationSeverity.WARNING, firstNotification.severityLevel().get());
+        assertEquals("WARNING", firstNotification.rawSeverityLevel().get());
+        assertEquals(NotificationCategory.SECURITY, firstNotification.category().get());
+        assertEquals("SECURITY", firstNotification.rawCategory().get());
+        assertEquals(new InternalInputPosition(42, 4242, 424242), firstNotification.position());
+
+        assertFalse(secondGqlStatusObject instanceof GqlNotification);
         assertEquals("gql_status", secondGqlStatusObject.gqlStatus());
         assertEquals("status_description", secondGqlStatusObject.statusDescription());
         assertEquals(
@@ -386,9 +412,6 @@ class MetadataExtractorTest {
                         "_severity", Values.value("WARNING"),
                         "_classification", Values.value("SECURITY")),
                 secondGqlStatusObject.diagnosticRecord());
-
-        assertEquals(1, summary.notifications().size());
-        assertEquals(firstGqlStatusObject, summary.notifications().get(0));
     }
 
     @Test

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
@@ -24,8 +24,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import neo4j.org.testkit.backend.messages.responses.Summary;
 import org.neo4j.driver.internal.InternalNotificationSeverity;
+import org.neo4j.driver.summary.GqlNotification;
 import org.neo4j.driver.summary.InputPosition;
-import org.neo4j.driver.summary.Notification;
 import org.neo4j.driver.summary.Plan;
 import org.neo4j.driver.summary.ProfiledPlan;
 import org.neo4j.driver.summary.QueryType;
@@ -82,15 +82,16 @@ public class SummaryUtil {
                             .gqlStatus(gqlStatusObject.gqlStatus())
                             .statusDescription(gqlStatusObject.statusDescription())
                             .diagnosticRecord(gqlStatusObject.diagnosticRecord());
-                    if (gqlStatusObject instanceof Notification notification) {
-                        builder = builder.position(toInputPosition(notification.position()))
+                    if (gqlStatusObject instanceof GqlNotification notification) {
+                        builder = builder.position(
+                                        toInputPosition(notification.position().orElse(null)))
                                 .severity(notification
-                                        .severityLevel()
+                                        .severity()
                                         .map(InternalNotificationSeverity.class::cast)
                                         .map(InternalNotificationSeverity::type)
                                         .map(InternalNotificationSeverity.Type::toString)
                                         .orElse("UNKNOWN"))
-                                .rawSeverity(notification.rawSeverityLevel().orElse(null))
+                                .rawSeverity(notification.rawSeverity().orElse(null))
                                 .classification(notification
                                         .classification()
                                         .map(Objects::toString)


### PR DESCRIPTION
BREAKING CHANGE: this update separates the new GQL Status Object hierarchy from the legacy `Notification` type by introducing a new `GqlNotification` interface that extends the `GqlStatusObject`.

The update is based on the feedback received on the GQL Status Object feature, which is currently in preview. This should make it easier to understand the new GQL Status Objects and migrate from using the legacy `Notification` to the new types.

Eventually, the new hierarchy is expected to replace the legacy `Notification` that is expected to be deprecated and phased out at a later date.