### PR TITLE
fix(bolt): unpack DateTimeZoneId with valid zone handling

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpacker.java
@@ -421,10 +421,8 @@ public class CommonValueUnpacker implements ValueUnpacker {
         return ZonedDateTime.of(localDateTime, zoneId);
     }
 
-    private ZonedDateTime newZonedDateTimeUsingUtcBaseline(long epochSecondLocal, int nano, ZoneId zoneId) {
-        Instant instant = Instant.ofEpochSecond(epochSecondLocal, nano);
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, zoneId);
-        return ZonedDateTime.of(localDateTime, zoneId);
+    ZonedDateTime newZonedDateTimeUsingUtcBaseline(long epochSecondLocal, int nano, ZoneId zoneId) {
+        return Instant.ofEpochSecond(epochSecondLocal, nano).atZone(zoneId);
     }
 
     private ProtocolException instantiateExceptionForUnknownType(byte type) {

--- a/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/TemporalTypesIT.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.neo4j.driver.Values.isoDuration;
 import static org.neo4j.driver.Values.ofOffsetDateTime;
 import static org.neo4j.driver.Values.parameters;
+import static org.neo4j.driver.internal.util.Neo4jFeature.BOLT_V44;
 import static org.neo4j.driver.internal.util.Neo4jFeature.TEMPORAL_TYPES;
 
 import java.time.LocalDate;
@@ -322,6 +323,18 @@ class TemporalTypesIT {
         testDurationToString(-40, 2_123_456_789, "P0M0DT-37.876543211S");
         testDurationToString(40, -2_123_456_789, "P0M0DT37.876543211S");
         testDurationToString(-40, -2_123_456_789, "P0M0DT-42.123456789S");
+    }
+
+    @EnabledOnNeo4jWith(BOLT_V44)
+    @Test
+    void shouldUnpackValidDateTimeZoneId() {
+        String date = "2025-10-26T02:30:00+01:00[Europe/Stockholm]";
+        String query = String.format("RETURN datetime('%s') AS dt", date);
+        Result result = session.run(query);
+
+        assertEquals(
+                ZonedDateTime.parse(date).withLaterOffsetAtOverlap(),
+                result.single().get(0).asZonedDateTime());
     }
 
     private static <T> void testSendAndReceiveRandomValues(Supplier<T> valueSupplier, Function<Value, T> converter) {

--- a/driver/src/test/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpackerTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/messaging/common/CommonValueUnpackerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.messaging.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+final class CommonValueUnpackerTest {
+    @Test
+    void shouldMakeZonedDateTimeUsingUtcBaseline() {
+        CommonValueUnpacker unpacker = new CommonValueUnpacker(mock(), true);
+        long epochSecondLocal = 1761442200L;
+        int nano = 0;
+        ZoneId zoneId = ZoneId.of("Europe/Stockholm");
+
+        ZonedDateTime date = unpacker.newZonedDateTimeUsingUtcBaseline(epochSecondLocal, nano, zoneId);
+
+        assertEquals(
+                ZonedDateTime.parse("2025-10-26T02:30:00+01:00[Europe/Stockholm]")
+                        .withLaterOffsetAtOverlap(),
+                date);
+    }
+}

--- a/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/util/Neo4jFeature.java
@@ -22,12 +22,14 @@ import static java.util.Objects.requireNonNull;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_4_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v3_5_0;
 import static org.neo4j.driver.internal.util.ServerVersion.v4_0_0;
+import static org.neo4j.driver.internal.util.ServerVersion.v4_4_0;
 
 public enum Neo4jFeature {
     SPATIAL_TYPES(v3_4_0),
     TEMPORAL_TYPES(v3_4_0),
     BOLT_V3(v3_5_0),
-    BOLT_V4(v4_0_0);
+    BOLT_V4(v4_0_0),
+    BOLT_V44(v4_4_0);
 
     private final ServerVersion availableFromVersion;
 


### PR DESCRIPTION
This update fixes a bug where an incorrect `ZonedDateTime` could be returned, especially during DST periods.