### PR TITLE
fix(uuid): Fix `Value#asObject()` of `UUID` value

### DIFF
--- a/driver/src/main/java/org/neo4j/driver/internal/value/UUIDValue.java
+++ b/driver/src/main/java/org/neo4j/driver/internal/value/UUIDValue.java
@@ -27,14 +27,14 @@ public final class UUIDValue extends ValueAdapter {
 
     public UUIDValue(UUID val) {
         if (val == null) {
-            throw new IllegalArgumentException("Cannot construct StringValue from null");
+            throw new IllegalArgumentException("Cannot construct UUIDValue from null");
         }
         this.val = val;
     }
 
     @Override
-    public String asObject() {
-        return asString();
+    public UUID asObject() {
+        return asUUID();
     }
 
     @Override


### PR DESCRIPTION
This update fixes a bug in `Value#asObject()` implementation of `UUID` value that attempted to map it to a `String`.