### PR TITLE
fix(bolt): unpack DateTimeZoneId with valid zone handling

### DIFF
--- a/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.Values.isoDuration;
 import static org.neo4j.driver.Values.ofOffsetDateTime;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V44;
 import static org.neo4j.driver.internal.util.Neo4jFeature.TEMPORAL_TYPES;
 
 import java.time.LocalDate;
@@ -318,6 +319,16 @@ class TemporalTypesIT {
         testDurationToString(-40, 2_123_456_789, "P0M0DT-37.876543211S");
         testDurationToString(40, -2_123_456_789, "P0M0DT37.876543211S");
         testDurationToString(-40, -2_123_456_789, "P0M0DT-42.123456789S");
+    }
+
+    @EnabledOnNeo4jWith(BOLT_V44)
+    @Test
+    void shouldUnpackValidDateTimeZoneId() {
+        var date = "2025-10-26T02:30:00+01:00[Europe/Stockholm]";
+        var query = "RETURN datetime('%s') AS dt".formatted(date);
+        var result = session.run(query);
+
+        assertEquals(ZonedDateTime.parse(date), result.single().get(0).asZonedDateTime());
     }
 
     private static <T> void testSendAndReceiveRandomValues(Supplier<T> valueSupplier, Function<Value, T> converter) {

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
@@ -25,6 +25,7 @@ public enum Neo4jFeature {
     SERVER_SIDE_ROUTING_ENABLED_BY_DEFAULT(new Version(5, 0, 0)),
     BOLT_V3(new Version(3, 5, 0)),
     BOLT_V4(new Version(4, 0, 0)),
+    BOLT_V44(new Version(4, 4, 0)),
     BOLT_V51(new Version(5, 5, 0));
 
     private final Version availableFromVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
-    <neo4j-bolt-connection-bom.version>11.0.0</neo4j-bolt-connection-bom.version>
+    <neo4j-bolt-connection-bom.version>11.0.1</neo4j-bolt-connection-bom.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <!-- Please note that when updating this dependency -->
     <!-- (i.e. due to a security vulnerability or bug) that the -->


### PR DESCRIPTION
This update fixes a bug where an incorrect `ZonedDateTime` could be returned, especially during DST periods.