### PR TITLE
feat(uuid): add support for Neo4j UUID and Bolt 6.1

### DIFF
--- a/benchkit-backend/pom.xml
+++ b/benchkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchkit-backend</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver-bom</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/driver-it/jul-to-slf4j-log4j-it/pom.xml
+++ b/driver-it/jul-to-slf4j-log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-jul-to-slf4j-log4j-it</artifactId>

--- a/driver-it/jul-to-slf4j-logback-it/pom.xml
+++ b/driver-it/jul-to-slf4j-logback-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-jul-to-slf4j-logback-it</artifactId>

--- a/driver-it/log4j-it/pom.xml
+++ b/driver-it/log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-log4j-it</artifactId>

--- a/driver-it/pom.xml
+++ b/driver-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-it</artifactId>

--- a/driver-it/slf4j-log4j-it/pom.xml
+++ b/driver-it/slf4j-log4j-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-slf4j-log4j-it</artifactId>

--- a/driver-it/slf4j-logback-it/pom.xml
+++ b/driver-it/slf4j-logback-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-it</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-slf4j-logback-it</artifactId>

--- a/driver/clirr-ignored-differences.xml
+++ b/driver/clirr-ignored-differences.xml
@@ -953,4 +953,16 @@
         <method>org.neo4j.driver.types.Vector asVector()</method>
     </difference>
 
+    <difference>
+        <className>org/neo4j/driver/types/TypeSystem</className>
+        <differenceType>7012</differenceType>
+        <method>org.neo4j.driver.types.Type UUID()</method>
+    </difference>
+
+    <difference>
+        <className>org/neo4j/driver/Value</className>
+        <differenceType>7012</differenceType>
+        <method>java.util.UUID asUUID()</method>
+    </difference>
+
 </differences>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>neo4j-java-driver</artifactId>

