### PR TITLE
feat(unix): add support for bolt+unix

### DIFF
--- a/observation/micrometer/src/main/java/org/neo4j/driver/observation/micrometer/DefaultBoltExchangeConvention.java
+++ b/observation/micrometer/src/main/java/org/neo4j/driver/observation/micrometer/DefaultBoltExchangeConvention.java
@@ -18,6 +18,7 @@ package org.neo4j.driver.observation.micrometer;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DefaultBoltExchangeConvention implements BoltExchangeConvention {
@@ -43,12 +44,17 @@ public class DefaultBoltExchangeConvention implements BoltExchangeConvention {
 
     @Override
     public KeyValues getLowCardinalityKeyValues(BoltExchangeContext context) {
-        return KeyValues.of(
-                DB_SYSTEM_NAME,
-                NETWORK_PROTOCOL_NAME,
-                boltVersion(context),
-                serverAddress(context),
-                serverPort(context));
+        return KeyValues.of(DB_SYSTEM_NAME, NETWORK_PROTOCOL_NAME, boltVersion(context), serverAddress(context))
+                .and(extraLowCardinalityKeyValues(context));
+    }
+
+    private KeyValues extraLowCardinalityKeyValues(BoltExchangeContext context) {
+        var list = new ArrayList<KeyValue>();
+        var serverPort = serverPort(context);
+        if (serverPort != null) {
+            list.add(serverPort);
+        }
+        return KeyValues.of(list);
     }
 
     @Override
@@ -66,8 +72,11 @@ public class DefaultBoltExchangeConvention implements BoltExchangeConvention {
     }
 
     private KeyValue serverPort(BoltExchangeContext context) {
-        return Neo4jDriverDocumentation.BoltExchangeLowCardinalityKeyNames.SERVER_PORT.withValue(
-                String.valueOf(context.port()));
+        var port = context.port();
+        return port >= 0
+                ? Neo4jDriverDocumentation.BoltExchangeLowCardinalityKeyNames.SERVER_PORT.withValue(
+                        String.valueOf(port))
+                : null;
     }
 
     private KeyValue messages(BoltExchangeContext context) {

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
-    <neo4j-bolt-connection-bom.version>8.3.0</neo4j-bolt-connection-bom.version>
+    <neo4j-bolt-connection-bom.version>8.4.0</neo4j-bolt-connection-bom.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <!-- Please note that when updating this dependency -->
     <!-- (i.e. due to a security vulnerability or bug) that the -->


### PR DESCRIPTION
The new `bolt+unix` scheme allows connecting to Neo4j server over a Unix socket.

Example:
```java
try (var driver = GraphDatabase.driver("bolt+unix:///var/run/neo4j.sock")) {
    // use the driver
    var result = driver.executableQuery("SHOW DATABASES")
            .withConfig(QueryConfig.builder().withDatabase("system").build())
            .execute();
    result.records().forEach(System.out::println);
}
```