### PR TITLE
fix(query): Allow null parameters map

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/Query.java
+++ b/driver/src/main/java/org/neo4j/driver/Query.java
@@ -66,7 +66,7 @@ public class Query {
      * @param parameters the parameter map
      */
     public Query(String text, Map<String, Object> parameters) {
-        this(text, Values.value(parameters));
+        this(text, parameters == null ? Values.EmptyMap : Values.value(parameters));
     }
 
     /**

--- a/driver/src/test/java/org/neo4j/driver/QueryTest.java
+++ b/driver/src/test/java/org/neo4j/driver/QueryTest.java
@@ -18,6 +18,8 @@ package org.neo4j.driver;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.driver.Values.parameters;
 
@@ -108,5 +110,19 @@ class QueryTest {
     @Test
     void shouldProhibitEmptyQuery() {
         assertThrows(IllegalArgumentException.class, () -> new Query(""));
+    }
+
+    @Test
+    void shouldAllowNullParamsValue() {
+        var query = new Query("MATCH (n) RETURN n", (Value) null);
+        assertNotNull(query);
+        assertEquals(Values.EmptyMap, query.parameters());
+    }
+
+    @Test
+    void shouldAllowNullParamsMap() {
+        var query = new Query("MATCH (n) RETURN n", (Map<String, Object>) null);
+        assertNotNull(query);
+        assertEquals(Values.EmptyMap, query.parameters());
     }
 }


### PR DESCRIPTION
This update makes sure the following does not throw an exception:
```java
new Query("MATCH (n) RETURN n", (Map<String, Object>) null)
```

It matches the existing handling for `Value` parameters:
```java
new Query("MATCH (n) RETURN n", (Value) null)
```

Part of: DRIVERS-299
