### PR TITLE
feat(bom): delete netty-bom from neo4j-java-driver-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,13 +49,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
It is not uncommon to expect BOM to only include the project maintained dependencies. `netty-bom` has been deleted from `neo4j-java-driver-bom` in this update.