### PR TITLE
feat(native): add support for Netty native transports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
-    <neo4j-bolt-connection-bom.version>8.0.1</neo4j-bolt-connection-bom.version>
+    <neo4j-bolt-connection-bom.version>8.2.0</neo4j-bolt-connection-bom.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <!-- Please note that when updating this dependency -->
     <!-- (i.e. due to a security vulnerability or bug) that the -->


### PR DESCRIPTION
This update brings support for using Netty native transports.

Providing that a valid native dependency is added, it will be discovered and used instead of the default `NIO` transport.

For example:
```
<dependency>
    <groupId>io.netty</groupId>
    <artifactId>netty-transport-native-io_uring</artifactId>
    <classifier>linux-x86_64</classifier>
</dependency>
```
