### PR TITLE
TestKit backend: omit profile's hasPageCacheStats

### DIFF
--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/SummaryUtil.java
@@ -166,7 +166,6 @@ public class SummaryUtil {
                 .identifiers(plan.identifiers())
                 .dbHits(plan.dbHits())
                 .rows(plan.records())
-                .hasPageCacheStats(plan.hasPageCacheStats())
                 .pageCacheHits(plan.pageCacheHits())
                 .pageCacheMisses(plan.pageCacheMisses())
                 .pageCacheHitRatio(plan.pageCacheHitRatio())

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/Summary.java
@@ -182,8 +182,6 @@ public class Summary implements TestkitResponse {
 
         private long rows;
 
-        private boolean hasPageCacheStats;
-
         private long pageCacheHits;
 
         private long pageCacheMisses;


### PR DESCRIPTION
When serializing a `ProfiledPlan` in the TestKit backend, skip `hasPageCacheStats` as that's not corresponding to a key in the raw profile as transmitted via bolt.