--- a/driver/src/main/java/org/neo4j/driver/Value.java
+++ b/driver/src/main/java/org/neo4j/driver/Value.java
@@ -26,6 +26,7 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.value.LossyCoercion;
@@ -515,6 +516,15 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
     UnsupportedType asUnsupportedType();
 
     /**
+     * Returns the value as a {@link UUID}, if possible.
+     *
+     * @return the value as a {@link UUID}, if possible
+     * @throws Uncoercible if value types are incompatible
+     * @since 6.2.0
+     */
+    UUID asUUID();
+
+    /**
      * Returns the value as a {@link LocalDate}, if possible.
      *
      * @param defaultValue default to this value if the value is a {@link NullValue}
@@ -706,6 +716,10 @@ public interface Value extends MapAccessor, MapAccessorWithDefaultValue {
      *         <tr>
      *             <td>{@link TypeSystem#UNSUPPORTED}</td>
      *             <td>{@link UnsupportedType}</td>
+     *         </tr>
+     *         <tr>
+     *             <td>{@link TypeSystem#UUID()}</td>
+     *             <td>{@link UUID}</td>
      *         </tr>
      *     </tbody>
      * </table>

--- a/driver/src/main/java/org/neo4j/driver/Values.java
+++ b/driver/src/main/java/org/neo4j/driver/Values.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -67,6 +68,7 @@ import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.internal.value.PointValue;
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.internal.value.TimeValue;
+import org.neo4j.driver.internal.value.UUIDValue;
 import org.neo4j.driver.internal.value.UnsupportedTypeValue;
 import org.neo4j.driver.internal.value.VectorValue;
 import org.neo4j.driver.mapping.Property;
@@ -186,6 +188,9 @@ public final class Values {
         }
         if (value instanceof UnsupportedType) {
             return value((UnsupportedType) value);
+        }
+        if (value instanceof UUID) {
+            return value((UUID) value);
         }
 
         if (value instanceof List<?>) {
@@ -734,6 +739,17 @@ public final class Values {
      */
     private static Value value(Point point) {
         return new PointValue(point);
+    }
+
+    /**
+     * Returns a value from {@link UUID}.
+     *
+     * @param val the UUID value
+     * @return the value
+     * @since 6.2.0
+     */
+    public static Value value(UUID val) {
+        return new UUIDValue(val);
     }
 
     /**

--- a/driver/src/main/java/org/neo4j/driver/internal/types/InternalTypeSystem.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/types/InternalTypeSystem.java
@@ -37,6 +37,7 @@ import static org.neo4j.driver.internal.types.TypeConstructor.RELATIONSHIP;
 import static org.neo4j.driver.internal.types.TypeConstructor.STRING;
 import static org.neo4j.driver.internal.types.TypeConstructor.TIME;
 import static org.neo4j.driver.internal.types.TypeConstructor.UNSUPPORTED;
+import static org.neo4j.driver.internal.types.TypeConstructor.UUID;
 import static org.neo4j.driver.internal.types.TypeConstructor.VECTOR;
 
 import org.neo4j.driver.Value;
@@ -74,6 +75,7 @@ public class InternalTypeSystem implements TypeSystem {
     private final TypeRepresentation nullType = constructType(NULL);
     private final TypeRepresentation vectorType = constructType(VECTOR);
     private final TypeRepresentation unsupportedType = constructType(UNSUPPORTED);
+    private final TypeRepresentation uuidType = constructType(UUID);
 
     private InternalTypeSystem() {}
 
@@ -185,6 +187,11 @@ public class InternalTypeSystem implements TypeSystem {
     @Override
     public Type UNSUPPORTED() {
         return unsupportedType;
+    }
+
+    @Override
+    public Type UUID() {
+        return uuidType;
     }
 
     private TypeRepresentation constructType(TypeConstructor tyCon) {

--- a/driver/src/main/java/org/neo4j/driver/internal/types/TypeConstructor.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/types/TypeConstructor.java
@@ -58,7 +58,8 @@ public enum TypeConstructor {
     DURATION,
     NULL,
     VECTOR,
-    UNSUPPORTED;
+    UNSUPPORTED,
+    UUID;
 
     private static TypeConstructor typeConstructorOf(Value value) {
         return ((InternalValue) value).typeConstructor();

--- a/driver/src/main/java/org/neo4j/driver/internal/value/UUIDValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/UUIDValue.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.driver.internal.value;
+
+import java.util.Objects;
+import java.util.UUID;
+import org.neo4j.driver.exceptions.value.Uncoercible;
+import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.types.Type;
+
+public final class UUIDValue extends ValueAdapter {
+    private final UUID val;
+
+    public UUIDValue(UUID val) {
+        if (val == null) {
+            throw new IllegalArgumentException("Cannot construct StringValue from null");
+        }
+        this.val = val;
+    }
+
+    @Override
+    public String asObject() {
+        return asString();
+    }
+
+    @Override
+    public UUID asUUID() {
+        return val;
+    }
+
+    @Override
+    public <T> T as(Class<T> targetClass) {
+        if (targetClass.isAssignableFrom(UUID.class)) {
+            return targetClass.cast(asUUID());
+        }
+        throw new Uncoercible(type().name(), targetClass.getCanonicalName());
+    }
+
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+
+    @Override
+    public Type type() {
+        return InternalTypeSystem.TYPE_SYSTEM.UUID();
+    }
+
+    @Override
+    public org.neo4j.bolt.connection.values.Type boltValueType() {
+        return org.neo4j.bolt.connection.values.Type.UUID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        var that = (UUIDValue) o;
+        return Objects.equals(val, that.val);
+    }
+
+    @Override
+    public int hashCode() {
+        return val.hashCode();
+    }
+}

--- a/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/ValueAdapter.java
@@ -28,6 +28,7 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import org.neo4j.bolt.connection.values.Vector;
 import org.neo4j.driver.Value;
@@ -314,6 +315,11 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
     @Override
     public UnsupportedType asUnsupportedType() {
         throw new Uncoercible(type().name(), "UnsupportedType");
+    }
+
+    @Override
+    public UUID asUUID() {
+        throw new Uncoercible(type().name(), "UUID");
     }
 
     @Override

--- a/driver/src/main/java/org/neo4j/driver/types/TypeSystem.java
+++ b/driver/src/main/java/org/neo4j/driver/types/TypeSystem.java
@@ -178,4 +178,12 @@ public interface TypeSystem {
      * @see UnsupportedType
      */
     Type UNSUPPORTED();
+
+    /**
+     * Returns a {@link Type} instance representing a UUID type.
+     *
+     * @return the type instance
+     * @since 6.2.0
+     */
+    Type UUID();
 }

