### PR TITLE
feat(bom): Add netty-bom to neo4j-java-driver-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,6 +49,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This helps with ensuring compatible Netty versions, especially when Netty Native Transport is used.