### PR TITLE
feat(idempotent): add support for autocommit retries

### DIFF
--- a/benchkit-backend/pom.xml
+++ b/benchkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchkit-backend</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver-bom</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/driver-it/jul-to-slf4j-log4j-it/pom.xml
+++ b/driver-it/jul-to-slf4j-log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-jul-to-slf4j-log4j-it</artifactId>

--- a/driver-it/jul-to-slf4j-logback-it/pom.xml
+++ b/driver-it/jul-to-slf4j-logback-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-jul-to-slf4j-logback-it</artifactId>

--- a/driver-it/log4j-it/pom.xml
+++ b/driver-it/log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-log4j-it</artifactId>

--- a/driver-it/pom.xml
+++ b/driver-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-it</artifactId>

--- a/driver-it/slf4j-log4j-it/pom.xml
+++ b/driver-it/slf4j-log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-slf4j-log4j-it</artifactId>

--- a/driver-it/slf4j-logback-it/pom.xml
+++ b/driver-it/slf4j-logback-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-slf4j-logback-it</artifactId>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver</artifactId>

--- a/driver/src/main/java/org/neo4j/driver/AutoCommitRetriesMode.java
+++ b/driver/src/main/java/org/neo4j/driver/AutoCommitRetriesMode.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver;
+
+/**
+ * Defines mode for automatic retries that apply to {@link Session#run(String)} and its overload variants.
+ *
+ * @since 6.1.0
+ */
+public enum AutoCommitRetriesMode {
+    /**
+     * Enables automatic retries.
+     */
+    ENABLED,
+    /**
+     * Disables automatic retries.
+     */
+    DISABLED,
+    /**
+     * Represents the default mode. Its behavior is defined by configuration option that uses it.
+     * @see SessionConfig.Builder#withAutoCommitRetriesMode(AutoCommitRetriesMode)
+     */
+    DEFAULT
+}