--- a/driver/src/test/java/org/neo4j/driver/integration/ObjectMappingIT.java
+++ b/driver/src/test/java/org/neo4j/driver/integration/ObjectMappingIT.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Named;
@@ -80,6 +81,7 @@ final class ObjectMappingIT {
         var point3d = (Point) new InternalPoint3D(0, 0, 0, 0);
         var vector = new InternalFloat64Vector(new double[] {0.0, 100.0});
         var unsupportedType = new InternalUnsupportedType("name", "99.99", "message");
+        var uuid = UUID.randomUUID();
 
         var properties = Map.ofEntries(
                 Map.entry("string", Values.value(string)),
@@ -105,7 +107,8 @@ final class ObjectMappingIT {
                 Map.entry("point2d", Values.value(point2d)),
                 Map.entry("point3d", Values.value(point3d)),
                 Map.entry("vector", Values.value(vector)),
-                Map.entry("unsupportedType", Values.value(unsupportedType)));
+                Map.entry("unsupportedType", Values.value(unsupportedType)),
+                Map.entry("uuid", Values.value(uuid)));
 
         // when
         var valueHolder = valueFunction.apply(properties);
@@ -130,6 +133,7 @@ final class ObjectMappingIT {
         assertEquals(point3d, valueHolder.point3d());
         assertEquals(vector, valueHolder.vector());
         assertEquals(unsupportedType, valueHolder.unsupportedType());
+        assertEquals(uuid, valueHolder.uuid());
     }
 
     static Stream<Arguments> shouldMapValueArgs() {
@@ -173,7 +177,8 @@ final class ObjectMappingIT {
             Point point2d,
             Point point3d,
             Float64Vector vector,
-            UnsupportedType unsupportedType) {}
+            UnsupportedType unsupportedType,
+            UUID uuid) {}
 
     public record StringValueHolder(String string) {}
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-parent</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
   </parent>
 
   <groupId>org.neo4j.doc.driver</groupId>

--- a/observation/metrics/pom.xml
+++ b/observation/metrics/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/observation/micrometer/pom.xml
+++ b/observation/micrometer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-observation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j.driver</groupId>
   <artifactId>neo4j-java-driver-parent</artifactId>
-  <version>6.1-SNAPSHOT</version>
+  <version>6.2-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Neo4j Java Driver Project</name>
@@ -35,7 +35,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
 
     <!-- Versions -->
-    <neo4j-bolt-connection-bom.version>11.1.0</neo4j-bolt-connection-bom.version>
+    <neo4j-bolt-connection-bom.version>12.0.0</neo4j-bolt-connection-bom.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <!-- Please note that when updating this dependency -->
     <!-- (i.e. due to a security vulnerability or bug) that the -->

--- a/testkit-backend/pom.xml
+++ b/testkit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>neo4j-java-driver-parent</artifactId>
         <groupId>org.neo4j.driver</groupId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>testkit-backend</artifactId>

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java
@@ -45,6 +45,7 @@ public class GetFeatures implements TestkitRequest {
             "Feature:Bolt:5.7",
             "Feature:Bolt:5.8",
             "Feature:Bolt:6.0",
+            "Feature:Bolt:6.1",
             "AuthorizationExpiredTreatment",
             "ConfHint:connection.recv_timeout_seconds",
             "Feature:Auth:Bearer",
@@ -79,7 +80,8 @@ public class GetFeatures implements TestkitRequest {
             "Optimization:HomeDatabaseCache",
             "Feature:Bolt:HandshakeManifestV1",
             "Feature:API:Type.UnsupportedType",
-            "Feature:IdempotentRetries"));
+            "Feature:IdempotentRetries",
+            "Feature:API:Type.UUID"));
 
     private static final Set<String> SYNC_FEATURES = new HashSet<>(Arrays.asList(
             "Feature:Bolt:3.0",

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/GenUtils.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/GenUtils.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import neo4j.org.testkit.backend.messages.requests.deserializer.types.CypherDateTime;
@@ -89,6 +90,7 @@ public final class GenUtils {
             case "CypherDate" -> LocalDate.class;
             case "CypherDuration" -> IsoDuration.class;
             case "CypherVector" -> Vector.class;
+            case "CypherUUID" -> UUID.class;
             default -> null;
         };
     }

--- a/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitValueSerializer.java
+++ b/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/responses/serializer/TestkitValueSerializer.java
@@ -46,6 +46,8 @@ public class TestkitValueSerializer extends StdSerializer<Value> {
             cypherObject(gen, "CypherFloat", value.asDouble());
         } else if (InternalTypeSystem.TYPE_SYSTEM.STRING().isTypeOf(value)) {
             cypherObject(gen, "CypherString", value.asString());
+        } else if (InternalTypeSystem.TYPE_SYSTEM.UUID().isTypeOf(value)) {
+            cypherObject(gen, "CypherUUID", value.asUUID());
         }
     }
 }

--- a/testkit-tests/pom.xml
+++ b/testkit-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
This update brings support for Neo4j UUID value and Bolt 6.1 that is required to support it.

Example:

```java
var result = driver.executableQuery("RETURN $value")
        .withParameters(Map.of("value", UUID.randomUUID())) // java.util.UUID value
        .execute();

var uuidValue = result.records().get(0).get("$value");
uuidValue.type(); // TypeSystem.UUID()
uuidValue.asUUID(); // java.util.UUID value
```

Resolves:  DRIVERS-363
