### PR TITLE
feat(observability): allow setting null provider

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -37,7 +37,6 @@ import org.neo4j.driver.internal.InternalNotificationConfig;
 import org.neo4j.driver.internal.RoutingSettings;
 import org.neo4j.driver.internal.SecuritySettings;
 import org.neo4j.driver.internal.observation.DriverObservationProvider;
-import org.neo4j.driver.internal.observation.NoopObservationProvider;
 import org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic;
 import org.neo4j.driver.net.ServerAddressResolver;
 import org.neo4j.driver.observation.ObservationProvider;
@@ -749,11 +748,10 @@ public final class Config implements Serializable {
          */
         @Preview(name = "Observability")
         public ConfigBuilder withObservationProvider(ObservationProvider observationProvider) {
-            this.observationProvider =
-                    Objects.requireNonNullElseGet(observationProvider, NoopObservationProvider::getInstance);
-            if (!(observationProvider instanceof DriverObservationProvider)) {
+            if (observationProvider != null && !(observationProvider instanceof DriverObservationProvider)) {
                 throw new IllegalArgumentException("Unssupported observation provider");
             }
+            this.observationProvider = observationProvider;
             return this;
         }
 

--- a/driver/src/test/java/org/neo4j/driver/ConfigTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ConfigTest.java
@@ -562,4 +562,11 @@ class ConfigTest {
         assertThrows(
                 IllegalArgumentException.class, () -> Config.builder().withObservationProvider(observationProvider));
     }
+
+    @Test
+    void shouldAllowNullObservationProvider() {
+        var config = Config.builder().withObservationProvider(null).build();
+
+        assertTrue(config.observationProvider().isEmpty());
+    }
 }

--- a/observation/micrometer/pom.xml
+++ b/observation/micrometer/pom.xml
@@ -142,27 +142,25 @@
         <profile>
             <id>generate-html</id>
             <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctor-maven-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>asciidoc-to-html</id>
-                                    <phase>prepare-package</phase>
-                                    <goals>
-                                        <goal>process-asciidoc</goal>
-                                    </goals>
-                                    <configuration>
-                                        <sourceDirectory>${project.build.directory}/docs</sourceDirectory>
-                                        <outputDirectory>${project.build.directory}/html</outputDirectory>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>asciidoc-to-html</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${project.build.directory}/docs</sourceDirectory>
+                                    <outputDirectory>${project.build.directory}/html</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
Setting `null` provider used to throw `IllegalArgumentException`. This update fixes that issue.