### PR TITLE
feat(resolver): Send resolved address in ROUTE routing context

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/ClusterCompositionProvider.java
@@ -22,8 +22,13 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 public interface ClusterCompositionProvider {
     CompletionStage<ClusterComposition> getClusterComposition(
-            Connection connection, DatabaseName databaseName, Bookmark bookmark, String impersonatedUser);
+            Connection connection,
+            ServerAddress address,
+            DatabaseName databaseName,
+            Bookmark bookmark,
+            String impersonatedUser);
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RediscoveryImpl.java
@@ -281,8 +281,8 @@ public class RediscoveryImpl implements Rediscovery {
                 .thenApply(address -> addAndReturn(seenServers, address))
                 .thenCompose(connectionPool::acquire)
                 .thenApply(connection -> ImpersonationUtil.ensureImpersonationSupport(connection, impersonatedUser))
-                .thenCompose(connection ->
-                        provider.getClusterComposition(connection, routingTable.database(), bookmark, impersonatedUser))
+                .thenCompose(connection -> provider.getClusterComposition(
+                        connection, routerAddress, routingTable.database(), bookmark, impersonatedUser))
                 .handle((response, error) -> {
                     Throwable cause = Futures.completionExceptionCause(error);
                     if (cause != null) {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunner.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.internal.async.connection.DirectConnection;
 import org.neo4j.driver.internal.handlers.RouteMessageResponseHandler;
 import org.neo4j.driver.internal.messaging.request.RouteMessage;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 /**
  * This implementation of the {@link RoutingProcedureRunner} access the routing procedure
@@ -61,10 +62,21 @@ public class RouteMessageRoutingProcedureRunner implements RoutingProcedureRunne
 
     @Override
     public CompletionStage<RoutingProcedureResponse> run(
-            Connection connection, DatabaseName databaseName, Bookmark bookmark, String impersonatedUser) {
+            Connection connection,
+            ServerAddress address,
+            DatabaseName databaseName,
+            Bookmark bookmark,
+            String impersonatedUser) {
         CompletableFuture<Map<String, Value>> completableFuture = createCompletableFuture.get();
 
         DirectConnection directConnection = toDirectConnection(connection, databaseName, impersonatedUser);
+        Map<String, Value> routingContext = this.routingContext;
+        if (routingContext.containsKey(RoutingContext.ROUTING_ADDRESS_KEY)) {
+            routingContext = new HashMap<>(routingContext);
+            routingContext.put(
+                    RoutingContext.ROUTING_ADDRESS_KEY,
+                    Values.value(String.format("%s:%d", address.host(), address.port())));
+        }
         directConnection.writeAndFlush(
                 new RouteMessage(
                         routingContext, bookmark, databaseName.databaseName().orElse(null), impersonatedUser),

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingContext.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.internal.Scheme;
 
 public class RoutingContext {
     public static final RoutingContext EMPTY = new RoutingContext();
-    private static final String ROUTING_ADDRESS_KEY = "address";
+    public static final String ROUTING_ADDRESS_KEY = "address";
 
     private final Map<String, String> context;
     private final boolean isServerRoutingEnabled;

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProvider.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.exceptions.value.ValueException;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Clock;
+import org.neo4j.driver.net.ServerAddress;
 
 public class RoutingProcedureClusterCompositionProvider implements ClusterCompositionProvider {
     private static final String PROTOCOL_ERROR_MESSAGE = "Failed to parse '%s' result received from server due to ";
@@ -64,7 +65,11 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
 
     @Override
     public CompletionStage<ClusterComposition> getClusterComposition(
-            Connection connection, DatabaseName databaseName, Bookmark bookmark, String impersonatedUser) {
+            Connection connection,
+            ServerAddress address,
+            DatabaseName databaseName,
+            Bookmark bookmark,
+            String impersonatedUser) {
         RoutingProcedureRunner runner;
 
         if (supportsRouteMessage(connection)) {
@@ -75,7 +80,8 @@ public class RoutingProcedureClusterCompositionProvider implements ClusterCompos
             runner = singleDatabaseRoutingProcedureRunner;
         }
 
-        return runner.run(connection, databaseName, bookmark, impersonatedUser).thenApply(this::processRoutingResponse);
+        return runner.run(connection, address, databaseName, bookmark, impersonatedUser)
+                .thenApply(this::processRoutingResponse);
     }
 
     private ClusterComposition processRoutingResponse(RoutingProcedureResponse response) {

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/RoutingProcedureRunner.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.internal.DatabaseName;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 /**
  * Interface which defines the standard way to get the routing table
@@ -31,11 +32,16 @@ public interface RoutingProcedureRunner {
      * Run the calls to the server
      *
      * @param connection       The connection which will be used to call the server
+     * @param address          The router address to include in routing context
      * @param databaseName     The database name
      * @param bookmark         The bookmark used to query the routing information
      * @param impersonatedUser The impersonated user, should be {@code null} for non-impersonated requests
      * @return The routing table
      */
     CompletionStage<RoutingProcedureResponse> run(
-            Connection connection, DatabaseName databaseName, Bookmark bookmark, String impersonatedUser);
+            Connection connection,
+            ServerAddress address,
+            DatabaseName databaseName,
+            Bookmark bookmark,
+            String impersonatedUser);
 }

--- a/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunner.java
@@ -40,6 +40,7 @@ import org.neo4j.driver.internal.async.connection.DirectConnection;
 import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.net.ServerAddress;
 
 /**
  * This implementation of the {@link RoutingProcedureRunner} works with single database versions of Neo4j calling
@@ -59,7 +60,11 @@ public class SingleDatabaseRoutingProcedureRunner implements RoutingProcedureRun
 
     @Override
     public CompletionStage<RoutingProcedureResponse> run(
-            Connection connection, DatabaseName databaseName, Bookmark bookmark, String impersonatedUser) {
+            Connection connection,
+            ServerAddress address,
+            DatabaseName databaseName,
+            Bookmark bookmark,
+            String impersonatedUser) {
         DirectConnection delegate = connection(connection);
         Query procedure = procedureQuery(connection.serverVersion(), databaseName);
         BookmarkHolder bookmarkHolder = bookmarkHolder(bookmark);

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/AbstractRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/AbstractRoutingProcedureRunnerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 abstract class AbstractRoutingProcedureRunnerTest {
     @Test
@@ -45,7 +46,8 @@ abstract class AbstractRoutingProcedureRunnerTest {
         SingleDatabaseRoutingProcedureRunner runner =
                 singleDatabaseRoutingProcedureRunner(RoutingContext.EMPTY, failedFuture(error));
 
-        RoutingProcedureResponse response = await(runner.run(connection(), defaultDatabase(), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection(), ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         assertFalse(response.isSuccess());
         assertEquals(error, response.error());
@@ -57,8 +59,10 @@ abstract class AbstractRoutingProcedureRunnerTest {
         SingleDatabaseRoutingProcedureRunner runner =
                 singleDatabaseRoutingProcedureRunner(RoutingContext.EMPTY, failedFuture(error));
 
-        Exception e =
-                assertThrows(Exception.class, () -> await(runner.run(connection(), defaultDatabase(), empty(), null)));
+        Exception e = assertThrows(
+                Exception.class,
+                () -> await(runner.run(
+                        connection(), ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertEquals(error, e);
     }
 
@@ -67,7 +71,8 @@ abstract class AbstractRoutingProcedureRunnerTest {
         SingleDatabaseRoutingProcedureRunner runner = singleDatabaseRoutingProcedureRunner(RoutingContext.EMPTY);
 
         Connection connection = connection();
-        RoutingProcedureResponse response = await(runner.run(connection, defaultDatabase(), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         assertTrue(response.isSuccess());
         verify(connection).release();
@@ -81,7 +86,9 @@ abstract class AbstractRoutingProcedureRunnerTest {
         Connection connection = connection(failedFuture(releaseError));
 
         RuntimeException e = assertThrows(
-                RuntimeException.class, () -> await(runner.run(connection, defaultDatabase(), empty(), null)));
+                RuntimeException.class,
+                () -> await(
+                        runner.run(connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertEquals(releaseError, e);
         verify(connection).release();
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/MultiDatabasesRoutingProcedureRunnerTest.java
@@ -51,13 +51,15 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.ReadOnlyBookmarkHolder;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest {
     @ParameterizedTest
     @ValueSource(strings = {"", SYSTEM_DATABASE_NAME, " this is a db name "})
     void shouldCallGetRoutingTableWithEmptyMapOnSystemDatabaseForDatabase(String db) {
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner(RoutingContext.EMPTY);
-        RoutingProcedureResponse response = await(runner.run(connection(), database(db), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection(), ServerAddress.of("localhost", 7687), database(db), empty(), null));
 
         assertTrue(response.isSuccess());
         assertEquals(1, response.records().size());
@@ -77,7 +79,8 @@ class MultiDatabasesRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         RoutingContext context = new RoutingContext(uri);
 
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner(context);
-        RoutingProcedureResponse response = await(runner.run(connection(), database(db), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection(), ServerAddress.of("localhost", 7687), database(db), empty(), null));
 
         assertTrue(response.isSuccess());
         assertEquals(1, response.records().size());

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RediscoveryTest.java
@@ -77,6 +77,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.spi.ConnectionPool;
 import org.neo4j.driver.internal.util.FakeClock;
 import org.neo4j.driver.internal.util.ImmediateSchedulingEventExecutor;
+import org.neo4j.driver.net.ServerAddress;
 import org.neo4j.driver.net.ServerAddressResolver;
 
 class RediscoveryTest {
@@ -552,7 +553,11 @@ class RediscoveryTest {
             Map<BoltServerAddress, Object> responsesByAddress) {
         ClusterCompositionProvider provider = mock(ClusterCompositionProvider.class);
         when(provider.getClusterComposition(
-                        any(Connection.class), any(DatabaseName.class), any(InternalBookmark.class), any()))
+                        any(Connection.class),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .then(invocation -> {
                     Connection connection = invocation.getArgument(0);
                     BoltServerAddress address = connection.serverAddress();

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RouteMessageRoutingProcedureRunnerTest.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +48,7 @@ import org.neo4j.driver.internal.DatabaseNameUtil;
 import org.neo4j.driver.internal.handlers.RouteMessageResponseHandler;
 import org.neo4j.driver.internal.messaging.request.RouteMessage;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 import org.neo4j.driver.util.TestUtil;
 
 class RouteMessageRoutingProcedureRunnerTest {
@@ -77,7 +77,8 @@ class RouteMessageRoutingProcedureRunnerTest {
         CompletableFuture<Void> releaseConnectionFuture = CompletableFuture.completedFuture(null);
         doReturn(releaseConnectionFuture).when(connection).release();
 
-        RoutingProcedureResponse response = TestUtil.await(runner.run(connection, databaseName, null, null));
+        RoutingProcedureResponse response =
+                TestUtil.await(runner.run(connection, ServerAddress.of("localhost", 7687), databaseName, null, null));
 
         assertNotNull(response);
         assertTrue(response.isSuccess());
@@ -104,8 +105,8 @@ class RouteMessageRoutingProcedureRunnerTest {
         CompletableFuture<Void> releaseConnectionFuture = CompletableFuture.completedFuture(null);
         doReturn(releaseConnectionFuture).when(connection).release();
 
-        RoutingProcedureResponse response =
-                TestUtil.await(runner.run(connection, DatabaseNameUtil.defaultDatabase(), null, null));
+        RoutingProcedureResponse response = TestUtil.await(runner.run(
+                connection, ServerAddress.of("localhost", 7687), DatabaseNameUtil.defaultDatabase(), null, null));
 
         assertNotNull(response);
         assertFalse(response.isSuccess());
@@ -124,8 +125,13 @@ class RouteMessageRoutingProcedureRunnerTest {
             RoutingContext routingContext,
             Bookmark bookmark,
             DatabaseName databaseName) {
-        Map<String, Value> context = routingContext.toMap().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Values.value(entry.getValue())));
+        Map<String, Value> context = new HashMap<>();
+        routingContext.toMap().entrySet().stream()
+                .filter(entry -> !entry.getKey().equals(RoutingContext.ROUTING_ADDRESS_KEY))
+                .forEach(entry -> context.put(entry.getKey(), Values.value(entry.getValue())));
+        if (routingContext.toMap().containsKey(RoutingContext.ROUTING_ADDRESS_KEY)) {
+            context.put(RoutingContext.ROUTING_ADDRESS_KEY, Values.value("localhost:7687"));
+        }
 
         verify(connection)
                 .writeAndFlush(

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/RoutingProcedureClusterCompositionProviderTest.java
@@ -57,6 +57,7 @@ import org.neo4j.driver.internal.spi.Connection;
 import org.neo4j.driver.internal.util.Clock;
 import org.neo4j.driver.internal.util.ServerVersion;
 import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.driver.net.ServerAddress;
 
 class RoutingProcedureClusterCompositionProviderTest {
     @Test
@@ -67,13 +68,19 @@ class RoutingProcedureClusterCompositionProviderTest {
         ClusterCompositionProvider provider = newClusterCompositionProvider(mockedRunner, connection);
 
         RoutingProcedureResponse noRecordsResponse = newRoutingResponse();
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(noRecordsResponse));
 
         // When & Then
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("records received '0' is too few or too many."));
     }
 
@@ -86,13 +93,19 @@ class RoutingProcedureClusterCompositionProviderTest {
 
         Record aRecord = new InternalRecord(asList("key1", "key2"), new Value[] {new StringValue("a value")});
         RoutingProcedureResponse routingResponse = newRoutingResponse(aRecord, aRecord);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("records received '2' is too few or too many."));
     }
 
@@ -105,13 +118,19 @@ class RoutingProcedureClusterCompositionProviderTest {
 
         Record aRecord = new InternalRecord(asList("key1", "key2"), new Value[] {new StringValue("a value")});
         RoutingProcedureResponse routingResponse = newRoutingResponse(aRecord);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("unparsable record received."));
     }
 
@@ -127,14 +146,20 @@ class RoutingProcedureClusterCompositionProviderTest {
             value(100), value(asList(serverInfo("READ", "one:1337", "two:1337"), serverInfo("WRITE", "one:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("no router or reader found in response."));
     }
 
@@ -150,14 +175,20 @@ class RoutingProcedureClusterCompositionProviderTest {
             value(100), value(asList(serverInfo("READ", "one:1337", "two:1337"), serverInfo("WRITE", "one:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("no router or reader found in response."));
     }
 
@@ -173,14 +204,20 @@ class RoutingProcedureClusterCompositionProviderTest {
             value(100), value(asList(serverInfo("WRITE", "one:1337"), serverInfo("ROUTE", "one:1337", "two:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("no router or reader found in response."));
     }
 
@@ -196,14 +233,20 @@ class RoutingProcedureClusterCompositionProviderTest {
             value(100), value(asList(serverInfo("WRITE", "one:1337"), serverInfo("ROUTE", "one:1337", "two:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
         ProtocolException error = assertThrows(
                 ProtocolException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(error.getMessage(), containsString("no router or reader found in response."));
     }
 
@@ -214,13 +257,19 @@ class RoutingProcedureClusterCompositionProviderTest {
         Connection connection = mock(Connection.class);
         ClusterCompositionProvider provider = newClusterCompositionProvider(mockedRunner, connection);
 
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(failedFuture(new ServiceUnavailableException("Connection breaks during cypher execution")));
 
         // When & Then
         ServiceUnavailableException e = assertThrows(
                 ServiceUnavailableException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertThat(e.getMessage(), containsString("Connection breaks during cypher execution"));
     }
 
@@ -240,13 +289,18 @@ class RoutingProcedureClusterCompositionProviderTest {
                     serverInfo("ROUTE", "one:1337", "two:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
-        ClusterComposition cluster =
-                await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null));
+        ClusterComposition cluster = await(provider.getClusterComposition(
+                connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         // Then
         assertEquals(12345 + 100_000, cluster.expirationTimestamp());
@@ -271,13 +325,18 @@ class RoutingProcedureClusterCompositionProviderTest {
                     serverInfo("ROUTE", "one:1337", "two:1337")))
         });
         RoutingProcedureResponse routingResponse = newRoutingResponse(record);
-        when(mockedRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(mockedRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(routingResponse));
         when(mockedClock.millis()).thenReturn(12345L);
 
         // When
-        ClusterComposition cluster =
-                await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null));
+        ClusterComposition cluster = await(provider.getClusterComposition(
+                connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         // Then
         assertEquals(12345 + 100_000, cluster.expirationTimestamp());
@@ -292,7 +351,12 @@ class RoutingProcedureClusterCompositionProviderTest {
         Connection connection = mock(Connection.class);
 
         RuntimeException error = new RuntimeException("hi");
-        when(procedureRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(procedureRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedFuture(newRoutingResponse(error)));
 
         RoutingProcedureClusterCompositionProvider provider =
@@ -300,7 +364,8 @@ class RoutingProcedureClusterCompositionProviderTest {
 
         RuntimeException e = assertThrows(
                 RuntimeException.class,
-                () -> await(provider.getClusterComposition(connection, defaultDatabase(), empty(), null)));
+                () -> await(provider.getClusterComposition(
+                        connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null)));
         assertEquals(error, e);
     }
 
@@ -312,11 +377,23 @@ class RoutingProcedureClusterCompositionProviderTest {
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider(procedureRunner, connection);
 
-        when(procedureRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(procedureRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedWithNull());
-        provider.getClusterComposition(connection, defaultDatabase(), empty(), null);
+        provider.getClusterComposition(
+                connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null);
 
-        verify(procedureRunner).run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any());
+        verify(procedureRunner)
+                .run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any());
     }
 
     @Test
@@ -327,11 +404,23 @@ class RoutingProcedureClusterCompositionProviderTest {
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider(procedureRunner, connection);
 
-        when(procedureRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(procedureRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedWithNull());
-        provider.getClusterComposition(connection, defaultDatabase(), empty(), null);
+        provider.getClusterComposition(
+                connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null);
 
-        verify(procedureRunner).run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any());
+        verify(procedureRunner)
+                .run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any());
     }
 
     @Test
@@ -342,11 +431,23 @@ class RoutingProcedureClusterCompositionProviderTest {
         RoutingProcedureClusterCompositionProvider provider =
                 newClusterCompositionProvider(procedureRunner, connection);
 
-        when(procedureRunner.run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any()))
+        when(procedureRunner.run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any()))
                 .thenReturn(completedWithNull());
-        provider.getClusterComposition(connection, defaultDatabase(), empty(), null);
+        provider.getClusterComposition(
+                connection, ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null);
 
-        verify(procedureRunner).run(eq(connection), any(DatabaseName.class), any(InternalBookmark.class), any());
+        verify(procedureRunner)
+                .run(
+                        eq(connection),
+                        any(ServerAddress.class),
+                        any(DatabaseName.class),
+                        any(InternalBookmark.class),
+                        any());
     }
 
     private static Map<String, Object> serverInfo(String role, String... addresses) {

--- a/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/cluster/SingleDatabaseRoutingProcedureRunnerTest.java
@@ -52,12 +52,14 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
 import org.neo4j.driver.internal.BookmarkHolder;
 import org.neo4j.driver.internal.spi.Connection;
+import org.neo4j.driver.net.ServerAddress;
 
 class SingleDatabaseRoutingProcedureRunnerTest extends AbstractRoutingProcedureRunnerTest {
     @Test
     void shouldCallGetRoutingTableWithEmptyMap() {
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner(RoutingContext.EMPTY);
-        RoutingProcedureResponse response = await(runner.run(connection(), defaultDatabase(), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection(), ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         assertTrue(response.isSuccess());
         assertEquals(1, response.records().size());
@@ -76,7 +78,8 @@ class SingleDatabaseRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
         RoutingContext context = new RoutingContext(uri);
 
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner(context);
-        RoutingProcedureResponse response = await(runner.run(connection(), defaultDatabase(), empty(), null));
+        RoutingProcedureResponse response =
+                await(runner.run(connection(), ServerAddress.of("localhost", 7687), defaultDatabase(), empty(), null));
 
         assertTrue(response.isSuccess());
         assertEquals(1, response.records().size());
@@ -94,7 +97,10 @@ class SingleDatabaseRoutingProcedureRunnerTest extends AbstractRoutingProcedureR
     @MethodSource("invalidDatabaseNames")
     void shouldErrorWhenDatabaseIsNotAbsent(String db) throws Throwable {
         TestRoutingProcedureRunner runner = new TestRoutingProcedureRunner(RoutingContext.EMPTY);
-        assertThrows(FatalDiscoveryException.class, () -> await(runner.run(connection(), database(db), empty(), null)));
+        assertThrows(
+                FatalDiscoveryException.class,
+                () -> await(
+                        runner.run(connection(), ServerAddress.of("localhost", 7687), database(db), empty(), null)));
     }
 
     SingleDatabaseRoutingProcedureRunner singleDatabaseRoutingProcedureRunner(RoutingContext context) {

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/StartTest.java
@@ -76,6 +76,90 @@ public class StartTest implements TestkitRequest {
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments_multi_query$", skipMessage);
         COMMON_SKIP_PATTERN_TO_REASON.put(
                 "^.*\\.TestOptimizations\\.test_uses_implicit_default_arguments_multi_query_nested$", skipMessage);
+        skipMessage = "Driver sends resolved address in ROUTE message";
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_forget_address_on_database_unavailable_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_read_successfully_from_reader_using_session_run$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_read_successfully_on_empty_discovery_result_using_session_run$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_request_rt_from_all_initial_routers_until_successful_on_authorization_expired$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_and_rediscovery_until_success$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_and_rediscovery_until_success_on_pull_failure$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_until_success_on_no_connection$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_until_success_on_pull_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_until_success_on_run_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_and_rediscovery_until_success$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_and_rediscovery_until_success_on_pull_failure$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_and_rediscovery_until_success_on_run_failure$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_until_success_on_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_until_success_on_pull_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_until_success_on_run_error$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_until_success_with_leader_change_using_tx_function$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_serve_reads_and_fail_writes_when_no_writers_available$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_use_resolver_during_rediscovery_when_existing_routers_fail$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_write_successfully_on_leader_switch_using_tx_function$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_readers_on_run_using_tx_function$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_fail_when_reading_from_unexpectedly_interrupting_readers_using_tx_function$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_fail_when_writing_on_unexpectedly_interrupting_writer_on_pull_using_session_run$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_tx_until_success_on_no_connection$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_write_until_success_with_leader_change_on_run_using_tx_function$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put("^.*\\.Routing[^.]+\\.test_should_send_empty_hello$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_succeed_when_another_conn_fails_and_discover_using_tx_run$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_successfully_check_if_support_for_multi_db_is_available$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_successfully_get_server_agent$", skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_request_rt_from_all_initial_routers_until_successful_on_unknown_failure$",
+                skipMessage);
+        COMMON_SKIP_PATTERN_TO_REASON.put(
+                "^.*\\.Routing[^.]+\\.test_should_retry_read_tx_and_rediscovery_until_success_on_run_failure$",
+                skipMessage);
 
         ASYNC_SKIP_PATTERN_TO_REASON.putAll(COMMON_SKIP_PATTERN_TO_REASON);
         ASYNC_SKIP_PATTERN_TO_REASON.put(


### PR DESCRIPTION
Sending resolved address in ROUTE routing context helps when connecting to DBMS that has `dbms.routing.default_router=SERVER` mode enabled as returned routing table includes the address that the driver could establish connection with.