### PR TITLE
perf: Use a single BoltConnectionProvider for all connection pools

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/DriverFactory.java
@@ -59,6 +59,7 @@ import org.neo4j.driver.internal.adaptedbolt.BoltConnectionProviderFactoryLoader
 import org.neo4j.driver.internal.adaptedbolt.BoltObservationProvider;
 import org.neo4j.driver.internal.adaptedbolt.DriverBoltConnectionSource;
 import org.neo4j.driver.internal.adaptedbolt.ErrorMapper;
+import org.neo4j.driver.internal.adaptedbolt.ProviderClosingBoltConnectionSource;
 import org.neo4j.driver.internal.adaptedbolt.SingleRoutedBoltConnectionSource;
 import org.neo4j.driver.internal.boltlistener.BoltConnectionListener;
 import org.neo4j.driver.internal.homedb.HomeDatabaseCache;
@@ -278,9 +279,11 @@ public class DriverFactory {
         }
         var routingContextAddress = "%s:%d".formatted(uri.getHost(), uri.getPort() != -1 ? uri.getPort() : 7687);
 
+        var boltConnectionProvider = createBoltConnectionProvider(
+                eventLoopGroup, clock, loggingProvider, config, observationProvider, boltConnectionProviderFactory);
         var pooledSourceSupplierFactory = createPooledBoltConnectionSource(
                 config,
-                eventLoopGroup,
+                boltConnectionProvider,
                 clock,
                 loggingProvider,
                 boltConnectionListener,
@@ -291,8 +294,7 @@ public class DriverFactory {
                 observationProvider,
                 authTokenManager,
                 securityPlanSupplier,
-                notificationConfig,
-                boltConnectionProviderFactory);
+                notificationConfig);
         if (Scheme.isRoutingScheme(uri.getScheme())) {
             boltConnectionSource = createRoutedBoltConnectionProvider(
                     config,
@@ -309,7 +311,7 @@ public class DriverFactory {
         } else {
             boltConnectionSource = new SingleRoutedBoltConnectionSource(pooledSourceSupplierFactory.create(uri, null));
         }
-        return boltConnectionSource;
+        return new ProviderClosingBoltConnectionSource(boltConnectionSource, boltConnectionProvider);
     }
 
     private RoutedBoltConnectionSource createRoutedBoltConnectionProvider(
@@ -342,7 +344,7 @@ public class DriverFactory {
 
     private BoltConnectionSourceFactory createPooledBoltConnectionSource(
             Config config,
-            ScheduledExecutorService eventLoopGroup,
+            BoltConnectionProvider boltConnectionProvider,
             Clock clock,
             LoggingProvider loggingProvider,
             BoltConnectionListener boltConnectionListener,
@@ -353,17 +355,8 @@ public class DriverFactory {
             BoltObservationProvider observationProvider,
             org.neo4j.bolt.connection.pooled.AuthTokenManager authTokenManager,
             SecurityPlanSupplier securityPlanSupplier,
-            NotificationConfig notificationConfig,
-            BoltConnectionProviderFactory boltConnectionProviderFactory) {
+            NotificationConfig notificationConfig) {
         return (uri, expectedVerificationHostname) -> {
-            var boltConnectionProvider = createBoltConnectionProvider(
-                    uri,
-                    eventLoopGroup,
-                    clock,
-                    loggingProvider,
-                    config,
-                    observationProvider,
-                    boltConnectionProviderFactory);
             var listeningBoltConnectionProvider = BoltConnectionListener.listeningBoltConnectionProvider(
                     boltConnectionProvider, boltConnectionListener);
             var connectTimeoutMillisAdjusted = connectTimeoutMillis;
@@ -397,7 +390,6 @@ public class DriverFactory {
     }
 
     private BoltConnectionProvider createBoltConnectionProvider(
-            URI uri,
             ScheduledExecutorService eventLoopGroup,
             Clock clock,
             LoggingProvider loggingProvider,

--- a/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/ProviderClosingBoltConnectionSource.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/adaptedbolt/ProviderClosingBoltConnectionSource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.adaptedbolt;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import org.neo4j.bolt.connection.BoltConnection;
+import org.neo4j.bolt.connection.BoltConnectionProvider;
+import org.neo4j.bolt.connection.BoltConnectionSource;
+import org.neo4j.bolt.connection.RoutedBoltConnectionParameters;
+
+public record ProviderClosingBoltConnectionSource(
+        BoltConnectionSource<RoutedBoltConnectionParameters> delegate, BoltConnectionProvider provider)
+        implements BoltConnectionSource<RoutedBoltConnectionParameters> {
+
+    public ProviderClosingBoltConnectionSource {
+        Objects.requireNonNull(delegate);
+        Objects.requireNonNull(provider);
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> getConnection() {
+        return delegate.getConnection();
+    }
+
+    @Override
+    public CompletionStage<BoltConnection> getConnection(RoutedBoltConnectionParameters parameters) {
+        return delegate.getConnection(parameters);
+    }
+
+    @Override
+    public CompletionStage<Void> verifyConnectivity() {
+        return delegate.verifyConnectivity();
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsMultiDb() {
+        return delegate.supportsMultiDb();
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsSessionAuth() {
+        return delegate.supportsSessionAuth();
+    }
+
+    @Override
+    public CompletionStage<Void> close() {
+        return delegate.close()
+                .handle((ignored, throwable) -> {
+                    if (throwable != null) {
+                        return provider.close()
+                                .handle((closedResult, closeThrowable) -> {
+                                    if (closeThrowable != null) {
+                                        throwable.addSuppressed(closeThrowable);
+                                    }
+                                    return CompletableFuture.<Void>failedStage(throwable);
+                                })
+                                .thenCompose(Function.identity());
+                    } else {
+                        return provider.close();
+                    }
+                })
+                .thenCompose(Function.identity());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
-    <neo4j-bolt-connection-bom.version>10.1.1</neo4j-bolt-connection-bom.version>
+    <neo4j-bolt-connection-bom.version>11.0.0</neo4j-bolt-connection-bom.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <!-- Please note that when updating this dependency -->
     <!-- (i.e. due to a security vulnerability or bug) that the -->


### PR DESCRIPTION
Using a single `BoltConnectionProvider` is sufficient.