--- a/driver/src/main/java/org/neo4j/driver/Config.java
+++ b/driver/src/main/java/org/neo4j/driver/Config.java
@@ -173,6 +173,14 @@ public final class Config implements Serializable {
     @Experimental
     private final boolean tryTcpFastOpen;
 
+    /**
+     * Defines whether automatic retries that apply to {@link Session#run(String)} and its overload variants are
+     * disabled.
+     *
+     * @since 6.1.0
+     */
+    private final boolean autoCommitRetriesDisabled;
+
     private Config(ConfigBuilder builder) {
         this.logging = builder.logging;
         this.logLeakedSessions = builder.logLeakedSessions;
@@ -196,6 +204,7 @@ public final class Config implements Serializable {
         this.telemetryDisabled = builder.telemetryDisabled;
         this.observationProvider = builder.observationProvider;
         this.tryTcpFastOpen = builder.tryTcpFastOpen;
+        this.autoCommitRetriesDisabled = builder.autoCommitRetriesDisabled;
     }
 
     /**
@@ -433,6 +442,16 @@ public final class Config implements Serializable {
     }
 
     /**
+     * Returns whether automatic retries that apply to {@link Session#run(String)} and its overload variants are disabled.
+     *
+     * @return {@code true} if retries are disabled or {@code false} otherwise
+     * @since 6.1.0
+     */
+    public boolean isAutoCommitRetriesDisabled() {
+        return autoCommitRetriesDisabled;
+    }
+
+    /**
      * Used to build new config instances
      */
     public static final class ConfigBuilder {
@@ -455,6 +474,7 @@ public final class Config implements Serializable {
         private int eventLoopThreads = 0;
         private ObservationProvider observationProvider;
         private boolean tryTcpFastOpen;
+        private boolean autoCommitRetriesDisabled;
 
         @SuppressWarnings("deprecation")
         private NotificationConfig notificationConfig = NotificationConfig.defaultConfig();
@@ -952,6 +972,28 @@ public final class Config implements Serializable {
         @Experimental
         public ConfigBuilder withTryTcpFastOpen(boolean enabled) {
             this.tryTcpFastOpen = enabled;
+            return this;
+        }
+
+        /**
+         * Disables automatic retries that apply to {@link Session#run(String)} and its overload variants.
+         * <p>
+         * Retries are limited to a specific set of errors. Namely, those errors marked as idempotent by the DBMS, i.e.,
+         * errors that are guaranteed to not have altered the state of any database. At the time of writing, this set
+         * encompasses only admission control errors.
+         * <p>
+         * When set to {@literal true}, calls will fail without retrying when receiving an error from the server, even when
+         * only idempotent work has occurred. By default, these calls will be rerun with a one-shot retry to avoid
+         * friction when encountering rate limiting and other errors that can be safely retried.
+         * <p>
+         * Default value: {@literal false}.
+         *
+         * @param retriesDisabled {@code true} if retries are disabled or {@code false} otherwise
+         * @return this builder
+         * @since 6.1.0
+         */
+        public ConfigBuilder withAutoCommitRetriesDisabled(boolean retriesDisabled) {
+            this.autoCommitRetriesDisabled = retriesDisabled;
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/SessionConfig.java
+++ b/driver/src/main/java/org/neo4j/driver/SessionConfig.java
@@ -72,6 +72,14 @@ public final class SessionConfig implements Serializable {
     @SuppressWarnings("deprecation")
     private final NotificationConfig notificationConfig;
 
+    /**
+     * The {@link AutoCommitRetriesMode} for automatic retries that apply to {@link Session#run(String)} and its
+     * overload variants.
+     *
+     * @since 6.1.0
+     */
+    private final AutoCommitRetriesMode autoCommitRetriesMode;
+
     private SessionConfig(Builder builder) {
         this.bookmarks = builder.bookmarks;
         this.defaultAccessMode = builder.defaultAccessMode;
@@ -80,6 +88,7 @@ public final class SessionConfig implements Serializable {
         this.impersonatedUser = builder.impersonatedUser;
         this.bookmarkManager = builder.bookmarkManager;
         this.notificationConfig = builder.notificationConfig;
+        this.autoCommitRetriesMode = builder.autoCommitRetriesMode;
     }
 
     /**
@@ -204,6 +213,17 @@ public final class SessionConfig implements Serializable {
                 : Collections.emptySet();
     }
 
+    /**
+     * Returns {@link AutoCommitRetriesMode} for automatic retries that apply to {@link Session#run(String)} and its
+     * overload variants.
+     *
+     * @return the {@link AutoCommitRetriesMode}
+     * @since 6.1.0
+     */
+    public AutoCommitRetriesMode autoCommitRetriesMode() {
+        return autoCommitRetriesMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -219,12 +239,20 @@ public final class SessionConfig implements Serializable {
                 && Objects.equals(fetchSize, that.fetchSize)
                 && Objects.equals(impersonatedUser, that.impersonatedUser)
                 && Objects.equals(bookmarkManager, that.bookmarkManager)
-                && Objects.equals(notificationConfig, that.notificationConfig);
+                && Objects.equals(notificationConfig, that.notificationConfig)
+                && Objects.equals(autoCommitRetriesMode, that.autoCommitRetriesMode);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bookmarks, defaultAccessMode, database, impersonatedUser, bookmarkManager);
+        return Objects.hash(
+                bookmarks,
+                defaultAccessMode,
+                database,
+                impersonatedUser,
+                bookmarkManager,
+                notificationConfig,
+                autoCommitRetriesMode);
     }
 
     @Override
@@ -232,9 +260,16 @@ public final class SessionConfig implements Serializable {
         return String.format(
                 """
                 SessionParameters{bookmarks=%s, defaultAccessMode=%s, database='%s', fetchSize=%d, impersonatedUser=%s, \
-                bookmarkManager=%s}\
+                bookmarkManager=%s, notificationConfig=%s, disableAutoCommitRetries=%s}\
                 """,
-                bookmarks, defaultAccessMode, database, fetchSize, impersonatedUser, bookmarkManager);
+                bookmarks,
+                defaultAccessMode,
+                database,
+                fetchSize,
+                impersonatedUser,
+                bookmarkManager,
+                notificationConfig,
+                autoCommitRetriesMode);
     }
 
     /**
@@ -247,6 +282,7 @@ public final class SessionConfig implements Serializable {
         private String database = null;
         private String impersonatedUser = null;
         private BookmarkManager bookmarkManager;
+        private AutoCommitRetriesMode autoCommitRetriesMode = AutoCommitRetriesMode.DEFAULT;
 
         @SuppressWarnings("deprecation")
         private NotificationConfig notificationConfig = NotificationConfig.defaultConfig();
@@ -473,6 +509,29 @@ public final class SessionConfig implements Serializable {
                             .map(NotificationCategory.class::cast)
                             .collect(Collectors.toSet());
             notificationConfig = notificationConfig.disableCategories(disabledCategories);
+            return this;
+        }
+
+        /**
+         * Sets {@link AutoCommitRetriesMode} for automatic retries that apply to {@link Session#run(String)} and its
+         * overload variants.
+         * <p>
+         * Retries are limited to a specific set of errors. Namely, those errors marked as idempotent by the DBMS, i.e.,
+         * errors that are guaranteed to not have altered the state of any database. At the time of writing, this set
+         * encompasses only admission control errors.
+         * <p>
+         * When set to {@link AutoCommitRetriesMode#DISABLED}, calls will fail without retrying when receiving an error
+         * from the server, even when only idempotent work has occurred.
+         * <p>
+         * Default value: {@link AutoCommitRetriesMode#DEFAULT}, which delegates to the driver level
+         * {@link Config#isAutoCommitRetriesDisabled()} value.
+         *
+         * @param autoCommitRetriesMode the {@link AutoCommitRetriesMode}
+         * @return this builder
+         * @since 6.1.0
+         */
+        public Builder withAutoCommitRetriesMode(AutoCommitRetriesMode autoCommitRetriesMode) {
+            this.autoCommitRetriesMode = Objects.requireNonNull(autoCommitRetriesMode);
             return this;
         }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/SessionFactoryImpl.java
@@ -60,6 +60,7 @@ public class SessionFactoryImpl implements SessionFactory {
     private final AuthTokenManager authTokenManager;
     private final HomeDatabaseCache homeDatabaseCache;
     private final DriverObservationProvider observationProvider;
+    private final boolean defaultAutoCommitRetriesDisabled;
 
     @SuppressWarnings("deprecation")
     SessionFactoryImpl(
@@ -79,6 +80,7 @@ public class SessionFactoryImpl implements SessionFactory {
         this.authTokenManager = authTokenManager;
         this.homeDatabaseCache = Objects.requireNonNull(homeDatabaseCache);
         this.observationProvider = Objects.requireNonNull(observationProvider);
+        this.defaultAutoCommitRetriesDisabled = config.isAutoCommitRetriesDisabled();
     }
 
     @SuppressWarnings("deprecation")
@@ -100,7 +102,12 @@ public class SessionFactoryImpl implements SessionFactory {
                 overrideAuthToken,
                 telemetryDisabled,
                 authTokenManager,
-                homeDatabaseCache);
+                homeDatabaseCache,
+                switch (sessionConfig.autoCommitRetriesMode()) {
+                    case DEFAULT -> defaultAutoCommitRetriesDisabled;
+                    case DISABLED -> true;
+                    case ENABLED -> false;
+                });
     }
 
     private Set<Bookmark> toDistinctSet(Iterable<Bookmark> bookmarks) {
@@ -175,7 +182,8 @@ public class SessionFactoryImpl implements SessionFactory {
             AuthToken authToken,
             boolean telemetryDisabled,
             AuthTokenManager authTokenManager,
-            HomeDatabaseCache homeDatabaseCache) {
+            HomeDatabaseCache homeDatabaseCache,
+            boolean disableAutoCommitRetries) {
         Objects.requireNonNull(bookmarks, "bookmarks may not be null");
         Objects.requireNonNull(bookmarkManager, "bookmarkManager may not be null");
         return leakedSessionsLoggingEnabled
@@ -194,6 +202,7 @@ public class SessionFactoryImpl implements SessionFactory {
                         telemetryDisabled,
                         authTokenManager,
                         homeDatabaseCache,
+                        disableAutoCommitRetries,
                         observationProvider)
                 : new NetworkSession(
                         connectionProvider,
@@ -210,6 +219,7 @@ public class SessionFactoryImpl implements SessionFactory {
                         telemetryDisabled,
                         authTokenManager,
                         homeDatabaseCache,
+                        disableAutoCommitRetries,
                         observationProvider);
     }
 

--- a/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSession.java
@@ -53,6 +53,7 @@ public class LeakLoggingNetworkSession extends NetworkSession {
             boolean telemetryDisabled,
             AuthTokenManager authTokenManager,
             HomeDatabaseCache homeDatabaseCache,
+            boolean autoCommitRetriesDisabled,
             DriverObservationProvider observationProvider) {
         super(
                 connectionProvider,
@@ -69,6 +70,7 @@ public class LeakLoggingNetworkSession extends NetworkSession {
                 telemetryDisabled,
                 authTokenManager,
                 homeDatabaseCache,
+                autoCommitRetriesDisabled,
                 observationProvider);
         this.stackTrace = captureStackTrace();
     }

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -299,9 +299,7 @@ public class NetworkSession {
             return CompletableFuture.completedStage(null)
                     .thenCompose(ignored -> {
                         var messages = new ArrayList<Message>(2);
-                        apiTelemetryWork
-                                .getTelemetryMessageIfEnabled(connection)
-                                .ifPresent(messages::add);
+                        telemetryEnabled.ifPresent(messages::add);
                         messages.add(newRunMessage(connection, query, parameters, config));
                         return connection.writeAndFlush(responseHandler, messages, parentObservation);
                     })

--- a/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/async/NetworkSession.java
@@ -49,6 +49,7 @@ import org.neo4j.bolt.connection.message.Message;
 import org.neo4j.bolt.connection.message.Messages;
 import org.neo4j.bolt.connection.message.RunMessage;
 import org.neo4j.bolt.connection.summary.RunSummary;
+import org.neo4j.bolt.connection.summary.TelemetrySummary;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokenManager;
@@ -88,6 +89,7 @@ import org.neo4j.driver.internal.security.InternalAuthToken;
 import org.neo4j.driver.internal.telemetry.ApiTelemetryWork;
 import org.neo4j.driver.internal.util.Futures;
 import org.neo4j.driver.internal.value.BoltValueFactory;
+import org.neo4j.driver.types.TypeSystem;
 
 public class NetworkSession {
     private final DriverBoltConnectionSource boltConnectionProvider;
@@ -115,6 +117,7 @@ public class NetworkSession {
     private final AuthTokenManager authTokenManager;
     private final HomeDatabaseCache homeDatabaseCache;
     private final HomeDatabaseCacheKey homeDatabaseKey;
+    private final boolean autoCommitRetriesDisabled;
     private final DriverObservationProvider observationProvider;
 
     public NetworkSession(
@@ -132,6 +135,7 @@ public class NetworkSession {
             boolean telemetryDisabled,
             AuthTokenManager authTokenManager,
             HomeDatabaseCache homeDatabaseCache,
+            boolean autoCommitRetriesDisabled,
             DriverObservationProvider observationProvider) {
         Objects.requireNonNull(bookmarks, "bookmarks may not be null");
         Objects.requireNonNull(bookmarkManager, "bookmarkManager may not be null");
@@ -154,63 +158,106 @@ public class NetworkSession {
         this.authTokenManager = authTokenManager;
         this.homeDatabaseCache = Objects.requireNonNull(homeDatabaseCache);
         this.homeDatabaseKey = HomeDatabaseCacheKey.of(overrideAuthToken, impersonatedUser);
+        this.autoCommitRetriesDisabled = autoCommitRetriesDisabled;
         this.observationProvider = Objects.requireNonNull(observationProvider);
     }
 
     public CompletionStage<ResultCursor> runAsync(
             Query query, TransactionConfig config, Observation parentObservation, Class<?> resultType) {
         ensureSessionIsOpen();
+        var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.AUTO_COMMIT_TRANSACTION);
+        apiTelemetryWork.setEnabled(!telemetryDisabled);
         var disposable = ensureNoOpenTxBeforeRunningQuery()
-                .thenCompose(ignore -> acquireConnection(mode, parentObservation))
-                .thenCompose(connection -> {
-                    var parameters = query.parameters().asMap(Values::value);
-                    var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.AUTO_COMMIT_TRANSACTION);
-                    apiTelemetryWork.setEnabled(!telemetryDisabled);
-                    var resultCursor = new ResultCursorImpl(
-                            connection,
-                            query,
-                            fetchSize,
-                            this::handleNewBookmark,
-                            true,
-                            null,
-                            this::handleDatabaseName,
-                            null,
-                            observationProvider,
-                            resultType);
-                    var cursorStage = CompletableFuture.completedStage(null)
-                            .thenCompose(ignored -> {
-                                var messages = new ArrayList<Message>(3);
-                                apiTelemetryWork
-                                        .getTelemetryMessageIfEnabled(connection)
-                                        .ifPresent(messages::add);
-                                messages.add(newRunMessage(connection, query, parameters, config));
-                                messages.add(Messages.pull(-1, fetchSize));
-                                return connection.writeAndFlush(resultCursor, messages, parentObservation);
-                            })
-                            .thenCompose(ignored -> resultCursor.resultCursor())
-                            .handle((resultCursorImpl, throwable) -> {
-                                var error = completionExceptionCause(throwable);
-                                if (error != null) {
-                                    return connection.close().<ResultCursorImpl>handle((ignored, closeError) -> {
+                .thenCompose(ignored -> autoCommitRun(
+                        query,
+                        config,
+                        apiTelemetryWork,
+                        autoCommitRetriesDisabled,
+                        false,
+                        parentObservation,
+                        resultType))
+                .thenApply(DisposableResultCursorImpl::new);
+        resultCursorStage = disposable.exceptionally(error -> null);
+        return disposable.thenApply(Function.identity());
+    }
+
+    private CompletionStage<ResultCursorImpl> autoCommitRun(
+            Query query,
+            TransactionConfig config,
+            ApiTelemetryWork apiTelemetryWork,
+            boolean autoCommitRetriesDisabled,
+            boolean skipPull,
+            Observation parentObservation,
+            Class<?> resultType) {
+        return acquireConnection(mode, parentObservation, skipPull).thenCompose(connection -> {
+            var parameters = query.parameters().asMap(Values::value);
+            var resultCursor = new ResultCursorImpl(
+                    connection,
+                    query,
+                    fetchSize,
+                    this::handleNewBookmark,
+                    true,
+                    null,
+                    this::handleDatabaseName,
+                    apiTelemetryWork,
+                    observationProvider,
+                    resultType);
+            var telemetryEnabled = apiTelemetryWork.getTelemetryMessageIfEnabled(connection);
+            var mayRetry = new AtomicBoolean();
+            return CompletableFuture.completedStage(null)
+                    .thenCompose(ignored -> {
+                        var messages = new ArrayList<Message>(3);
+                        telemetryEnabled.ifPresent(messages::add);
+                        messages.add(newRunMessage(connection, query, parameters, config));
+                        messages.add(Messages.pull(-1, fetchSize));
+                        return connection.writeAndFlush(resultCursor, messages, parentObservation);
+                    })
+                    .thenCompose(ignored -> resultCursor.resultCursor().exceptionally(resultCursorThrowable -> {
+                        if (telemetryEnabled.isPresent()) {
+                            if (apiTelemetryWork.acknowledged().get()) {
+                                mayRetry.set(isIdempotent(completionExceptionCause(resultCursorThrowable)));
+                            }
+                        } else {
+                            mayRetry.set(isIdempotent(completionExceptionCause(resultCursorThrowable)));
+                        }
+                        if (resultCursorThrowable instanceof RuntimeException runtimeException) {
+                            throw runtimeException;
+                        } else {
+                            throw new CompletionException(resultCursorThrowable);
+                        }
+                    }))
+                    .handle((resultCursorImpl, throwable) -> {
+                        var error = completionExceptionCause(throwable);
+                        if (error != null) {
+                            return connection
+                                    .close()
+                                    .handle((ignored, closeError) -> {
                                         if (closeError != null) {
                                             error.addSuppressed(closeError);
+                                        }
+                                        if (!autoCommitRetriesDisabled && mayRetry.get()) {
+                                            return autoCommitRun(
+                                                    query,
+                                                    config,
+                                                    apiTelemetryWork,
+                                                    true,
+                                                    true,
+                                                    parentObservation,
+                                                    resultType);
                                         }
                                         if (error instanceof RuntimeException runtimeException) {
                                             throw runtimeException;
                                         } else {
                                             throw new CompletionException(error);
                                         }
-                                    });
-                                } else {
-                                    return CompletableFuture.completedStage(resultCursorImpl);
-                                }
-                            })
-                            .thenCompose(Function.identity())
-                            .thenApply(DisposableResultCursorImpl::new);
-                    return cursorStage.thenApply(Function.identity());
-                });
-        resultCursorStage = disposable.exceptionally(error -> null);
-        return disposable.thenApply(Function.identity());
+                                    })
+                                    .thenCompose(Function.identity());
+                        } else {
+                            return CompletableFuture.completedStage(resultCursorImpl);
+                        }
+                    })
+                    .thenCompose(Function.identity());
+        });
     }
 
     public CompletionStage<RxResultCursor> runRx(
@@ -219,51 +266,85 @@ public class NetworkSession {
             CompletionStage<RxResultCursor> cursorPublishStage,
             Observation parentObservation) {
         ensureSessionIsOpen();
+        var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.AUTO_COMMIT_TRANSACTION);
+        apiTelemetryWork.setEnabled(!telemetryDisabled);
         var newResultCursorStage = ensureNoOpenTxBeforeRunningQuery()
-                .thenCompose(ignore -> acquireConnection(mode, parentObservation))
-                .thenCompose(connection -> {
-                    var parameters = query.parameters().asMap(Values::value);
-                    var apiTelemetryWork = new ApiTelemetryWork(TelemetryApi.AUTO_COMMIT_TRANSACTION);
-                    apiTelemetryWork.setEnabled(!telemetryDisabled);
-                    var runFailed = new AtomicBoolean(false);
-                    var responseHandler = new RunRxResponseHandler(
-                            logging, connection, query, this::handleNewBookmark, runFailed, this::handleDatabaseName);
-                    var cursorStage = CompletableFuture.completedStage(null)
-                            .thenCompose(ignored -> {
-                                var messages = new ArrayList<Message>(2);
-                                apiTelemetryWork
-                                        .getTelemetryMessageIfEnabled(connection)
-                                        .ifPresent(messages::add);
-                                messages.add(newRunMessage(connection, query, parameters, config));
-                                return connection.writeAndFlush(responseHandler, messages, parentObservation);
-                            })
-                            .thenCompose(ignored -> responseHandler.cursorFuture)
-                            .handle((resultCursor, throwable) -> {
-                                var error = completionExceptionCause(throwable);
-                                if (error != null) {
-                                    return connection.close().<RxResultCursor>handle((ignored, closeError) -> {
+                .thenCompose(ignore -> autoCommitRunRx(
+                        query, config, apiTelemetryWork, autoCommitRetriesDisabled, false, parentObservation));
+        resultCursorStage = newResultCursorStage
+                .thenCompose(cursor -> cursor == null ? CompletableFuture.completedFuture(null) : cursorPublishStage)
+                .exceptionally(throwable -> null);
+        return newResultCursorStage;
+    }
+
+    private CompletionStage<RxResultCursor> autoCommitRunRx(
+            Query query,
+            TransactionConfig config,
+            ApiTelemetryWork apiTelemetryWork,
+            boolean autoCommitRetriesDisabled,
+            boolean skipPull,
+            Observation parentObservation) {
+        return acquireConnection(mode, parentObservation, skipPull).thenCompose(connection -> {
+            var parameters = query.parameters().asMap(Values::value);
+            var runFailed = new AtomicBoolean(false);
+            var telemetryEnabled = apiTelemetryWork.getTelemetryMessageIfEnabled(connection);
+            var responseHandler = new RunRxResponseHandler(
+                    logging,
+                    connection,
+                    query,
+                    this::handleNewBookmark,
+                    runFailed,
+                    this::handleDatabaseName,
+                    apiTelemetryWork);
+            return CompletableFuture.completedStage(null)
+                    .thenCompose(ignored -> {
+                        var messages = new ArrayList<Message>(2);
+                        apiTelemetryWork
+                                .getTelemetryMessageIfEnabled(connection)
+                                .ifPresent(messages::add);
+                        messages.add(newRunMessage(connection, query, parameters, config));
+                        return connection.writeAndFlush(responseHandler, messages, parentObservation);
+                    })
+                    .thenCompose(ignored -> responseHandler.cursorFuture)
+                    .handle((resultCursor, throwable) -> {
+                        if (resultCursor != null) {
+                            throwable = responseHandler.error;
+                        }
+                        var error = completionExceptionCause(throwable);
+                        if (error != null) {
+                            return connection
+                                    .close()
+                                    .handle((ignored, closeError) -> {
                                         if (closeError != null) {
                                             error.addSuppressed(closeError);
+                                        }
+                                        var mayRetry = false;
+                                        if (telemetryEnabled.isPresent()) {
+                                            if (apiTelemetryWork.acknowledged().get()) {
+                                                mayRetry = isIdempotent(error);
+                                            }
+                                        } else {
+                                            mayRetry = isIdempotent(error);
+                                        }
+                                        if (!autoCommitRetriesDisabled && mayRetry) {
+                                            return autoCommitRunRx(
+                                                    query, config, apiTelemetryWork, true, true, parentObservation);
                                         }
                                         if (error instanceof RuntimeException runtimeException) {
                                             throw runtimeException;
                                         } else {
                                             throw new CompletionException(error);
                                         }
-                                    });
-                                } else if (runFailed.get()) {
-                                    return connection.close().handle((ignored1, ignored2) -> resultCursor);
-                                } else {
-                                    return CompletableFuture.completedStage(resultCursor);
-                                }
-                            })
-                            .thenCompose(Function.identity());
-                    return cursorStage.thenApply(Function.identity());
-                });
-        resultCursorStage = newResultCursorStage
-                .thenCompose(cursor -> cursor == null ? CompletableFuture.completedFuture(null) : cursorPublishStage)
-                .exceptionally(throwable -> null);
-        return newResultCursorStage;
+                                    })
+                                    .thenCompose(Function.identity());
+                        } else if (runFailed.get()) {
+                            return connection.close().handle((ignored1, ignored2) -> resultCursor);
+                        } else {
+                            return CompletableFuture.completedStage(resultCursor);
+                        }
+                    })
+                    .thenCompose(Function.identity());
+        });
     }
 
     public CompletionStage<UnmanagedTransaction> beginTransactionAsync(
@@ -297,7 +378,7 @@ public class NetworkSession {
 
         // create a chain that acquires connection and starts a transaction
         var newTransactionStage = ensureNoOpenTxBeforeStartingTx()
-                .thenCompose(ignore -> acquireConnection(mode, parentObservation))
+                .thenCompose(ignore -> acquireConnection(mode, parentObservation, false))
                 .thenCompose(connection -> {
                     var tx = new UnmanagedTransaction(
                             connection,
@@ -431,10 +512,12 @@ public class NetworkSession {
     }
 
     private CompletionStage<BoltConnectionWithCloseTracking> acquireConnection(
-            AccessMode mode, Observation parentObservation) {
+            AccessMode mode, Observation parentObservation, boolean skipPull) {
         var overrideAuthToken = connectionContext.overrideAuthToken();
         var authTokenManager = overrideAuthToken != null ? NoopAuthTokenManager.INSTANCE : this.authTokenManager;
-        var newConnectionStage = pulledResultCursorStage(connectionStage, parentObservation)
+        var newConnectionStage = (skipPull
+                        ? CompletableFuture.<BoltConnectionWithCloseTracking>completedStage(null)
+                        : pulledResultCursorStage(connectionStage, parentObservation))
                 .thenCompose(ignored -> acquireAdaptedConnection(mode, parentObservation))
                 .thenApply(connection ->
                         (DriverBoltConnection) new BoltConnectionWithAuthTokenManager(connection, authTokenManager))
@@ -663,6 +746,16 @@ public class NetworkSession {
         };
     }
 
+    private static boolean isIdempotent(Throwable throwable) {
+        if (throwable instanceof Neo4jException neo4jException) {
+            var val = neo4jException.diagnosticRecord().get("_idempotent");
+            if (val != null && val.hasType(TypeSystem.getDefault().BOOLEAN())) {
+                return val.asBoolean();
+            }
+        }
+        return false;
+    }
+
     /**
      * The {@link NetworkSessionConnectionContext#mode} can be mutable for a session connection context
      */
@@ -720,6 +813,7 @@ public class NetworkSession {
         private final Consumer<DatabaseBookmark> bookmarkConsumer;
         private final AtomicBoolean runFailed;
         private final Consumer<String> databaseNameConsumer;
+        private final ApiTelemetryWork apiTelemetryWork;
         private RunSummary runSummary;
         private Throwable error;
         private int ignoredCount;
@@ -730,13 +824,15 @@ public class NetworkSession {
                 Query query,
                 Consumer<DatabaseBookmark> bookmarkConsumer,
                 AtomicBoolean runFailed,
-                Consumer<String> databaseNameConsumer) {
+                Consumer<String> databaseNameConsumer,
+                ApiTelemetryWork apiTelemetryWork) {
             this.logging = logging;
             this.connection = connection;
             this.query = query;
             this.bookmarkConsumer = bookmarkConsumer;
             this.runFailed = runFailed;
             this.databaseNameConsumer = Objects.requireNonNull(databaseNameConsumer);
+            this.apiTelemetryWork = apiTelemetryWork;
         }
 
         @Override
@@ -749,6 +845,13 @@ public class NetworkSession {
                     // higher order error has occurred
                     error = throwable;
                 }
+            }
+        }
+
+        @Override
+        public void onTelemetrySummary(TelemetrySummary summary) {
+            if (apiTelemetryWork != null) {
+                apiTelemetryWork.acknowledge();
             }
         }
 

--- a/driver/src/test/java/org/neo4j/driver/ParametersTest.java
+++ b/driver/src/test/java/org/neo4j/driver/ParametersTest.java
@@ -119,6 +119,7 @@ class ParametersTest {
                 false,
                 mock(AuthTokenManager.class),
                 mock(),
+                false,
                 NoopObservationProvider.getInstance());
         return new InternalSession(session, NoopObservationProvider.getInstance());
     }

--- a/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
+++ b/driver/src/test/java/org/neo4j/driver/internal/async/LeakLoggingNetworkSessionTest.java
@@ -171,6 +171,7 @@ class LeakLoggingNetworkSessionTest {
                 true,
                 AuthTokenManagers.basic(AuthTokens::none),
                 mock(),
+                false,
                 NoopObservationProvider.getInstance());
     }
 

--- a/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
+++ b/driver/src/test/java/org/neo4j/driver/testutil/TestUtil.java
@@ -234,6 +234,7 @@ public final class TestUtil {
                 telemetryDisabled,
                 mock(AuthTokenManager.class),
                 mock(),
+                false,
                 NoopObservationProvider.getInstance());
     }
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.neo4j.doc.driver</groupId>

--- a/observation/metrics/pom.xml
+++ b/observation/metrics/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/observation/micrometer/pom.xml
+++ b/observation/micrometer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-observation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j.driver</groupId>
   <artifactId>neo4j-java-driver-parent</artifactId>
-  <version>6.0-SNAPSHOT</version>
+  <version>6.1-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Neo4j Java Driver Project</name>

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>testkit-backend</artifactId>

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -78,7 +78,8 @@ public class GetFeatures implements TestkitRequest {
             "Feature:API:Driver:MaxConnectionLifetime",
             "Optimization:HomeDatabaseCache",
             "Feature:Bolt:HandshakeManifestV1",
-            "Feature:API:Type.UnsupportedType"));
+            "Feature:API:Type.UnsupportedType",
+            "Feature:IdempotentRetries"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewDriver.java
@@ -111,6 +111,7 @@ public class NewDriver implements TestkitRequest {
                 .ifPresent(configBuilder::withDisabledNotificationClassifications);
         Optional.ofNullable(data.maxConnectionLifetimeMs)
                 .ifPresent(timeout -> configBuilder.withMaxConnectionLifetime(timeout, TimeUnit.MILLISECONDS));
+        configBuilder.withAutoCommitRetriesDisabled(data.disableAutoCommitRetries);
         var metrics = MetricsObservationProvider.newInstance(configBuilder).metrics();
         var clientCertificateManager = Optional.ofNullable(data.getClientCertificateProviderId())
                 .map(testkitState::getClientCertificateManager)
@@ -298,6 +299,7 @@ public class NewDriver implements TestkitRequest {
         private ClientCertificate clientCertificate;
         private String clientCertificateProviderId;
         private Long maxConnectionLifetimeMs;
+        private boolean disableAutoCommitRetries;
     }
 
     @RequiredArgsConstructor

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/NewSession.java
@@ -36,6 +36,7 @@ import neo4j.org.testkit.backend.messages.responses.Session;
 import neo4j.org.testkit.backend.messages.responses.TestkitResponse;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AutoCommitRetriesMode;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.NotificationClassification;
 import org.neo4j.driver.SessionConfig;
@@ -106,6 +107,11 @@ public class NewSession implements TestkitRequest {
                         .map(NotificationClassification::valueOf)
                         .collect(Collectors.toSet()))
                 .ifPresent(builder::withDisabledNotificationClassifications);
+        Optional.ofNullable(data.disableAutoCommitRetries)
+                .ifPresentOrElse(
+                        disable -> builder.withAutoCommitRetriesMode(
+                                disable ? AutoCommitRetriesMode.DISABLED : AutoCommitRetriesMode.ENABLED),
+                        () -> builder.withAutoCommitRetriesMode(AutoCommitRetriesMode.DEFAULT));
 
         var userSwitchAuthToken = data.getAuthorizationToken() != null
                 ? AuthTokenUtil.parseAuthToken(data.getAuthorizationToken())
@@ -173,6 +179,7 @@ public class NewSession implements TestkitRequest {
         private String notificationsMinSeverity;
         private Set<String> notificationsDisabledCategories;
         private AuthorizationToken authorizationToken;
+        private Boolean disableAutoCommitRetries;
     }
 
     @FunctionalInterface

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.0-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
This update introduces automatic retries for auto-commit queries executed via session `run` methods. At present, the driver performs a single immediate retry, and only for idempotent errors.

This behaviour is enabled by default, but can be disabled at both the driver and session levels.

Driver configuration:
```java
var config = Config.builder()
        .withAutoCommitRetriesDisabled(true) // Defaults to false
        .build();
```

Session configuration:
```java
var config = SessionConfig.builder()
        .withAutoCommitRetriesMode(AutoCommitRetriesMode.DISABLED) // Defaults to AutoCommitRetriesMode.DEFAULT that delegates to driver configuration
        .build();
```

Closes: DRIVERS-308
